### PR TITLE
Record Candidate 5 Quick Task authority

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -665,11 +665,13 @@ task failure. Selection and both pure waits inspect only included members. A `no
 complete persisted policy-member universe, retains `excluded_by_policy` for every excluded member,
 and cannot be cause-free.
 
-V17 remains the sole RuntimeSession continuation writer. An ordinary Conversation can reuse its
-thread only from positive exact-thread evidence on the original ProviderAttempt. A ManagedRun can
-use the accepted V15/V22 causal experiment. Every other case uses the atomic Context Pack and
-fallback RuntimeSession transaction. V17 never writes ProviderAttempt state, and ProviderAttempt
-never creates or rewrites RuntimeSession state.
+V17 remains the sole RuntimeSession continuation writer. For an operation with an existing source
+RuntimeSession, an ordinary Conversation can reuse its thread only from positive exact-thread
+evidence on the original ProviderAttempt. A ManagedRun can use the accepted V15/V22 causal
+experiment. Every other existing-session case uses the atomic Context Pack and fallback
+RuntimeSession transaction. The Candidate-5 initial operation below instead has no source
+RuntimeSession and creates its first session; it is not a fallback. V17 never writes
+ProviderAttempt state, and ProviderAttempt never creates or rewrites RuntimeSession state.
 
 The coordinator consumes one persisted V16 decision, one V17 plan, one ProcessSupervisor-owned
 live `FencedProcess`, and ProviderAttemptService preparation. It consumes the fresh prepared
@@ -677,6 +679,103 @@ capability and returns only an inert attempt projection. It retains no service, 
 receipt, process, attempt, or ambiguity state. Its method and the process fence are crate-private.
 The read-only V2.0 execution-decision query exposes no mutation capability. No production
 composition root can start coordination or authorize provider dispatch.
+
+### XY-1276 candidate-5 target
+
+Candidate 5 is architecture only. Current source still has no accepted Quick Task
+dispatch. Exact Candidate-4 staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is materially rejected and cannot supply
+implementation evidence. The accepted replacement keeps all existing owners and adds no
+module, actor, task, channel, ledger, wrapper, runner, transport, fixed hierarchy, or
+alternate dispatch owner.
+
+The initial target order is:
+
+```text
+Conversation create + prospective Turn UUID intent -> one exact-L0 V16 decision ->
+V17 first snapshots + starting RuntimeSession + inert initial plan ->
+conversations-owner atomic Turn/history admission -> exact active-1 effect proof ->
+Account Service selected-account pre-spawn fence -> fresh ProcessGeneration ->
+V34 thread fence/start/bind -> ProviderAttempt
+```
+
+The prospective Turn UUID is intent only. It has no Turn foreign key, and no Turn row exists
+before Conversation admission. PostgreSQL V16 is the sole Quick Task account selector over
+the complete locked V14 universe.
+Account Service owns lifecycle facts and the exact V16-selected credential/store fence;
+it cannot preselect or replace the account. V17 creates the first RuntimeSession. It does
+not consume a source RuntimeSession for initial planning and does not use sticky affinity,
+explicit successor, or Context-Pack fallback for that operation. The existing
+conversations owner creates and finalizes Turns. Initial admission creates exactly one
+active revision-1 sequence-1 user Turn and its ordinal-0 completed Message item as one
+transaction after V17 commits. Runtime only composes these owners and receives their typed
+results.
+
+The routing snapshot shape is closed. L0 has all six RuntimeSession, account-snapshot, and
+profile-snapshot identity/revision fields null. L6 has all six present and all revisions
+positive. Only those columns lose `NOT NULL`; their foreign keys remain, and one exact
+all-null/all-present check permits `conversation_turn + (L0 or L6)` or
+`managed_run_execution + L6`. Half-null lineage and source-less ManagedRun reject. The
+existing routing-completeness trigger keeps its L6 branch unchanged with exactly one
+sticky member and adds only zero-sticky L0 for a prospective Turn, open exact-revision
+Conversation with no RuntimeSession or Turn, and exact locked V14 membership, order,
+account revisions, two quota facts, eight capability facts, and blockers. Source fields,
+sticky members, closed or stale Conversation state, existing session/Turn state, and
+mixed, incomplete, extra, duplicate, or reordered evidence reject.
+
+Snapshot resolution and V16 routing accept a source RuntimeSession identity/revision pair
+only jointly present or absent. The absent branch writes proven L0; V16 selects in policy
+order, admits one cross-key `Fresh`, and replays only the same key. V17 consumes selected
+L0 and atomically creates the selected account snapshot, copied profile snapshot, first
+revision-1 unfenced starting RuntimeSession, and inert plan. Any failure rolls back that
+complete lineage and its receipt, activity, and outbox. Codecs and readbacks permit zero
+sticky only for L0. Continuation-plan completeness proves L0 and the new lineage;
+routing-decision completeness stays unchanged.
+
+Each ProcessGeneration, thread, and ProviderAttempt effect fence locks and requires the
+exact intent-bound Turn to remain active revision 1 and cross-linked to the same
+Conversation and V17-created RuntimeSession. ProcessGeneration and pre-bind thread effects
+require the applicable `starting` session revision. ProviderAttempt preparation and
+authorization require the exact post-bind `active` revision and fence/bind receipts. Only a
+fresh ProcessGeneration result can spawn. Replay, rejection, and uncertainty use existing
+durable reads without spawn, replacement, adoption, successor creation, duplicate attempt,
+or Turn terminalization. Only positive proof of a definite pre-effect refusal can let the
+conversations owner move that Turn to failed revision 2 while the session is starting.
+Every ambiguous or started effect keeps the Turn active and returns `Unknown` for manual
+recovery.
+
+Explicit successor remains PostgreSQL-only, non-dispatch evidence. Its transaction locks
+the exact Turn named by the selected routing decision and requires the same
+Conversation/source RuntimeSession, `failed`, and revision 2 before any effect. It has no
+runtime grant or product surface.
+
+V34 is the sole integration migration after enum-only V33. It owns RuntimeSession
+state/thread fields and only seven named trigger-function roll-forwards:
+`enforce_routing_completeness`, `enforce_runtime_session_state`, `enforce_turn_state`,
+`enforce_history_item_state`, `enforce_provider_attempt_transition`,
+`enforce_provider_attempt_binding`, and
+`enforce_continuation_plan_completeness`. The
+[normative contract](../specs/vnext-authority.md#v34-trigger-function-roll-forwards)
+defines their exact predicates. Trigger bindings and ACLs remain unchanged. Every
+non-enumerated trigger behavior and unrelated write keeps existing active-only semantics.
+There is no broad starting-session bypass.
+
+The [reset decision](../decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset)
+owns rejection and continuity evidence. The
+[acceptance gate](../specs/vnext-gates.md#xy-1276-candidate-5-quick-task-acceptance)
+keeps the same six sibling StageOrchestrator stages. Implementation, exact-tree review,
+Phase A, digest-only child review, final preparation, Phase B, canonical aggregate
+validation, landing, installation, and live verification remain pending.
+
+Evidence order is source repair, one formatter, clean behavioral commit P and full
+exact-tree review; Phase A on clean P; a direct-child C candidate changing only reported
+`authority.rs` digest arrays; bounded exact-delta review; one final mechanical preparation
+with C fully staged followed by a byte-identical commit; Phase B on clean C binding P/C and
+S0/R1/R2; then the sole canonical aggregate on unchanged clean C. Preparation and aggregate
+cannot precede Phase A when digests are stale. A non-digest post-review change restarts
+review and Phase A. Bytes after preparation invalidate preparation; bytes after Phase B
+invalidate Phase B and aggregate evidence. Seven trigger bodies do not add a seventh
+aggregate stage.
 
 The accepted XY-1355 target adds no live execution path here. V14 makes PostgreSQL the sole owner
 of a revisioned complete routing-policy snapshot over the entire account inventory, canonical
@@ -968,15 +1067,17 @@ V16 command per request, but its method is crate-private and no daemon, applicat
 command, scheduler, Codex, credential, or UI composition root can call it. Digest regeneration plus
 executable validation remain deferred to the integrated freeze.
 
-V17 consumes only one persisted selected V16 decision identity plus its exact consumer revision.
-PostgreSQL derives the selected account, V14 snapshot, source RuntimeSession,
-Conversation, RoleProfile snapshot, and evidence universe; callers cannot provide candidates,
-policy, exclusions, compatibility, or selection. A qualifying ManagedRun same-thread path requires
-one canonical V22-bridged experiment lineage and exact positive thread attestation. A qualifying
-ordinary Conversation same-thread path requires positive exact-thread evidence from the original
-ProviderAttempt. Each path must bind the source RuntimeSession, thread, selected account, and
-consumer. Unknown, stale, negative, mismatched, incomplete, or ambiguous evidence selects the
-fallback path rather than inferring compatibility.
+For current existing-session continuation, V17 consumes only one persisted selected V16 decision
+identity plus its exact consumer revision. PostgreSQL derives the selected account, V14 snapshot,
+source RuntimeSession, Conversation, RoleProfile snapshot, and evidence universe; callers cannot
+provide candidates, policy, exclusions, compatibility, or selection. A qualifying ManagedRun
+same-thread path requires one canonical V22-bridged experiment lineage and exact positive thread
+attestation. A qualifying ordinary Conversation same-thread path requires positive exact-thread
+evidence from the original ProviderAttempt. Each path must bind the source RuntimeSession, thread,
+selected account, and consumer. Unknown, stale, negative, mismatched, incomplete, or ambiguous
+evidence selects the existing-session fallback path rather than inferring compatibility. The
+Candidate-5 initial no-source decision follows the first-session path above and cannot enter either
+existing-session branch.
 
 The fallback path validates the complete deterministic Context-Pack encoding and manifest, stages
 any content-addressed bytes under the existing blob coordination, then inserts its Context Pack,
@@ -1197,10 +1298,13 @@ private app-server process protocol, not process arguments or a long-lived envir
 The Account UUID and provider binding never change in a live process. Same-account token
 refresh does not create account rebinding.
 
-For new work, `fixed` considers one configured account and `balanced` selects the first
-fully eligible account in versioned canonical order. Both check separate 300-minute and
-10080-minute quota facts. Manual recovery uses versioned enable/disable, mode, or order
-commands and then submits a new task. Automatic cross-account same-thread fallback and
+For new work, the Account Registry supplies versioned `fixed` or `balanced` controls and
+complete credential-negative facts. V16 alone selects the Quick Task account. In fixed
+mode it considers one configured account. In balanced mode it selects the first fully
+eligible account in versioned canonical order. Both use separate 300-minute and
+10080-minute quota facts. Account Service then fences only that exact selected account
+immediately before spawn. Manual recovery uses versioned enable/disable, mode, or order
+commands and submits a new task. Automatic cross-account same-thread fallback and
 all-depleted wake remain later XY-1304 obligations.
 
 ## Manual reset-card service

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -351,6 +351,164 @@ their shell destinations live. GPUI is not generally usable. Remaining Slice 1 U
 is Accounts and Conversation. The slices replace the former component-first/global-gate
 sequence.
 
+## XY-1276 candidate-5 architecture reset
+
+Candidate 5 is the approved replacement architecture for the next XY-1276 source
+candidate. It does not claim implementation, validation, readiness, usability, landing,
+installation, or production behavior. Commit
+`1f61b8554c8d9642ba515612a615f33214c75cea` is the exact docs-authority checkpoint
+baseline used for this reconstruction. It is historical checkpoint identity, not
+permission to omit later main commits or a permanently frozen executable implementation
+base. Behavioral commit P must integrate the then-current main, preserve all intervening
+account-observation, concurrency, Reset Card, and other current behavior, and bind its
+exact integration base in the full exact-tree review and Phase-A evidence.
+
+The Candidate-4 review used checkout
+`/Users/x/code/y/hack-ink/decodex/.worktrees/xy-1276-candidate4-recovery-1` at base and
+HEAD `04156d0c43a7e511b469a366a856bdff9a848433`. Its exact staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1` and cached binary diff SHA-256
+`b673af2bb84264e947edf66c556d742c81f0ea7efb2f72bdb0771e809cfe644a` are materially
+rejected and superseded source evidence. Independent exact-tree source review returned
+`CHANGES_REQUESTED`. Fresh isolated root-cause research and skeptic review both returned
+`AUTHORITY_RESET_REQUIRED`.
+
+Continuity is `same_decision_changed_context`. The product decision to deliver one
+ordinary Quick Task remains. The evidence lineage changed because exact Candidate-4
+source exposed five P1 defects. This section supersedes the Candidate-4 architecture
+packet and promotes the accepted Candidate-5 owner order into repository authority.
+
+The five P1 defects are:
+
+1. Explicit successor did not lock and require the exact routing-selected Turn to be in
+   the same Conversation and source RuntimeSession, `failed`, and revision 2 before any
+   successor effect. Initial effect fencing also lacked an exact selected active-revision-1
+   Turn proof.
+2. Initial user-Turn and history admission was not one atomic one-winner owner
+   transaction. Classification and refusal followed a committed generic history command,
+   and ordinal and kind constraints were incomplete.
+3. Exact ProcessGeneration create-envelope replay after daemon or local-state loss could
+   become conflict and terminalize a Turn while external activity was ambiguous.
+4. V34 changed trigger-function semantics after the prior packet prohibited trigger
+   changes. The prohibited combination of active-only triggers and Turn-before-thread
+   ordering was not implementable.
+5. Quick Task had two account selectors. Account Service used fewer readiness facts before
+   V16 selected from complete evidence, so valid input could select account A first, select
+   account B in V16, and then fail the Turn.
+
+Candidate 5 fixes the owner order. Account Service owns lifecycle readiness and control
+facts plus the exact V16-selected credential/store pre-spawn fence. It does not select a
+Quick Task account. The Conversation owner creates the Conversation. A routing fixture
+supplies only a prospective Turn UUID as intent, with no Turn foreign key or row. One
+PostgreSQL V16 decision selects from the complete locked V14 universe without a source
+RuntimeSession or sticky member. V17 atomically creates the first selected-account and
+profile snapshots, one revision-1 unfenced `starting` RuntimeSession, and one inert initial
+plan. The existing conversations owner then atomically admits the exact first active
+revision-1 user Turn and its ordinal-zero completed Message history item. Runtime only
+composes these owner calls; it does not select an account or create plan, session, Turn,
+or history authority.
+
+The V16 routing snapshot has exactly two lineage shapes. `L0` has all six
+RuntimeSession/account/profile identity-and-revision fields null. `L6` has all six fields
+present and all three revisions positive. V34 drops `NOT NULL` only on those six columns,
+retains their foreign keys, and adds one exact all-null/all-present check. Conversation
+Turn routing accepts L0 or L6; ManagedRun routing accepts only L6. The existing
+`enforce_routing_completeness()` trigger keeps L6 unchanged with exactly one sticky member
+and adds only the exact zero-sticky L0 branch over an open exact-revision Conversation,
+no existing RuntimeSession or Turn, and complete locked V14 membership, order, account
+revisions, two quota facts per member, eight ordered capability facts per member, and
+blocker facts. Partial lineage,
+source fields, sticky L0, an existing session or Turn, closed or stale Conversation,
+source-less ManagedRun, and mixed, incomplete, duplicate, extra, or reordered evidence
+reject.
+
+Only narrow existing-owner roll-forwards support that shape. Snapshot resolution accepts
+the source identity/revision pair only jointly present or absent and writes proven L0 when
+absent. V16 routes exact L0 in policy order, makes one competing initial key `Fresh`, and
+replays only the same key. V17 consumes the selected L0 and atomically creates its new
+lineage and inert plan, with complete rollback on failure. Codecs and readbacks allow a
+jointly absent source pair and zero sticky members only for L0. Continuation-plan
+completeness proves the selected L0 and new lineage. Routing-decision completeness is
+unchanged.
+
+Before a ProcessGeneration, thread, or provider effect, the establishment path must lock
+and require that exact selected Turn as active revision 1 and cross-linked to the same
+Conversation and V17-created RuntimeSession. ProcessGeneration and pre-bind thread effects
+require the applicable `starting` RuntimeSession revision. ProviderAttempt preparation and
+authorization require the exact post-bind `active` revision and its fence/bind receipts.
+Account Service then repeats the selected-account readiness, credential, provider, and
+HostCredentialStore fence immediately before spawn. Drift fails closed without another V16
+decision, account, fallback, or wake.
+
+Only a `Fresh` ProcessGeneration result can continue to spawn. `Replayed`, `Rejected`, or
+uncertain durable state uses existing ProcessGeneration, RuntimeSession, ProviderAttempt,
+and Conversation reads. It cannot spawn, replace, adopt, create a successor, duplicate an
+attempt, or terminalize the Turn. The conversations owner can change active revision 1 to
+failed revision 2 under a starting RuntimeSession only after positive proof of a definite
+pre-effect refusal. Replayed, ambiguous, fenced, thread-started, thread-bound, or
+ProviderAttempt-active/unknown work keeps the Turn active and returns `Unknown` for manual
+recovery.
+
+Explicit successor remains PostgreSQL-only, non-dispatch evidence with no runtime grant or
+product surface. Its transaction must lock the exact Turn named by the selected routing
+decision and require the same Conversation and source RuntimeSession, status `failed`, and
+revision 2 before any effect. An active revision-1, completed revision-2, absent, wrong,
+cross-linked, or changed Turn rejects before any successor effect.
+
+The unlanded migration allocation remains V33/V34. Current V32 stays byte-for-byte as the
+alpha.9.2 four-function capability replacement. V33 adds only the `initial_thread`
+plan-kind enum value.
+V34 is the sole integration migration. It owns RuntimeSession state and thread fields and
+only the seven exact required trigger-bound function roll-forwards of
+`decodex.enforce_routing_completeness()`,
+`decodex.enforce_runtime_session_state()`, `decodex.enforce_turn_state()`,
+`decodex.enforce_history_item_state()`,
+`decodex.enforce_provider_attempt_transition()`,
+`decodex.enforce_provider_attempt_binding()`, and
+`decodex.enforce_continuation_plan_completeness()`. Their exact permitted predicates are
+in the [normative contract](../specs/vnext-authority.md#v34-trigger-function-roll-forwards).
+Trigger bindings and ACLs do not change. All unrelated writes keep their existing
+active-only behavior. Candidate 5 adds no V35, compatibility DDL, or broad starting-session
+bypass.
+
+Candidate 5 preserves the six sibling StageOrchestrator stages, the current account and UI
+behavior, the current deterministic one-word account alias, current automation behavior,
+treatment of negative Reset Card inventory counts as empty inventory, V17 same-thread and
+Context-Pack authority, and XY-1304 containment. It adds no module or fixed hierarchy.
+
+Rejected alternatives are external thread creation or binding before durable one-winner
+Turn admission; mandatory sticky selection in Account Service; a new ledger, any
+pre-admission Turn row or state, generic transaction or recovery framework, transport or
+idempotency protocol, compatibility alias or path, generic runner or wrapper, scheduler
+redesign, product explicit-successor command or grant, automatic fallback or wake, V32 or
+V33 churn, V35, and any broad trigger bypass.
+
+Candidate-5 evidence has one non-commutative order:
+
+1. Repair the behavioral source, run the formatter exactly once, create clean behavioral
+   commit P, and complete a full exact-tree review of P.
+2. Run Phase A on clean P.
+3. Form direct-child candidate C by changing only the `authority.rs` digest array or
+   arrays reported by Phase A.
+4. Complete a bounded exact-delta review from P to the fully staged C tree.
+5. Run final mechanical preparation exactly once with C fully staged, then commit those
+   exact bytes as C without another write so the prepared tree equals C.
+6. Run Phase B on clean C and bind P, C, the Phase-A receipt, and S0/R1/R2 evidence.
+7. Run the sole canonical aggregate on clean C with the unchanged six sibling stages.
+
+When authority digests are stale, neither preparation nor the aggregate can run before
+Phase A. Any non-digest change after the full review restarts that review and Phase A. Any
+byte change after preparation invalidates preparation. Any byte change after Phase B
+invalidates Phase B and aggregate evidence. The seventh trigger body does not create a
+seventh aggregate stage.
+
+Candidate-5 implementation, behavioral commit and exact-tree review, Phase A, digest-only
+child review, final mechanical preparation, Phase B, canonical aggregate validation,
+landing, installation, and live verification are pending. The acceptance matrix and exact
+stage topology are in
+[vNext Gates](../specs/vnext-gates.md#xy-1276-candidate-5-quick-task-acceptance). The
+command sequence is in
+[Commands And Validation](../operations/commands-and-validation.md#xy-1276-candidate-5-validation-boundary).
+
 ## XY-1262 gate split
 
 The XY-1262 foundation gate is accepted only for the evidence scope enumerated in the

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -165,6 +165,90 @@ continuity, ProcessGeneration fencing, ProviderAttempt capability consumption
 and ambiguity, same-UID transport, concurrency, hostile cross-links, and reverse
 production isolation.
 
+## XY-1276 candidate-5 validation boundary
+
+The [authority reset](../decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset)
+owns the Candidate-4 rejection record and Candidate-5 decision. The
+[gate contract](../specs/vnext-gates.md#xy-1276-candidate-5-quick-task-acceptance)
+owns the exact rows, sibling stages, dependencies, and isolation.
+
+This docs-only reconstruction uses
+`1f61b8554c8d9642ba515612a615f33214c75cea` as its exact docs-authority checkpoint
+baseline. This is historical checkpoint identity, not permission to omit later main
+commits or a permanently frozen executable implementation base. This reconstruction runs
+no formatter, compiler, test, migration, PostgreSQL process, preparation command, digest
+capture, install, or live verification. Candidate-5 implementation and every executable
+step below remain pending.
+Exact Candidate-4 base/HEAD `04156d0c43a7e511b469a366a856bdff9a848433`, staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1`, and cached binary diff SHA-256
+`b673af2bb84264e947edf66c556d742c81f0ea7efb2f72bdb0771e809cfe644a` are rejected
+evidence. The exact-tree review result is `CHANGES_REQUESTED`. No Candidate-4 command
+result, preparation output, or digest can attest Candidate 5.
+
+The Candidate-5 source owner must use this order:
+
+1. Integrate the then-current main, complete only the Candidate-5 behavioral source repair,
+   run `cargo make fmt` exactly once, create clean behavioral commit P, and obtain one full
+   independent exact-tree review of P. Preserve byte-identical V32 alpha.9.2, enum-only
+   V33, sole integration V34, all intervening account-observation and concurrency behavior,
+   all Reset Card and other current behavior, the deterministic one-word alias, and
+   automation behavior. Bind P's exact integration base in that review and in Phase-A
+   evidence.
+2. Run the existing Manager-authorized Phase A authority capture on clean P.
+3. From P, form one direct-child candidate C by changing only the digest array or arrays
+   in `crates/decodex-postgres/src/authority.rs` that Phase A reports. Every other byte and
+   every unreported digest array must remain identical to P.
+4. Obtain one bounded independent exact-delta review of P to the fully staged C tree.
+5. With C fully staged, run final mechanical preparation exactly once with
+   `cargo make check-vnext-retained-title-preparation`. Commit the staged tree as C without
+   any further write, formatter, amendment, or rerun. The prepared tree must equal C.
+6. Run Phase B on clean C. It must bind clean P and C, the immutable Phase-A receipt and
+   hash, and complete S0/R1/R2 parity for both source trees.
+7. On unchanged clean C, run the sole canonical
+   `cargo make test-vnext-postgres-store` aggregate exactly once, with the unchanged six
+   sibling stages.
+   Landing, installation, and live verification can continue only after Phase B and the
+   aggregate accept that exact C.
+
+When Phase A reports stale authority digests, neither preparation nor the aggregate may
+run before Phase A. Any non-digest source change after the full review starts a new full
+exact-tree review and Phase A. Any byte change after final preparation invalidates that
+preparation. Any byte change after Phase B invalidates Phase B and aggregate evidence.
+Results from an owner branch, Candidate 4, an earlier tree, a partial rerun, or a focused
+command do not combine into acceptance. Preparation keeps its exact start/end source
+binding, bounded credential-negative diagnostics, and `acceptance=false` report. Phase A
+and Phase B keep their existing clean committed-tree requirements and add no Candidate-5
+alias or mode.
+
+The aggregate must schedule exactly these Candidate-5 obligations as six sibling
+stages:
+
+```text
+xy_1276_row_1
+xy_1276_rows_2_3
+xy_1276_row_4
+xy_1276_row_5
+xy_1276_row_6
+xy_1276_row_7
+```
+
+Each stage depends only on `cluster_preflight`; final evidence depends on all six. Do not
+add a focused copy, focused task, new gate, alternate StageOrchestrator, or extra sibling.
+Rows 1 through 4 must cover the Candidate-5 Turn, account, ProcessGeneration,
+RuntimeSession, ProviderAttempt, explicit-successor, and trigger matrix. Rows 5 through 7
+keep their existing transport obligations.
+
+The migration inventory after implementation must be contiguous V1-V34. V32 must remain
+byte-identical. V33 is `V33__initial_thread_plan_kind.sql` and changes only enum
+vocabulary. V34 is `V34__runtime_session_thread_establishment.sql` and is the sole
+integration migration. Among trigger-bound functions, it may replace only the seven bodies
+enumerated in the
+[normative contract](../specs/vnext-authority.md#v34-trigger-function-roll-forwards).
+Required narrow roll-forwards of existing non-trigger owner commands and effect fences
+remain governed by that contract. Trigger bindings and ACLs stay unchanged. V35,
+compatibility DDL, broad starting-session bypass, and a new validation command are out of
+scope.
+
 ## Vstyle audit authority
 
 Vstyle is an explicit read-only audit and is not part of the blocking `lint` or `check`

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -14,6 +14,15 @@ defined in the [retirement decision](specs/private-artifact/decision.md#reposito
 The [private-artifact archive](specs/private-artifact/README.md) is historical
 evidence only after that point. It is not a runtime or future-work input.
 
+XY-1276 Candidate 5 is approved architecture, not implemented or ready behavior. Exact
+Candidate-4 staged tree `f82b866e21f12742648023a2b468cc057afa52a1` is materially
+rejected and superseded source evidence. Current source remains on the V1-V32 ledger with
+Quick Task dispatch unavailable. See the
+[reset decision](decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset),
+[normative contract](specs/vnext-authority.md#xy-1276-quick-task-thread-establishment),
+[acceptance gate](specs/vnext-gates.md#xy-1276-candidate-5-quick-task-acceptance), and
+[validation boundary](operations/commands-and-validation.md#xy-1276-candidate-5-validation-boundary).
+
 ## Start here
 
 - [Runtime architecture](architecture/runtime-architecture.md): process topology, CLI bootstrap, app-server runs, operator HTTP/MCP, and state ownership.
@@ -121,6 +130,19 @@ evidence only after that point. It is not a runtime or future-work input.
   scalar RuntimeSession/profile/account snapshot identities are cross-domain provenance, while
   RuntimeSession aggregate/event/kind markers, complete session or snapshot objects, and outbox
   links to activity carrying those ownership shapes remain migration-owner-only.
+  Candidate 5 reserves unlanded enum-only V33 and sole integration V34. V16 will be the
+  sole initial Quick Task account selector. Initial Conversation routing uses exact L0,
+  with all six RuntimeSession/account/profile lineage fields null and zero sticky members;
+  unchanged L6 has all six present, positive revisions, and exactly one sticky member.
+  V17 will atomically create the first selected snapshots, revision-1 unfenced starting
+  RuntimeSession, and inert initial plan before the conversations owner atomically admits
+  the first active revision-1 Turn and ordinal-0 completed Message. Account Service will
+  fence only the selected account immediately before spawn. V34 will own RuntimeSession
+  thread fields and seven exact trigger-function roll-forwards with unchanged bindings and
+  ACLs. Candidate evidence must review clean behavioral commit P, run Phase A on P, review
+  a reported-digest-only child C, prepare fully staged C once, commit without changing its
+  bytes, run Phase B on clean C, and then run the sole six-stage aggregate on unchanged C.
+  None of this target is implemented or accepted in current source.
 - `crates/decodex-codex/` owns typed app-server contracts, exact-build capability profiles, redacted normalized events, fixed and bounded read-only launch/probe behavior, and immutable one-account process supervision. Current dispatch is disabled. Slice 1 can enable only the fenced initial-selection path; XY-1304 remains later automatic fallback/wake acceptance.
 - `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner that composes protocol and infrastructure adapters.
 - `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are composition

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -82,8 +82,13 @@ collision table, or mutable reroll. The ChatGPT provider identity
 `Val`.
 
 Wire and native-client boundaries accept only one 2–16-byte ASCII word with one
-initial uppercase letter and lowercase remaining letters. They reject the v1
-`Account ABCDE-FGHIJ` form rather than retaining a compatibility branch.
+initial uppercase letter and lowercase remaining letters. Every other display shape
+rejects, and there is no compatibility branch.
+
+The XY-1276 Candidate-5 reset preserves this deterministic one-word alias exactly. The
+alias contract is complete and unrelated to the Quick Task authority reset. Candidate 5
+also preserves current account UI text, account lifecycle commands, fixed routing
+controls, and user-controlled account order.
 
 ## HostCredentialStore
 
@@ -164,11 +169,14 @@ receipt at the same revision. Any real change increments exactly one owning revi
 No command changes observed health, quota, credentials, ProcessGeneration, or
 ProviderAttempt state as a side effect.
 
-For a new task, `fixed` considers only its target. An ineligible fixed target returns a
-typed no-route result. `balanced` selects the first fully eligible account in canonical
-order after independent capability, credential, process, attempt, and two-window quota
-checks. Manual recovery changes enablement, fixed/balanced mode, or order with these
-commands and then submits a new task. It does not rebind or replay an existing thread.
+The Account Registry and Account Service own these controls and readiness facts, but
+Account Service does not select a Quick Task account. For a new Quick Task, one V16
+decision is the sole selector over the complete locked V14 universe. In `fixed` mode V16
+considers only the target; an ineligible target returns typed no-route. In `balanced` mode
+V16 selects the first fully eligible account in canonical order after independent
+capability, credential, process, attempt, and two-window quota checks. Manual recovery
+changes enablement, fixed/balanced mode, or order with these commands and then submits a
+new task. It does not rebind or replay an existing thread.
 
 Automatic cross-account same-thread fallback and all-depleted scheduler wake are not
 Slice 1 requirements. An all-depleted result exposes the exact reset evidence and waits
@@ -279,6 +287,14 @@ metadata and compare every field with the ProcessGeneration intent and Account R
 Any mismatch stops before spawn. The existing ProcessGeneration and ProviderAttempt
 state machines own crash and effect ambiguity. No account-specific process or effect
 ledger is added.
+
+For Candidate-5 Quick Task, the ProcessGeneration intent must name the exact account from
+the single V16 decision and the exact V17 account snapshot. Account Service repeats the
+complete selected-account revision, enabled state, AccountLifecycle and exact-build
+capability, provider binding, credential version and fingerprint, and actual store-binding
+check immediately before spawn. It cannot choose another account. Drift fails closed
+without a second V16 call, fallback, wake, or alternate account. A replayed, rejected, or
+uncertain ProcessGeneration result also cannot cause re-selection or Turn terminalization.
 
 ## Reset Card fencing
 
@@ -402,6 +418,11 @@ not read an old account pool, mapping, helper, environment projection, migration
 manifest, or migration receipt. V27 is the landed clean-break account schema in the
 current V1–V32 migration ledger and accepts only an empty Account Registry. A populated
 older registry requires a fresh local product database.
+
+Candidate 5 does not change the current V1-V32 ledger or this cutover. Its V33 and V34
+allocations remain unlanded until implementation and acceptance. It adds no V35,
+compatibility DDL, legacy account input, account alias change, account UI change, or
+account lifecycle command.
 
 An operator can move credentials once by creating owner-private
 `decodex/account-credential-import/1` files and calling the ordinary versioned account

--- a/openwiki/specs/execution-coordinator-authority.md
+++ b/openwiki/specs/execution-coordinator-authority.md
@@ -17,10 +17,16 @@ composed authority:
 The XY-1396 and XY-1397 candidates are rejection evidence. They do not supply
 implementation authority.
 
-This candidate is source-only work before the unified core-freeze gate. No
+The XY-1402 candidate was source-only work before the unified core-freeze gate. No
 formatter, build, compiler, lint, static analysis, migration parser, SQL parser,
 test, fixture, generator, service, VM, UI check, live Codex experiment, account
 operation, or provider effect is part of this candidate evidence.
+
+XY-1276 Candidate 5 is approved architecture only. Exact Candidate-4 staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is materially rejected and superseded
+source evidence. Candidate-5 implementation and all executable acceptance remain
+pending. The reset is in the
+[authority decision](../decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset).
 
 ## Owner composition
 
@@ -31,10 +37,13 @@ ProviderAttempt state.
 
 | Owner | Sole authority retained |
 | --- | --- |
-| Conversation owner | Ordinary Conversation and Turn lifecycle. Quick Task stays an ordinary multi-turn Conversation. |
+| Conversation owner | Ordinary Conversation and Turn lifecycle, including Candidate-5 atomic initial admission and legal terminalization. Quick Task stays an ordinary multi-turn Conversation. |
 | ManagedRun owner | ManagedRun lifecycle, execution assignment, wait state, and acceptance. |
-| V14 and V16 | Complete account universe, eligibility facts, account selection, and immutable route decision. |
-| V17 | Exact same-thread RuntimeSession reuse or atomic Context Pack plus fallback RuntimeSession creation. |
+| V14 | Complete account universe, policy, eligibility, capability, and quota facts. It does not select. |
+| V16 | Sole account selection and immutable route decision. |
+| Account Service | Account lifecycle facts and the exact V16-selected credential/store pre-spawn fence. It does not select Quick Task accounts. |
+| V17 | Candidate-5 first-session initial planning, exact same-thread RuntimeSession reuse, atomic Context Pack plus fallback RuntimeSession creation, and PostgreSQL-only explicit-successor evidence. |
+| V34 RuntimeSession owner | Candidate-5 RuntimeSession state/thread fields and exact bounded thread establishment. |
 | ProcessSupervisor | ProcessGeneration intent, live fence, positive death evidence, and account-local quarantine. |
 | ProviderAttemptService | Atomic prepared binding, provider-effect state, positive evidence, restore projection, and reconciliation. |
 | Reviewer | Execution-scoped, read-only review. Missing or ambiguous output grants no approval or completion. |
@@ -51,18 +60,34 @@ root can call this sequence.
 
 V14, V16, and V17 use one closed consumer union:
 
-- `conversation_turn` binds the Conversation identity and revision, source
-  RuntimeSession identity and revision, and reserved Turn identity; and
+- `conversation_turn` binds the Conversation identity, revision, and prospective or
+  reserved Turn identity. Existing continuation also binds a source RuntimeSession.
+  Candidate-5 initial routing uses the prospective UUID as intent only, with no Turn
+  foreign key or row, and keeps that source identity absent in immutable L0. V17 later
+  creates the first RuntimeSession in the continuation-plan lineage; and
 - `managed_run_execution` binds the ManagedRun identity and revision and one
   distinct managed execution identity.
 
-The ordinary variant does not contain a ManagedRun identity. The Conversation
-owner can materialize its reserved Turn after ProviderAttempt preparation.
+The ordinary variant does not contain a ManagedRun identity. The XY-1402 source shape
+permits the Conversation owner to materialize a reserved Turn after ProviderAttempt
+preparation. Candidate-5 initial Quick Task supersedes that order: it admits the exact
+Turn/history pair before every ProcessGeneration, thread, or ProviderAttempt effect.
 ProviderAttempt does not create or rewrite a RuntimeSession or a Turn.
 
 The managed variant does not move ManagedRun lifecycle authority. The ManagedRun
 read model consumes all ProviderAttempt result projections. It does not copy
 provider-effect authority into a second ledger.
+
+Candidate 5 closes the routing lineage union further. L0 has all six RuntimeSession,
+account-snapshot, and profile-snapshot identity/revision fields null. L6 has all six
+present with positive revisions. Conversation Turn routing accepts L0 or L6; ManagedRun
+routing accepts only L6. Only those six columns become nullable, their foreign keys stay,
+and an exact all-null/all-present check rejects half-null lineage and source-less
+ManagedRun. The existing L6 completeness branch and one-sticky rule do not change. The
+new L0 branch alone accepts zero sticky members and exact locked V14 evidence for an open
+exact-revision Conversation with no RuntimeSession or Turn. It rejects source fields,
+sticky L0, existing session or Turn, closed or stale Conversation, and incomplete, mixed,
+extra, duplicate, or reordered evidence.
 
 ## V25 and V26 forward cutover
 
@@ -102,6 +127,51 @@ After the checks pass, V26:
 There is no live, latent, compatibility, or fallback V12 writer after V26.
 Rollback means restore of a pre-V26 database. It does not mean reverse SQL or a
 dual-writer interval.
+
+## XY-1276 candidate-5 boundary
+
+`ExecutionCoordinator` stays zero-sized, crate-private, and stateless. It does not own
+Conversation creation, Turn admission or terminalization, account selection,
+RuntimeSession creation or thread state, ProcessGeneration state, credential access, or
+ProviderAttempt state. Candidate 5 adds no coordinator relation, receipt, retry machine,
+actor, task, channel, module, wrapper, generic transaction framework, or fixed hierarchy.
+
+The initial Quick Task sequence is exact:
+
+1. The Conversation owner creates one Conversation, and the routing fixture supplies only
+   a prospective Turn UUID as intent.
+2. One V16 decision selects the account from the complete locked V14 universe. Initial
+   selection has exact L0 lineage and no sticky member. Competing cross-key initial
+   choices produce one `Fresh`; same-key replay is read-only.
+3. V17 atomically creates the first selected-account/profile snapshots, one revision-1
+   unfenced `starting` RuntimeSession, and one inert initial plan. Any failure rolls back
+   the complete new lineage and related effects.
+4. The conversations owner atomically admits the exact active revision-1 initial user
+   Turn and ordinal-0 completed Message item. No Turn row exists before this transaction.
+5. Before each external or durable effect, the applicable owner locks and rechecks that
+   exact active Turn and its Conversation/RuntimeSession cross-link.
+6. Account Service fences the exact V16-selected account immediately before spawn. Only
+   then can a fresh ProcessGeneration, V34 thread establishment, and ProviderAttempt
+   proceed.
+
+The coordinator cannot call V16 a second time, select or substitute an account, invoke
+fallback or wake, terminalize a Turn, treat replay as fresh, or invoke explicit successor.
+Exact ProcessGeneration replay, rejection, or uncertainty is typed durable readback with
+no spawn, Turn failure, successor, replacement, adoption, or duplicate attempt. The
+existing owner reads provide manual-recovery state; no new ledger is permitted.
+
+V17 explicit successor remains PostgreSQL-only and has no runtime grant. Its transaction
+must lock and require the exact Turn named by the selected routing decision under the
+same Conversation/source RuntimeSession as failed revision 2 before any effect. Candidate
+5 keeps the accepted V17 same-thread and Context-Pack owners separate and keeps XY-1304
+automatic fallback/wake disabled.
+
+V34 owns RuntimeSession state/thread fields. Among trigger-bound functions, it owns only
+the seven constrained roll-forwards listed in the
+[normative contract](vnext-authority.md#v34-trigger-function-roll-forwards). Required
+narrow changes to existing owner commands and effect fences remain with those owners.
+Trigger bindings, ACLs, unrelated active-only writes, and every non-enumerated trigger
+behavior remain unchanged.
 
 ## Route projection
 
@@ -155,8 +225,9 @@ For a ManagedRun, V17 retains the accepted V15/V22 causal experiment path. An
 exact accepted experiment and positive `thread/read` attestation must bind the
 same source RuntimeSession thread.
 
-If same-thread evidence is absent, stale, negative, incomplete, ambiguous, or
-cross-linked, V17 uses its atomic fallback path. The transaction creates the
+For an operation with an existing source RuntimeSession, if same-thread evidence is
+absent, stale, negative, incomplete, ambiguous, or cross-linked, V17 uses its atomic
+fallback path. The transaction creates the
 Context Pack, account snapshot, starting fallback RuntimeSession, continuation
 plan, activity, outbox, and exact receipt as one authority cluster. V17 does not
 write ProviderAttempt state. ProviderAttempt does not write RuntimeSession state.

--- a/openwiki/specs/process-generation-authority.md
+++ b/openwiki/specs/process-generation-authority.md
@@ -22,6 +22,14 @@ readback with non-secret account credential binding. It does not add a second le
 routing, account selection, RuntimeSession creation, ProviderAttempt storage, remote
 authentication, UI, packaging, release, provider effects, or production dispatch.
 
+Candidate 5 may compose one ready generation and its bounded live `FencedProcess` into
+ordinary Quick Task only through the existing owners. Exact Candidate-4 staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is materially rejected and supplies no
+implementation authority. Candidate-5 implementation and acceptance are pending. V23
+does not gain Turn, routing, account-selection, RuntimeSession, or ProviderAttempt
+authority. See the
+[normative owner contract](vnext-authority.md#xy-1276-quick-task-thread-establishment).
+
 ## Owner and durable model
 
 `ProcessSupervisor` is the only product component that writes ProcessGeneration state.
@@ -155,6 +163,23 @@ The launch sequence is:
    includes the immutable initial account revision, credential version/fingerprint,
    provider binding, and account-capability profile.
 
+For the Candidate-5 Quick Task path, the establishment owner must first lock and prove
+the exact prospective Turn bound in the selected V16 decision as active revision 1 under
+the same Conversation and V17-created starting RuntimeSession. Account Service then reads
+and compares the exact
+V16-selected account readiness, revision, provider binding, credential version and
+fingerprint, exact-build capability, and actual HostCredentialStore binding immediately
+before spawn. Account Service cannot select or substitute an account. A mismatch stops
+without another V16 decision, fallback, wake, or alternate account.
+
+The exact ProcessGeneration create envelope is effect authority only when its durable
+classification is `Fresh`. `Replayed`, `Rejected`, and uncertain or locally lost results
+return typed durable readback and no spawn authority. They cannot spawn, replace, adopt,
+create a successor, prepare a duplicate ProviderAttempt, or terminalize the selected Turn.
+Recovery uses existing ProcessGeneration, RuntimeSession, ProviderAttempt, and Conversation
+reads. It adds no ledger or recovery framework. The same no-duplicate rule applies at the
+fence and ready lost-result cuts.
+
 The daemon-local in-flight reservation prevents background reconciliation from
 projecting an active fence, bind, or exact termination as restored authority. It is
 per generation, so it does not serialize unrelated accounts. The opaque child retains
@@ -236,6 +261,9 @@ XY-1401 owns ProviderAttempt persistence. XY-1400 preserves this exact boundary:
 - one pre-dispatch transaction must bind a prepared attempt to its consumer intent,
   accepted RuntimeSession, exact ProcessGeneration, request identity, and correlation
   or idempotency key;
+- Candidate-5 initial-thread preparation must also lock and require its exact selected
+  Turn to remain active revision 1 under the same Conversation and accepted
+  RuntimeSession, after exact V34 thread bind;
 - an unproved `dispatch_authorized` attempt becomes or remains `unknown` after lost
   supervision;
 - process death, kqueue exit, boot change, EOF, timeout, restart, missing events, row
@@ -245,6 +273,10 @@ XY-1401 owns ProviderAttempt persistence. XY-1400 preserves this exact boundary:
 - a replacement may reconcile the attempt but cannot replay it; and
 - a successor is a distinct user-authorized effect with explicit duplicate-risk
   acknowledgement.
+
+For Candidate 5, explicit successor remains PostgreSQL-only and non-dispatch. It cannot
+be used as ProcessGeneration recovery. Replayed, rejected, or ambiguous generation state
+also cannot justify the conversations owner changing the Turn to failed revision 2.
 
 ProcessGeneration quarantine protects replacement integrity. ProviderAttempt protects
 effect integrity. A macOS orphan can retain credentials and finish an in-flight effect;

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -452,6 +452,234 @@ Quick Task creation belongs to XY-1276. External Codex activity may be provenanc
 Quick/Advisor/Lead conversations; on an active ManagedRun it marks the session `diverged` and blocks
 side effects until tool/repository readback reconciles them.
 
+### XY-1276 Quick Task thread establishment
+
+Status: Candidate 5 is approved architecture only. Implementation, behavioral commit and
+exact-tree review, Phase A, digest-only child review, final mechanical preparation, Phase
+B, canonical aggregate validation, landing, installation, and live verification are
+pending. The rejected Candidate-4 evidence and migration allocation are in the
+[authority decision](../decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset).
+
+Quick Task remains an ordinary multi-turn Conversation. Candidate 5 uses existing owners
+in this exact order:
+
+1. The Conversation owner creates the Conversation.
+2. The routing fixture supplies a prospective Turn UUID as intent identity. It does not
+   create the Turn, and no routing column has a foreign key to `turns`.
+3. V16 runs once for the initial operation. It loads and locks the complete V14 universe
+   and selects the account. The request has no source RuntimeSession and no sticky member.
+4. V17 consumes that exact selected decision. In one transaction it creates the first
+   selected-account snapshot, the first selected RoleProfile snapshot, one `starting`
+   RuntimeSession, one inert `initial_thread` plan, activity, outbox, and exact receipt.
+5. The existing conversations owner admits the exact prospective Turn and its first history
+   item in one transaction.
+6. Every establishment effect fence locks and rechecks that exact Turn as active revision 1
+   under the same Conversation and V17-created RuntimeSession. ProcessGeneration and
+   pre-bind thread effects require the applicable `starting` revision. ProviderAttempt
+   preparation and authorization require the exact post-bind `active` revision and its
+   fence/bind receipts.
+7. Account Service fences the exact V16-selected account immediately before spawn.
+8. Only a fresh ProcessGeneration fence can spawn. V34 then owns exact thread-start fence
+   and bind. ProviderAttempt owns preparation, authorization, and provider-effect state.
+
+There is no second V16 call, fallback, wake, alternate account, or account re-selection in
+this initial operation. V17 consumes the selected V16 decision and does not select an
+account. Its initial planning is first-session creation. It is not explicit successor and
+is not Context-Pack fallback. V17 same-thread and Context-Pack fallback keep their existing
+owners and remain separate from this initial operation. XY-1304 continues to own later
+automatic fallback and wake.
+
+The owner boundary is:
+
+| Owner | Candidate-5 authority |
+| --- | --- |
+| Account Registry and V14 | Complete lifecycle, control, capability, quota, and routing facts. They do not select. |
+| Account Service | Account lifecycle operations and the exact selected-account readiness, credential, provider, and HostCredentialStore pre-spawn fence. It does not select the Quick Task account. |
+| V16 | The sole Quick Task account selector and immutable initial route-decision writer. |
+| V17 | Initial snapshots, first starting RuntimeSession, and inert initial plan; existing same-thread and Context-Pack planning; PostgreSQL-only explicit-successor evidence. |
+| Conversation owner | Conversation creation, atomic initial Turn/history admission, legal Turn finalization, and exact Turn lock/read proof. |
+| V34 RuntimeSession owner | RuntimeSession state/thread fields, exact thread fence and bind, acknowledgement, and the seven constrained trigger-function roll-forwards below. |
+| ProcessSupervisor | ProcessGeneration intent, fresh spawn authority, exact readback, positive death evidence, and account-local quarantine. |
+| ProviderAttemptService | Attempt preparation, dispatch authorization, ambiguity, positive evidence, and reconciliation. |
+| ExecutionCoordinator | A crate-private stateless sequence across these owners. It stores no state and grants no authority. |
+
+User-controlled fixed routing, balanced order, account UI, deterministic account aliases,
+and account lifecycle commands remain unchanged. Account Service can report and fence the
+facts that V16 selected. It cannot preselect, substitute, fall back to, or wake another
+account. In particular, if account A passes an Account Service subset but fails a V14
+capability and account B is fully eligible, V16 must select B. V17 creates only B's
+snapshots and RuntimeSession. Later B drift fails closed before spawn without a second
+decision, account A, or another fallback.
+
+For `routing_snapshots`, the initial-lineage shape is closed and named:
+
+- `L0` means all six lineage fields are null: `runtime_session_id`,
+  `runtime_session_revision`, `account_snapshot_id`,
+  `account_snapshot_source_revision`, `profile_snapshot_id`, and
+  `profile_snapshot_source_revision`.
+- `L6` means all six fields are present and each of
+  `runtime_session_revision`, `account_snapshot_source_revision`, and
+  `profile_snapshot_source_revision` is positive.
+
+V34 may drop `NOT NULL` only from those six columns. It must preserve the existing
+RuntimeSession, account-snapshot, and profile-snapshot foreign keys and add one closed
+all-null/all-present shape check. The only valid combinations are
+`conversation_turn AND (L0 OR L6)` and `managed_run_execution AND L6`. Half-null
+lineage and a source-less ManagedRun reject.
+
+The existing deferred `decodex.enforce_routing_completeness()` trigger function gains
+one narrow L0 branch. It can accept only the exact prospective Conversation Turn intent
+when the locked Conversation exists, is open, and has the exact expected revision; the
+Conversation has no RuntimeSession and no Turn; every candidate member has
+`sticky=false`; and candidate membership, policy positions, account revisions, both
+quota observations, all eight capability observations, and blocker rows exactly equal
+the locked V14 universe. Missing, extra, duplicate, or reordered evidence rejects. Any
+source field in L0, sticky member, existing session or Turn, closed or revision-changed
+Conversation, ManagedRun consumer, mixed lineage, or evidence mismatch rejects. Its
+existing L6 branch stays unchanged, including the requirement for exactly one sticky
+member.
+
+The supporting roll-forwards remain in their existing owners:
+
+- `resolve_routing_snapshot_exact` accepts the source RuntimeSession identity/revision
+  pair only when both values are present or both are absent. The absent branch proves
+  the initial predicates and zero sticky members, then writes exact L0.
+- `route_account_exact` applies the same pair rule. It selects in policy order from the
+  exact L0 snapshot and replays the exact stored decision. The existing Conversation
+  lock makes a conflicting or second cross-key initial decision lose; one decision is
+  `Fresh`, and exact-key replay is read-only.
+- `plan_initial_thread_continuation_exact` consumes that selected L0 decision and, in
+  one transaction, creates the selected account snapshot, copied profile snapshot,
+  first revision-1 unfenced `starting` RuntimeSession, and inert `initial_thread` plan.
+  Any rejected predicate or write rolls back every one of those rows and their receipt,
+  activity, and outbox effects.
+- Routing codecs and strict readbacks represent the source pair as jointly optional.
+  They permit zero sticky members only for L0 and require the unchanged one-sticky L6
+  shape otherwise.
+- `decodex.enforce_continuation_plan_completeness()` proves both the selected L0
+  decision and the newly created selected-account/profile/session lineage.
+- `decodex.enforce_routing_decision_completeness()` is unchanged. V34 does not replace
+  it or introduce another routing-decision trigger.
+
+#### Atomic initial admission
+
+The conversations owner admits exactly one Turn with all of these values:
+
+- the prospective Turn UUID bound as intent in the selected routing decision;
+- sequence 1 and role `user`;
+- `possible_side_effects=unknown`;
+- status `active` and revision 1; and
+- the exact Conversation and V17-created starting RuntimeSession cross-link.
+
+After V17 creates the session, the Conversation owner uses the prospective UUID and, in
+the same transaction, inserts that exact Turn as active revision 1 and exactly one
+ordinal-0 completed Message history item. The `Fresh`, `Replay`, or refusal decision,
+Turn row, history row, exact receipt, activity, and outbox are one owner transaction.
+Exact-key replay is read-only and returns
+the stored result. Every competing key, including concurrent cross-key admission, returns
+refusal and commits no Turn, history, activity, or outbox effect. A nonzero ordinal,
+non-Message kind, second item, wrong Turn identity, wrong role or sequence, wrong side-effect
+state, wrong status or revision, or cross-link rejects the whole transaction.
+
+Before ProcessGeneration preparation or spawn, before a thread fence or start, before
+thread bind, and before ProviderAttempt preparation or authorization, the effect owner must
+lock and require the exact selected Turn to remain active revision 1 under the same
+Conversation and V17-created RuntimeSession. ProcessGeneration and thread establishment
+through bind require the applicable `starting` revision. ProviderAttempt preparation and
+authorization require the exact post-bind `active` revision and exact fence/bind receipts.
+A terminalization race loses that fence and cannot start or complete the effect.
+
+Account Service then reads the exact V16-selected account revision, `enabled` state,
+AccountLifecycle and exact-build capability, provider binding, credential version and
+fingerprint, and actual HostCredentialStore binding. It compares those facts with V14,
+V16, V17, and ProcessGeneration intent immediately before spawn. Drift is a definite
+pre-spawn refusal. It cannot cause re-selection.
+
+#### Process and effect replay
+
+The exact ProcessGeneration create envelope has four typed outcomes for this path:
+
+- `Fresh` alone returns the non-clone spawn authority and may continue;
+- `Replayed` returns durable readback and no spawn authority;
+- `Rejected` returns durable refusal/readback and no spawn authority; and
+- uncertain or locally lost state returns `Unknown` after bounded durable readback.
+
+`Replayed`, `Rejected`, and `Unknown` cannot spawn, replace, adopt, create a successor,
+prepare a duplicate ProviderAttempt, or terminalize the Turn. Recovery uses the existing
+ProcessGeneration, RuntimeSession, ProviderAttempt, and Conversation reads. It adds no
+ledger or recovery framework; no Turn row exists before the Conversation admission
+transaction. The same rule applies after result loss at ProcessGeneration fence or ready,
+RuntimeSession thread fence, start or bind, and
+ProviderAttempt prepared or authorized. Ambiguous work remains bound to the original Turn
+and returns `Unknown` for manual recovery.
+
+The conversations owner may transition the exact active revision-1 user Turn to `failed`
+revision 2 while its RuntimeSession is still starting only when positive readback proves a
+definite pre-effect refusal. The proof must exclude every ProcessGeneration state that
+can have created a child. A fresh result remains definite only after
+existing positive spawn-noncreation evidence proves that it created no child. Ambiguous,
+replayed, rejected, or uncertain ProcessGeneration state is never definite. The proof
+must also exclude a thread fence, thread start or bind, and a prepared, authorized, or
+unknown ProviderAttempt. Fenced, thread-started, thread-bound, or
+attempt-active/unknown work keeps the Turn active. No other owner can terminalize it.
+
+#### Explicit successor
+
+Explicit successor remains PostgreSQL-only, non-dispatch evidence. It has no protocol
+field, product command, runtime `EXECUTE` grant, facade, re-export, fallback, or wake path.
+Before it changes a RuntimeSession, creates a Context Pack or snapshot, writes a plan,
+activity, outbox, or receipt, its transaction locks the exact Turn named by the routing
+decision. The row must belong to the same Conversation and source RuntimeSession, have
+status `failed`, and have revision 2.
+
+An active revision-1 Turn, completed revision-2 Turn, absent Turn, wrong Turn, cross-linked
+Turn, changed revision, or a terminalization race rejects before every successor effect.
+This evidence does not make explicit successor a supported product operation. XY-1304 must
+separately reopen and reconcile the Turn and ProviderAttempt lifecycle before any future
+caller can be proposed.
+
+#### V34 trigger-function roll-forwards
+
+V34 may replace exactly the seven trigger-bound bodies below. This closed list applies
+only to trigger-bound function replacement; it does not prohibit the narrow supporting
+roll-forwards of `resolve_routing_snapshot_exact`, `route_account_exact`,
+`plan_initial_thread_continuation_exact`, routing codecs/readbacks, the existing
+`decodex.authorize_provider_attempt_dispatch_exact(uuid,bigint,uuid,bigint)` command,
+or the existing `decodex.complete_exact_continuation_rejection(text,text,text)` helper.
+Those functions stay with their current owners and acquire no selection or dispatch
+authority beyond the predicates in this section.
+
+| Trigger function | Existing binding, unchanged | Exact authorized Candidate-5 predicate |
+| --- | --- | --- |
+| `decodex.enforce_routing_completeness()` | `routing_policy_revision_complete`, `routing_evidence_complete`, and `routing_snapshot_complete`, deferred after insert | Preserve the complete existing policy, evidence, and L6 snapshot branches unchanged, including exactly one sticky L6 member. Add only the exact L0 snapshot branch defined above: all six lineage fields null; exact prospective Conversation Turn intent; open exact-revision Conversation; no RuntimeSession or Turn; zero sticky members; and member identity/order, account revisions, two quota rows per member, eight ordered capability rows per member, and blocker rows exactly equal to the locked V14 universe. Reject source fields in L0, partial lineage, source-less ManagedRun, closed or changed Conversation, existing session/Turn, sticky L0, and every missing, extra, duplicate, or reordered child. |
+| `decodex.enforce_runtime_session_state()` | `runtime_sessions_state_guard`, before insert or update | Preserve current revision-one insert, identity, timestamp, terminal-immutability, `starting` or `active` to `ended` or `diverged`, and ended-session active-Turn rules. Replace the generic `starting` to `active` edge and add only two other nonterminal edges. An unfenced `starting` row with null thread, last-turn, request, and response fields can advance one revision to `starting` by setting only the complete request ID/digest pair. That exact request-fenced row is the only row that can advance one revision to `active`: it preserves the request pair, sets the response ID equal to the request ID, sets the exact response digest and thread ID, and keeps last-known Turn null. An `active` row can advance one revision to `active` only for an exact last-known-Turn acknowledgement while all thread receipt and binding fields stay unchanged. A generic `starting` to `active`, missing or mismatched receipt halves, response without request, thread binding without response, combined edge, or unrelated field drift rejects. |
+| `decodex.enforce_turn_state()` | `turns_state_guard`, before insert or update | Preserve current active-session behavior. Under `starting`, insert only the prospective Turn UUID bound as intent in the selected routing decision, under the exact V17 session and Conversation as sequence 1, role `user`, `possible_side_effects=unknown`, status `active`, and revision 1. Update only that same row from active revision 1 to failed revision 2 while the session is still `starting` and the owner transaction has positive definite pre-effect refusal proof. A completed transition, another role, sequence, status, revision, side-effect value, identity, cross-link, or starting-session write rejects. |
+| `decodex.enforce_history_item_state()` | `history_items_state_guard`, before insert or update | Preserve current active-session behavior. Under `starting`, insert only in the admission transaction and only when no item already exists for the exact initial Turn: ordinal 0, kind Message, status `completed`, and revision 1 under the same Conversation. An update, streaming or failed item, second item, another ordinal or kind, wrong Turn, or cross-link rejects. |
+| `decodex.enforce_provider_attempt_transition()` | `provider_attempt_transition_guard`, before insert or update | Add only `runtime_session_binding_protocol` and `runtime_session_binding_idempotency_key` to the immutable ProviderAttempt tuple after insert. Keep the current revision-one `prepared` initial state, transition algebra, unknown reason rules, positive terminal-evidence requirement, and every other immutable field unchanged. |
+| `decodex.enforce_provider_attempt_binding()` | `provider_attempt_binding_complete`, deferred after insert | Add one `initial_thread` branch. It requires the exact selected V16 decision and V17 plan, selected-account snapshot, ready ProcessGeneration revision and live epoch, exact completed V34 fence and bind receipts, the exact post-bind active RuntimeSession revision, and an existing selected Turn under that Conversation/session with status `active` and revision 1. The two new binding-receipt fields must identify that exact bind receipt. Every non-initial plan keeps both fields null and retains the existing same-thread, Context-Pack, ManagedRun, predecessor, and positive-lineage predicates. An absent, terminal, changed-revision, wrong, or cross-linked Turn rejects. |
+| `decodex.enforce_continuation_plan_completeness()` | `continuation_plan_complete`, deferred after insert | Add one Conversation `initial_thread` branch for a selected exact-L0 V16 decision. Require its prospective Turn intent and the new selected account snapshot, copied profile snapshot, one revision-1 unfenced `starting` RuntimeSession, and inert initial plan created by the V17 transaction. Reject non-L0 or partial source lineage, sticky L0, fallback, Context Pack, successor, external effect, alternate account, or extra first session. Keep existing same-thread and Context-Pack predicates unchanged. Explicit-successor completeness must also require the exact selected Turn as failed revision 2 under the same Conversation/source RuntimeSession, but this deferred trigger cannot replace the explicit-successor command's lock before its first write. |
+
+The non-trigger dispatch-authorization command must itself lock and require the exact
+initial Turn as active revision 1 under the same Conversation and exact post-bind active
+RuntimeSession before it can authorize the provider effect. The non-trigger continuation
+rejection helper may only derive the operation from the exact already-reserved receipt so
+each existing V17 entrypoint retains its own stable rejection; it adds no transport or
+idempotency mechanism. The trigger-only closed list does not authorize any unrelated
+non-trigger replacement.
+
+V34 does not replace any other trigger function. In particular,
+`decodex.enforce_routing_decision_completeness()` remains unchanged. V34 does not drop,
+create, rebind, enable, disable, or rename a trigger. Trigger ACLs and the runtime/PUBLIC
+prohibition remain unchanged. Existing active-only behavior remains for every
+non-enumerated operation and every unrelated write. The two narrow starting-session
+permissions are not a generic starting-session bypass.
+
+V32 remains byte-for-byte the alpha.9.2 four-function capability replacement. V33 remains
+enum-only. V34 is the sole unlanded integration migration. There is no V35 or
+compatibility DDL. Candidate 5 adds no new module, fixed hierarchy, product or test seam,
+ledger, generic transaction or recovery framework, transport/idempotency mechanism,
+wrapper, runner, scheduler, or explicit-successor product surface.
+
 Long-term context consists of immutable Project, Advisor, and Program revisions. Project
 context records decisions, constraints, repository facts, active Programs/Objectives,
 unresolved risks, and accepted handoffs. Advisor briefs compact cross-project status and
@@ -684,13 +912,15 @@ passive-receipt tracking. Host-owned before/after receipts prove causal no-mutat
 and cannot establish account-owned readiness.
 
 XY-1358 owns the original causal experiment ledger. XY-1367/V22 repairs its two-effect retained-title
-authority without changing V15. After an exact V16 decision, V17 owns same-thread continuation
-when exact positive account/profile/build evidence permits it. Otherwise, V17 owns one atomic
-Context Pack plus fallback RuntimeSession. V25/V26 preserve this authority for ordinary
-Conversation Turns and ManagedRun executions. The stateless ExecutionCoordinator sequences V16,
-V17, one live ProcessGeneration fence, and ProviderAttempt preparation. Current production
-dispatch stays structurally disabled until its applicable slice gate passes. Ambiguous-turn
-replay remains blocked by ProviderAttempt. ManagedRun
+authority without changing V15. For an exact V16 decision with an existing source RuntimeSession,
+V17 owns same-thread continuation when exact positive account/profile/build evidence permits it.
+Otherwise, that existing-session operation uses one atomic Context Pack plus fallback
+RuntimeSession. Candidate-5 initial routing has no source RuntimeSession and instead uses the
+first-session `initial_thread` path above; it cannot enter either existing-session branch. V25/V26
+preserve the existing-session authority for ordinary Conversation Turns and ManagedRun executions.
+The stateless ExecutionCoordinator sequences V16, V17, one live ProcessGeneration fence, and
+ProviderAttempt preparation. Current production dispatch stays structurally disabled until its
+applicable slice gate passes. Ambiguous-turn replay remains blocked by ProviderAttempt. ManagedRun
 consumes the attempt result and keeps only domain lifecycle authority.
 Repository/worktree/Git and artifact effects retain their own accepted authorities; routing never
 owns or weakens those boundaries.

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -106,7 +106,7 @@ Permission is issue-scoped and does not bypass each issue's own dependencies:
 | XY-1273 | Credential-vault metadata and immutable runner/account binding; no sticky or policy assignment. |
 | XY-1274 | Exact-microsecond quota persistence, `/2` canonical mutation identity, atomic V8 zero-state migration, and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
 | XY-1275 | Umbrella for user-owned profile persistence and RuntimeSession snapshots. It closes only through the serial XY-1345 -> XY-1346 -> XY-1337 order. Account-owned plugin, skill, and MCP readiness remains typed `unknown`; XY-1336 neither closes nor blocks this issue. |
-| XY-1276 | Slice-1 Quick Task creation after the Slice-1 account and exact-build callback gates. It is not blocked by XY-1304. |
+| XY-1276 | Candidate-5 architecture for one Slice-1 ordinary Quick Task. V16 is the sole task-account selector; V17 creates the first starting RuntimeSession; the conversations owner atomically admits the first Turn/history pair; V34 owns bounded thread establishment. Implementation and acceptance are pending. It is not blocked by XY-1304. |
 | XY-1300 | Slice-3 representative E2E, restart, UI, packaging, and clean-startup acceptance. It is not globally blocked by XY-1304. |
 | XY-1304 | Later automatic cross-account same-thread fallback and all-depleted wake aggregate acceptance, followed by a separate reviewed enablement amendment. It is not a prerequisite for Quick Task, Project/Lead, ManagedRun, GPUI, or first Mac dogfood. |
 | XY-1345 | Accepted exact-command authority and isolated PostgreSQL 18 prototype only; no production migration or Rust command path. |
@@ -187,6 +187,68 @@ fresh-capability consumption, and positive-only reconciliation,
 Conversation and ManagedRun owner isolation, Reviewer ambiguity, same-UID transport, and reverse
 production isolation. XY-1402 executes none of that matrix and enables no provider effect or
 production dispatch.
+
+### XY-1276 candidate-5 Quick Task acceptance
+
+Candidate 5 is architecture authority only. Candidate-5 implementation and every
+executable acceptance step are pending. Exact Candidate-4 staged tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is materially rejected and superseded source
+evidence. The decision record and five P1 causes are in the
+[authority reset](../decisions/vnext-authority.md#xy-1276-candidate-5-architecture-reset).
+The normative owner and trigger predicates are in
+[vNext Authority](vnext-authority.md#xy-1276-quick-task-thread-establishment).
+
+The gate keeps exactly seven representative rows. This authority reset authors no test
+and runs no executable row.
+
+| Row | Required integrated Candidate-5 proof |
+| --- | --- |
+| 1 | Prove the positive initial `conversation_turn + L0` shape with all six RuntimeSession/account/profile lineage fields null, an open exact-revision Conversation with no RuntimeSession or Turn, zero sticky members, and exact locked V14 member identity/order, account revisions, two quota rows, eight ordered capability rows, and blockers. Drop `NOT NULL` only on those six columns, retain every foreign key, and prove the exact all-null/all-present check. Prove source identity/revision are jointly absent or present in commands, codecs, and readbacks. Preserve unchanged L6 with all six fields present, positive revisions, and exactly one sticky member for existing-session Conversation and ManagedRun routing. Reject every half-null or source-bearing L0, sticky L0, existing session or Turn, closed or stale Conversation, source-less ManagedRun, and mixed, incomplete, missing, extra, duplicate, or reordered evidence. Under competing cross-key initial choices, the Conversation lock permits exactly one V16 `Fresh`; same-key replay is read-only. V16 remains the sole selector and selects in exact policy order. |
+| 2 | Prove V17 consumes only the selected exact L0 and atomically creates the selected account snapshot, copied profile snapshot, first revision-1 unfenced `starting` RuntimeSession, inert `initial_thread` plan, receipt, activity, and outbox. Failure at any predicate or write rolls back all of them. V17 does not select. After that commit, prove one Conversation-owner admission transaction creates the prospective UUID as the exact active-revision-1 sequence-1 user Turn with unknown possible side effects and exactly one ordinal-0 completed Message item; no Turn row exists before admission. Reject nonzero ordinal, non-Message, wrong role, sequence, side-effect state, status, revision, identity, cross-link, and every second item. Under cross-key admission concurrency, commit one `Fresh`; exact-key replay is read-only; every competing key commits no Turn, history, successful receipt, activity, or outbox effect. |
+| 3 | Before each ProcessGeneration, RuntimeSession thread, or ProviderAttempt effect, lock and prove the exact intent-bound Turn active at revision 1 under the same Conversation and V17-created RuntimeSession. Require the applicable `starting` revision through thread bind and the exact post-bind `active` revision plus fence/bind receipts for ProviderAttempt preparation and authorization. At ProcessGeneration fence/ready, thread fence/start/bind, and ProviderAttempt prepared/authorized lost-result or restart cuts, prove no duplicate spawn, Turn failure, successor, replacement, adoption, or duplicate attempt. `Replayed`, `Rejected`, and uncertain ProcessGeneration state use existing readback and keep the Turn active. Make account A positive for the Account Service controls but capability-negative in complete V14 evidence while B is fully eligible. Require one V16 decision selecting B and one V17 transaction creating only B's lineage; create no A snapshot or session. Make B stale before spawn and require refusal without a new decision, account A, fallback, or wake. |
+| 4 | Prove only positive definite pre-effect refusal can move the exact active revision-1 Turn to failed revision 2 under a starting RuntimeSession. Replayed, ambiguous, fenced, thread-started, thread-bound, and ProviderAttempt prepared/authorized/unknown work remains active and returns `Unknown`. Prove explicit successor locks and accepts only the selected Turn as failed revision 2 under the same Conversation/source RuntimeSession; reject active revision 1, completed revision 2, absent, wrong, cross-linked, changed, and racing Turns before any successor effect. Prove normal terminal ProviderAttempt evidence, Conversation-owned Turn finalization, RuntimeSession acknowledgement, durable transcript retention, and publication only after readback. Exercise all seven authorized trigger bodies, including the narrow L0 routing-completeness branch, and preserve the unchanged L6 branch, routing-decision completeness, trigger bindings and ACLs, unrelated active-only writes, account observations, and bounded history cursors. Reject every non-enumerated or broad starting-session trigger behavior. |
+| 5 | Preserve result-before-stream ordering, one existing actor owner, one command-or-registration operation slot, bounded deferred publication, explicit publication-source behavior, non-reserving per-session acceptance, and no starvation across sessions. |
+| 6 | Preserve duplicate/conflicting command order, disconnect and reconnect, exact snapshot-cursor order, receiver-close/`try_send` outcomes, retention of the exact active bounded flush to a typed terminal result, one-shot peer-Close finalization, `JoinSet` wake, and leak-free accounting with real transport behavior. No local write or close proves peer receipt. |
+| 7 | Preserve `Accepting -> DrainingApplication -> DrainingEgress -> Closed`, one absolute deadline, retained command completion, complete ordinal and transport reconciliation, exact 64-session admission including handshakes, service settlement, and cleanup only after closed accounting. |
+
+V34 migration acceptance must enumerate exactly these seven replaced trigger functions:
+`decodex.enforce_routing_completeness()`,
+`decodex.enforce_runtime_session_state()`, `decodex.enforce_turn_state()`,
+`decodex.enforce_history_item_state()`,
+`decodex.enforce_provider_attempt_transition()`,
+`decodex.enforce_provider_attempt_binding()`, and
+`decodex.enforce_continuation_plan_completeness()`. It must prove the exact predicates in
+the normative contract and reject every other starting-session or trigger behavior.
+Trigger bindings, ACLs, and non-enumerated trigger functions remain unchanged. V32 must be
+byte-identical to current alpha.9.2 authority, V33 must be enum-only, and V34 must be the
+only integration migration. V35 and compatibility DDL are forbidden.
+
+The canonical aggregate keeps exactly six sibling stages:
+`xy_1276_row_1`, `xy_1276_rows_2_3`, `xy_1276_row_4`, `xy_1276_row_5`,
+`xy_1276_row_6`, and `xy_1276_row_7`. Each depends only on
+`cluster_preflight`. Final evidence depends on all six. Ordinary failure in one sibling
+does not prevent independent siblings. Harness corruption remains fail-closed. The first
+three stages keep separate databases. Rows 5 through 7 keep existing transport isolation.
+Do not add a focused copy, focused task, new gate, or seventh sibling stage.
+
+Acceptance evidence is non-commutative. First repair behavior, run one formatter, create
+clean commit P, and complete its full exact-tree review. Run Phase A on clean P before any
+preparation or aggregate when authority digests are stale. A direct-child candidate C may
+then change only the `authority.rs` digest arrays that Phase A reports. After bounded
+exact-delta review, fully stage C, run final mechanical preparation exactly once, and
+commit without another byte change so the prepared tree equals C. Run Phase B on clean C,
+binding P, C, the Phase-A receipt, and S0/R1/R2, then run the sole canonical aggregate on
+unchanged clean C. A non-digest post-review change restarts full review and Phase A. Any
+byte after preparation invalidates preparation; any byte after Phase B invalidates Phase B
+and aggregate evidence. Seven trigger bodies still map to the unchanged six aggregate
+stages.
+
+Ordinary Quick Task receives no explicit-successor input, variant, facade, re-export,
+runtime grant, fallback, or wake. Candidate 5 preserves the current account/UI/automation
+behavior, deterministic one-word account alias, and treatment of negative Reset Card
+inventory counts as empty inventory,
+and XY-1304 containment. The exact-tree validation order is in
+[Commands And Validation](../operations/commands-and-validation.md#xy-1276-candidate-5-validation-boundary).
 
 XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
 manifest, configuration value, remote catalog entry, process binding, or user declaration
@@ -870,8 +932,10 @@ added. No retained-title evidence gate enables production routing.
 
 ### Account lifecycle and Mac dogfood gate
 
-The accepted Mac gate covers only the latest architecture. It starts a fresh V1–V32
-PostgreSQL database with an empty Account Registry, verifies the signed daemon wrapper
+The current accepted Mac gate starts a fresh V1–V32 PostgreSQL database with an empty
+Account Registry. Candidate 5 does not rewrite that receipt. Candidate-5 implementation
+acceptance must instead start a fresh V1–V34 database after V34 lands, with no V35 or
+compatibility DDL. The gate verifies the signed daemon wrapper
 and same-UID Unix transport, imports test accounts through the ordinary public account
 command, restarts once for exact-build callback attestation, and verifies list, routing,
 quota, Reset Card readback, use, and terminal replay.


### PR DESCRIPTION
## Summary
- freeze the Candidate 5 Quick Task ownership and SQL authority
- make V16 the sole account selector and keep V17/Conversation/Account Service boundaries explicit
- bind the Phase A, digest-child, preparation, Phase B, and six-stage aggregate order
- preserve deterministic hash-derived one-word account aliases

## Evidence
- exact staged tree: ce2dd78d995a388fb9baaf53a90716891567ae8c
- isolated exact-tree authority review: APPROVED/READY, no P0/P1/P2
- module-boundary review: PASS
- docs-only change; both Git diff checks are clean
- no formatter, compile, PostgreSQL, or runtime validation was run for this docs-only checkpoint