### PR TITLE
Replace migration chain with latest-schema authority

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -1,1620 +1,504 @@
 # Runtime Architecture
 
-This page explains the active vNext ownership skeleton and preserves a map of the
-excluded v0.2 source for provenance. Checked-in manifests, source, tests, and the vNext
-authority documents remain authoritative. The XY-1403 private-artifact retirement
-takes effect only at the exact
-[repository effective point](../specs/private-artifact/decision.md#repository-effective-point).
-
-## Workspace shape
-
-The root manifest enumerates the active members explicitly. Five library owners form the
-vNext runtime boundary:
-
-- `decodex-core`: domain/application contracts and ports, including logical
-  Conversation/RuntimeSession/history and deterministic Context Pack compilation, plus the XY-1306 typed
-  `~/.decodex` path, configuration, stable-identity, blob, and disposable-cache
-  foundation. Its external dependency set is architecture-tested and limited to
-  bounded TOML/Serde parsing, SHA-256, OS randomness/no-follow filesystem support, and
-  test-only temporary storage.
-- `decodex-protocol`: exact-current V2.0 typed wire contracts and
-  the owner-only same-UID Unix transport authority. It depends only on core, structured
-  serialization, Tokio/Tungstenite, and the libc calls required for descriptor-relative
-  namespace ownership and kernel peer facts.
-- `decodex-postgres`: the PostgreSQL 18 product-state adapter; depends on core plus the
-  accepted tokio-postgres/deadpool/refinery stack and owns embedded migrations,
-  optimistic transactions, leases, append-only activity, outbox delivery, inert
-  account/window metadata, normalized history, immutable session snapshots, blob metadata,
-  Context Pack revisions, and inert transition proposals.
-- `decodex-codex`: typed app-server contracts, schema/live capability negotiation, and
-  redacted event normalization. It depends only on core, performs no SQL, owns no database
-  connection, and exposes no child-launch surface. Current live turn dispatch is
-  unavailable. Slice 1 can enable its fenced initial-selection path; XY-1304 governs only
-  later automatic fallback and wake.
-- `decodex-runtime`: service lifecycle, connection/session execution, resumable event
-  publication, idempotency receipts, private immutable-account process supervision, and the
-  sole PostgreSQL/Codex adapter composition; depends on the other four owners plus the
-  maintained Tokio/Tungstenite transport stack. Runtime source and tests have no Axum or
-  product TCP listener.
-
-`apps/decodexd` depends only on runtime. The `apps/decodex-cli` and
-`apps/decodex-gpui` client roots depend only on protocol, so they cannot reach stores,
-Codex, repositories, or orchestration directly. Radar and Publisher remain independent
-auxiliary workspace members. `tests/scripts/test_vnext_architecture.py` checks the exact
-dependency graph and exclusion of the legacy package through Cargo metadata.
-
-`decodex-protocol` owns the reusable bounded WebSocket client alongside the shared wire
-contract. It reads only the client projection of typed configuration: profile data is
-validated, while server-host repositories, PostgreSQL data, and cache policy are consumed
-as opaque TOML and never represented by the client profile. A local profile uses its
-explicit identity pin or the shared-host stable identity file. It also carries only the
-closed `same_uid` or `disabled` policy and an optional service-owner UID whose presence is
-fixed by that policy. A remote profile requires its explicit pin and carries only inert
-host and port data. Each local connect captures the current fixed Unix endpoint, validates
-its directory and socket identities, connects that path, verifies the kernel server-peer
-UID, and validates the path again. The client then sends a pinned V2.0 hello,
-verifies welcome and snapshot version/identity, issues `get_doctor_status`, and re-verifies
-the result, embedded report, and exact complete current component set before returning status.
-Report ordering is not authority. Reads, writes, frames, messages,
-interleaved events, and deadlines are bounded; socket, parser, HTTP, and server-provided
-text collapse into closed redacted failure classes.
-
-`apps/decodex-cli` exposes the canonical `status` and `doctor` commands with active or
-`--profile NAME` selection and human or `--output json` rendering. Both commands cross the
-same V2.0 query; `status` is compact and `doctor` is line-oriented, while each retains every
-typed check. JSON uses `decodex/cli-diagnostics/1`. Exit code 0 means every check is ready,
-1 means a complete report contains unavailable or unknown checks, and 2 means a closed
-client/configuration/protocol failure. The `reset-card` command family is a thin protocol
-client for the shared daemon service and uses `decodex/reset-card-cli/1` JSON. The CLI has
-no credential, Codex-process, provider-ID, PostgreSQL, or effect authority.
-
-`decodexd` is the only V2.0 server composition root. It reads the bounded active-profile
-configuration, acquires and publishes the non-cloneable local listener, and retains its
-one namespace lock before it creates the stable server identity, opens product storage,
-connects to PostgreSQL, projects supervisor loss, or starts any daemon-local mutation
-service. A process that cannot acquire the listener returns the typed transport refusal
-without a PostgreSQL connection or product-state mutation. The bootstrap owner moves that
-same listener into the lifecycle task without another bind or lock acquisition.
-
-The daemon derives
-`~/.decodex/server/decodex.sock` from the typed root. The server directory must have the
-configured owner and exact mode 0700. A persistent regular `decodex.lock` must have that
-owner, exact mode 0600, and one link. The daemon takes one nonblocking exclusive `flock`
-before it inspects either socket name and retains it through cleanup. It recovers only an
-unchanged, securely owned, single-link `decodex.sock.stage` or `decodex.sock` that returns exact
-connection refusal. Success, timeout, another error, changed identity, wrong type, wrong
-owner, wrong mode, or extra link preserves the entry and refuses startup.
-The authority states are `Configured -> Locked -> Staged -> Published -> Stopping ->
-Quiescent -> Cleaned -> Released`.
-
-Publication binds the fixed `decodex.sock.stage`, sets mode 0600, captures its
-device/inode/owner/mode/link-count identity,
-validates the retained directory, lock, staging socket, and absent canonical name, and
-uses same-directory descriptor-relative `renameat` to publish `decodex.sock`. It then
-requires the staging name to be absent and the canonical name to have the captured
-identity. There is no self-connect challenge. Pending accept has no 250-millisecond
-watchdog. Validation is point-in-time at publication, each accepted connection, each
-client reconnect, and cleanup.
-
-The local stream uses WebSocket route `/v1/ws`. The literal `ws://localhost/v1/ws` in
-each client is handshake metadata passed with an already admitted Unix stream. It cannot
-resolve or dial TCP. The WebSocket uses structured JSON and typed
-hello, command, receipt, result, snapshot, event, and refusal envelopes. Major versions
-must match exactly; this build accepts only V2.0. V1.x and V2.1 receive typed refusals
-before application payload handling. Events carry server ID, monotonic
-cursor, entity revision, correlation, and causation. The stable server-host ID supports
-operator pinning, while each daemon process creates a distinct bounded publication-epoch
-ID. A reconnect resumes retained ordered deltas only when both IDs match; an absent or
-changed epoch, stale cursor, or changed server ID receives a bounded snapshot fallback.
-Only a snapshot or event cursor fully applied by the client is a resume checkpoint; the
-Welcome cursor is an informational server high-water mark and must not advance client
-progress before following replay deltas are applied.
-
-Kernel credentials are mandatory on both sides. The daemon admits only a client whose
-kernel effective UID equals the exact configured service-owner UID. The client accepts
-only a daemon with that same kernel UID. Directory permissions, the stable server ID,
-PostgreSQL roles, environment credential references, and database identities cannot
-replace that principal. Remote and cross-UID transport remain inert. This boundary does
-not claim confinement against hostile code that already has the same UID.
-An established stream retains the kernel peer fact that admission proved. A later pathname
-change does not revoke that stream. A new connection or reconnect performs fresh endpoint
-and peer checks and fails closed.
-
-One top-level runtime task owns the listener and namespace lock. It also directly polls
-the ProcessGeneration and ProviderAttempt background reconciliation futures. Those
-futures are not detached tasks and cannot outlive the lifecycle. One `JoinSet` owns every
-session and command task. The owner assigns a monotonic stable spawn ID and a closed
-session/command kind before each spawn and maps it to the Tokio task ID. Requested
-shutdown, listener-invalidating refusal, child panic, unexpected child failure, or early
-service-future completion starts one stopping phase and creates one absolute,
-non-extendable deadline. Sessions receive a cooperative stop signal. The owner closes
-command ingress and receives through `None`, so a buffered submission or outstanding
-pre-close permit cannot escape task accounting. Commands received before the deadline
-enter the same task set. A submission that crosses an outstanding permit after the
-deadline receives a stable task identity but its command future is never polled. The
-owner harvests `join_next_with_id`; it calls `abort_all` once only if the deadline
-expires, and it continues harvesting through `None`.
-
-The same top-level task also owns daemon service futures. This includes the Reset Card
-worker and the account-observation scheduler. The scheduler starts all independent ready
-accounts concurrently, publishes each completion independently, and retains no more than
-one active observation owner for one Account UUID. Reset Card has no detached worker or
-heartbeat task. At the start of stopping, the application synchronously closes provider
-work registration and receives a cooperative service-stop signal. Queued blocking closures
-cannot start after that gate closes. An already registered provider operation uses its
-existing bounded process deadline and remains included in service settlement even if its
-command task is cancelled. Service settlement is intentionally outside the shorter
-session/command shutdown deadline because cancelling a Tokio wrapper cannot stop an
-already-running blocking process. The namespace listener and lock remain held until every
-service future and registered provider operation has settled.
-
-The bounded `TerminationReceipt` records session and command spawn counts, harvested and
-expected counts, panic, failure, forced-cancellation, and owner-integrity counts, the
-lowest stable identity in each abnormal task class, and endpoint and cleanup refusals.
-Its deterministic rank is cleanup refusal, endpoint refusal, owner integrity, child
-panic, unexpected child failure, forced deadline, then requested shutdown. Stable task
-ties use the lowest spawn ID. After all owned command and session tasks are harvested,
-the lifecycle signals each daemon-local service future and polls it to completion. An
-in-flight reconciliation pass completes while the namespace lock remains held. The
-lifecycle then drops the application and its services. It removes only the retained
-canonical socket identity, closes the listener, and releases the namespace lock as the
-final authority operation. A mismatch preserves the observed entry and returns a
-cleanup refusal.
-
-Runtime receipt lookup is keyed by exact-current V2.0 and the command idempotency key;
-the stored request fingerprint additionally covers that version, typed payload, and optional
-expected revision. A duplicate returns the original command identity and stored result without
-a second application execution. Conflicting reuse is rejected. The one exact-current namespace
-has a fixed lifetime receipt capacity. Accepted keys are never evicted, duplicates remain
-readable at capacity, and new keys are refused before
-application execution once full. Replay buffers, snapshot item counts, human-readable
-wire scalars, inbound and outbound message sizes, writes, and per-client outbound queues
-are bounded. Queue overflow disconnects that client with WebSocket close code 1013;
-an oversized outbound frame closes with code 1009. A successful application publication
-is retained even if its initiating client overflows, so cursor resume cannot lose the
-mutation. Once accepted, command execution is shielded from connection-task cancellation;
-a disconnect can suppress delivery but cannot cancel receipt/event recording. Snapshot
-types contain only small state and cannot carry artifact bytes.
-
-This slice deliberately keeps its replay/idempotency ledger in memory. A daemon restart
-loses that transient ledger; the stable server-host identity remains persisted, while a
-fresh publication-epoch ID makes every old cursor fall back even when restarted cursor
-values are equal or overlap. Durable PostgreSQL product-state and transaction primitives
-live in `decodex-postgres`.
-`decodexd` loads only the typed `~/.decodex/config.toml` and passes its explicit Unix-socket
-directory, port, database, operator-pinned expected PostgreSQL peer UID, and distinct
-migration/runtime identities with independently resolved optional credentials to that adapter.
-For the macOS source-install path, a separate `decodexd supervise-local` process owns one
-foreground PostgreSQL child and one service child. It starts the service child only after
-PostgreSQL is ready. PostgreSQL exit or any pinned process, directory, or socket generation
-change stops the service child before the supervisor exits. Launchd then starts one new
-coherent generation. Swift does not participate in this lifecycle.
-
-The source installer provisions only the latest credential-negative service. It writes
-the typed config and LaunchAgent, initializes a fresh PostgreSQL 18 database, and starts
-one `supervise-local` generation. It does not read or retire old account sources.
-Normal startup has no watcher, mapping input, helper or `:8192` dependency, credential
-environment projection, migration state, or fallback. Existing local credentials enter
-the new authority only through ordinary account import after installation.
-The adapter opens each directory component relative to a retained descriptor, pins the directory
-and socket device/inode identities, requires the final directory and socket to be owned by the
-configured UID with no group/other directory write access, and verifies the connected kernel peer
-UID before PostgreSQL authentication starts. It repeats path binding and peer verification for
-every migration and runtime-pool connection, so a pre-planted endpoint cannot select its own trust
-root and later ancestor or endpoint replacement cannot redirect credentials. A single-use migration pool performs only
-forward migration and migration verification and is closed before the runtime pool is built.
-The adapter reports available only after PostgreSQL 18, checksum, pgcrypto, immutable migration,
-two-connection pool checks, and an exact steady-state authority audit pass. The audit starts from
-the original `session_user` and evaluates both its immediately effective authority and every role
-reachable through `SET ROLE`, including NOINHERIT/SET-only chains; membership admin option is
-itself unsafe because it could create a new SET path. Effective ownership is one closed PostgreSQL
-18 inventory covering the Decodex schema, relations, functions, types, collations, conversions,
-operators, operator classes/families, extended statistics, and text-search
-configurations/dictionaries. Extension control is audited separately from extension schema:
-`pg_depend` extension-membership edges for every Decodex object and dependent execution object,
-plus extension members referenced by those objects, are unsafe whenever the extension owner is
-runtime-effective, regardless of `pg_extension.extnamespace`.
-Superuser/BYPASSRLS/role/database administration, database/schema CREATE,
-TRUNCATE/TRIGGER/REFERENCES/MAINTAIN, excess table DML or grant options,
-`session_replication_role` SET/ALTER SYSTEM, and any effective non-`origin` login value are unsafe
-in any reachable authority state. At the V14 boundary, the audit verifies all 110 shipped
-non-internal trigger bindings, including regular and deferred constraint triggers, by table, event
-mask, row/statement level, constraint and deferral state, origin-enabled mode, and function binding,
-then compares
-each bound function's exact metadata and `pg_proc.prosrc` bytes with the canonical body embedded in
-the immutable forward migration ledger through V23. It additionally closes the entire runtime-callable `decodex` function
-namespace over exact signatures and overloads, argument/result shape, language, volatility,
-parallel/strict/set behavior, planner metadata, exact security-invoker/definer state and exact per-function settings,
-and canonical source. Unexpected functions, overloads, owner-executed functions, or unsafe settings
-are unsafe; missing functions or noncanonical source are incompatible. Disabled or misbound triggers
-are unsafe; a replaced same-signature safety-function body is incompatible.
-Every non-internal trigger on a Decodex runtime relation must be one of those 110 exact V14 bindings.
-The same closed execution-path audit permits no user rule, row-security policy, or enabled/forced RLS
-on those relations and rejects non-`pg_catalog` function/operator dependencies from defaults,
-generated expressions, constraints, indexes, rules, or policies unless they resolve to one of the
-119 canonical V14 functions. Every canonical function has the exact function-local
-`pg_catalog, decodex` search path, so runtime-selected callable or operator shadows cannot redirect
-trigger or constraint execution. A trigger cannot therefore invoke an adjacent public owner-executed
-function merely because runtime DML fires it.
-One version-specific canonical PostgreSQL 18 manifest additionally closes all Decodex relations,
-columns, defaults, constraints, indexes, enum labels, and internally generated constraint triggers.
-Defaults, constraints, indexes, and internal triggers include their exact stable catalog dependency
-identities rather than raw OIDs. The manifest emits one row per stable semantic dependency edge,
-normalizing exact physical catalog duplicates before semantic mapping while preserving distinct
-dependency types and endpoints. Reverse dependency edges from constraints to user constraint
-triggers resolve through a stable relation-and-trigger-name key without promoting those user
-triggers into dependency targets or internal-trigger rows.
-Constraint inventory covers both `conrelid` in Decodex and external constraints whose `confrelid`
-references Decodex. Internal trigger identity is tied to the exact canonical constraint, relation
-side, trigger function, event semantics, deferral state, and referenced relation/index rather than
-generated trigger names or OIDs.
-`public.refinery_schema_history` is always schema-qualified and must have
-exactly table SELECT. Ownership, SET-reachable authority, table or column grant option, writes,
-TRUNCATE, REFERENCES, TRIGGER, and MAINTAIN are unsafe; missing SELECT is incompatible before the
-history row query runs. The ordered ledger must exactly match every embedded migration version,
-name, and checksum; missing, extra, duplicate, reordered, or tampered identity is incompatible.
-V14–V19 historically bind intended runtime enum and command privileges through the exact
-migration-owned V12 ManagedRun-safety procedure ACL. V26 retires that procedure and derives the
-same runtime principal from the accepted V24 ProviderAttempt preparation procedure before it
-revokes V12 authority. The binding accepts zero runtime grantees for
-migrate-before-provision and exactly one direct, non-grantable runtime grantee for an already
-provisioned database; ambiguous owners, grantors, overloads, or grantees fail closed. Production authority failures
-remain generic. Authority digest changes use two explicit phases. Phase A's capture-only PostgreSQL
-18 mode migrates and provisions a non-default runtime principal, captures normalized manifests at
-source S0, first restore R1, and second restore R2 without constructing `PostgresStore`, and
-uses the same finalized semantic-authority contract as production readiness at every checkpoint.
-One shared restore-target prerequisite now owns the future Phase A R1 and R2 boundary and the
-separate one-shot R1 prerequisite gate. Before target creation, a closed PostgreSQL 18
-`pg_restore` list parser privately proves that the custom archive has exactly one active
-`pgcrypto` extension declaration. It rejects absent, duplicate, disabled, malformed, or ambiguous
-declarations without retaining or publishing raw TOC data. After the guard, the helper creates a
-fresh `template0` target, proves that `pgcrypto` is absent, and connects as the migration role to
-execute exactly
-`CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public VERSION '1.4';`. The ordinary restore
-keeps `--exit-on-error` under the bootstrap identity and adds no owner, ACL, role, or session
-authorization override. No migration or runtime provisioning follows a restore.
-
-The replacement `--capture-authority-restore-prerequisite-v2` gate binds one clean HEAD and tree,
-the selected PostgreSQL 18 toolchain, the v2 pass and diagnostic schemas, and definition fingerprint
-`53bb20b8e43a6199c3aa578269cee8b941ed549fd8f10db0dce361a03016524a`. One sequential state owner
-covers CLI selection, preflight, private work, cluster initialization and start, role setup, S0,
-archive creation, the restore helper, semantic checks, cleanup, receipt validation, final source
-binding, and publication. Completed execution checkpoints can be only a validated prefix. The first
-fixed checkpoint and reason are immutable. Actual lifecycle state derives one exact cleanup-owner
-sequence: empty before private work exists, `private_work_cleanup` after private work exists, or
-`cluster_stop` followed by `private_work_cleanup` after cluster stop becomes applicable. Each
-required owner moves from pending to active to completed. `cleanup_finalization` is a separate
-fail-closed owner. Cleanup can be `passed` only when the required sequence is complete and
-finalization is complete. The receipt carries both sequences and the finalization proof.
-
-An interruption before an action, after an action but before its transition, between actions, or
-during finalization belongs to the active or pending cleanup owner. Expected cleanup operation
-failure is `cleanup_failed`; an interruption is `interrupted`; and unexpected cleanup state is
-`harness_corruption`. A cleanup failure is secondary when an execution primary exists. Otherwise,
-the exact cleanup owner becomes primary. Receipt validation, source binding, and publication also
-have separate owners and cannot replace an earlier primary failure.
-
-The gate creates, migrates, provisions, populates, and semantically verifies S0 once. It dumps once,
-guards and restores fresh R1 once, and runs the same full semantic owner once at R1. Explicit
-in-process counters reject a duplicate prerequisite or restore. The gate stops before R2, digest
-derivation, candidate publication, Phase B, and the aggregate. Pass and failure receipts are
-canonical, create-only, mode 0600, file-fsynced, and directory-fsynced. A failure receipt contains
-only the fixed v2 projection. It contains no raw exception, command, child output, environment,
-path, selected tool name, database, role, owner, ACL, OID, SQL, connection, TOC content, catalog
-row, count, or discovered identity. The same canonical failure diagnostic goes to standard error
-for publication-failure recovery. The raw-error `StageOrchestrator` remains outside this privacy
-boundary. Failure-document construction and repair stay under `receipt_validation`. Incomplete or
-corrupt cleanup proof produces one fixed `failure_document_repaired=true` diagnostic. It preserves
-a valid earlier primary, uses only fixed lifecycle values, and never emits exception text. The
-fixed `receipt_validation/harness_corruption` diagnostic remains available on standard error if
-normal construction or durable publication cannot complete.
-
-The v1 gate ran once and returned ownerless `gate/stage_failed` evidence. It did not prove that the
-archive guard, prerequisite, restore, or R1 semantic authority ran. The v1 spelling and schemas are
-retired and have no alias. Candidate 3 remains frozen and unadjudicated. A source-bound v2 result
-must exercise and reject candidate 3 before the three-rejected-candidate threshold is crossed. The
-Manager owns cross-process one-shot authorization. A v2 pass has `acceptance=false` and permits only
-a later decision about revised Phase A. This v2 source is unexecuted and does not establish
-acceptance.
-Rust is the sole owner of this closed, ordered, typed contract. It preserves the prior 39
-predicate descriptors and appends one unsafe identity for unexpected runtime-executable
-security-definer authority. Finalization rejects a missing, duplicate, unknown, reordered, or
-misclassified observation before production verification or fixture serialization can consume it.
-The immutable artifact contains the versioned ordered definition, its observations, and a SHA-256
-fingerprint. The fingerprint input starts with a domain string and then uses big-endian
-32-bit byte lengths for both schema strings and every UTF-8 descriptor field.
-Python independently applies this encoding. It requires the emitted fingerprint and the one
-supported fingerprint to match, binds each Boolean observation to the definition in order, and
-requires identical complete artifacts at S0, R1, and R2. Python does not contain a predicate list
-and does not inspect Rust source for semantic authority.
-The runtime verifier examines the login identity and each inherited or `SET ROLE`-reachable
-identity. Effective privileges include `PUBLIC` and column grants. Non-system relation-like entry
-objects are closed to the exact Decodex and migration-ledger allowlist. Every runtime-executable
-non-system `SECURITY DEFINER` normal function, procedure, or window function must be an expected
-runtime entry. Aggregate rows are excluded because PostgreSQL `CREATE AGGREGATE` has no
-`SECURITY DEFINER` capability. The required `public.digest(bytea,text)` dependency is bound to the
-exact `pgcrypto` 1.4 extension membership, namespace, owner relationship, function metadata, and
-default ACL.
-Phase A atomically publishes a versioned summary receipt only when the mismatch array is the
-exact ordered subset of the post-V21 schema-contract digest followed by the configured-authority digest:
-zero, either singleton, or both in canonical order. Unrelated, duplicate, or reordered mismatches
-fail closed. Semantic predicates, ledger, binding, identity, and both S0=R1 and R1=R2 restore edges
-remain intact. Raw manifests
-and temporary cluster state are not retained in the receipt. A separate V13 upgrade database binds
-only the exact
-ManagedRun-safety anchor, then proves the migration-owned 15-function/five-type runtime delta and
-V19 internal sealing from raw catalogs. The receipt is derivation evidence, never acceptance.
-Forward-only V20 leaves the exact schema observer unchanged and recreates only nine named CHECK
-constraints whose leading `BETWEEN` expressions were not a dump/restore textual fixed point. Their
-equivalent explicit lower/upper predicates preserve behavior and dependencies; the two-restore
-capture proves the resulting authoritative definitions are stable across repeated restoration.
-Phase A finishes capture, PostgreSQL shutdown and workspace removal, and final source-tree
-revalidation before preparing a mode-0600 receipt in the operator-selected private external
-directory. After the complete bytes are flushed and fsynced, a create-only hard link publishes the
-final path. That link is the commit and linearization point: pre-link failure leaves no new final
-path, while post-link temporary cleanup, directory-fsync, signal, crash, or status failure never
-rolls the immutable receipt back. Directory fsync is still required for a normal-success durability
-claim; failure after the link creates an ambiguous producer outcome resolved only by receipt
-readback. Phase A exit status and output are not evidence.
-Phase B is the sole consumer and acceptance boundary. It ignores producer exit and output, never
-overwrites an existing path, and may consume only an extant exact-schema receipt whose immutable
-bytes and hash attest the exact Phase A HEAD/tree, `capture_only=true`, `acceptance=false`, the
-canonical zero/one/two mismatch set and order, exact
-database/principal/migration-ledger evidence, and complete
-source/restore and semantic-authority parity. For one or two mismatches it requires a clean direct
-single-parent child that changes exactly the reported digest array or arrays and no other source;
-for zero mismatches it requires the same clean Phase A HEAD and tree. It repeats the full S0→R1→R2
-capture and publishes `acceptance=true` only for zero digest
-mismatches and complete semantic evidence, bound to both trees and the Phase A receipt hash.
-Malformed, substituted, duplicate, or lineage-mismatched receipts fail
-closed. This bounded contract assumes one clean committed writer and an operator-owned private
-external directory; it creates no persistent PostgreSQL authority or producer/consumer protocol.
-Phase B may change only the digest arrays reported by Phase A, must record both Phase A and Phase B
-trees, and is invalidated by an unreported array or any other source delta. An unchanged-tree Phase
-B still emits a fresh acceptance receipt explicitly bound to Phase A. Older receipts are immutable
-provenance only and cannot attest source changes outside their binding. Normal
-acceptance has no expected-mismatch branch: manifest readiness must pass before behavioral or
-restart stages run.
-
-The PostgreSQL harness has one top-level stage authority for the normal aggregate. Fatal preflight
-owns argument/mode validation, clean source binding, PostgreSQL tool and temporary-root discovery,
-cluster initialization/start, and base-role creation. Phase A/B private-output and receipt-lineage
-validation remains on those direct entrypoints rather than entering the aggregate graph. After
-preflight, meaningful semantic suites form explicit prerequisite edges and produce only `passed`,
-`failed`, or `blocked`: an ordinary expected failure blocks its consumers while independent
-branches continue.
-One `managed_run_v26_suite` stage owns the ManagedRun V26 database, migration, runtime
-provisioning, baseline capture, source behavior, post-behavior capture, dump, restore, restored
-capture, and restored behavior. The focused ManagedRun mode and the normal aggregate call this same
-stage owner. Its exact test selectors use nextest's zero-selection failure mode. Final aggregate
-evidence depends on this stage.
-Required nested restore results are promoted to their owning suite, so a capture, restore, parity,
-or production-check failure cannot be reported as owner success. One private live-doctor mutation
-SQL executor owns every ordinary, role-as, and secret-bearing mutation child, SQL delivery state,
-command completion, output handling, and cleanup; the live-doctor coordinator owns only probe
-readiness and its own child. Both child kinds receive bounded terminate, kill-fallback, and reap
-attempts on every exit, and failure to establish a reaped state is harness corruption. Mutation
-probes and fixture restorations remain distinct stages. Ordinary mutation delivery remains blocked
-when `Popen` fails; once successful `Popen` returns with the SQL payload owned in argv, delivery is
-possible and every later failure remains restoration-eligible. A secret mutation remains blocked
-through its completed fail-closed logging prelude, becomes may-have-dispatched immediately before
-the first mutation-frame payload write, and remains restoration-eligible after any later write,
-flush, timeout, protocol, exit, or cleanup failure. Successful exit records only command
-acknowledgement, never exact server receipt or non-vacuous mutation application; an optional
-postcondition probe is separate evidence. The scheduler consumes one restoration claim from the
-attempt record exactly once. Pre-dispatch failure blocks restoration, eligible probe failure still
-attempts it, and later probes on the shared fixture require restoration to pass. Unexpected
-assertion/key/type failures, corrupt report state, source-binding or redaction failure, and other
-unexpected exceptions stop new scheduling as harness corruption. Before cluster start the same
-outer owner attempts direct removal of a created private work directory without reporting cluster
-teardown. Once the cluster has started, teardown and final report emission always remain eligible.
-The process-visible primary is selected before aggregate output/report emission; cleanup or
-emission corruption remains secondary when an earlier semantic failure exists. The normal
-aggregate emits `decodex/postgres-aggregate-stage-report/1`. The focused ManagedRun mode emits
-`decodex/postgres-managed-run-v26-stage-report/1` from the same stage owner. Other focused suites
-and Phase A/B receipt modes retain their direct output or capture behavior.
-
-The three bound identity sequences must be exact. Runtime receives USAGE only on the activity and
-outbox sequences; the migration-owned history-version sequence remains inaccessible. SELECT,
-UPDATE/`setval`, ownership, grant options, and SET-reachable surplus authority are unsafe. Every
-string-to-system-catalog identity explicitly qualifies `pg_catalog`; the
-authority audit and schema-qualified migration-ledger verification remain correct under a hostile
-runtime `search_path` that shadows both ledger and system-catalog names. Missing required schema,
-table, sequence, function, or ledger-read authority is incompatible.
-At the V14 boundary, twenty-seven canonical `SECURITY DEFINER` functions comprise the three V3
-cursor/history functions, eleven V5-V7 Project/Policy/Program/Objective command entrypoints, and two
-V9 RoleProfile command entrypoints, two V10 RuntimeSession command entrypoints, and four V11 exact
-WorkItem commands, the inert future running/resume guard, the one V12 ManagedRun safety
-consumer, and the three V14 routing-authority commands. The cursor issuer derives Conversation,
-snapshot version, parent, page size, position, item identity, and expiry under serialized
-Conversation authority; the bounded pruner is callable by runtime, while the capture function is
-trigger-only and runtime cannot execute it directly. Runtime has no cursor-table INSERT authority.
-The other ninety-two canonical V14 functions are security invokers. The additional-function adversarial fixture creates a fixture-only migration-owned,
-runtime-executable `SECURITY DEFINER` function with an unsafe per-function setting and migration-owner
-trigger authority, proves runtime direct trigger DDL is denied, executes the owner-authority effect,
-and restores the trigger before the independent doctor rejection. A separate public-function trigger
-fixture proves runtime DML can execute an owner effect without direct function `EXECUTE`, protected
-table `UPDATE`, or `TRIGGER`; the closed V14 trigger inventory rejects that path. A public,
-runtime-owned extension fixture attaches a migration-owned Decodex collation as an extension member,
-proves the runtime can transactionally drop it, and is rejected through the dependency audit. The
-closed 119-function V14 inventory remains independent of the distinct same-signature canonical-source
-substitution fixture. Missing, malformed, unsafe, unreachable,
-authentication-failed, or incompatible bootstrap retains a typed unavailable adapter;
-there is no ambient/default database or alternate state authority. Repository and
-PostgreSQL socket validation rejects a symbolic link or non-directory at every descriptor-opened
-component, a non-socket endpoint, untrusted directory permissions/ownership, an endpoint owner or
-kernel peer that differs from the operator UID pin, and any directory/socket identity replacement.
-
-Protocol V2.0 defines `get_doctor_status` as a read-only query/result with a client query
-identity and no mutation receipt, deduplication, replay, receipt-capacity use, event
-publication, or entity revision. Reusing a query identity performs a new ordered
-observation. V2.0 is exact-current: V1.x receives `major_mismatch`, and another V2 minor
-receives `unsupported_minor`, before application payload handling. `ClientHello` may pin the stable
-server identity before snapshot, query, or command access. The doctor report is mechanically
-capped at 32 unique typed checks and has no free-form external text. Server repository
-paths are an aggregate typed check only, so
-remote clients receive neither host paths nor repository names and cannot reinterpret
-them locally. App-server capabilities are closed enum values; current unprobed capability,
-plugin, vault, and blob-content observations remain honestly `unknown` rather than ready.
-Each accepted V2.0 doctor read revalidates the retained socket binding, obtains a
-runtime connection through the verified connector, performs a live query, reruns the
-complete runtime-authority and immutable migration checks—including the exact embedded
-ledger and required `pgcrypto` extension—and reports any failure as typed unavailable.
-It never reconnects migration
-credentials, runs migration, or repins an endpoint. A stale but securely bound listener refusal is
-database-unreachable; directory/socket replacement or peer-identity drift is unsafe-host-path.
-PostgreSQL socket recreation after restart therefore requires a daemon restart under the explicit
-operator authority instead of silently adopting the replacement.
-
-The XY-1273 account foundation keeps a canonical Decodex account UUID and a closed readiness
-observation in core. PostgreSQL persists only display metadata, that observation, ordinary
-credential-negative JSON, and revision evidence; the forward-only V4 migration adds the honest
-`unavailable` observation without adding any credential, vault-reference, selector, or routing
-column. The repository exposes only exact-ID reads and inert mutations.
-
-Codex child creation has one dormant runtime-owned explicit manual composition path. Runtime first
-observes the exact manually selected PostgreSQL account ID/revision in the `available` state, then
-releases the result row and pooled client before reserving process capacity or invoking a vault. It
-repeats the same exact observation after process-group cleanup or quarantine transfer and constructs
-only a non-live post-cleanup result. Readiness may change while mechanics run; a stale, non-ready, or
-unavailable final observation suppresses the result. No transaction, row lock, client checkout, or
-caller callback spans vault or process work. A synchronously blocked host vault can still retain its
-local task and mechanical capacity indefinitely, outside PostgreSQL.
-
-The manual launcher, request, result, capacity counter, permit, vault port, wire DTOs, stdout pump,
-and process supervisor are private to non-reexported runtime modules. The Codex adapter does not
-depend on PostgreSQL and exposes no child-launch operation.
-Cargo-metadata architecture guards enumerate every workspace library and binary target and prove the
-current normal-dependency graph: only runtime directly owns both sibling adapters, while `decodexd`
-reaches them only through runtime; production edges do not enable synthetic fixture features.
-Compile-fail contracts prove that the private launcher, capacity, command, probe, and vault types are
-absent from current crate APIs. Metadata does not prove the absence of future source changes or
-wrappers. The private account binding and host vault project into the not-yet-bound child exactly
-once, after which repeated `account/read` observations compare the exact identity in zeroizing,
-redacted process memory and attest the exact process ID. No account-identity digest is returned.
-A mismatch synchronously terminates the process group or transfers cleanup to the bounded quarantine;
-uncertain cleanup never returns a runner. The default vault is unavailable. Children retain the
-single normal shared `~/.codex` for configuration and plugins, receive only `HOME` and a fixed
-`PATH` from the parent, mark all other inherited descriptors close-on-exec, use a fixed app-server
-argv, and discard stderr. Outbound JSON serialization writes directly into fixed 8 KiB
-zeroizing blocks; the pointer-only block index may grow, but no growing ordinary allocation ever
-owns credential bytes. Serialization failure, frame overflow, transport failure, and normal
-teardown drop the same wiping owners. Inbound reads,
-partial frames, queued frames, overflow/disconnect values, and unread teardown state remain in
-fixed-allocation zeroizing blocks; the exact-size contiguous parse copy is zeroizing. A lexical gate
-rejects every escaped inbound JSON string before locked serde_json 1.0.150 can copy it into ordinary
-scratch; this intentionally closed subset fails unusual escaped paths/messages closed. Every completed
-owned string field under the typed RPC DTOs deserializes directly into a per-field zeroizing owner,
-so a later missing, malformed, nested, or wrong-type field cannot ordinarily free it. This guarantee
-does not claim that all opaque Serde structural/number scratch is zeroizing, only that inbound string
-bytes cannot enter its escaped-string scratch. No `CODEX_HOME`,
-credential file, global configuration mutation, ambient-account production probe, or live credential
-switch is exposed.
-
-Runner capacity is fixed at 64 and in-memory under one daemon-owned runtime authority. Reserving a
-private non-clone permit also reserves one of 64 fixed cleanup slots before spawn. The permit enters
-every version/schema preflight `ProcessGroupOwner` immediately after successful
-`spawn`, before any fallible post-spawn step. It returns to the launch attempt only after confirmed
-process-group absence and successful child reaping, then moves sequentially into the next preflight and
-final app-server. Confirmed final shutdown releases it only after the same proof; uncertain cleanup
-moves it into a hard-capped quarantine before control returns. The one capacity-lifecycle janitor must
-be successfully created before capacity authority exists; failure makes capacity construction fail
-closed, so no child can require later launch-triggered recovery. No caller or `Drop` path enters the
-background retry loop. A weak daemon registry reuses exactly one live capacity authority but does not
-make it process-immortal. A finite join coordinator stops and joins the janitor when the last capacity,
-permit, or quarantined job releases that authority; if the last release occurs on the janitor itself,
-the coordinator performs the join without self-wait. Construction failure after worker start shuts
-down and joins that worker before returning. The janitor scans the fixed slots
-round-robin and performs one nonblocking cleanup attempt per job per round, so one stuck group cannot
-starve later groups. Atomic slot states keep each job discoverable while reserved, ready, or in
-flight; an in-flight guard restores the same slot after unwind and a per-iteration unwind boundary
-keeps the persistent owner alive. Poison is recovered, and timed predicate rechecks prevent lost
-wakeup. There is no queue-full or
-contended-admission leak: the 65th permit is rejected before spawn. The failed attempt cannot launch
-another group. PostgreSQL's
-exact revision/state predicate excludes stale, unavailable, unknown, depleted,
-authentication-failed, plugin-unready, and a current conflated disabled observation. That
-disabled shape is source evidence, not target authority; Slice 1 uses the independent
-versioned `enabled` boolean. A fresh daemon starts with no
-persisted capacity or assignment authority. This feature-gated manual path remains nonproduction
-and does not construct a V23 ProcessGeneration or create restart authority. There is no account
-inventory, automatic selector, weighting, stickiness, fallback, quota wake, or live routing API;
-it is current source evidence only. Slice 1 adds limited initial fixed/balanced selection
-through the owning V14/V16 and account authorities. XY-1304 remains the later automatic
-fallback/wake gate.
-
-### Durable ProcessGeneration supervision
-
-V23 adds the durable ProcessGeneration owner described in
-[the XY-1400 authority specification](../specs/process-generation-authority.md). PostgreSQL
-commits one account-exclusive `starting` intent before `ProcessSupervisor` can receive a fresh
-spawn fence. Replay is readback only. One private `AttestedAppServerLaunch` retains the protected
-executable reference snapshot and canonical macOS execution identity, then derives the intent's
-account and launch-manifest hash. That hash binds the exact image and BuildId, canonical-suspended
-execution policy, command, fixed `app-server --stdio` arguments, working directory, clear-then-set
-environment, account, initial account revision, canonical credential version/fingerprint, provider
-binding, and exact-build startup/lifetime/account-callback capability. The same non-secret facts
-are part of the existing V23 intent, prepare fence, ready transition, and strict readback. No new
-ledger is added. The supervisor accepts no independent runner digest or raw `Command`. The
-immutable snapshot supplies preflight bytes and the static code-identity reference. The final
-macOS app-server executes the canonical image while suspended and resumes only after exact dynamic
-code, path, session, and process-group verification. After spawn, the supervisor persists the exact
-boot, PID, process-start, process-group, and session identities.
-
-The current launch profile accepts only the source-attested macOS
-`codex-cli 0.146.0-alpha.9.2` image and forces
-`CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1`. This is exact-build startup-state
-evidence: it selects disabled-ephemeral remote-control mode, but it is not a permanent denial
-policy. The supervisor retains child stdin and stdout privately for lifetime ownership.
-`FencedProcess` and every returned ProcessGeneration capability expose no raw channel or generic
-protocol writer. Every other build, including the current unrecorded Linux image, fails closed
-before profile-dependent version or schema preflight spawn.
-
-That accepted lifetime profile is not by itself an AccountLifecycle readiness receipt. The
-exact `codex-cli 0.146.0-alpha.9.2` profile recognizes the root
-`account/chatgptAuthTokens/refresh` request and response schemas and services that callback
-through the Account Service. Readiness is issued only after the exact executable, generated
-schema, and live callback preflights pass. The callback path rechecks the account revision,
-credential version/fingerprint, provider binding, and enabled state immediately before the
-ProcessGeneration fence. Unsupported callback profiles fail closed before account launch.
-
-The supported-OS adapter owns boot and process identity, generic session/descriptor setup, exact
-owned signaling, group observation, and positive exit witnesses. Linux uses `/proc` start ticks
-and pidfd. macOS uses a versioned stable `kern.bootsessionuuid`, `proc_pidinfo`, and a one-shot
-kqueue `NOTE_EXIT` filter. A persisted boot identity from another format is incomparable and
-cannot prove that a prior boot ended.
-Both use a new session. Generic retained-title and preflight setup grants no ProcessGeneration
-lifetime capability and does not install Linux `PR_SET_PDEATHSIG`. No exact Linux lifetime profile
-is accepted. A future parent-death primitive must be reachable only through such a profile. On
-macOS, stdio EOF is only a best-effort request and is not death evidence. Only the original
-unreaped child can authorize a group signal. A restored same-boot process can receive only a
-read-only exact witness; it is not adopted, reacquired, proxied, terminated, or signaled.
-
-Daemon startup projects present `starting`, `ready`, and `stopping` rows to
-`death_unknown` and runs one positive-only pass. The server lifecycle then owns and polls
-bounded background reconciliation until shutdown. An old boot is positive prior-boot death proof.
-Same-boot absence, mismatch, an unbound identity, timeout, and group absence alone remain
-uncertain. The partial unique account index derives account-local quarantine without another
-writer. One item failure does not disable the store, managed repositories, or reconciliation for
-other accounts.
-
-On macOS, a restored generation becomes `dead` only after the attached exact kqueue witness returns
-`EVFILT_PROC/NOTE_EXIT` and the process group is quiescent, or after boot change. If the process
-exits before witness attachment, the event cannot be reconstructed and the account stays
-quarantined for the rest of the boot. ProcessGeneration makes no claim about credential revocation
-or provider-effect outcome; XY-1401 retains that ambiguity in ProviderAttempt.
-
-### Durable ProviderAttempt authority
-
-V24 adds the generic ProviderAttempt owner described in
-[the XY-1401 authority specification](../specs/provider-attempt-authority.md).
-One PostgreSQL preparation transaction binds exactly one reserved Conversation Turn identity or
-ManagedRun execution to its accepted V17 plan, V16 decision, RuntimeSession, selected account,
-live ready ProcessGeneration revision and epoch, request identity and digest, and provider
-idempotency or correlation keys. The Conversation owner can materialize the reserved Turn later;
-an existing Turn must match the same Conversation and accepted RuntimeSession.
-The fixed-search-path reservation trigger runs as the migration owner because runtime has Turn
-DML but no ProviderAttempt relation access; runtime and PUBLIC cannot execute the helper directly.
-Unreserved Turn writes pass, and conflicting reserved materialization fails closed.
-ProviderAttemptService selects no account and creates no RuntimeSession or Turn.
-
-The ordinary machine is `prepared -> canceled | dispatch_authorized`,
-`dispatch_authorized -> succeeded | failed_definitive | not_submitted | unknown`, and
-`unknown -> succeeded | failed_definitive | not_submitted` only from positive evidence.
-Restore projects present prepared and dispatch-authorized rows to `unknown` under the shared
-execution restore gate. A late positive result stays bound to the original attempt after process
-death. A replacement reconciles but cannot recreate a fresh dispatch fence.
-
-Daemon bootstrap completes restore projection and one bounded positive-only reconciliation pass
-before it reports ProviderAttempt readiness. The server lifecycle then owns and polls bounded
-background passes until shutdown. Diagnostics omit provider keys and request digests. The current
-composition has no provider evidence adapter that can dispatch, no public consumer for the fresh
-fence, and an unavailable `CodexAdapter`.
-V26 removes the drained V12 ManagedRun submitted-turn, effect, safety-input, and effect-barrier
-authority. No compatibility or fallback V12 writer remains.
-
-`ServiceBootstrap` exposes independent ProcessGeneration and ProviderAttempt readiness and
-authority-bound borrowed runtime ports. Neither port is cloneable or can escape its bootstrap
-owner. The ProcessGeneration port provides bounded or exact diagnostics, exact positive-only
-reconciliation, and exact owned-child termination. The ProviderAttempt port provides bounded
-redacted diagnostics, exact positive-only reconciliation, and an exact positive receipt
-operation. ProcessGeneration spawn and ready remain crate-private and have no caller.
-`CodexAdapter::unavailable()` remains in the daemon composition.
-No protocol, CLI, scheduler, routing, RuntimeSession, ProviderAttempt, credential, remote-auth, or
-UI path reaches ProcessGeneration spawn. Production dispatch remains structurally disabled.
-A future live-dispatch protocol gateway must be a separate typed authority that source-rejects
-`remoteControl/enable` and all alternate-control RPCs before dispatch can be enabled. This slice
-does not implement that gateway.
-
-### Stateless execution coordination
-
-V25 adds the closed enum vocabulary in one transaction. V26 and the zero-sized
-`ExecutionCoordinator` implement the
-[XY-1402 source projection](../specs/execution-coordinator-authority.md). V14, V16, and V17 now
-preserve one closed consumer union. The ordinary variant binds a Conversation and reserved Turn to
-its exact source RuntimeSession. The managed variant binds one ManagedRun revision and one distinct
-managed execution. Ordinary work does not acquire ManagedRun state.
-
-V16 remains the sole account eligibility and selection writer. It loads the complete persisted V14
-universe. It preserves each 300-minute and 10,080-minute fact independently and applies sticky
-affinity only after eligibility. It classifies both quota facts at its own decision instant, so a
-fact that ages after V14 retains the exact stale or reset-elapsed cause. Pure current positive quota
-depletion produces `waiting_usage`. Pure unresolved ProcessGeneration or ProviderAttempt authority produces
-`waiting_reconciliation`. Any mixed set remains `no_route` with every exact cause and no wake or
-task failure. Selection and both pure waits inspect only included members. A `no_route` uses the
-complete persisted policy-member universe, retains `excluded_by_policy` for every excluded member,
-and cannot be cause-free.
-
-V17 remains the sole RuntimeSession continuation writer. An ordinary Conversation can reuse its
-thread only from positive exact-thread evidence on the original ProviderAttempt. A ManagedRun can
-use the accepted V15/V22 causal experiment. Every other case uses the atomic Context Pack and
-fallback RuntimeSession transaction. V17 never writes ProviderAttempt state, and ProviderAttempt
-never creates or rewrites RuntimeSession state.
-
-The coordinator consumes one persisted V16 decision, one V17 plan, one ProcessSupervisor-owned
-live `FencedProcess`, and ProviderAttemptService preparation. It consumes the fresh prepared
-capability and returns only an inert attempt projection. It retains no service, lifecycle, retry,
-receipt, process, attempt, or ambiguity state. Its method and the process fence are crate-private.
-The read-only V2.0 execution-decision query exposes no mutation capability. No production
-composition root can start coordination or authorize provider dispatch.
-
-The accepted XY-1355 target adds no live execution path here. V14 makes PostgreSQL the sole owner
-of a revisioned complete routing-policy snapshot over the entire account inventory, canonical
-user order, explicit per-member disposition, sticky affinity plus source RuntimeSession revision,
-account/profile/build compatibility, exact evidence revisions, and required-capability
-applicability. Runtime and callers cannot supply that universe. V14 exposes only exact policy
-replacement, ordinary compatibility-evidence publication, and immutable snapshot-resolution
-commands; resolution classifies facts and blockers but cannot select, wait, wake, continue, or
-dispatch. The core routing component will be
-a pure kernel over the database-produced snapshot; V16 will atomically persist its decision and
-complete evidence linkage. Codex remains a positive-evidence adapter. An unknown required
-capability blocks, while an empty required-capability set makes unknown plugin inventory non-
-applicable rather than positive readiness evidence.
-
-V2.0 also carries `get_conversation_history`. Its request contains a logical Conversation UUID,
-an optional opaque PostgreSQL-issued Conversation-bound snapshot cursor, and a page size capped at
-eight on the wire (the repository's internal cap is 100). PostgreSQL assigns append-only
-per-Conversation positions and derives the next position and snapshot high-water from indexed
-history while holding the Conversation lock; there is no runtime-writable stored counter. The first
-page also pins the current append-only history-version sequence. Later pages fetch only `limit + 1`
-immutable item versions at or before that sequence and through the high-water position. Concurrent
-appends are neither duplicated nor silently skipped, and later streaming updates cannot change an
-issued page or its replay.
-
-Every continuation is a random identifier resolved only through an immutable persisted issuance row
-that binds Conversation, positive high-water, immutable version sequence, fixed page size, positive
-item position, exact item identity, and optional issued parent. The canonical issuer derives and
-extends the chain under serialized authority; ordinary runtime DML cannot mint one. A page exposes
-at most one continuation. Chains expire after one hour and are capped at 512 rows per Conversation
-and 4,096 globally; canonical retries reuse an existing row, while new issuance at capacity returns
-typed `resource_exhausted`. Bounded pruning removes expired chains and obsolete history versions but
-retains current versions, active-cursor versions, and versions required for exact command replay.
-Never-issued, expired, cross-Conversation, edited, zero-position, changed-page-size, and forged
-truncation tokens fail closed.
-
-Each command first commits an immutable pending receipt containing protocol version, operation,
-project and scope identity, entity identity, idempotency key, canonical request digest, expected
-revision, and every payload hash and length. The receipt owns a fenced claim token and finite expiry.
-Conflicting reuse fails before filesystem or metadata effects; exact completed replay returns the
-stored original response bytes, and the first successful caller decodes that same stored response
-rather than rereading mutable current state after commit. An expired claim can be reassigned, but a stale token cannot complete
-it. Blob-backed writers then acquire sorted session-level hash locks in namespace 1273 on dedicated
-non-pooled connections, followed by sorted per-shard capacity locks in namespace 1274. After byte
-publication, transaction B acquires hierarchy key 1271 and required parent/child rows, registers
-metadata/references/activity/outbox, persists the exact response, and completes the fenced receipt
-atomically. Database triggers never acquire hash or shard locks. Cancellation or uncertain unlock
-closes the dedicated session and releases its locks.
-
-Cursor paths use hierarchy 1271, cursor key 1272, then rows; they never acquire hash locks in that
-transaction. Garbage collection uses hash then shard coordination, rechecks every live-reference
-table and grace age in a short transaction, commits metadata deletion, and unlinks afterward.
-Filesystem publication, verification, scans, and unlinking occur outside hierarchy, cursor, and
-database transactions. `decodexd`, its daemon-private runtime identity, and BlobStore access are one
-trusted service boundary; arbitrary/manual use of that credential is unsupported and equivalent to
-daemon compromise. PostgreSQL owns committed metadata/domain/receipt authority but does not itself
-attest external bytes.
-
-Inline text is capped at 16 KiB. Larger payloads are published create-only and atomically, fully
-hash/length verified, and synchronized with their containing directory before transaction B. Direct
-and transitive bytes are reverified on every successful read. Bounded grace-aged inventory
-reclamation is deterministic and resumable and removes only hashes absent from live history,
-immutable replay versions, Artifact revisions, and Context Packs. A crash can leave only
-inventory-visible unreferenced bytes; metadata deletion commits before orphan unlink. Missing,
-length-mismatched, or tampered content fails closed.
-
-The typed history projection carries one canonical media type for both inline and offloaded payloads
-plus a flat credential-negative metadata map. It accepts at most 32 fields, 64 UTF-8 bytes per key,
-and only booleans or strings of at most 256 UTF-8 bytes; nested or credential-shaped forms fail
-before persistence or wire decode. Core owns both opaque types and their serde validation.
-Credential-bearing normalized key suffixes and concrete authorization/token/assignment/key patterns
-fail closed, while benign prose such as `secret sauce`, `token budget`, and `session summary` remains
-valid. PostgreSQL's closed projection predicate mirrors that classification, so store-created rows
-cannot become unreadable at the protocol boundary. This is normalized provenance, not raw app-server
-JSON.
-
-V3 state triggers author creation/update timestamps at persistence. Starting or active
-RuntimeSessions always begin with `ended_at = NULL`, active Turns always begin with
-`completed_at = NULL`, and terminal RuntimeSession or Turn states cannot be inserted. Immutable
-snapshot, blob-verification, Artifact-revision, Context-Pack, and transition-proposal creation times
-are database-authored rather than caller-authored.
-
-Logical Conversation identity has no Codex-thread or account component. One Conversation can have
-multiple explicitly manual or synthetic RuntimeSessions, each bound to immutable non-secret account
-and profile snapshots. A RuntimeSession's Codex-thread and last-known-turn correlations are also
-immutable across every lifecycle transition. Composite foreign keys prevent sessions, Context Packs, transition proposals,
-history items, and typed Artifact revisions from crossing that boundary. History-item Artifact
-identity/revision correlation is immutable after insertion and an update carrying a different valid
-reference fails rather than reporting an ignored mutation. Each Artifact parent revision is tied by
-a deferred composite foreign key to an exact immutable revision row. Before every parent advance,
-the state guard requires the exact old revision row; every new revision requires revision 1 or the
-exact immutable predecessor plus a legal predecessor-state transition. Typed and direct-SQL
-transactions therefore cannot skip history, commit a parent advance without its matching revision,
-or manufacture a revision the parent has not selected.
-Database triggers take
-conflicting parent row locks in child-write and terminal-transition directions, enforcing parent
-eligibility and terminal immutability under concurrent runtime SQL. History-item create/update,
-activity, outbox evidence, exact response, and fenced receipt completion are one transaction B after
-the pending receipt and any blob publication. Context Packs separate the mandatory
-pinned revision, use canonical length-delimited binary encoding, bind policy/Conversation/side
-effects/complete provenance/bytes/digests in one opaque verified value, and reconstruct that complete
-immutable value on read. Source rows are staged before the parent under a transaction advisory lock;
-the parent seals their exact contiguous count, and database triggers reject subsequent source or pack
-insert/update/delete poisoning while the deferred parent reference prevents orphan commits. Persisted
-rollover/fallback rows are proposals only: their schema
-forces dispatch disabled. This slice exposes no account selection, live turn start/resume/steer,
-automatic rollover, Context-Pack dispatch, ambiguous replay, or scheduler wake in current source.
-Slice 1 later enables only eligible quota-aware fixed/balanced initial selection and manual
-recovery. XY-1304 remains the separate later automatic fallback/wake gate and does not block
-Quick Task, Project/Lead, ManagedRun, GPUI, or first Mac dogfood. XY-1358/V15 owns experiment creation and positive-only observation
-authority; XY-1360 owns continuation and atomic Context-Pack fallback; XY-1362 owns scheduler wake;
-XY-1276 owns production Quick Task creation. XY-1272 owns only PostgreSQL
-configured-principal and ACL authority closure against V8. XY-1345 owns accepted exact-command
-authority/prototype evidence, XY-1346 owns expected V9 exact receipts plus RoleProfiles, and
-re-bounded XY-1337 owns expected V10 RuntimeSession snapshots and transitions.
-
-V15 is a persistence protocol, not an execution composition root. V22 is its forward-only
-retained-title bridge. PostgreSQL first records immutable intent. It then commits a one-way
-`creation_possible` fence before one `thread/start`. The V22 binding stores the exact request and
-raw response identities and SHA-256 digests. It also stores the exact thread ID, cwd, marker,
-non-ephemeral state, and nullable returned name. The pinned build requires that name to be null.
-A replayed creation fence never authorizes another start. Recovery can read only the exact durable
-binding for the same experiment and attempt. If that binding is absent, the start outcome is
-terminally ambiguous. Recovery never retries, searches, or adopts a thread.
-
-After a durable start binding, PostgreSQL commits one separate title-set fence. Only a fresh fence
-authorizes one `thread/name/set`. Fence replay or a lost set response authorizes one bounded
-`thread/read` for the exact bound ID. It never authorizes another set. PostgreSQL creates a
-retained-title attestation only when that read returns the prepared title, marker, cwd, and thread
-ID. Title-qualified positive observations require this attestation. V17 same-thread plans require
-an observation linked to it. Historical V15 rows and receipts remain immutable. Runtime cannot
-execute the obsolete title-in-start binder or unattested observation command.
-
-The V22 completeness trigger rejects a same-thread plan that cites historical unattested evidence.
-It does not reinterpret that evidence as retained-title authority.
-
-The feature-gated manual composition fixes request IDs 3, 4, and 5 for start, title set, and read.
-It derives database idempotency keys from the experiment ID and operation. No external RPC has a
-transport retry.
-
-List omission, pagination exhaustion, missing events, lossy history, and stale caches have no
-persisted representation and authorize nothing. The
-immutable V14 snapshot is the run-revision provenance authority for V15 experiments; V16 decisions
-retain that same composite snapshot lineage, and V17 plans retain the composite V16 decision
-lineage. The snapshot likewise retains its source RuntimeSession revision as immutable provenance
-after checking the locked current session. Later legitimate ManagedRun and RuntimeSession advances
-therefore neither rewrite historical evidence nor invalidate its foreign keys, while creation still
-rejects a revision that is not current under the command's hierarchy, ManagedRun, experiment,
-snapshot, and RuntimeSession lock boundary before committing `creation_possible`.
-
-The composition also reports conversation execution unavailable. Authentication, TLS,
-remote binding, HTTP artifact transfer, MCP, scheduling, live Codex execution, mutating
-CLI operations, and GPUI behavior remain disabled and belong to later issues.
-
-The synchronous product-state availability port reflects verified configuration and local
-pool lifecycle: closing the pool makes it unavailable. Live PostgreSQL failures remain
-authoritative at each asynchronous store operation; availability does not claim a synchronous
-network-liveness probe.
-
-Pure database commands do not use that split-phase flow. They execute through an
-operation-specific, command-complete migration-owner `SECURITY DEFINER` function. PostgreSQL builds
-the complete JSONB request from the typed values it consumes, inserts or waits on
-`exact_command_receipts(protocol_version, idempotency_key)`, and completes the receipt, domain
-mutation, canonical activity, outbox, and stored response in one transaction. Runtime has only the
-operation-function `EXECUTE` grant: it has no exact-receipt table privilege, private-helper access,
-or canonical activity/outbox mutation authority. A deferred constraint trigger rejects any commit
-with an executing row; completed rows and authoritative response bytes are immutable and
-undeletable. Stable domain rejection completes and replays, while cancellation, connection,
-serialization, deadlock, and unexpected database failures roll back.
-
-Normal exact-command execution is one command per top-level `READ COMMITTED` transaction. A
-separate read/lock follows `ON CONFLICT DO NOTHING`; `40001` and `40P01` retry the complete
-identical transaction. JSONB identity uses equality, explicit null keys, typed enum/numeric values,
-and exact PostgreSQL text semantics. Effects use actual `RETURNING` rows and canonical audit
-identities. Operation is part of the envelope, so cross-operation key reuse conflicts. The accepted
-proof and vertical ownership are in
-[the XY-1345 evidence](../evidence/xy-1345-exact-command-authority.md). V9 implements this boundary
-for immutable global RoleProfiles through `bootstrap_role_profiles_exact` and
-`update_role_profile_exact`; V10 extends it through `create_runtime_session_exact` and
-`transition_runtime_session_exact` without changing the V9 receipt or RoleProfile authority.
-
-The V9 RoleProfile model contains only advisor, lead, task, and reviewer. Bootstrap receives four
-role-implied scalar configuration groups and commits the complete set or nothing. Updates append an
-immutable revision under an expected-revision row lock and atomically advance the selected role's
-single current pointer. Runtime neither selects nor mutates the RoleProfile or exact-receipt
-relations directly; it parses the response bytes returned by the two command-complete entrypoints
-and retries a complete top-level transaction only after a classified infrastructure SQLSTATE.
-
-V10 is a forward-only zero-state cutover over the retained V3 snapshot and RuntimeSession table
-identities. One access-exclusive fence rejects every legacy RuntimeSession receipt, snapshot,
-session, Turn, or structurally classified activity/outbox row before altering the empty tables.
-Classification closes aggregate, event, effect, link, and payload representations recursively,
-including legacy `runtime_session_recorded` events under another aggregate and nested aggregate
-markers. Forward-only V21 replaces only the steady-state function behind the existing trigger
-bindings: scalar `runtime_session_id`, `profile_snapshot_id`, and `account_snapshot_id` values are
-foreign provenance references and do not claim event ownership by themselves. RuntimeSession
-aggregate/event/kind markers, complete `runtime_session`/`runtime_session_snapshot`,
-`profile_snapshot`, or `account_snapshot` objects, structurally complete canonical session or
-snapshot field sets under any other key, and outbox links to activity carrying any of those
-ownership shapes remain reserved. Runtime callers may therefore publish canonical
-cross-domain activity such as HistoryItem provenance, but cannot forge RuntimeSession activity or
-outbox authority; delivery-only updates to an already reserved outbox row remain permitted while
-its immutable authority fields are unchanged.
-Creation accepts only the RuntimeSession and Conversation identities, one role, the complete
-non-secret account snapshot identity/facts, nullable Codex thread identity, and initial state.
-PostgreSQL acquires hierarchy coordinator 1271 before selecting or locking an open Conversation or
-RuntimeSession tuple, then resolves exactly one current immutable RoleProfile
-revision, inserts or equality-validates the account snapshot, writes the complete profile snapshot,
-creates revision 1 with a null last-known-turn identity, appends canonical activity/outbox rows,
-and stores the exact response bytes in one transaction. Transition identity is only RuntimeSession
-identity, expected revision, and target state; success returns prior/new state and revision plus the
-unchanged full profile/account/session facts and canonical audit identities. Missing, duplicate,
-stale, illegal, invalid-account, and account-snapshot-conflict outcomes are committed stable
-rejections. Runtime retains SELECT-only snapshot/session readback and can execute only the two
-public command owners; direct DML, private helpers, and forged RuntimeSession activity/outbox
-namespaces are closed.
-
-V12 rolls the V3 invoker-rights Turn and HistoryItem state guards forward after V10 made
-RuntimeSessions SELECT-only for runtime. Their statement-level `BEFORE` guards acquire hierarchy
-coordinator 1271 before row-trigger reads; the Turn guard retains only its Conversation row lock,
-and the HistoryItem guard retains only its Conversation and Turn row locks while reading the exact
-RuntimeSession without locking it. Both direct hierarchy paths require `READ COMMITTED` and fail
-retryably with `40001` under any other isolation level. The ManagedRun safety owner follows the
-same global order: reserve the exact receipt, validate the request, acquire 1271, acquire the
-run-scoped `(1338, hash(run))` lock, and only then read or lock hierarchy, run, session, barrier,
-receipt, or Turn state. This prevents an unknown-turn absence decision from crossing a concurrent
-same-session Turn insertion without granting runtime `UPDATE` on RuntimeSessions.
-
-### Managed repository stage-two authority
-
-PostgreSQL is the durable managed-repository authority. It owns the current projection,
-monotonic generation/tip, globally immutable complete-descriptor operation assignments,
-append-only authority transitions and operation evidence, exact generation/tip compare-and-swap,
-atomic command completeness, and state loaded after restart. The pure values, facts, descriptors,
-and deciders in `decodex-core` are mechanism-neutral and non-authoritative; a caller projection,
-snapshot, operation view, or generic observation cannot substitute for a transaction-internal
-PostgreSQL load.
-
-One repository operation ID spans every repository and operation kind. Complete canonical
-descriptor equality returns `ExistingExact(OperationView, NoDispatch)`; any difference is
-permanent `OperationIdConflict`. For a new assignment, one top-level transaction loads and locks
-current authority, evaluates the pure decision, inserts the immutable assignment, appends
-`PossiblyEffected`, fences the allocation or head, appends the authority transition, and advances
-the projection by exact generation/tip compare-and-swap. Commit-time completeness prevents a
-partial durable command.
-
-The PostgreSQL adapter may retain a private non-executable preparation seed until COMMIT. Only a
-successful COMMIT acknowledgement returning on that same live control path can turn the seed into
-one fresh affine receipt. The receipt cannot be persisted, queried, cloned, publicly constructed,
-or reconstructed. Persistence, readback, exact repeat, restart, terminal state, and unknown COMMIT
-outcome never grant dispatch. If the COMMIT outcome is unknown, the invocation produces no receipt
-and performs no external execution.
-
-Allocate is PostgreSQL-only; all admission, path-reacquisition, stat, Git, and target-availability
-evidence used before it is strictly read-only. `Register`, `WorktreeReady`, and `Commit` are distinct
-durably fenced `PossiblyEffected` external operations. `Register` uses the accepted pinned Git
-2.54 worktree-add mechanism and completes only on exact reciprocal registration with unchanged
-head. `WorktreeReady` completes only with its exact head unchanged. `Commit` consumes exact head `H`
-and completes only after positive readback of one exact advance to canonical `H-prime`. Restart can
-issue only operation-specific readback; it cannot retry, replay, adopt, repair, import, or
-reconstruct execution authority.
-
-Accepted XY-1354 supplies descriptor-assisted, symlink-free persisted absolute-path reacquisition
-and pinned Git 2.54 unchanged. `decodexd` remains the sole repository-effect owner inside the
-trusted single-daemon/same-UID V1 boundary. Authorized whole-cluster restore is inside the trusted
-PostgreSQL-administrator boundary and may redefine authority; V1 has no automatic full-cluster
-rollback detection. XY-1349 solely owns V13 persistence, XY-1350 owns only read-only acquisition
-and executor/readback mechanics against this contract, and XY-1351 owns the first shared saga path.
-
-V13 is accepted. The routing migration order is XY-1356/V14 complete policy and candidate-set
-authority, XY-1358/V15 causal experiment authority, XY-1359/V16 atomic routing decisions, then
-XY-1360/V17 continuation authority after source inspection proved durable atomic fallback state was
-required. XY-1361 first composed these boundaries with production dispatch disabled. V25/V26 then
-makes V14, V16, and V17 consumer-generic and retires the drained V12 ManagedRun barrier and
-submitted-turn authority. Repository, worktree, Git, and artifact reconciliation owners remain
-unchanged. Routing never reclassifies or replays their effects.
-
-V16 is the sole routing-decision authority. It uses a pure routing kernel and one
-operation-specific PostgreSQL exact command. The command selects and locks the immutable V14
-snapshot and its current policy, exact Conversation or ManagedRun consumer, account,
-compatibility, capability, blocker, process, attempt, and quota
-sources; callers provide no candidate array or evidence. It persists one inert `selected`,
-`waiting_usage`, `waiting_reconciliation`, or `no_route` row together with complete member, quota,
-capability, blocker, and
-normalized exact-depletion references in the same transaction. Five-hour and seven-day facts,
-raw timestamp text, source identity, exact microsecond precision, and evidence revision remain
-separate. Missing or inexact provenance cannot establish eligibility. The adapter strictly reads
-the database result back through the pure kernel. The XY-1402 coordinator may invoke exactly one
-V16 command per request, but its method is crate-private and no daemon, application, protocol
-command, scheduler, Codex, credential, or UI composition root can call it. Digest regeneration plus
-executable validation remain deferred to the integrated freeze.
-
-V17 consumes only one persisted selected V16 decision identity plus its exact consumer revision.
-PostgreSQL derives the selected account, V14 snapshot, source RuntimeSession,
-Conversation, RoleProfile snapshot, and evidence universe; callers cannot provide candidates,
-policy, exclusions, compatibility, or selection. A qualifying ManagedRun same-thread path requires
-one canonical V22-bridged experiment lineage and exact positive thread attestation. A qualifying
-ordinary Conversation same-thread path requires positive exact-thread evidence from the original
-ProviderAttempt. Each path must bind the source RuntimeSession, thread, selected account, and
-consumer. Unknown, stale, negative, mismatched, incomplete, or ambiguous evidence selects the
-fallback path rather than inferring compatibility.
-
-The fallback path validates the complete deterministic Context-Pack encoding and manifest, stages
-any content-addressed bytes under the existing blob coordination, then inserts its Context Pack,
-selected-account snapshot, starting RuntimeSession, continuation plan, audit rows, outbox rows, and
-exact receipt in one PostgreSQL transaction. A unique decision link makes both paths mutually
-exclusive and exactly once across keys and replay. `replay_permitted` and `dispatch_enabled` are
-structurally false. No ManagedRun identity or Conversation identity changes, and no Turn is
-submitted or replayed. The XY-1402 coordinator consumes one exact V17 plan only for a selected V16
-decision. No production root can call that method. Schema and configured-authority digest regeneration and all
-executable acceptance remain deferred to the single integrated post-freeze gate, so ordinary
-runtime readiness continues to fail closed on this moving-core tree.
-
-V18 consumes only the exact persisted V16 `waiting_usage` decision identity and expected
-ManagedRun revision. PostgreSQL derives the exact earliest-ready instant, policy lineage, run
-lineage, and database clock; the caller supplies no timestamp, candidate, quota evidence,
-eligibility, exclusion, account, or replacement decision. One append-only transition relation is
-the lifecycle, domain-operation result, historical-readback, and cross-key replay authority. Every
-accepted registration, claim, reclaim, fire, cancellation, or supersession operation has one
-globally unique operation identity, canonical request, exact predecessor revision/tip, complete
-resultant state, immutable effect/response bytes, and transaction-bound activity/outbox identities.
-The mutable wake head is only a due-order index and current-tip fence; deferred equality and chain
-checks require it to point to the exact newly appended transition. No command success or historical
-readback is constructed from the head.
-
-Unique registration-decision and run-revision links make registration converge to one durable
-wake, while a different operation identity targeting an existing decision rejects instead of
-aliasing it. V9 exact receipts replay byte-identically by protocol key; the same domain operation
-under a new key can return only its immutable transition result after canonical request equality.
-Due acquisition orders independent waits by exact earliest-ready instant, registration time, and
-wake identity and never pools account quotas. A fixed sixty-second database-authored lease is
-recorded on a claim or reclaim transition after global scheduler serialization. Lease expiry and
-restart append a new reclaim transition rather than rewriting history. Registration, claim, fire,
-and cancellation retain V16's hierarchy/run lock order, so replacement decisions cannot cross a
-stale-lineage check.
-
-Pending or leased heads advance to terminal immutable transitions when explicit cancellation,
-ManagedRun revision/lifecycle/wait reason, divergence, policy revision, V16 decision kind, or
-ambiguous replacement lineage is stale. A valid leased wake fires exactly once into one immutable
-transition containing one `routing_resolution_request_id` whose only authority is fresh routing resolution;
-`fresh_routing_resolution_only=true`, `prior_decision_reusable=false`, and
-`production_enabled=false` are structural. The fired record carries no old universe or evidence,
-and no runtime, protocol, daemon, CLI, scheduler composition root, Codex adapter, credential owner,
-or UI imports V18. Executable timing, crash, replay, concurrency, restart, ACL, hostile-input, and
-isolation acceptance remains deferred to the single integrated post-freeze gate.
-
-V19 is an acceptance-enabling authority repair, not a scheduler feature. V18 and its checksum are
-immutable history. Four new command-complete `SECURITY INVOKER` internals retain the exact V18
-register, claim/reclaim, fire, and cancel transaction paths and add one nullable authority instant.
-Each unchanged public `SECURITY DEFINER` command calls its schema-qualified internal with typed
-`NULL`, so production still samples `clock_timestamp()` only at the original post-lock point; the
-existing Rust/domain/adapter signatures and 51-function runtime execute allowlist do not change.
-Only the migration owner can execute an internal with explicit time. PUBLIC and runtime execution
-are revoked, the internals have no overloads or defaults, and startup closes their exact source,
-metadata, ACL, dependencies, ownership, and role reachability with the canonical function and
-configured-authority inventories.
-
-An explicit instant must be finite and exactly representable in the nonnegative Unix-microsecond
-domain, at most `253402300739999999`, leaving the literal 60-second lease inside the canonical
-application ceiling. Registration cannot precede either the locked V16 decision time or locked
-ManagedRun update time; every later explicit transition cannot precede the locked head timestamp.
-These checks do not change the typed-`NULL` production path. The repair is forward-only: rollback
-means restoring a pre-V19 cluster where the four internals are absent, never editing or reversing
-V18. Schema and configured-authority digest regeneration remains deferred to the refrozen unified
-acceptance boundary.
-
-No production crate or application imports or constructs a V15/V22 experiment execution root.
-The V22 manual Rust runner requires its explicit Cargo feature and binary target. `decodexd`,
-protocol handlers, routing orchestration, and schedulers do not enable or import it. The runner has
-no turn, list, search, archive, retry, adoption, routing, or dispatch API. XY-1402 replaces the
-disabled stateful routing wrapper with a zero-sized coordinator over V16, V17, a live
-ProcessGeneration fence, and ProviderAttempt preparation. The coordinator does not import V18 or
-provide scheduler registration, claiming, firing, cancellation, supersession, credentials, Codex
-mutation, dispatch, replay, or production enablement. The V2.0 protocol adds only a read-only
-immutable decision projection. It exposes none of the authority commands. Production dispatch
-remains disabled until the separate aggregate gate and enablement amendment.
-The production runtime composes the already accepted repository owners exactly once during daemon bootstrap.
-When PostgreSQL is available, it opens the pinned executor, constructs the repository saga over the
-same `PostgresStore`, and performs bounded readback-only restart reconciliation before the protocol
-listener can serve. Executor-open or restart-reconciliation failure leaves the repository runtime
-and product-state composition unavailable and projects `ServerRepositories` unavailable in doctor;
-the typed bootstrap readiness distinguishes executor, reconciliation, and residual-backlog failure.
-Startup observes at most 256 eligible operations plus one residual probe and refuses repository
-readiness if any eligible work remains. It does not create a second store, dispatch path, retry, or
-fallback. Foreground admission, allocation, Register, WorktreeReady, and Commit enter through this
-same retained runtime composition. The protocol still exposes no managed-repository mutation route
-in this gate.
-
-GitHub pull-request and check effects are a separate sealed provider boundary in
-`crates/decodex-runtime/src/github_effects.rs`. It requires explicit provider/repository/revision
-authority, complete pagination, durable markers, and positive readback, but XY-1353 does not invent
-a live credentialed provider or persistence owner. The later Reviewer/landing owner must connect
-that boundary to PostgreSQL effect lineage and an explicitly authorized provider; until then there
-is no live GitHub mutation route.
-
-Legacy `command_receipts` retain the receipt-first fenced-claim protocol only for unrelated blob,
-filesystem, external, or long-running sagas whose point of no return cannot fit in one PostgreSQL
-transaction; managed-repository operations do not use this protocol. Such a flow commits an
-immutable pending receipt before effects; a fenced claim then
-applies the expected revision, appends activity, enqueues outbox, stores exact response bytes, and
-completes transaction B. Durable exact history replay retains its immutable version and referenced
-blob while the legacy receipt exists. Outbox claims are bounded and
-fenced by a token rotated on every claim or reclaim. Any effect that may have begun must be
-reconciled through a meaningful receipt and authoritative readback after claim expiry or
-restart. Lease, retry, and retention durations are exact positive whole milliseconds capped
-at 365 days; stored lease functions enforce the same fixed-millisecond boundary, lease rows
-cannot exceed it relative to their update time, and in-flight outbox leases carry a persisted
-claim-or-renewal timestamp anchor. Delivered outbox retention is finite, positive,
-whole-millisecond, chronological, and capped at 365 days. Delivered rows are terminal and
-immutable until retention pruning is due; no other outbox state is deletable, and table
-truncation is forbidden. Direct SQL therefore cannot delete and recreate a completed external
-effect as replayable work.
-Operation-time triggers reject caller-shifted anchors and
-deadlines beyond the same 365-day horizon; relative-duration `CHECK` constraints remain
-wall-clock independent. Quota mutation responses and command receipts use already validated exact
-UTC Unix-microsecond values, persisted losslessly with no rounding or truncation, rather than caller
-timestamp text. Account and quota-window rows are
-inert observations with recursive credential-material rejection across normalized keys and
-recognizable secret-bearing value encodings. PostgreSQL explicitly normalizes Rust's full
-Unicode `White_Space` set, applies an explicit ASCII case fold, and evaluates the remaining
-case-sensitive regular expressions under the built-in `C` collation. The integration gate
-repeats credential vectors in a Turkish ICU database so database-default case rules cannot
-weaken the direct-SQL boundary; this crate exposes no
-eligibility, account selection, fallback, wake scheduling, or credential storage.
-
-Provider ingress must additionally retain the exact raw timestamp representation until exact UTC
-Unix-microsecond construction succeeds. V14 through V16 do not assume a provider precision and
-fail closed on any value that would require rounding or truncation. Natural characterization and
-retained-title Desktop discovery remain post-freeze evidence owned by XY-1357 and XY-1363,
-respectively; neither is a runtime authority path.
-
-## Retired private-artifact runtime projection
-
-At and after the repository effective point, vNext has no private-artifact runtime,
-API, controller, status surface, command composition, PostgreSQL authority, executor,
-platform layer, or garbage collector. The archived
-[foundations](../specs/private-artifact/foundations.md),
-[persistence and GC](../specs/private-artifact/persistence-gc.md),
-[executor contract](../specs/private-artifact/executor-platform.md), and
-[operations design](../specs/private-artifact/operations-delivery.md) are historical
-and non-executable. Their rules, inventories, delivery edges, CORE-FREEZE, ACC,
-preparation, and unified validation terms cannot authorize current or future work.
-
-Existing text below about the general Decodex root, BlobStore, repositories, Artifact
-revisions, and filesystem helpers describes accepted non-private-artifact surfaces.
-XY-1403 does not change them. The retained-title evidence path uses bounded canonical
-privacy-safe Git receipts and creates no new runtime route, platform layer, storage
-system, schema, compatibility path, or product Artifact.
-
-## Owned vNext paths, configuration, blobs, and cache
-
-`crates/decodex-core/src/paths.rs` owns one absolute, lexically normalized Decodex root
-and the typed private-filesystem contract. On Unix, `path_unix.rs` implements that
-contract by opening every component relative to an already validated directory
-descriptor; reads, listing, removal, temporary-file publication, and synchronization
-therefore cannot be redirected by an ancestor rename or symlink swap. `identity.rs`,
-`blob.rs`, and `cache.rs` own their independent persistence/integrity/bounding policies;
-`storage.rs` owns only their shared redacted error contract.
-The platform default is `~/.decodex`; configured roots are bounded to 4 KiB and roots
-below any `.codex` component are rejected before I/O. Existing root ancestors, the root,
-and every owned descendant reject
-symlinks and unexpected file kinds. On Unix, every owned directory and file must belong
-to the effective OS user; directories must be private mode 0700 and files must deny
-group/other and executable access. Owned writes use same-directory
-private temporary files, file and directory synchronization, and atomic rename or
-create-only hard-link publication. Root layout is fixed:
-
-- `config.toml`: at most 64 KiB, UTF-8 TOML, owner-readable and non-executable with
-  no group/other access (normally mode 0600; mode 0400 is also accepted);
-- `logs/`: Decodex log ownership only; no logging runtime is added by XY-1306;
-- `blobs/sha256/<prefix>/<digest>`: at most 64 MiB per in-memory write, atomically
-  published and fully SHA-256-verified on existing writes and reads;
-- `cache/`: disposable hashed entries bounded simultaneously by configured per-entry,
-  aggregate-byte, and entry-count caps under hard ceilings; recovery removes only exact
-  private `.tmp-<32 lowercase hex>` artifacts left by interrupted atomic writes; and
-- `server/identity`: one canonical RFC 9562 UUID version 4 generated from OS randomness,
-  persisted create-only, and stable across concurrent initialization;
-- `server/decodex.lock`: persistent regular one-link namespace lock with exact mode
-  0600; it is never unlinked during normal lifecycle;
-- `server/decodex.sock.stage`: fixed unpublished bind and crash-recovery name, absent
-  after successful publication; and
-- `server/decodex.sock`: fixed published same-UID Unix endpoint with exact mode 0600.
-
-`crates/decodex-core/src/config.rs` denies unknown fields and discards parser details and
-input excerpts from typed errors. Debug implementations redact operator-provided profile,
-host, repository, database, role, and credential-reference strings. Profiles are a closed
-`local`/`remote` enum. A local profile is valid only as `disabled` with no owner UID or
-`same_uid` with one exact owner UID. It contains no address. Remote profiles carry only a
-bounded host, port, and required expected server identity as inert data. Repository roots exist only in
-`ServerHostConfig` as absolute, normalized, at-most-4-KiB `ServerRepositoryPath` values,
-so a remote profile has no client-local repository-path field. PostgreSQL configuration
-is one explicit bounded Unix-socket directory/port/database, an expected server peer UID, plus
-distinct migration/runtime users and optional, distinct credential environment-variable references.
-`decodex.example.toml` is the redacted canonical shape.
-XY-1307 consumes that data at the runtime composition boundary; core itself still opens
-no database. No CLI, remote listener/security, or credential-vault implementation is part
-of the core foundation.
-
-## Account lifecycle and credential authority
-
-The Mac dogfood and final runtime follow the
-[Account Lifecycle Authority](../specs/account-lifecycle-authority.md). PostgreSQL owns
-credential-negative account state, independent versioned enablement, routing controls,
-and finite operation receipts. One versioned
-HostCredentialStore owns secret bundles. The `decodexd` Account Service owns enrollment,
-import, stable alias derivation, list, enable/disable, logout, refresh/rotation, app-server refresh
-callbacks, runner projection, account observations, and recovery.
-
-The macOS HostCredentialStore uses non-synchronizing Keychain generic-password items. The
-Account Service is its only reader and writer. Exact create, read, compare-and-swap rotate,
-and delete operations remain inside that single-write boundary. MacDogfoodReady also
-requires the complete Account Service, exact-build refresh callback, provider adapter,
-PostgreSQL lifecycle state, startup reconciliation, and clean-start package proof.
-Final AccountLifecycleReady additionally requires the Linux store, explicit Codex auth,
-full bounded account presentation, and later automatic fallback/wake acceptance.
-
-Runner processes use the shared normal `~/.codex`. Initial credentials enter only the
-private app-server process protocol, not process arguments or a long-lived environment.
-The Account UUID and provider binding never change in a live process. Same-account token
-refresh does not create account rebinding.
-
-For new work, `fixed` considers one configured account and `balanced` selects the first
-fully eligible account in versioned canonical order. Both check separate 300-minute and
-10080-minute quota facts. Manual recovery uses versioned enable/disable, mode, or order
-commands and then submits a new task. Automatic cross-account same-thread fallback and
-all-depleted wake remain later XY-1304 obligations.
-
-## Manual reset-card service
-
-Protocol V2.0 exposes bounded account discovery, reset-card observations, manual consume,
-and durable operation-status reads. An observation carries the provider-reported available
-count when present, an explicit detail-completeness flag, and public descriptors only for a
-complete unique inventory. The public identity is one canonical vNext account UUID, its
-optimistic revision, and a card descriptor made only from grant and expiry timestamps. No
-protocol or client type carries the provider credit ID.
-
-The shared Rust service and CLI contain no macOS-only reset-card implementation. They
-run on the supported macOS and Linux runtime hosts. Only the native SwiftUI client is
-macOS-specific.
-Reset-card clients currently accept only a local profile. They reject a remote profile
-before connection because the repository has no authenticated remote reset-card
-transport. The stable JSON account and inventory projections include the selected
-profile name and verified server UUID. A caller can retain that authority on later
-calls with `--profile NAME --expected-server-id UUID`.
-
-`decodexd` is the sole account-operation, app-server process, exact-ID, mutation, and
-effect coordinator. In Mac dogfood and the final runtime, Reset Card obtains one exact versioned bundle
-through the Account Service and HostCredentialStore. PostgreSQL stores only the UUID,
-revision, provider binding evidence, and non-secret account state. New admission requires
-`enabled=true`, AccountLifecycle readiness, no unsettled account operation, an admitted
-observed state, and exact Registry/HostCredentialStore agreement on account revision,
-credential version/fingerprint, and provider binding. The final pre-effect transaction
-repeats every check. The current environment-variable references are pre-cutover
-projection only.
-
-Before any reset-card read or consume, the Codex adapter requires the generated schema to
-advertise both `account/rateLimits/read` and
-`account/rateLimitResetCredit/consume`. It attests the configured account in an isolated
-app-server process. A read accepts the upstream count-only, capped, unknown-extension, or
-otherwise partial detail forms without discarding valid quota facts. A zero reported count
-is a definitive empty inventory even when the optional detail array is null. Only a complete,
-bounded, unique descriptor set can enter exact-credit resolution or effect reconciliation.
-Quota decoding selects the upstream `codex` limit-ID snapshot, or the required default
-snapshot when that map entry is absent. It never merges unrelated limit-ID buckets. A null
-quota window or reset timestamp becomes an independent unsupported-duration result and does
-not invalidate another duration. Before the read, the Account Service refreshes only an
-expired access token or one that cannot cover the bounded process deadline. It serializes
-that refresh under the existing per-account lock and reuses the existing journal and
-credential compare-and-swap. A client selects a public descriptor. The daemon resolves its
-one current opaque provider credit ID.
-
-The consume path commits the logical command, account UUID and revision, public
-descriptor, provider idempotency key, and then the exact provider credit ID before it
-begins the external effect. The provider receipt stores the closed outcome separately
-from the fresh authoritative inventory reconciliation record. `reset`, `no_credit`, and
-`already_redeemed` become terminal only when that exact credit is absent; `nothing_to_reset`
-requires the credit to remain present or its public descriptor to have expired. If the
-process, provider, or daemon stops after the effect can have happened, the durable
-operation becomes `effect_ambiguous`. Restart recovery uses only the persisted exact
-credit ID and the same idempotency key. It never rematches the public descriptor or
-generates a new key. The CLI `status` operation observes this durable state without
-resending the consume command.
-
-Enrollment stores a credential-negative, domain-separated SHA-256 binding fingerprint
-over the account UUID, provider account ID, expected email, and plan type. Restart
-rejects binding drift. A preexisting account can initialize a missing fingerprint only
-when it has no unsettled reset-card operation. Generic account mutation cannot replace
-or remove an established binding.
-
-The reset-card ledger is not part of generic outbox pruning. A durable terminal same-key
-receipt replays unconditionally before current enabled, readiness, store, provider,
-account-state, operation, and revision gates. New work alone reaches the admission and
-effect-start checks above, including the oldest matching public descriptor. After
-terminal authoritative readback proves the effect
-present, PostgreSQL removes the private exact credit ID and provider-key projection
-atomically while it retains the public receipt, reconciliation result, status, and
-same-key replay. A terminal pre-effect rejection or exhausted `not_started` claim also
-removes that private projection.
-
-An active pending command receipt remains `AcceptanceUnknown`; a client must retain its
-key. After the finite claim expires, the same exact key and request can enter the
-receipt's row-locked reclaim path. That path waits for an older transaction to become
-visible, replays an exact committed result if one exists, or installs a new fenced claim
-after rollback. A deterministic pre-effect business rejection completes the claimed
-receipt with a closed rejection and replays that result for the same key. A mechanical
-preparation failure leaves the receipt pending; it remains `AcceptanceUnknown` until the
-same exact request can reclaim it after expiry.
-
-The macOS UI calls an in-process Rust protocol client and decodes the stable JSON
-projection returned across that private ABI. The Rust bridge may start one finite official
-Codex device-login child in an owner-private temporary home when the user explicitly chooses
-`Refresh login`; it never starts the Decodex CLI, a helper, or app-server. The bridge exposes
-only the official URL, one-time code, and closed session state to Swift. It gives the resulting
-private auth-file descriptor to the daemon, which verifies the exact provider, account revision,
-and credential binding before a host-store CAS, then removes the temporary home after success,
-failure, cancellation, or client destruction. Its five-second Reset Card second-click
-confirmation is presentation state only.
-Swift does not stage or read credentials, create a temporary Codex home, launch a process,
-resolve an opaque credit ID, or call the provider method. It persists only a credential-negative
-pending Reset Card operation handle so it can read durable daemon status after an app restart.
-Provider observation, provider-effect retry, and authoritative reconciliation remain
-daemon-only. The UI starts all independent daemon value reads concurrently. It keeps one
-bounded `WaitForAccountObservation` query open instead of owning a second 15-second clock.
-Each daemon publication advances an opaque generation and wakes one coalesced cached-value
-reload; a 30-second daemon heartbeat and bounded reconnect backoff cover missed delivery and
-restart. Panel-open and manual triggers also reload cached values only; none of these reads
-start OpenAI or app-server work. `Refresh login` is the app's only credential-replacement
-surface; the native app ABI has no separate direct refresh command. After successful login
-replacement, bounded local readback waits for the daemon's new revision-scoped observation
-instead of treating an old unauthorized value as the result of the new login.
-
-After the caller creates and durably records an idempotency key for `use`, every CLI
-result repeats that key and one closed `dispatch_state`: `definitely_not_dispatched`,
-`potentially_dispatched`, `durably_accepted`, or `rejected_before_acceptance`. The CLI
-does not generate the key. The Swift client removes a pending handle only for a durable
-terminal result or a rejection before acceptance. It retains the same handle and key for
-the two nonterminal dispatch states. The Swift journal binds each handle to the profile
-name and server UUID. Its atomic write/readback, private modes, intent lock, and journal
-dispatch lock make journal classification and terminal removal one cross-process
-critical section. Corrupt journal data is preserved and blocks new use instead of being
-discarded.
-
-```mermaid
-sequenceDiagram
-    participant Swift as Optional macOS UI
-    participant Native as In-process Rust client
-    participant Protocol as V2.0 same-UID Unix WebSocket
-    participant App as Runtime application
-    participant Store as PostgreSQL reset-card ledger
-    participant Worker as Reset-card worker
-    participant Codex as Account-bound Codex process
-
-    opt macOS UI path
-        Swift->>Native: Submit credential-negative typed request
-    end
-    Native->>Protocol: Consume public descriptor with exact revision and key
-    Protocol->>App: Prepare command
-    App->>Store: Persist receipt and reset-card operation
-    Store-->>App: Prepared
-    App-->>Protocol: Durable prepared state
-    Protocol-->>Native: Receipt and prepared result
-    opt macOS UI path
-        Native-->>Swift: Decode stable JSON result
-    end
-    Worker->>Store: Claim operation
-    Worker->>Codex: Read complete inventory
-    Codex-->>Worker: Complete inventory
-    Worker->>Store: Persist exact provider credit ID
-    Worker->>Store: Begin fenced external effect
-    Worker->>Codex: Consume with persisted provider key
-    Codex-->>Worker: Closed outcome
-    Worker->>Codex: Read fresh authoritative inventory
-    Codex-->>Worker: Authoritative inventory
-    Worker->>Store: Persist receipt
-    Worker->>Store: Reconcile readback and terminal state
-    opt macOS UI status path
-        Swift->>Native: Submit same-key status request
-    end
-    Native->>Protocol: Poll status with the same key
-    Protocol->>App: Query durable operation
-    App->>Store: Read durable operation state
-    Store-->>App: Current durable status
-    App-->>Protocol: Prepared ambiguous completed or failed before effect
-    Protocol-->>Native: Verified status result
-    opt macOS UI status path
-        Native-->>Swift: Decode stable JSON status
-    end
+Status: accepted vNext target architecture. Current source still contains superseded
+numbered schema and startup-provisioning machinery. This document defines the replacement
+target; it does not claim that current source has completed the reset.
+
+There are no external or deployed Decodex users. Local PostgreSQL state is disposable
+development state. The architecture supports an empty-target latest-schema bootstrap,
+not database upgrades.
+
+## Process topology
+
+`decodexd` is the only product daemon and server composition root. It owns:
+
+- the owner-only same-UID Unix WebSocket listener;
+- PostgreSQL runtime connections and product-state adapters;
+- Account Service and HostCredentialStore access;
+- Codex app-server child processes;
+- ProcessSupervisor and ProviderAttemptService;
+- repository and worktree effects;
+- provider observation and reconciliation; and
+- bounded shutdown of every admitted task and child.
+
+`apps/decodex-cli`, `apps/decodex-gpui`, and `apps/decodex-app` are clients. They do not
+read PostgreSQL, credentials, rollout files, blob paths, repositories, or provider-private
+identities directly. `crates/decodex-runtime` is the only library owner that composes the
+protocol and infrastructure adapters.
+
+The local transport endpoint is `~/.decodex/server/decodex.sock`. The server directory,
+persistent lock, staging socket, and published socket keep their existing owner-only
+mode, ownership, one-link, descriptor-relative publication, peer-UID, and replacement
+checks. Remote, cross-UID, and unauthenticated loopback control remain disabled.
+
+## One latest schema
+
+`crates/decodex-postgres/schema.sql` is the only executable PostgreSQL schema owner. It is
+unversioned and represents the complete latest accepted schema. It contains final
+definitions directly for:
+
+- `pgcrypto` and the Decodex namespace;
+- all enum labels;
+- all relations, columns, defaults, constraints, and indexes;
+- all functions and exact function-local settings;
+- all ordinary and constraint triggers and their final bindings;
+- stable object dependencies;
+- owners, grants, revokes, and default privileges; and
+- the exact current `schema_fingerprint` and runtime-authority binding.
+
+It contains no numbered step, ordered history, old-state predicate, upgrade prefix,
+drain, backfill, compatibility branch, rollback branch, finalizer, or fallback. It does
+not alter or drop an old Decodex object to reach the latest shape. Required final enum
+values and object bodies appear in their final `CREATE` definitions.
+
+The old numbered SQL directory, Refinery dependency and runner, schema-history relation,
+version constants, migration error surface, migration-source includes/parsers, prefix and
+upgrade test helpers, and executable schema in `spikes/vnext-storage` are rejected. They
+must be deleted directly. No removal migration is allowed.
+
+### Schema module boundary
+
+The allowed `decodex-postgres` Rust `schema` module has three inseparable duties:
+
+1. prove the clean-target precondition;
+2. execute the one latest schema in one transaction; and
+3. run exact post-execution catalog and configured-authority verification before commit.
+
+The module is not allowed when it only wraps `include_str!`. There is no
+`SchemaManager`, registry, version constant, generated schema pipeline, bootstrap facade,
+or cutover coordinator. Authority-verifier declarations are read-only expected facts;
+they cannot create, alter, repair, or become a second executable schema.
+
+### Empty-target bootstrap
+
+Schema bootstrap is an explicit operator operation, separate from the daemon serve path.
+The implementation-owned command must:
+
+1. accept one explicitly configured PostgreSQL 18 Unix-socket endpoint and an
+   operator-pinned expected server UID;
+2. resolve the schema-owner credential only for this invocation;
+3. verify the socket directory and endpoint by descriptor identity and kernel peer UID
+   before authentication data is sent;
+4. require data checksums and an exact accepted fresh-database catalog baseline, apart
+   from externally provisioned login roles; no user-created schema, relation, function,
+   type, extension, or other product object may exist;
+5. begin one transaction;
+6. execute the complete latest schema once;
+7. verify PostgreSQL major, checksums, `pgcrypto`, catalog shape, dependencies,
+   ownership, ACLs, function/trigger semantics, `schema_fingerprint`, and configured
+   runtime authority; and
+8. commit only when every verification succeeds.
+
+The operation fails closed on a nonempty target. The schema it creates makes a second
+invocation fail. There is no idempotent "ensure schema" mode.
+
+The exact command name is implementation-owned and is not yet specified. Installer code
+may invoke the accepted operator bootstrap for a newly created local target, but it must
+not move schema creation into normal daemon startup.
+
+### Runtime startup
+
+Normal `decodexd` startup resolves only the runtime PostgreSQL credential. It resolves no
+schema-owner credential and executes zero DDL. Its database sequence is:
+
+1. verify the configured Unix-socket path and expected server UID;
+2. connect as the configured runtime identity;
+3. verify PostgreSQL 18, data checksums, and `pgcrypto`;
+4. verify the exact current catalog and `schema_fingerprint`;
+5. verify the complete configured-authority and semantic contract; and
+6. retain the runtime pool only after all checks pass.
+
+Startup never creates, upgrades, repairs, finalizes, or rolls back a schema. It does not
+read a schema-owner password, numbered SQL, a schema-history relation, an old database,
+or a cutover receipt. Any mismatch maps to typed unavailable product state. Doctor/status
+revalidates the same read-only current-authority boundary and never runs DDL or repins an
+endpoint.
+
+### Current catalog and authority verification
+
+The verifier keeps the existing PostgreSQL 18 safety depth. It checks the exact closed
+inventory and semantics of schemas, relations, columns, defaults, enum labels,
+constraints, indexes, functions, triggers, rules, policies, RLS state, sequences, and
+stable catalog dependencies. Foreign keys are checked when a Decodex relation is either
+the child or parent. Extension authority follows dependency membership, not only schema
+placement.
+
+For each function, verification covers identity, overload set, owner, language,
+`SECURITY DEFINER`/invoker status, volatility, parallel safety, configuration, source
+body, ACL, and dependencies. For each trigger it covers name, relation, timing, events,
+constraint semantics, enabled state, function binding, and dependencies. No unexpected
+user trigger, rule, policy, RLS mode, overload, or expression dependency may create an
+indirect runtime path.
+
+Configured-authority verification starts at the runtime login and follows every inherited,
+NOINHERIT, membership-admin, and `SET ROLE` path. It rejects:
+
+- superuser, `BYPASSRLS`, role administration, or ownership of a Decodex object;
+- database, schema, table, function, trigger, rule, policy, sequence, or extension DDL;
+- `TRUNCATE`, grant options, unsafe default privileges, or retention bypass;
+- `session_replication_role` or equivalent trigger-bypass authority;
+- relation DML or helper execution outside the exact adapter contract;
+- sequence authority beyond exact required `USAGE`;
+- PUBLIC execution or relation authority outside the closed contract; and
+- hostile `search_path`, same-signature overload, external cascade, or extension-member
+  paths that could run with stronger authority.
+
+All database functions use exact safe function-local search paths. Trigger-only helpers
+are not directly executable by runtime or PUBLIC. The runtime role cannot mutate current
+catalog identity or `schema_fingerprint`.
+
+The verifier has no schema-history, version-prefix, checksum-ledger, or upgrade predicate.
+It does not parse a sequence of SQL sources. Historical relation/function/trigger counts
+are not authority. The exact current candidate establishes its own reviewed closed
+inventory.
+
+## State ownership
+
+| State or surface | Authority |
+| --- | --- |
+| Projects, Agents, policies, Programs, Objectives, WorkItems, ManagedRuns, Automations, profiles, context, messages, mappings, and UI-visible activity | PostgreSQL domain relations with optimistic revisions, leases, append-only activity, and transactional outbox |
+| Conversations, Turns, RuntimeSessions, history, Context Packs, and routing | PostgreSQL current domain authority |
+| Account product state | PostgreSQL Account Registry |
+| Credentials | one versioned HostCredentialStore |
+| Provider process lifecycle | ProcessSupervisor plus ProcessGeneration records |
+| External Codex turn effects | ProviderAttemptService plus ProviderAttempt records |
+| Repository operation authority and evidence | PostgreSQL managed-repository state |
+| Repository bytes and worktrees | Git and filesystem on the daemon host |
+| PR/check/merge readback | GitHub |
+| Large output/evidence bytes | local content-addressed blob store with PostgreSQL metadata |
+| Codex rollout and thread visibility | shared normal `~/.codex` |
+| GPUI cache | bounded disposable local cache only |
+
+PostgreSQL is not event sourced. `schema_fingerprint`, exact-command receipts,
+account-operation records, ProcessGeneration, ProviderAttempt, activity, outbox, and
+repository-effect records are current domain integrity. They do not record schema
+history or grant schema bootstrap authority.
+
+## Exact commands
+
+Pure database mutations use operation-specific, command-complete database functions.
+PostgreSQL constructs the complete typed request envelope and authoritative response.
+Runtime supplies a protocol-scoped idempotency key and typed operation inputs. It does not
+supply an authoritative request hash, selected row, generated identity, timestamp,
+snapshot, activity identity, or outbox identity.
+
+An exact receipt can be executing only inside its top-level transaction. Commit-time
+completeness rejects an incomplete receipt. Completed success and stable rejection are
+immutable and replay exact stored response bytes. Mechanical database failure rolls back
+instead of becoming a stable domain rejection. The runtime role has no exact-receipt
+relation privilege or private-helper authority.
+
+These records protect command idempotency and atomicity. They are not schema bootstrap,
+schema upgrade, or schema-history records.
+
+## Candidate-5 Quick Task
+
+Candidate 5 is the accepted target for one ordinary multi-turn Quick Task. It is not a
+ManagedRun and has no WorkItem, reviewer, PR, harness, or Goal. Current source must be
+aligned to this target while preserving current-main account observation behavior.
+
+### Owner order
+
+The exact initial order is:
+
+```text
+Conversation create
+-> prospective Turn UUID intent
+-> Routing Snapshot
+-> Routing Decision
+-> first account/profile snapshots + starting RuntimeSession + inert initial plan
+-> Conversation-owned atomic Turn/history admission
+-> Account Service selected-account pre-spawn fence
+-> fresh ProcessGeneration
+-> RuntimeSession thread fence/start/bind
+-> ProviderAttempt
 ```
 
-The current observable flow prepares work synchronously, performs the provider effect in
-the daemon worker, and exposes terminal progress through durable status polling.
+Routing Snapshot locks the complete policy member universe, canonical order, account
+revisions, two separate quota facts per member, required capability facts, and blockers.
+Routing Decision is the sole account selector. Account Service owns lifecycle facts and
+rechecks only the selected account's current readiness, credential version/fingerprint,
+provider binding, and HostCredentialStore binding immediately before spawn. It cannot
+preselect, replace, fall back to, or wake another account.
 
-This service implements the reset-card portion of the [vNext authority contract](../specs/vnext-authority.md)
-and its operator commands and focused tests are listed in [Commands and validation](../operations/commands-and-validation.md).
+Continuation Plan consumes the selected initial decision. In one transaction it creates
+the selected account snapshot, copied RoleProfile snapshot, first revision-1 unfenced
+`starting` RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and
+outbox. Failure rolls back the complete cluster.
 
-## Active Codex adapter foundation
+Conversation authority then admits exactly one Turn with the prospective UUID, sequence
+1, role `user`, `possible_side_effects=unknown`, status `active`, and revision 1 under the
+same Conversation and new RuntimeSession. The same transaction creates exactly one
+ordinal-0 completed Message plus receipt/activity/outbox. A competing key creates no
+partial domain effect. No Turn row exists before this transaction.
 
-`crates/decodex-codex/` structurally extracts request/notification methods from generated
-schema, validates native-collaboration object variants, required fields, field types, and
-referenced enums from `ThreadReadResponse`, and compares canonical JSON digests with the
-accepted XY-1262 receipt before spawning an app server.
-Marker presence is only schema evidence: live method outcomes become explicit `supported`,
-`unsupported`, `unavailable`, or `degraded` states. Every successful probe must enter its
-profile into the exact-build cache, which rejects conflicting replacement and has no
-nearest-build or stale fallback.
+### Closed lineage
 
-Each `SupervisedProcess` owns one immutable shared-home account authority. Credential
-environment variables are removed from the child, initialize must report the normal
-`$HOME/.codex`, no credential-switch operation exists, and read-only `account/read` must
-establish an exact redacted, zeroizing in-memory account identity before a successful probe. On Unix the child starts in a new session;
-bounded shutdown checks the entire process group independently of the leader and escalates
-from termination to kill. Raw JSON-RPC, stderr, account details, and free-form model deltas
-stay inside the adapter. Callers receive typed probe results, stable errors, correlation-
-only message events, and run-local collaboration actors identified by validated UUIDs or
-digests rather than optional nickname/role fields. Build identity is an exact opaque
-fingerprint; statuses, activity kinds, tools, capability reasons, and read-only methods
-are closed enums, so protocol text is not exported through debug or serialization paths.
+The latest schema defines two routing lineage shapes:
 
-The Codex app-server JSONL transport uses its native bare envelope. Outbound requests,
-notifications, and request-error replies omit a `jsonrpc` member. Inbound responses can
-omit the member or include the legacy string `"2.0"`; another value, an explicit null, or
-a non-string value fails closed. Credential projection also requires the exact typed
-`chatgptAuthTokens` success result. Exact request digests cover these native wire bytes,
-so a retained-title experiment prepared with the former envelope cannot be resumed as the
-same request and remains safely ambiguous.
+- `L0`: all six RuntimeSession, account-snapshot, and profile-snapshot identity/revision
+  fields are null; and
+- `L6`: all six are present and the three revisions are positive.
 
-The production command opens the canonical `codex` executable and first rejects interpreter-driven
-files. On macOS, only current native 64-bit thin Mach-O images and native 32/64-bit universal Mach-O
-containers cross this boundary. On Linux, only native ELF images cross it, and account-bound launch
-additionally requires executable sealed-memfd support (`MFD_EXEC`, `F_SEAL_EXEC`, and the write,
-grow, shrink, and seal seals) plus procfs descriptor execution. A host missing any required Linux
-primitive returns executable-unavailable during command construction, before vault projection.
-Shebang wrappers and other formats therefore fail before vault projection on both platforms.
-The platform loader remains responsible for validating the complete image and selecting an
-architecture slice or ELF interpreter; dynamic-loader and shared-library integrity remain part of
-the host OS trust boundary rather than the build digest.
+Conversation routing permits `L0` or `L6`. ManagedRun routing permits only `L6`. All
+existing foreign keys remain. One exact all-null/all-present constraint rejects partial
+lineage.
 
-The runtime copies the accepted source descriptor into a bounded protected object and hashes that
-object for the opaque build identity. On macOS this is a private fsynced mode-0500 file protected by
-`UF_IMMUTABLE`. On Linux it is an fsynced mode-0500 memfd whose contents, size, executable mode, and
-seal set are irreversibly sealed; the runtime verifies every required seal and that
-`/proc/self/fd/<owned-fd>` resolves to the same object. Linux version, schema, and app-server spawns
-execute the sealed memfd. The descriptor is close-on-exec: it remains open while the kernel resolves
-the native ELF image and is closed atomically on successful exec.
+`L0` requires one open exact-revision Conversation, no existing RuntimeSession or Turn,
+zero sticky members, and exact equality with the complete locked routing universe.
+Source fields, sticky members, closed or stale Conversation state, a source-less
+ManagedRun, or missing, extra, duplicate, cross-linked, or reordered evidence fails
+closed. `L6` retains the existing exact one-sticky-member rule.
 
-macOS version and schema preflights execute the immutable snapshot. The final macOS app-server must
-use the canonical executable path because process-aware network extensions assign traffic policy to
-the loaded canonical image. The runtime uses `posix_spawn` to create that image in a new session and
-keeps it suspended before user code starts. Daemon bootstrap has already hashed and statically
-validated the canonical image and immutable snapshot. Each account launch rechecks the canonical
-path, device, and inode, then requires the suspended kernel dynamic-code object to match the
-snapshot's exact CDHash, canonical path, session, and process group. Only a complete match receives
-`SIGCONT`.
-The parent protocol endpoints use private, validated FIFOs opened with atomic close-on-exec flags;
-the FIFO names are removed while the child is still suspended. The child restores the default
-`SIGPIPE` disposition and receives only the fixed `HOME`, system `PATH`, and
-`CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` projection.
+There is one initial route decision. Same-key replay is read-only. A competing cross-key
+initial decision loses under the Conversation lock. Initial planning is first-session
+creation and cannot enter same-thread reuse, explicit successor, or Context Pack fallback.
 
-Startup original-path identity and digest checks establish the exact build. Per-launch metadata
-checks detect path-object drift. On macOS, suspended dynamic-code attestation closes the final
-check-to-exec interval; on Linux, sealed memfd execution is that primitive. A source replacement
-cannot run or receive credentials after the final check. Failure to create, seal, resolve, attest,
-or execute the selected object fails closed. This protection assumes the daemon process and its uid
-are not already compromised. Only tests can inject a fake executable.
-Preflight output/files, generated-schema file count/per-file/aggregate
-bytes/depth, inbound and outbound app-server frames, the stdout queue, collaboration
-receiver count, and thread-list/search results are mechanically bounded; schema traversal
-rejects symlinks and special files. Both preflight commands use bounded process-group
-supervision and descendant cleanup. Failed bounded cleanup transfers the still-owned child, process
-group, and lifetime guard to the hard-capped fair quarantine rather than relinquishing process
-authority. Transfer is bounded; background retries are isolated per round and may intentionally
-retain capacity indefinitely when group death cannot be confirmed.
+### Thread and effect fences
 
-The probe sends `initialize`, `initialized`, read-only `account/read`, and bounded
-`thread/list(useStateDbOnly=true)` with a fixed nonmatching search term. It sends exact-ID
-`thread/read(includeTurns=false)` only if that filtered list unexpectedly returns a thread.
-The exact `alpha.9.2` image advertises `thread/search`, but the method did not return during the
-bounded live check. The probe does not call it and records it as `not_probed`; it does not claim
-global title discovery. Account identity is pseudonymized and re-attested after every authority read;
-an identity change discards the in-progress negotiation, and restart retains the expected
-identity for re-attestation. Search, archive, paginated persisted history, and native collaboration
-remain explicitly `not_probed` while their method or side-effect/event gates are closed. Paginated
-history schema evidence comes from the structural `ThreadStartParams.historyMode` /
-`ThreadHistoryMode` contract, never from a list cursor.
-Current `DispatchGate` has no enabled state and denies thread start/resume, turn
-start/steer/interrupt, and approval responses. The composition root therefore reports
-conversation execution unavailable even though schema validation, read-only probing,
-normalization, and supervision are implemented. Slice 1 must replace that current-source
-posture only for its fenced initial-selection/Quick Task flow. XY-1304 is required later
-for automatic fallback and wake, not for this limited enablement.
+Before ProcessGeneration preparation or spawn, each thread fence/start/bind, and each
+ProviderAttempt prepare/authorize operation, the owner locks and verifies the exact
+selected Turn as active revision 1 under the same Conversation and RuntimeSession.
 
-## Frozen v0.2 runtime provenance
+ProcessGeneration and thread establishment through bind require the applicable
+`starting` RuntimeSession revision. ProviderAttempt preparation and dispatch authorization
+require the exact post-bind `active` revision and the exact completed thread fence and
+bind receipts. A terminalization race loses before an effect.
 
-Everything below this heading maps the preserved `apps/decodex/` source. That package
-is excluded from the active Cargo workspace and is not a runtime, fallback, compatibility
-facade, or implementation authority for vNext.
+Only `Fresh` ProcessGeneration outcome returns the non-clone spawn authority. `Replayed`,
+`Rejected`, and `Unknown` return readback or refusal without spawn authority. They cannot
+spawn, replace, adopt, create a successor, duplicate an attempt, or terminalize the Turn.
 
-`apps/decodex/src/main.rs` calls `decodex::run()`. `run()` does four things (`apps/decodex/src/lib.rs`):
+Conversation authority may move the active revision-1 Turn to `failed` revision 2 under
+the starting session only when positive readback proves definite pre-effect refusal. The
+proof must exclude any process state that may have created a child, every thread fence or
+start/bind, and every prepared, authorized, or unknown ProviderAttempt. Ambiguous work
+keeps the Turn active and returns `Unknown` for manual recovery.
 
-1. Install `color_eyre` error reporting.
-2. Initialize daily rolling tracing files in `~/.codex/decodex/logs`.
-3. Install a panic hook that aborts after the default panic output.
-4. Parse and run the Clap CLI.
+Explicit successor is PostgreSQL-only non-dispatch evidence. It locks the exact Turn named
+by the route decision before any write and requires the same Conversation/source session,
+status `failed`, and revision 2. It has no product or runtime mutation surface.
 
-The crate has a compile-time Unix-only guard: macOS and Linux are supported; Windows is rejected (`apps/decodex/src/lib.rs`).
+### Final trigger definitions
 
-`apps/decodex/src/cli.rs` owns the command surface. Current top-level commands include:
+The latest schema creates the final bodies and unchanged bindings for these seven affected
+trigger functions:
 
-- `run`, `serve`, `status`, `project`, `lane`, `diagnose`, `evidence`, `recover`, `intake`, `mcp`, `probe`, `verify`
-- `commit`, `land`, `git-hook` for Decodex-owned Git lifecycle policy
-- `account`, `app`, `archive-linear`, `maintenance`
-- hidden `_attempt` for daemon-planned child attempts
+| Function | Final Candidate-5 responsibility |
+| --- | --- |
+| `decodex.enforce_routing_completeness()` | Preserve complete existing `L6` policy/evidence rules and add only the exact zero-sticky `L0` branch. |
+| `decodex.enforce_runtime_session_state()` | Permit only request fencing, exact start-response/thread binding, and last-Turn acknowledgement as the narrow nonterminal edges; reject generic `starting` to `active`. |
+| `decodex.enforce_turn_state()` | Under `starting`, permit only exact first-Turn admission and positive definite pre-effect failure; preserve all existing active-session behavior. |
+| `decodex.enforce_history_item_state()` | Under `starting`, permit only the admission transaction's exact ordinal-0 completed Message; preserve existing active-session behavior. |
+| `decodex.enforce_provider_attempt_transition()` | Keep the accepted state algebra and add the immutable RuntimeSession thread-binding receipt identities. |
+| `decodex.enforce_provider_attempt_binding()` | Require the exact initial route/plan/account/session/process/thread receipts and active revision-1 Turn for `initial_thread`; preserve other continuation branches. |
+| `decodex.enforce_continuation_plan_completeness()` | Require the selected `L0` decision and complete first account/profile/session lineage for `initial_thread`; preserve same-thread and Context Pack branches. |
 
-## Runtime state layout
+The latest schema does not roll an old body forward. It creates each final body once.
+`decodex.enforce_routing_decision_completeness()` remains a separate unchanged semantic
+boundary. No trigger is dropped, rebound, disabled, renamed, or used as a broad
+starting-session bypass.
 
-All local runtime state is under `~/.codex/decodex` (`apps/decodex/src/runtime/paths.rs`):
+<a id="account-lifecycle-and-credential-authority"></a>
 
-- `config.toml`: global operator config.
-- `accounts.jsonl`: shared ChatGPT/Codex account pool.
-- `projects/`: registered project contract directories.
-- `logs/`: Decodex tracing logs.
-- `agent-evidence/`: derived repair-agent evidence views.
-- `runtime.sqlite3`: single-machine runtime database.
+## Account lifecycle and observations
 
-`StateStore` opens the runtime DB and bootstraps schema with WAL enabled (`apps/decodex/src/state/sqlite_store/schema.rs`). Base tables include projects, leases, run attempts, protocol events and summaries, run activity summaries, worktrees, and Linear execution events. Bootstrap then adds worktree, review, evidence artifact, run-control, connector backoff, private execution event, Decision Contract, autonomy, Execution Program, Program Intake, loop guardrail, and migration schemas.
+The account system has three owners:
 
-## Project contracts
+1. Account Registry owns credential-negative product state.
+2. HostCredentialStore owns versioned secret bundles.
+3. Account Service coordinates enrollment, import, stable alias derivation, list,
+   enable/disable, logout, refresh/rotation, app-server refresh callbacks, runner
+   projection, account observations, recovery, and process pre-spawn checks.
 
-A project is not discovered from a checkout. It is explicitly registered from a project directory containing `project.toml` and `WORKFLOW.md` (`apps/decodex/src/config/service.rs`, `apps/decodex/src/cli/control_commands/project.rs`). `project.toml` fields are parsed by `ServiceConfigDocument` (`apps/decodex/src/config/document.rs`):
+The exact stable alias derivation and closed alias set remain owned by
+[Account Lifecycle Authority](../specs/account-lifecycle-authority.md). Account Service
+returns each alias. Clients present it and do not derive, rename, or own alias state.
+Account UUID remains the row and routing identity.
 
-- `service_id`
-- `[tracker]`
-- `[github]`
-- optional `[codex]`
-- optional `[autonomy]`
-- optional `[privacy_classifier]`
-- `[paths]`
+One Codex process keeps one immutable Account UUID and provider binding for its lifetime.
+Same-account token refresh may advance the credential version. It cannot switch accounts.
+Credentials never enter PostgreSQL, public protocol data, process arguments, logs, or a
+long-lived child environment.
 
-At the v0.2 freeze, `decodex.example.toml` was the safe project-config model. The current
-checked-in file now owns the vNext global config shape above and is not an input or
-compatibility template for the frozen package.
+The daemon account observer starts immediately, repeats on its bounded schedule, and
+wakes after relevant account/effect changes. Different accounts progress concurrently.
+Within one account, Reset Card work settles before profile observation so the profile uses
+the exact successor credential. At most one observation owner is active per Account UUID;
+additional wakes coalesce into one successor round. Slow work for one account does not
+delay another.
 
-## One-shot run flow
+Results publish progressively only against the current Account revision and cache
+generation. A changed account invalidates its old Reset Card/profile state before a stale
+in-flight result can publish.
 
-`decodex run` is implemented by `apps/decodex/src/cli/control_commands/run.rs` and `apps/decodex/src/orchestrator/entrypoints/run.rs`.
+`GetResetCards` and `GetAccountProfile` are isolated reads. They do not contact the
+provider, start an app-server, join a refresh future, wait for an observation round, or
+cause provider work. Profile reads use the latest persisted projection plus bounded
+daemon refresh status. Reset Card reads use a revision-fenced daemon-lifetime public
+cache. Restart discards that cache and reports typed retryable unavailability until the
+new observation warms it.
 
-The high-level flow is:
+The UI starts independent daemon value reads concurrently and keeps one bounded
+`WaitForAccountObservation` query open instead of owning a second refresh clock. Each
+daemon publication advances an opaque generation and wakes one coalesced cached-value
+reload. Panel-open and manual triggers reload cached values only; they do not start
+provider or app-server work.
 
-1. Open the global runtime store.
-2. Resolve a project config from `--config`, current checkout registry mapping, or the registered project table.
-3. Register or refresh the project config in runtime state.
-4. Load the project `WORKFLOW.md`.
-5. Respect stored tracker connector backoff.
-6. Optionally explain the queue for `--dry-run --explain`.
-7. Call `run_configured_cycle`.
+The macOS UI uses its existing in-process Rust protocol client. `Refresh login` is its
+only credential-replacement surface, and the native app ABI has no separate direct
+credential-refresh command. Account Service and HostCredentialStore retain credential
+verification, mutation, and refresh ownership. Swift does not stage or read credentials
+and does not own provider observation. After successful login replacement, bounded
+readback waits for the daemon's new revision-scoped observation instead of accepting an
+old unauthorized value.
 
-`run_configured_cycle` loads `ServiceConfig`, workflow, and a Linear client. If an issue id is supplied, it runs that target issue with inferred or explicit dispatch mode; otherwise it runs project selection (`apps/decodex/src/orchestrator/run_cycle.rs`). Preparation validates workflow read-first files, plans worktree state, resolves run identity, acquires leases, and materializes the lane through the run-cycle modules.
+Candidate-5 changes must preserve this current-main observation/cache and UI/backend
+behavior exactly.
 
-Recent source adds a baseline guard before ordinary, Program, and retry dispatch. `ensure_clean_baseline_before_dispatch` checks workflow canonicalization commands, records private events, serializes normalization with `.decodex-baseline-normalization.lock`, may create/land a baseline normalization PR, and blocks if canonicalization still rewrites tracked files (`apps/decodex/src/orchestrator/baseline_guard.rs`). This came from recent commits titled "Guard baseline canonicalization before dispatch" and should be considered part of current dispatch safety.
+## ProcessGeneration
 
-## Long-running control plane
+ProcessSupervisor is the sole ProcessGeneration writer. A generation binds one account,
+initial account revision, credential version/fingerprint, provider binding, exact-build
+capability profile, execution epoch, attested launch manifest, boot identity, process
+identity, state, revision, and timestamps. It stores no secret.
 
-The excluded frozen v0.2 `decodex serve` source calls
-`orchestrator::run_control_plane` through
-`apps/decodex/src/cli/control_commands/serve.rs`. Its historical operator listener
-default is `127.0.0.1:8192`. The active workspace, local service, and macOS App do not
-build, package, start, or connect to that listener.
+The durable states are `starting`, `ready`, `stopping`, `dead`, and `death_unknown`.
+Only positive generation-bound evidence can establish `dead`. PID or process-group
+absence, reuse, timeout, lease expiry, EOF, restart, identity mismatch, row absence, and
+negative search do not prove death.
 
-Each daemon tick (`apps/decodex/src/orchestrator/daemon.rs`):
+Startup projects every present nonterminal generation to `death_unknown`, performs one
+bounded positive-only reconciliation pass, and continues background reconciliation.
+Uncertainty blocks replacement only for the bound account. A restored process can be
+observed but not adopted, proxied, reacquired, signaled, or terminated. Exact termination
+requires the original unreaped child.
 
-- reconciles active child process state and retry queue entries
-- recovers and reconciles idle project state when no active children exist
-- reconciles post-review orchestration
-- reconciles terminal thread archive backlog
-- spawns due child attempts until no more can start
+The execution-epoch authorization digest remains outside PostgreSQL. Database restore or
+row replay cannot mint a fresh process fence. ProcessGeneration proves replacement
+safety, not provider non-submission.
 
-`openwiki/workflows/runtime-operator-workflows.md` records the current cadence: operator snapshots publish every 15 seconds, and Linear-backed queue/status scans run at most every 5 minutes per project unless `POST /api/linear-scan` requests a scan.
+## ProviderAttempt
 
-## Frozen app-server execution
+ProviderAttemptService is the sole external Codex turn-effect writer. One attempt binds
+either a Conversation Turn or a ManagedRun execution to the accepted route decision,
+continuation plan, RuntimeSession, selected account, ready ProcessGeneration, execution
+epoch, request identity/digest, and provider correlation/idempotency keys.
 
-The excluded v0.2 `apps/decodex/src/agent/app_server/run.rs` owned direct live
-`codex app-server` execution. It is provenance only and must not be used by vNext. One
-legacy attempt:
+The ordinary states are:
 
-1. Records run attempt status as `starting`.
-2. Writes activity markers when configured.
-3. Publishes a run-control channel for lane control.
-4. Spawns `codex app-server` through the JSON-RPC client.
-5. Initializes the client and records user-agent/capability evidence.
-6. Runs capability preflight and optional `command/exec` health check.
-7. Logs into a selected Codex account when account-pool routing is configured.
-8. Starts or resumes a thread session.
-9. Records `running`, executes the turn loop, then records `succeeded`.
-10. Retires the run-control channel as completed or failed.
+```text
+prepared -> canceled | dispatch_authorized
+dispatch_authorized -> succeeded | failed_definitive | not_submitted | unknown
+unknown -> succeeded | failed_definitive | not_submitted
+```
 
-`openwiki/specs/contracts-and-data.md` summarizes protocol requirements: Decodex uses `stdio://`, expects generated-schema compatibility, requires phase-goal methods, exposes issue-scoped dynamic tools, and treats `decodex probe stdio://` with `PROBE_OK` as a live compatibility check.
+Terminal outcomes after authorization require positive evidence. Timeout, process death,
+EOF, restart, lease expiry, absent rows, missing events, exhausted lists, and negative
+search cannot establish `not_submitted`. A replacement can reconcile the original attempt
+but cannot replay it. Late positive evidence remains attributable to the original attempt.
 
-## Tracker bridge and completion
+On restore, present `prepared` and `dispatch_authorized` attempts project to `unknown`.
+Startup performs one bounded positive-only pass and background reconciliation continues
+without starving later attempts.
 
-The issue-scoped tracker bridge in `apps/decodex/src/agent/tracker_tool_bridge.rs` binds the agent to one leased issue. It exposes dynamic tool names such as `issue_transition`, `issue_comment`, `issue_label_add`, `issue_progress_checkpoint`, `issue_review_checkpoint`, `issue_review_handoff`, `issue_review_repair_complete`, `issue_closeout_complete`, and `issue_terminal_finalize`.
+## Stateless execution coordination
 
-The important architecture boundary is not the tool list itself; it is who owns what:
+ExecutionCoordinator is a zero-sized crate-private sequencer. It retains no relation,
+receipt, retry state, task, channel, lifecycle, account choice, RuntimeSession choice,
+process state, or ProviderAttempt state. It consumes typed outputs from the sole owners
+and returns an inert projection until a separately accepted product dispatch root exists.
 
-- The agent may perform bounded issue-scoped tracker writes through dynamic tools.
-- The runtime still owns leases, worktrees, retries, recovery, crash fallback, post-review lifecycle, and cleanup.
-- Private evidence goes into runtime SQLite before any public Linear projection when a tool has both private and public effects.
-- Terminal completion must be explicit; the runtime should not guess whether a lane meant review handoff, manual attention, repair completion, or closeout.
+Conversation remains the ordinary Turn owner. ManagedRun remains its own lifecycle and
+acceptance owner. Routing Snapshot/Decision own eligibility and selection. Continuation
+Plan owns first-session, same-thread, and Context Pack planning. ProcessSupervisor owns
+process fences. ProviderAttemptService owns provider effects.
 
-## Operator HTTP and dashboard
+The protocol may expose read-only immutable execution-decision projection. It exposes no
+route, session, process, attempt, wake, retry, receipt, or dispatch mutation.
 
-`apps/decodex/src/orchestrator/operator_http.rs` owns the local HTTP endpoint, dashboard support constants, API routes, and WebSocket/control traffic. Routes are parsed in `apps/decodex/src/orchestrator/operator_http/routes.rs` and dispatched by `apps/decodex/src/orchestrator/operator_http/server.rs`: `/livez`, `/api/operator-snapshot`, `/dashboard/control`, `/api/accounts`, `/api/linear-scan`, `/api/lane/inspect`, `/api/lane/interrupt`, and `/api/lane/steer`/`/api/lane-steer`. `apps/decodex/src/orchestrator/operator_http/assets.rs` defines the dashboard/client limits, HTTP read timeout, and volatile run-activity fingerprint fields.
+## Managed repositories
 
-The published dashboard snapshot is a cached JSON serialization of `OperatorStatusSnapshot` protected by the `OperatorStateEndpoint` mutex; `publish_snapshot` is the only writer and broadcasts a `snapshot` WebSocket event after updating it (`apps/decodex/src/orchestrator/types/operator_endpoint.rs`). `/api/operator-snapshot` and the dashboard WebSocket read from that cache, inject live global account-control state, and add presentation fields (`apps/decodex/src/orchestrator/operator_http/snapshot.rs`). Runtime lifecycle state still belongs to SQLite, leases, worktrees, tracker ledgers, and daemon/recovery code; HTTP and WebSocket paths are readback/control projections, not new ownership stores.
+PostgreSQL remains durable authority for each managed repository projection, monotonic
+generation/tip, globally immutable operation assignment, append-only authority and
+operation evidence, exact compare-and-swap, transaction completeness, and restart loads.
+Git/filesystem execute admitted effects; GitHub supplies provider readback.
 
-Dashboard streaming has two readback paths. `snapshot` events follow control-plane publication, normally once per 15-second tick; `runActivity` events are a lighter 1-second stream that rebuilds current-lane projections without live external observers, strips volatile timing fields from its fingerprint, suppresses duplicate broadcasts, and can be filtered by project, issue, or run subscription (`apps/decodex/src/orchestrator/constants.rs`, `apps/decodex/src/orchestrator/operator_http/dashboard/run_activity.rs`, `apps/decodex/src/orchestrator/operator_http/dashboard/subscription.rs`). Dashboard control messages are intentionally narrow: focus/subscription changes are session-local, acknowledgements are session-local, and account selection only changes the global Codex account selector through the accounts module (`apps/decodex/src/orchestrator/operator_http/dashboard/control_actions.rs`).
+Each external operation has one complete canonical descriptor. Exact equality with an
+existing assignment returns readback with no dispatch. Any difference is a permanent
+operation-ID conflict. A fresh affine execution receipt exists only after successful
+commit acknowledgement on the same live adapter path. Readback, restart, terminal state,
+or an unknown commit outcome cannot reconstruct it.
 
-Account HTTP APIs delegate to account-domain commands: list with optional usage refresh, select, clear, logout, import, use, and reroll name (`apps/decodex/src/orchestrator/operator_http/api/account.rs`). Lane inspect, interrupt, and steer delegate to `lane_control` with registered-project resolution and keep audit/control effects in runtime state (`apps/decodex/src/orchestrator/operator_http/api/lane.rs`). Private execution evidence is read back through `decodex evidence`, where `build_private_evidence_readback` loads local SQLite private events, summarizes payloads by default, and emits stable `private-evidence:<project>/<issue>/<run>/<attempt>` references (`apps/decodex/src/orchestrator/agent_evidence/private_readback.rs`); dashboard/operator status may show the reference and read command, but raw private payloads are not a public dashboard contract.
+Restart may perform only operation-specific read-only reconciliation. It never retries,
+replays, adopts, repairs, or imports an external effect. These domain records remain
+current product authority and are unrelated to schema upgrades.
 
-Linear-facing updates stay sparse. The progress checkpoint tool first records the full execution-state checkpoint as private runtime evidence, then publishes only a low-frequency public Linear projection when the public lifecycle signal/idempotency key changes (`apps/decodex/src/agent/tracker_tool_bridge/tools/progress_checkpoint/handler.rs`, `apps/decodex/src/agent/tracker_tool_bridge/tools/progress_checkpoint/projection.rs`). Control-plane Linear scans run at most every 5 minutes per project unless `/api/linear-scan` queues an all-project or project-scoped scan for the next tick; that request still waits behind active tracker connector backoff (`apps/decodex/src/orchestrator/entrypoints_control_plane.rs`, `apps/decodex/src/orchestrator/entrypoints_control_plane/project_tick.rs`, `apps/decodex/src/orchestrator/operator_http/api/linear_scan.rs`). Rate-limit and timeout detection are modeled as connector backoff warnings (`tracker_rate_limited`, `tracker_transient_timeout`), persisted in runtime state, included in snapshots, and used to skip external observer reads until retry is safe (`apps/decodex/src/orchestrator/entrypoints_tracker_backoff.rs`, `apps/decodex/src/orchestrator/status/snapshot/observers/backoff.rs`).
+## Paths, blobs, and protocol
 
-Current non-goals are important boundaries: the operator HTTP server is loopback-local by default, not a durable workflow engine; dashboard focus/ack messages are not lifecycle events; account controls affect future account selection but do not rewrite existing lane authority; `/api/linear-scan` requests observation rather than dispatch; and lane steering/interrupt APIs must continue to honor lane-control preconditions, leases, private audit evidence, and tracker/public-text privacy boundaries.
+`decodex-core` owns the typed `~/.decodex` root for configuration, logs, stable server
+identity, SHA-256 blobs, and disposable cache. Repository paths and PostgreSQL socket
+paths reject symbolic links and replacement according to their owner-specific
+descriptor rules. Shared normal `~/.codex` remains Codex configuration, rollout, plugin,
+and thread-visibility authority.
 
-## MCP gateway
+The exact-current protocol carries bounded command/result/event envelopes, snapshots,
+history pages, account queries, Reset Card operations, and read-only diagnostics.
+Unsupported protocol revisions receive typed refusal. Non-loopback binding remains
+disabled until authentication, TLS, authorization, and redaction gates pass.
 
-`apps/decodex/src/mcp.rs` serves MCP over stdio or Streamable HTTP:
+Blob-backed commands keep their receipt-first, exact-response, create-only publication
+contract. PostgreSQL owns metadata and references; local CAS owns bytes. PostgreSQL alone
+does not attest external bytes. Clients never receive local blob paths.
 
-- Stdio defaults to `admin` capability profile.
-- Streamable HTTP defaults to `observe`, binds to `127.0.0.1:8193`, serves `POST /mcp`, validates origins, manages `Mcp-Session-Id`, and requires bearer auth for non-loopback or profiles above observe (`apps/decodex/src/mcp.rs`, `openwiki/workflows/runtime-operator-workflows.md`).
-- Tool profiles are `observe`, `plan`, `operate`, and `admin`.
-- Tools include `decodex_observe`, `decodex_plan`, goal/autonomy planning tools, `decodex_lane_control`, and `decodex_project_control` (`apps/decodex/src/mcp.rs`).
+## Local development replacement
 
-MCP is a typed facade over existing runtime and operator controls. It is not a bypass around Decision Contract acceptance, lane-control preconditions, tracker boundaries, review policy, or project enablement. The design rationale for keeping MCP typed and skills slim lives in [Design rationale](../decisions/design-rationale.md); the current remote-control drift audit lives in [Drift audits](../evidence/drift-audits.md).
+One reviewed operator-only action can stop the daemon and capture the complete
+credential-negative reset tuple. For every retained account, the tuple contains Account
+UUID, enabled state, account revision, provider binding, credential version/fingerprint,
+and host-store binding. It also contains routing revision, mode, fixed target, and the
+complete account order. The action can replace or directly transform the disposable
+local database, run empty-target bootstrap when needed, restore or rebind that exact
+tuple against unchanged host-vault credentials, prove exact readback, and restart the
+daemon.
+
+`fixed` mode requires one non-null target in the retained account set and order;
+`balanced` mode requires a null target. The order is a complete duplicate-free
+permutation of retained accounts, including disabled accounts, and readback proves each
+account's exact enabled state together with the exact mode, target, and order.
+
+For credential agreement, the action may invoke the existing `HostCredentialStore`
+owner. The owner performs a confined in-process exact read, recomputes and compares the
+credential fingerprint and binding, and returns only a typed credential-negative
+agreement result. Neither the action nor its result may expose, serialize, copy, log,
+persist, rotate, delete, or return token bytes. This is not a product or migration API,
+generic attestation framework, metadata sidecar, generic importer, schema migrator,
+backup/rollback path, receipt/finalizer, or fallback. Normal daemon startup never
+performs it.
+
+## Frozen provenance
+
+`apps/decodex/`, Lane Authority v2, PR #1092, private-artifact documents, old numbered
+schema evidence, old schema receipts, and storage-spike execution are historical only.
+They may explain past behavior or a rejected design. They cannot define vNext runtime,
+schema, command, test, or delivery authority.
+
+When a historical invariant is still required, restate and prove it against the one
+latest schema and current owner boundary. Do not revive its old version label, upgrade
+path, compatibility mechanism, or executable schema owner.
 
 ## Change guidance
 
-- CLI changes: start in `apps/decodex/src/cli.rs` and the owning submodule under `apps/decodex/src/cli/`; add parser tests under `apps/decodex/src/cli/tests/`.
-- Runtime scheduling changes: start in `apps/decodex/src/orchestrator/run_cycle.rs`, `apps/decodex/src/orchestrator/daemon.rs`, and the lifecycle-specific orchestrator submodule; expect dense tests under `apps/decodex/src/orchestrator/tests/`.
-- State changes: start in `apps/decodex/src/state/sqlite_store/schema.rs`, migrations, row parsers, and `StateStore`; protect replay/idempotency with state tests.
-- vNext app-server foundation changes: start in `crates/decodex-codex/`; run its schema,
-  fake-process, supervision, redaction, and dispatch-guard tests. The excluded
-  `apps/decodex/src/agent/app_server/` is provenance only.
-- Operator/MCP changes: update HTTP/MCP tests and check public/private projection boundaries before exposing new fields.
+- Schema creation changes start in `crates/decodex-postgres/schema.sql` and the substantive
+  `schema` module. Do not add another SQL owner.
+- Runtime database changes must preserve zero-DDL startup and current-authority
+  verification.
+- Candidate-5 changes must preserve sole account selection, atomic first Turn/history
+  admission, exact effect fencing, and current-main account cache-read isolation.
+- ProcessGeneration changes must preserve positive-only death and account-local
+  quarantine.
+- ProviderAttempt changes must preserve positive-only outcome evidence and no replay.
+- Account changes must preserve the Registry/store/service split and secret-negative
+  database/protocol boundary.
+- Historical migration evidence is provenance only. No acceptance claim may depend on a
+  historical upgrade or ledger proof.

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -1,395 +1,305 @@
 # Decodex vNext Authority Decision
 
-Status: accepted repository authority for vNext. The XY-1403 private-artifact
-retirement takes effect only at the exact repository effective point in the
-[retirement decision](../specs/private-artifact/decision.md#repository-effective-point).
+Status: accepted repository authority for the vNext target. This decision describes
+the target architecture. It does not claim that current source implements the target.
 
-Tracking issue: [XY-1260](https://linear.app/hack-ink/issue/XY-1260/promote-the-vnext-authority-contract-and-supersede-lane-authority-v2)
+Owner issue: [XY-1260](https://linear.app/hack-ink/issue/XY-1260/promote-the-vnext-authority-contract-and-supersede-lane-authority-v2)
 
-Source planning record: [Decodex vNext Design Baseline](https://linear.app/hack-ink/document/decodex-vnext-design-baseline-681f7d8ad284), accepted 2026-07-12 against repository snapshot `5546dcb3b2eb0a8aecf7d6a3b117d2605ea315b8`.
+## No-migration reset
 
-Authority amendment: Manager decision accepted 2026-07-13. The decision accepts the
-conceptual XY-1262 foundation/live-enablement split proposed by merged PR #1098 at
-`687605583817eca32cbdfb1107f3ee18d3106cea`, but only through this independently
-reviewed normative amendment. The merged proposal was evidence, not authority by
-itself. Repository authority remains normative; Linear is planning metadata.
+There are no external or deployed Decodex users. Current local PostgreSQL data is
+disposable development state. Decodex therefore has no supported database-upgrade
+contract and no compatibility obligation to an older Decodex catalog.
 
-XY-1271 storage-boundary amendment accepted 2026-07-14: retain the migration and
-daemon-private runtime identities, and treat `decodexd`, that identity, and BlobStore access as one
-trusted service boundary. PostgreSQL owns committed metadata/domain/receipt/activity/outbox state;
-local CAS owns large bytes, which PostgreSQL alone cannot attest. Blob-backed commands use a
-receipt-first, fenced, exact-response saga and dedicated session-level hash plus per-shard
-coordination around create-only synchronized CAS publication. Arbitrary/manual use of the private
-runtime credential is unsupported and equivalent to daemon compromise.
+This instruction changes the context of the accepted vNext product decision. The
+continuity relation is `same_decision_changed_context`: the product and Candidate-5
+Quick Task remain the target, but the old versioned schema plan is superseded.
 
-Readiness authority correction accepted 2026-07-16: Codex 0.144.2 and 0.144.4 expose
-no stable passive complete account-owned plugin, skill, and MCP readiness receipt. Passive
-inventory is therefore withdrawn from the accepted XY-1262 foundation evidence. Host files,
-manifests, configuration, remote catalogs, process binding, and user declarations do not become
-observed account readiness. The first-release doctor result remains typed `unknown` for plugins;
-`plugin_unready` is inert reserved state. XY-1336 tracks the upstream receipt gap outside the
-vNext critical path and neither closes nor blocks XY-1275.
+Decodex vNext has exactly one canonical, unversioned latest PostgreSQL schema source:
+`crates/decodex-postgres/schema.sql`. That file contains the final definitions for all
+accepted enums, relations, constraints, indexes, functions, triggers, dependencies,
+owners, and grants. It contains no old-state branch, drain, backfill, compatibility
+definition, or reverse operation. A definition that exists only to transform an older
+Decodex catalog has no place in the latest schema.
 
-XY-1423 account-lifecycle authority correction accepted for the vNext replacement
-boundary: PostgreSQL owns credential-negative account product state, a narrow
-HostCredentialStore owns only versioned secret bundles, and the `decodexd` Account
-Service coordinates every account operation. Versioned `enabled` state is independent
-from observed health and quota. Fixed selection, balanced selection, and complete account
-order are deterministic versioned CAS controls. The immediate boundary is
-MacDogfoodReady; final AccountLifecycleReady adds Linux, ambient Codex auth, full account
-presentation, and later automatic routing obligations.
+The following mechanisms are rejected product and repository architecture:
 
-The continuously watched legacy account file and environment-only access-token
-projection are retired. Normal Mac dogfood startup and installation cannot read either
-one. A clean local cutover creates an empty current database and uses the ordinary
-versioned account-import command once per local credential. After public readback
-verifies every account and routing control, the operator deletes the temporary import
-files and old account source. The product has no bulk migration, compatibility reader,
-dual authority, or fallback. Shared normal `~/.codex` remains Codex configuration,
-plugin, rollout, and thread visibility authority.
+- numbered schema SQL files and version constants;
+- Refinery or another schema migration runner;
+- a schema-history relation, ordered schema ledger, or upgrade-prefix check;
+- upgrade branches, compatibility DDL, migration receipts, finalizers, or fallback;
+- Phase A or Phase B schema-migration receipts and source/restore digest transitions;
+- a generated second executable schema owner;
+- a `SchemaManager`, schema registry, generator pipeline, bootstrap facade, or cutover
+  coordinator; and
+- the executable schema owner in `spikes/vnext-storage`.
 
-The exact protected Codex build must positively prove the
-`account/chatgptAuthTokens/refresh` callback before readiness. The current exact
-`codex-cli 0.146.0-alpha.9.2` profile handles the root refresh request and response through
-the Account Service, subject to exact-image, generated-schema, and live callback
-preflights. The existing V23 ProcessGeneration intent, manifest, fence, and readback bind
-the initial account revision, canonical credential version/fingerprint, provider identity,
-and callback profile; no new ledger is added. The normative details are in
-[Account Lifecycle Authority](../specs/account-lifecycle-authority.md).
+Delete the old machinery directly. Do not add a migration that removes migrations.
+Historical evidence that refers to migrations remains provenance only. In particular,
+the old V14, V16, V17, V33, and V34 labels and their allocation are rejected. Their
+accepted final domain semantics must be expressed in the latest schema and current
+owner names.
 
-XY-1274 quota-authority amendment accepted 2026-07-16: quota storage accepts only exact
-product-valid Unix microseconds, and no layer may round or truncate an ingress timestamp.
-Canonical quota mutation identities move to their `/2` typed-integer documents. The V8
-migration is an atomic zero-state boundary that locks every quota writer surface, rejects all
-structurally classified pre-V8 quota evidence, and alters the proven-empty `quota_windows`
-table in place. Populated V7 conversion and table drop/recreation are not compatibility
-features. Recovery is whole disposable pre-release database recreation; XY-1302 retains
-whole-ledger production-baseline and cutover authority. XY-1357 must retain and characterize the
-natural raw upstream timestamp before live quota ingestion or routing, and a value that cannot be
-converted exactly to UTC Unix microseconds keeps production routing disabled and reopens only the
-ingress authority. The normative
-details and proof gates live in the authority contract and gate manifest; the three rejected
-old-boundary candidates remain historical provenance in the runtime proof.
+`decodex-postgres` owns the one schema source and exact current-authority verification.
+A Rust `schema` module is allowed only when it owns all three substantive bootstrap
+responsibilities: the clean-target precondition, one transactional schema execution,
+and post-execution verification. A module that only wraps `include_str!` is not an
+owner and is prohibited.
 
-XY-1272 PostgreSQL-authority reset accepted 2026-07-16: XY-1272 owns only configured-principal
-and ACL manifest/readiness closure against landed V8. It owns no migration or Codex creation,
-mapping, or reconciliation surface. Under the later XY-1345 reset, XY-1346 owns expected V9 and
-re-bounded XY-1337 owns expected V10; XY-1358/V15 owns causal experiment creation
-and positive-only observation authority; XY-1276 owns production Quick Task creation. Lossy or
-paginated Codex evidence cannot authorize negative `Present`, `Complete`, or context-free `Absent`
-authority. A future configured PostgreSQL role must atomically extend configuration, bootstrap,
-manifest/readiness, and negative tests.
+Normal `decodexd` startup is runtime-only. It resolves no schema-owner credential,
+executes zero DDL, and does not create, alter, repair, or upgrade a catalog. It connects
+with the configured runtime identity and verifies the exact current catalog and
+configured authority. Any missing, extra, changed, unsafe, or unreachable authority
+keeps product state unavailable.
 
-XY-1345 exact-command authority amendment accepted 2026-07-16: pure database commands use
-operation-specific, command-complete `SECURITY DEFINER` entrypoints. PostgreSQL constructs and
-consumes the complete typed request envelope; runtime supplies only the protocol-scoped
-idempotency key and typed operation inputs. A separate `decodex.exact_command_receipts` relation is
-keyed by `(protocol_version, idempotency_key)`, while operation identity remains inside the
-envelope so cross-operation reuse conflicts. Runtime has no exact-receipt table privilege and no
-private-helper or canonical activity/outbox mutation authority. An executing row is transaction
-internal: a `DEFERRABLE INITIALLY DEFERRED` commit-time invariant rejects every incomplete commit,
-and completed response bytes and effects are immutable and undeletable. Stable domain rejection,
-idempotency conflict, and retryable infrastructure failure are distinct outcomes.
+Schema creation is one explicit operator action against an empty PostgreSQL 18 target.
+That action resolves the schema-owner credential, proves the clean-target precondition,
+executes the complete latest schema in one transaction, verifies the resulting catalog
+and configured authority, and commits only when every check passes. A second bootstrap
+against that now nonempty target fails closed. Bootstrap is not daemon startup.
 
-Normal execution is one exact command per top-level `READ COMMITTED` transaction. The command uses
-a later read/lock statement after `ON CONFLICT DO NOTHING`; classified `40001` and `40P01` failures
-retry the whole identical transaction. Request JSONB uses equality, includes every optional key
-with explicit JSON null, receives enums/numerics through typed inputs, and preserves exact
-PostgreSQL text/code-point semantics. Derived revisions, selected rows, generated identities,
-timestamps, digests, snapshots, activity/outbox identities, and responses are effects. Effect and
-response evidence comes from actual `RETURNING` rows and canonical audit identities.
+## Preserved PostgreSQL boundary
 
-Candidate 3 is superseded as implementation and remains hostile-test/design provenance only.
-[XY-1345 evidence](../evidence/xy-1345-exact-command-authority.md) records the passing isolated
-PostgreSQL 18 proof. The serial vertical order is XY-1345 authority/prototype, then XY-1346 exact
-receipts plus immutable global RoleProfile bootstrap/update in V9, then re-bounded XY-1337
-RuntimeSession V10. Legacy
-`command_receipts` semantics remain unchanged for unrelated external or long-running sagas.
+The reset keeps PostgreSQL 18, data checksums, `pgcrypto`, and the verified Unix-socket
+boundary. It also keeps exact attestations for:
 
-XY-1337 RuntimeSession amendment, implemented as expected V10: creation and transition are separate
-command-complete `SECURITY DEFINER` operations using the unchanged V9 exact receipt. PostgreSQL
-constructs creation identity from RuntimeSession ID, Conversation ID, role, complete non-secret
-account snapshot identity/facts, nullable Codex thread ID, and initial state, then resolves exactly
-one current immutable RoleProfile revision server-side. Transition identity contains only session
-ID, expected revision, and target state. Both commands atomically store domain state, canonical
-activity/outbox effects, and immutable response bytes; stable rejection completes in the same
-transaction. V10 is a zero-state forward cutover, preserves the existing table identities, removes
-runtime snapshot/session DML, fences RuntimeSession audit namespaces, and does not authorize Codex
-creation, reconciliation, routing, scheduling, WorkItems, ManagedRuns, UI, or plugin readiness.
-Forward-only V21 repairs that fence without changing the command or trigger boundary: a scalar
-RuntimeSession/profile/account snapshot identity is provenance owned by the enclosing domain event,
-not a RuntimeSession ownership claim. Aggregate/event/kind markers, complete RuntimeSession or
-profile/account snapshot objects under any wrapper, and outbox links to activity carrying those
-shapes remain reserved.
+- schemas, relations, columns, types, functions, triggers, constraints, indexes, and
+  stable dependencies;
+- object ownership, role reachability, function settings and bodies, ACLs, and runtime
+  callable surfaces;
+- configured runtime authority and the negative PUBLIC/runtime contract;
+- hostile `search_path`, overload, default-ACL, extension-membership, external-cascade,
+  trigger, rule, policy, RLS, grant-option, DDL, `TRUNCATE`, sequence, and retention
+  bypass cases; and
+- the pinned socket directory, socket identity, peer UID, PostgreSQL major, checksums,
+  and required extension.
 
-XY-1284 managed-repository authority reset was finalized by the accepted XY-1348
-stage-two amendment on 2026-07-17. PostgreSQL is the durable authority for the current
-repository projection, monotonic generation/tip, globally immutable operation
-assignment, append-only authority and operation evidence, compare-and-swap, atomic
-command completeness, and restart loads. Pure deciders and facts in `decodex-core` are
-mechanism-neutral inputs to that authority; no standalone object, snapshot, caller
-projection, or operation view is authoritative or can grant execution.
+The reset removes only history, upgrade, prefix, and migration-source predicates. The
+current verifier compares the live catalog with the one latest schema contract. It does
+not compare a history table or parse a sequence of old SQL files.
 
-Every repository operation ID has one complete canonical descriptor across all
-repositories and operation kinds. Exact descriptor equality resolves to
-`ExistingExact(OperationView, NoDispatch)`; any difference is permanent
-`OperationIdConflict`. A fresh affine execution receipt exists only after successful
-COMMIT acknowledgement on the same adapter control path that prepared the new assignment.
-Persistence, readback, exact repeat, restart, terminal state, and an unknown COMMIT
-outcome never mint or reconstruct it. An unknown COMMIT outcome therefore authorizes no
-external execution.
+Domain integrity records remain. Exact-command receipts, account-operation records,
+ProcessGeneration, ProviderAttempt, `schema_fingerprint`, runtime authority, activity,
+outbox, and repository-effect evidence protect current product behavior. None is a
+schema migration mechanism, schema-history substitute, or bootstrap permission.
 
-Allocate is PostgreSQL-only and uses strictly read-only repository evidence. `Register`,
-`WorktreeReady`, and `Commit` are distinct durably fenced `PossiblyEffected` operations with
-readback-only restart: no retry, replay, adoption, repair, or import is authorized.
-`Register` requires exact reciprocal registration, `WorktreeReady` preserves the exact
-head, and `Commit` advances exactly once from its authorized predecessor head to its exact
-successor. Accepted XY-1354 descriptor-assisted, symlink-free persisted absolute-path
-reacquisition and pinned Git 2.54 remain unchanged. Rejected candidate trees
-`6e20e9b3cf1415cce9b399da173b0410cc4c80dc`,
-`6979e3831da772fca3fe0f0e0b4699df642d3a65`, and
-`e42212add13af3f702e0ec8966ce3d6a7b682d12` are superseded evidence only, not current
-authority. The accepted V11 commit `33159d0cb2da7f86748f1a380def0927970a409a`
-and V12 commit `a6bfb0aefc72f2a65d14fc3755b556f959ec2d4e` remain unchanged.
+## Local development reset
 
-V13 is accepted on `main` as the sole XY-1349 managed-repository PostgreSQL authority
-migration. The serial routing migration owners are fixed: XY-1356 solely owns V14 durable
-routing-policy and complete candidate-set authority; XY-1358 solely owns V15 causal Codex
-experiment authority; XY-1359 solely owns V16 atomic routing decisions; XY-1360 owns V17
-continuation authority after source inspection proved durable atomic fallback state was required;
-and XY-1362 owns V18's ledger-first `waiting_usage` wake authority. Migration allocation, the
-embedded ledger, migration authority, schema/digest inventory, and aggregate migration evidence
-remain one non-commutative singleton serial-writer domain.
+One reviewed operator-only local action may preserve credential-negative account,
+routing, and binding metadata while it replaces the disposable database. The action
+may:
 
-XY-1355 live-routing authority reset accepted 2026-07-18 after three materially rejected
-XY-1304 candidates: PostgreSQL owns one revisioned complete routing-authority snapshot.
-Runtime and callers cannot supply authoritative policy order, candidate membership, sticky
-identity, eligibility facts, or exclusions. The database-produced snapshot binds every
-account-inventory member to an explicit disposition; canonical user-owned order and accepted
-Policy revision; sticky affinity and the exact RuntimeSession revision from which it was
-derived; account, RoleProfile, and Codex-build compatibility; exact account and evidence
-revisions; and the required capabilities plus applicability for each member. An omitted or
-unknown inventory member is a blocker, never silent absence or an eligible candidate.
-The existing bounded inert `PolicySnapshot` remains accepted Policy-revision content only; it is
-not a complete routing snapshot and cannot prove candidate completeness or provenance.
+1. stop `decodexd`;
+2. capture only the reviewed credential-negative Account UUID, enabled state, account
+   revision, provider binding, credential version/fingerprint, and host-store binding for
+   every retained account, plus routing revision, mode, fixed target, and complete order;
+3. drop and recreate the local database, or directly transform that one local database;
+4. run the one empty-target latest-schema bootstrap when the database was recreated;
+5. restore or rebind the exact captured tuple against the unchanged host-vault records;
+6. prove every Account UUID, enabled state, account revision, provider binding,
+   credential version/fingerprint, host-store binding, routing revision, mode, fixed
+   target, and order exactly; and
+7. start `decodexd` only after current-authority and binding readback pass.
 
-`decodex-core` remains a pure decision kernel over that complete database-produced value.
-PostgreSQL persists the atomic decision and evidence linkage; runtime sequences only effects;
-Codex supplies positive capability evidence and never routing authority. One app-server process
-remains immutably bound to one account, credentials never switch in a live process, and separate
-account quotas are never represented as a merged pool.
+For `fixed` mode, the fixed target is non-null and belongs to the retained account set
+and complete order. For `balanced` mode, it is null. The order is one duplicate-free
+permutation of all retained accounts, including disabled accounts. Restoration and
+readback prove the per-account enabled values and the routing mode, target, and order as
+one coherent tuple.
 
-Account-owned readiness is evaluated only for capabilities explicitly required by the accepted
-routing policy. Unknown never satisfies a required capability. When the accepted required-
-capability set is empty, unknown plugin inventory is non-applicable rather than positive readiness
-evidence. XY-1336 remains future passive-receipt tracking outside this routing chain. Host-owned
-before/after receipts establish only no-mutation integrity.
+Credential agreement may invoke the existing `HostCredentialStore` owner to perform a
+confined in-process exact read and recompute and compare the credential fingerprint and
+binding. It returns only a typed credential-negative agreement result. The operator
+action and result must never expose, serialize, copy, log, persist, rotate, delete, or
+return token bytes. Host-vault credentials remain in place and unchanged.
 
-Ingress retains the exact raw provider timestamp value. UTC Unix-microsecond construction must be
-exact and rejects every rounding or truncation path. V14 through V16 remain precision-agnostic and
-fail closed, allowing XY-1357 natural provider evidence to remain in the unified post-freeze gate.
+This is a finite local development action. It is not product account migration, a
+generic migrator, an import API, a generic attestation framework, a metadata sidecar, a
+backup or rollback mechanism, a receipt/finalizer, or a fallback. Normal installation
+and startup do not read an old database or an old account source.
 
-Mac Slice 1 uses V14/V16 only for quota-aware initial selection. `fixed` considers one
-target. `balanced` selects the first fully eligible account in canonical order. Recovery
-is an explicit versioned enable/disable, mode, or order change followed by a new task.
-Unknown or stale quota is ineligible, and all-depleted waits for explicit retry.
+## Candidate-5 Quick Task
 
-After V16, XY-1360 retains same-thread continuation and atomic Context-Pack fallback;
-XY-1362 retains the `waiting_usage` wake lifecycle; and XY-1363 retains title-discovery
-evidence. These are later obligations. XY-1304 owns only aggregate acceptance and a
-separate reviewed enablement amendment for automatic cross-account same-thread fallback
-and all-depleted wake. It does not block Quick Task, Project/Lead, ManagedRun, GPUI, or
-first Mac dogfood. Ambiguous-turn replay and repository, worktree, Git, and artifact
-reconciliation remain in ProviderAttempt and the accepted repository-effect authorities,
-not routing.
+Candidate 5 remains the accepted architecture for one ordinary Quick Task. It is a
+multi-turn Conversation with no WorkItem, ManagedRun, reviewer, PR, harness, or Goal.
+Candidate-4 tree `f82b866e21f12742648023a2b468cc057afa52a1` remains materially
+rejected provenance.
 
-The rejected dirty combined XY-1304/V14 candidate, its partial fourth repair, its caller-
-authoritative request shape, Rust authorization wrapper used as provenance, global
-`SupportedPositive` plugin requirement, combined experiment/routing schema, and sequential
-exclusion -> RuntimeSession -> decision composition are superseded evidence only. They must not
-be repaired, revived, or wholesale transplanted.
+Candidate 4 failed because it did not close five authority boundaries:
 
-XY-1403 selects Option 1. At and after its exact repository effective point, the
-private-artifact lane is retired from vNext. The
-[private-artifact archive](../specs/private-artifact/README.md) preserves the former
-package and all public receipt anchors as historical evidence. Its rule ledger,
-inventories, source census, V22 snapshots, corpus index, semantic modules, delivery
-edges, A0/A1/B/D0a/C/D phases, CORE-FREEZE, ACC, preparation, and unified validation
-are historical and non-executable. They are not current authority, runtime inputs,
-dependencies, or future-work inventory.
+1. effect and successor fences did not lock the exact selected Turn and revision;
+2. the first Turn and first history item were not one atomic, one-winner Conversation
+   transaction;
+3. ambiguous ProcessGeneration replay could terminalize a Turn;
+4. the required narrow trigger behavior contradicted an active-only trigger rule; and
+5. Account Service and routing could select different accounts.
 
-The [XY-1372 capability evidence](../evidence/xy-1372-private-artifact-capabilities.md)
-also remains historical evidence. It does not authorize a runtime, gate, platform
-requirement, or downstream experiment. XY-1373's former moving-core integration and
-landing condition is historical and non-executable. Its later cancellation preserves
-its history, comments, parent XY-1371, and `relatedTo` relations to XY-1374 and
-XY-1371. Cancellation does not claim that the integration completed.
+Candidate 5 uses existing owners in this exact order:
 
-XY-1371 and the XY-1378-XY-1391 private-artifact execution graph are inactive
-historical planning provenance. Repository authority already retired that program.
-They cannot gate a delivery slice or restore a private-artifact authority layer.
+1. Conversation authority creates the Conversation.
+2. Routing receives one prospective Turn UUID as intent. No Turn row or Turn foreign
+   key exists at this point.
+3. Routing Snapshot authority locks the complete account universe, policy order,
+   account revisions, separate quota facts, capability facts, and blockers.
+4. Routing Decision authority runs once and is the sole Quick Task account selector.
+5. Continuation Plan authority consumes that selected decision and atomically creates
+   the selected account snapshot, copied RoleProfile snapshot, first revision-1
+   unfenced `starting` RuntimeSession, inert `initial_thread` plan, exact receipt,
+   activity, and outbox.
+6. Conversation authority atomically admits the exact prospective UUID as the active
+   revision-1 sequence-1 user Turn and creates exactly one ordinal-0 completed Message.
+7. Account Service rechecks only the selected account's readiness, credential version
+   and fingerprint, provider binding, and HostCredentialStore binding immediately
+   before spawn. It cannot select or substitute an account.
+8. ProcessSupervisor may spawn only from a fresh ProcessGeneration fence.
+9. RuntimeSession Thread Establishment owns the exact thread-start fence, start binding,
+   activation, and acknowledgement.
+10. ProviderAttemptService owns attempt preparation, dispatch authorization, ambiguity,
+    positive evidence, and reconciliation.
 
-Only the retained-title evidence transport changes. XY-1369 and XY-1370 keep their
-bounded operator checks and commit reviewed public-safe attestations and digests as
-canonical Git evidence. Raw errors, paths, account or role text, credentials,
-provider data, raw schema, and unrestricted output stay out of Git and receipts.
-XY-1363 consumes the exact accepted Git receipt identities and uses the accepted V22
-one-shot title path. No new service, schema, storage system, runtime route, platform
-layer, issue, compatibility path, or product Artifact is created.
+Runtime is a stateless sequencer across these owners. It does not become an account,
+route, session, Turn, process, thread, or provider-effect authority.
 
-The accepted Artifact/BlobStore boundary for ordinary content-addressed product
-evidence does not change. The external empty-state cutover and user-owned
-RoleProfile/RuntimeSession authority also remain intact. Later automatic fallback and
-wake remain disabled until the separate reviewed XY-1304 enablement amendment.
+The routing lineage has two closed shapes. `L0` has all six RuntimeSession, account
+snapshot, and profile snapshot identity/revision fields absent. `L6` has all six fields
+present and all three revisions positive. Conversation routing permits `L0` or `L6`.
+ManagedRun routing permits only `L6`. `L0` requires an open exact-revision Conversation,
+no existing RuntimeSession or Turn, zero sticky members, and an exact complete locked
+account universe. Half-present lineage, sticky `L0`, source fields in `L0`, a source-less
+ManagedRun, stale Conversation state, or incomplete, duplicate, extra, cross-linked, or
+reordered evidence fails closed.
 
-Historical AR-CLOSE and pre-retirement package identities remain provenance. In
-particular, keep signed C2 commit
-`019f58a31b976056c000b73de3ec46b89284c6eb`, tree
-`a56976663774b1e901e27fdf4c5276a7e9c84cb8`, package tree
-`881a7d25801a4795a343d620164ed74a6dae136c`, and raw pre-retirement
-`authority/package.manifest` SHA-256
-`f88d5706b08e70170531dcda991d841c3b43543cf96a77500c0304f4a469753e`.
-These identities prove bytes only. They do not prove historical semantic fidelity
-or restore package authority.
+There is no second route decision, fallback, wake, alternate account, or account
+re-selection in the initial operation. Initial planning is first-session creation. It
+is not same-thread reuse, explicit successor, or Context Pack fallback. Those existing
+continuation modes keep their own contracts. Automatic cross-account fallback and
+all-depleted wake remain disabled under XY-1304.
 
-The V1 trust boundary is one trusted single-host service. `decodexd` remains the sole
-repository-effect owner. Its in-process repository executor is a correctness,
-determinism, and admitted-authority-continuity boundary, not isolation from malicious
-same-UID code. Project validation may supervise lifecycle, bound output and time, and
-detect mutation, but it is not hostile-code confinement. A hostile same-UID project or
-multi-tenant requirement would require a separate UID/sandbox authority plus a new
-feasibility gate; it cannot be inferred from this design.
+Every process, thread, and provider-effect fence locks and rechecks the exact selected
+Turn as active revision 1 under the same Conversation and first RuntimeSession.
+ProcessGeneration and thread establishment through bind require the applicable
+`starting` RuntimeSession revision. ProviderAttempt preparation and authorization
+require the exact post-bind `active` revision and exact thread fence/bind receipts.
 
-Authorized whole-cluster restore is inside the trusted PostgreSQL-administrator boundary
-and may redefine current authority; V1 has no automatic full-cluster rollback detection.
-The trusted single-daemon/same-UID boundary remains unchanged. XY-1349 solely owns V13
-persistence, XY-1350 may proceed in parallel only against this accepted contract, and
-XY-1351 owns the first shared saga path.
+Only a fresh ProcessGeneration result can spawn. Replayed, rejected, or uncertain state
+returns durable readback or `Unknown`; it cannot spawn, replace, adopt, create a
+successor, prepare a duplicate attempt, or terminalize the Turn. Conversation authority
+may move the exact Turn to `failed` revision 2 under a starting session only after
+positive proof of a definite pre-effect refusal. Any ambiguous or started effect keeps
+the Turn active for manual recovery.
 
-## Decision
+Explicit successor remains PostgreSQL-only, non-dispatch evidence. Before any write, it
+locks the Turn named by the selected decision and requires that Turn to be in the same
+Conversation and source RuntimeSession, `failed`, and revision 2. It has no protocol
+field, product command, runtime grant, facade, fallback, or wake path.
+
+The latest schema defines the final forms of the seven affected trigger functions
+directly:
+
+- `decodex.enforce_routing_completeness()`;
+- `decodex.enforce_runtime_session_state()`;
+- `decodex.enforce_turn_state()`;
+- `decodex.enforce_history_item_state()`;
+- `decodex.enforce_provider_attempt_transition()`;
+- `decodex.enforce_provider_attempt_binding()`; and
+- `decodex.enforce_continuation_plan_completeness()`.
+
+Their accepted narrow predicates are normative in the
+[vNext authority contract](../specs/vnext-authority.md#quick-task-thread-establishment).
+The latest schema does not alter old trigger bodies. It creates these final bodies and
+bindings. Every unrelated write keeps the existing active-only behavior. No broad
+starting-session bypass is allowed.
+
+Candidate 5 must preserve current-main account observation behavior: independent
+per-account provider refresh, Reset Card before profile within one account, concurrent
+progress across accounts, coalesced successor rounds, revision-fenced publication, and
+query paths that read daemon-owned cache/projection state without joining or starting
+refresh work. It also preserves deterministic one-word account aliases, current account
+and UI behavior, negative Reset Card counts as an empty inventory, automation behavior,
+same-thread and Context Pack authority, and XY-1304 containment.
+
+## Product decision
 
 Decodex vNext is a rebuild of the agent workspace, not an incremental extension of the
-current Linear-lane and SQLite runtime. The normative product and runtime contract is
-[the vNext authority contract](../specs/vnext-authority.md); its ordered proof and
-implementation boundaries are in [the vNext gate manifest](../specs/vnext-gates.md).
-
-The accepted planning baseline is provenance for this decision. Where the baseline and
-these repository documents agree, these repository documents own implementation. A
-concrete contradiction must stop the affected milestone for explicit resolution; later
-workers must not silently reinterpret either source.
-
-## Decision hierarchy
+frozen Linear-lane and SQLite runtime. The normative contract is
+[vNext Authority](../specs/vnext-authority.md). Ordered acceptance is in
+[vNext Gates](../specs/vnext-gates.md).
 
 Within vNext work, authority descends in this order:
 
 1. explicit user direction and checked-in project policy;
-2. this decision, the vNext authority contract, and the vNext gate manifest,
-   including the XY-1403 private-artifact retirement; the retired package is
-   historical evidence only;
-3. accepted project policies and versioned domain/protocol contracts created under
-   those documents;
-4. source, tests, migrations, and operational runbooks implementing an accepted gate;
-5. OpenWiki navigation and current-runtime descriptions;
-6. Linear plans and research as provenance or candidate changes.
+2. this decision, the vNext authority contract, and the vNext gate manifest;
+3. accepted domain and protocol contracts created under those documents;
+4. source, tests, the one latest schema, and operational runbooks that implement an
+   accepted gate;
+5. OpenWiki navigation and current-source descriptions; and
+6. Linear plans, historical evidence, and research as provenance.
 
-Current source remains authority for current v0.2 behavior but cannot override the
-accepted vNext target. Conversely, target documents do not claim that vNext behavior is
-already implemented. Git/filesystem and GitHub remain the authorities for repository
-content and provider readback respectively; PostgreSQL becomes product-state authority
-only when its bootstrap/cutover gate is accepted.
-
-## Supersession
-
-Lane Authority v2 and its C1-C7 program are superseded and frozen. Its decision,
-contract, effect registry, gate manifest, checkpoint ledger, fixtures, scripts, review
-findings, and incident scenarios remain useful historical evidence. They must not be
-continued, repaired, activated, or treated as vNext acceptance gates. In particular,
-vNext rejects Lane Authority v2's SQLite authority, Linear issue/lane identity, local
-Unix authority ledger, and compatibility migration target.
-
-PR #1092 is likewise historical/incident evidence: freeze or close it, do not merge it,
-and do not wholesale cherry-pick its implementation. Reuse a behavior only after the
-vNext owner and a focused gate/test make that behavior authoritative.
+Target documents do not claim that target behavior is already implemented. Current
+source does not override a later accepted target. A contradiction stops the affected
+work for an explicit decision.
 
 ## Accepted shape
 
-- PostgreSQL owns Decodex product state; a transactional outbox and leases support
-  commands and recovery. It is not event sourced.
-- A shared normal `~/.codex` owns persistent Codex rollout/thread continuity and Codex
-  UI visibility. Decodex maps only threads that it created.
+- PostgreSQL owns Decodex product state. It uses transactions, exact commands, leases,
+  append-only activity, and a transactional outbox. It is not event sourced.
+- A shared normal `~/.codex` owns persistent Codex rollout and thread visibility.
+  Decodex maps only threads that it created.
 - `decodexd` alone owns scheduling, app-server children, product mutations, repository
-  side effects, and adapters. GPUI, the menubar app, CLI, and MCP use the same versioned
-  application protocol and are not parallel authority paths.
-- Decodex owns Project, stable Advisor/Lead, execution-scoped Task/Reviewer, Program,
-  Objective, WorkItem, Conversation, RuntimeSession, ManagedRun, Automation,
-  ContextRevision, AgentMessage, Artifact, RoleProfile, and their policies.
-- One Project has exactly one stable Lead in V1. The Lead serializes decisions while
-  Task and Reviewer execution may be parallel. Advisor is global and advisory only.
-- A managed implementation Task owns its implement/review/repair/revalidate loop by
-  spawning an independent read-only reviewer subagent. Lead/Manager owns dispatch,
-  final acceptance, and merge; Quick Tasks are exempt, and missing/failed review is a
-  typed ManagedRun wait and optional WorkItem block rather than reviewed success.
-- A Project policy grants bounded unattended authority once; repository, tool, path,
-  merge, budget, approval, parallelism, and quiet-period limits remain hard stops.
-- Work lands through focused task branches/PRs directly to `main`; there is no long-lived
-  vNext branch.
+  side effects, and adapters. GPUI, SwiftUI, CLI, and MCP are clients.
+- PostgreSQL Account Registry owns credential-negative account state. One
+  HostCredentialStore owns secret bundles. Account Service coordinates account
+  operations.
+- One app-server process remains bound to one Account UUID and provider identity for its
+  lifetime. Credentials do not switch accounts in a live process.
+- PostgreSQL remains the complete routing-fact and decision authority. Runtime and
+  clients cannot supply the account universe, eligibility, policy order, selection, or
+  exclusions.
+- ProcessSupervisor and ProviderAttemptService retain separate replacement-safety and
+  external-effect-safety authority.
+- ExecutionCoordinator remains stateless and cannot authorize dispatch by itself.
+- Git/filesystem own repository bytes and worktrees. GitHub owns PR/check/merge
+  readback. PostgreSQL owns the admitted repository-effect state and evidence.
+- Local content-addressed storage owns large bytes; PostgreSQL owns their metadata and
+  references.
 
-Delivery uses exactly three vertical slices:
+Delivery uses three vertical slices:
 
-1. Accounts, Quick Task, and minimal Accounts/Conversation/Health GPUI, with no normal
-   legacy watcher, credential environment projection, helper, or `:8192` authority.
-2. Minimal Project/Lead/global Advisor entry, bounded Context Revision, WorkItem,
-   ManagedRun, the existing repository saga, Task-Reviewer result, explicit human
-   acceptance, and Project/Work/Run GPUI.
-3. One representative two-account self-hosting repository E2E across restart boundaries
-   and one Mac package, including clean-startup proof against legacy account authority.
+1. Accounts, Candidate-5 Quick Task, and minimal Accounts/Conversation/Health GPUI.
+2. Project, Lead, global Advisor, Context Revision, WorkItem, ManagedRun, repository
+   saga, Task-Reviewer result, human acceptance, and Project/Work/Run GPUI.
+3. One representative two-account self-hosting flow across restarts and one Mac package.
 
-The dependency recommendation is `Slice 1 -> Slice 2 -> Slice 3`. Current GPUI opens a
-real shell and window. Health is the only bounded live destination. Every other
-destination remains a placeholder. The Quick Task and WorkItem contracts do not make
-their shell destinations live. GPUI is not generally usable. Remaining Slice 1 UI work
-is Accounts and Conversation. The slices replace the former component-first/global-gate
-sequence.
+Automatic cross-account fallback and all-depleted wake are later work. They do not block
+Candidate-5 initial selection or the first Mac dogfood flow.
 
-## XY-1262 gate split
+## Supersession
 
-The XY-1262 foundation gate is accepted only for the evidence scope enumerated in the
-[gate manifest](../specs/vnext-gates.md): shared-home and one-account-per-process
-boundaries, creation-receipt ownership, negotiated app-server contracts, supported
-exact-ID/list/read/archive operations, lossy-read/divergence policy, native run-local
-collaboration normalization, process-scoped authentication/redaction, read-only
-integrity evidence, and pure duration-typed quota policy. This acceptance does not
-claim global Codex title search, live quota-driven routing, automatic continuation, or
-release readiness.
+Lane Authority v2, the frozen v0.2 runtime, PR #1092, and the private-artifact program are
+historical provenance. They are not vNext implementation or runtime inputs. The
+[private-artifact archive](../specs/private-artifact/README.md) remains evidence only.
 
-The separate [XY-1262 automatic-routing gate](https://linear.app/hack-ink/issue/XY-1304)
-remains failed and fail-closed for automatic cross-account same-thread fallback and
-all-depleted wake. It is not a global gate for the three slices. Slice 1 can use eligible
-quota-aware fixed or balanced initial selection and manual recovery after its own account,
-callback, ProcessGeneration, and ProviderAttempt fences pass. Unknown or stale quota never
-establishes eligibility. Automatic fallback and wake still require a later explicit
-repository authority amendment.
+Old migration-based PostgreSQL evidence may still explain a domain invariant or a past
+failure. It cannot authorize numbered SQL, a schema ledger, an upgrade proof, or a
+second schema owner. Any useful invariant must be restated under the latest-schema and
+current-authority gates before implementation relies on it.
 
-## Rejected alternatives and falsifiers
+## Decision falsifiers
 
-Rejected V1 alternatives are enumerated normatively in the contract. The decision may
-change only for evidence that cross-account continuation cannot preserve useful
-continuity, GPUI cannot meet pinned build/package/accessibility/test gates, PostgreSQL
-cannot be operated reliably on the intended host, app-server cannot provide required
-ownership/read/list/collaboration behavior, or real dogfood proves one Lead cannot keep
-decision latency within policy. Such evidence blocks or revises the owning gate; it does
-not authorize a compatibility facade or silent fallback.
+Stop and return to the authority owner if evidence shows that:
 
-For the XY-1284 managed-repository boundary, the prioritized falsifiers in the
-[gate manifest](../specs/vnext-gates.md#xy-1284-managed-repository-authority-gate) are
-incorporated into this decision as decision-changing evidence. In fixed order, they are:
-an architecture that cannot preserve admitted authority or separate its distinct state
-owners; unrecoverable or ambiguous restart/effect states; a security/authority path that
-does not fail closed or cannot disable repository-controlled execution; evidence that
-cannot distinguish completion from stale, duplicate, rollback, lost, or ambiguous
-outcomes; integrity that permits unreserved, drifted, undetected, or unreconciled effects;
-and performance that cannot meet an explicit later host budget without weakening an
-earlier guarantee. An earlier class cannot be traded for success in a later class. Any
-such contradiction stops the affected replacement gate and returns to an explicit
-architecture decision; it never authorizes a fourth patch under the rejected combined
-boundary, a mechanism outside the accepted stage-two contract, or a silent fallback.
+- one latest empty-target schema cannot express the accepted product safely;
+- current catalog and configured authority cannot be verified without a history ledger;
+- normal daemon startup requires DDL or a schema-owner credential;
+- the local credential-negative rebind cannot preserve exact host-vault bindings without
+  exposing token bytes outside the `HostCredentialStore` owner or changing them;
+- Candidate-5 owners cannot compose without a second account selector, coordinator
+  state, pre-admission Turn row, or ambiguous-effect replay;
+- ordinary Conversation execution requires a ManagedRun;
+- ProviderAttempt must create or rewrite RuntimeSession state;
+- ProcessGeneration uncertainty must be treated as provider non-submission; or
+- a hostile same-UID or multi-tenant requirement makes the accepted single-host trust
+  boundary invalid.
+
+A falsifier blocks the affected gate. It does not authorize a compatibility facade,
+silent fallback, generic migrator, or second authority path.

--- a/openwiki/operations/commands-and-validation.md
+++ b/openwiki/operations/commands-and-validation.md
@@ -1,711 +1,270 @@
 # Commands And Validation
 
-Use this page when deciding which command validates a change. It summarizes current task-runner authority and maps test families to source areas.
+Use this page to choose the command boundary for current work. `Makefile.toml` owns
+implemented task names. This document owns the target behavior for the latest-schema,
+runtime-authority, Candidate-5, and local database reset commands.
 
-The XY-1403 private-artifact retirement takes effect only at the exact
-[repository effective point](../specs/private-artifact/decision.md#repository-effective-point).
-At and after that point, the private-artifact archive defines no command or
-validation authority.
+There are no external or deployed users. Local PostgreSQL data is disposable. Database
+acceptance starts from one empty PostgreSQL 18 target and the one unversioned latest
+schema. Existing migration commands and harness modes are superseded and must not be used
+as acceptance for this reset.
 
 ## Task runner authority
 
-`Makefile.toml` owns repository task names. The broad readiness gate is:
+The broad repository gate remains:
 
 ```sh
 cargo make check
 ```
 
-It depends on the Node supply-chain audit, build, Node checks, Rust checks,
-formatting, lint, and tests (`Makefile.toml`). Use it before claiming broad readiness.
-For documentation-only or narrow source changes, run the smallest relevant checks
-and state the narrowed scope.
-
-The agent automation portfolio has a headless gate for hosts without full Xcode:
+For a documentation-only or narrow source change, run the smallest relevant check and
+state the narrowed scope. The agent automation gate for hosts without full Xcode remains:
 
 ```sh
 cargo make check-automations
 ```
 
-It excludes `decodex-gpui` from Rust check, lint, and test work but preserves the
-other repository gates. It installs the exact lock with lifecycle scripts disabled,
-checks npm advisories at high severity, verifies registry signatures for the resolved
-site graph, and audits every lockfile source and integrity value. The audit requires
-npm 11.17.0, Node 22.12.0 or newer, registry.npmjs.org package sources, SHA-512
-integrity, the exact reviewed lifecycle-script allowlist, and the pinned native and
-platform package identity set. It is valid only when the
-pull-request diff does not touch `decodex-gpui`, its dependencies, or Apple GPU/build
-integration. Changes on those surfaces require `cargo make check` on a host with full
-Xcode and Metal tools. The upstream validator discovers a usable full Xcode and
-scopes `DEVELOPER_DIR` to that subprocess. Both aggregates include the Node audit.
-Run either aggregate on a clean committed tree because PostgreSQL authority tests
-bind their evidence to the exact commit and tree.
+`cargo make check-automations` is valid only when the diff does not touch GPUI, its
+dependencies, or Apple GPU/build integration. Those surfaces require the broad gate on a
+host with full Xcode and Metal tools.
 
-## Main gates
+The current task runner still contains migration-era PostgreSQL checks. Until source and
+task-runner alignment lands, a passing broad command does not prove the new latest-schema
+contract. The implementation change must retire old tasks or change their behavior under
+the same reviewed source change.
 
-| Purpose | Command |
+## Current repository checks
+
+| Purpose | Implemented command |
 | --- | --- |
-| Broad repo check | `cargo make check` |
+| Broad repository check | `cargo make check` |
 | Agent automation check outside GPUI/Apple build surfaces | `cargo make check-automations` |
-| Site advisory, provenance, and registry-signature audit | `cargo make audit-node` |
+| Node advisory/provenance/signature audit | `cargo make audit-node` |
 | Rust type check | `cargo make check-rust` or `cargo check --all-features --all-targets --workspace` |
 | Rust tests | `cargo make test` or `cargo nextest run --workspace --all-targets --all-features` |
-| XY-1306 path/config/blob/cache foundation | `cargo test -p decodex-core --all-targets --all-features` |
-| XY-1307 daemon bootstrap and doctor protocol | `cargo test -p decodex-core -p decodex-protocol -p decodex-postgres -p decodex-runtime -p decodexd --all-targets --all-features` |
-| XY-1308 CLI diagnostic and local Git command matrix | `cargo make test-vnext-cli-diagnostics` |
 | vNext dependency architecture | `cargo make test-vnext-architecture` |
-| vNext PostgreSQL store, Conversation history, blobs, and Context Packs | `cargo make test-vnext-postgres-store` |
-| XY-1345 isolated exact-command authority proof | `python3 scripts/vnext/exact_command_prototype.py` |
-| vNext storage feasibility proof | `cargo make test-vnext-storage-proof` |
-| Rust formatting | `cargo make fmt-rust-check` |
-| Canonical gate contract | `cargo make test-gate-contract` |
-| TOML formatting | `cargo make fmt-toml-check` |
+| CLI diagnostic/process matrix | `cargo make test-vnext-cli-diagnostics` |
+| Rust formatting check | `cargo make fmt-rust-check` |
+| TOML formatting check | `cargo make fmt-toml-check` |
 | Rust lint | `cargo make lint-rust` |
 | Read-only Vstyle audit | `cargo make audit-vstyle-rust` |
 | Site type check | `cargo make check-node` or `npm --prefix site run check` |
 | Site build | `cargo make build` or `npm --prefix site run build` |
 
-`cargo make test` runs `cargo nextest run --workspace --all-targets --all-features`, the
-canonical gate contract tests, the vNext architecture test, and the XY-1308 CLI
-process matrix (`Makefile.toml`). The active `apps/decodex-cli` uses the server only
-for `status`, `doctor`, and `reset-card`. Its manual-authority `commit` and exact-base/head `land`
-commands are local Git authority and do not use Decodex server, planner, runtime,
-MCP, Linear, or tracker state. Rust compilation remains pinned by
-`rust-toolchain.toml` to `1.97.0`. The formatting tasks separately invoke
-`rustup run nightly-2026-07-16 cargo fmt`, which preserves the nightly-only options in
-`.rustfmt.toml` without depending on the mutable `nightly` alias. Supported hosts install
-that exact formatter toolchain once; formatting fails closed when it is unavailable:
-
-```sh
-rustup toolchain install nightly-2026-07-16 --profile minimal --component cargo --component rustfmt
-```
-
-## Retired private-artifact delivery contracts
-
-The archived
-[operations and delivery module](../specs/private-artifact/operations-delivery.md)
-preserves the former contracts. Every item in this table is historical and
-non-executable:
-
-| Former contract | Disposition |
-| --- | --- |
-| A0/A1/B/D0a/C/D and their delivery edges | Retired. They are not phases, dependencies, issue work, or future obligations. |
-| CORE-FREEZE | Retired. It is not a receipt boundary or current or future task. |
-| ACC | Retired. It cannot authorize acceptance-source changes. |
-| `check-vnext-postgres-preparation` | Retired package proposal. Do not add it from the archive. |
-| Package-defined `test-vnext-retained-title-core` behavior | Retired. The existing task name and current behavior come only from checked-in task, wrapper, and runbook authority. |
-| Single mechanical preparation pass | Retired. Do not run or recreate it from the archive. |
-| Unified complete validation protocol | Retired. It is not an acceptance or enablement gate. |
-
-The immutable [XY-1368 retained-title freeze](../specs/xy-1368-retained-title-freeze.md) is V22
-historical evidence only. It is not current command or task-runner authority.
-Current executable command names and behavior come from `Makefile.toml`, the current
-wrapper source, and the unchanged
-[XY-1368 validation runbook](xy-1368-retained-title-validation.md). Do not infer
-retired package behavior from those current surfaces.
-
-## Same-UID Unix transport validation
-
-XY-1399 A-prime was the source-only design ancestor. The current integrated implementation
-ports that transport onto exact-current protocol V2.0 and the shared Reset Card service. Validation
-must bind all results to the exact candidate tree and cover macOS and Linux. It validates:
-
-- fixed staging-name and canonical-name stale recovery under the persistent single-link
-  namespace lock;
-- stage bind, exact mode, captured device/inode/owner/mode/link-count identity, exactly
-  one socket link, and same-directory descriptor-relative `renameat` publication;
-- directory, lock, and socket replacement at publication, server admission, client
-  reconnect, and cleanup;
-- client and server kernel peer credentials and exact effective-UID equality;
-- WebSocket `/v1/ws` with exact-current V2.0, without TCP, Axum, self-connect, watchdog, or
-  compatibility fallback;
-- concurrent legitimate daemons, active sessions, in-flight commands, child panic,
-  absolute-deadline cancellation, deterministic termination receipt readback, explicit
-  `join_next_with_id` harvesting through empty, and zero owned work before cleanup;
-- immediate Reset Card work-admission closure at shutdown and settlement of every already
-  registered blocking provider operation before namespace cleanup;
-- SIGINT and SIGTERM graceful cleanup and SIGKILL stale-socket recovery;
-- exact cleanup refusal, listener close, and namespace-lock release order; and
-- reverse dependency isolation for remote/cross-UID transport, PKI, PostgreSQL end-user
-  authentication, routing, UI, packaging, release, and unrelated production dispatch.
-
-The integrated caller conversion removes `LoopbackEndpoint`, local-profile `address`,
-URL-based retained-session construction, the transport-level `InvalidEndpoint`, active
-local-daemon TCP socket fixtures, `BoundServer::address`, TCP V1 URIs, the fixed local
-`127.0.0.1:49152` endpoint, dependency-only Axum use, and the Axum workspace edge. Inert
-remote-profile port data and the GPUI `CompatibilityReason::InvalidEndpoint` display
-classification remain outside the local transport implementation.
-`crates/decodex-protocol/tests/local_transport_authority.rs`
-owns namespace, stale recovery, replacement, permission, peer, and path-length coverage.
-`crates/decodex-runtime/tests/websocket_protocol.rs` owns WebSocket continuity and
-zero-survivor service settlement. `apps/decodexd/tests/signal_shutdown.rs` owns real
-process signal and crash-recovery behavior.
-
-## XY-1402 source-only validation boundary
-
-XY-1402 is pre-core-freeze source work. Do not run a formatter, build, compiler,
-lint or static analysis, migration or SQL parser, test, fixture, generator,
-service, VM, UI or Accessibility check, live Codex experiment, account operation,
-or provider effect for its candidate. Bounded source inspection and the required
-signed commit receipt are not executable acceptance.
-
-V25 adds the execution route and wait enum vocabulary in a separate committed
-transaction. V26 is the current execution-coordination cutover. It removes the drained V12
-ManagedRun-local submitted-turn and effect-barrier authority. Its source inventory
-contains 80 relations, 182 functions, 74 safety functions, 146
-safety/state/retention triggers, and 70 runtime-callable functions. The accepted
-schema and configured-authority digests stay frozen at the V22 boundary until the
-later unified gate derives and verifies the integrated V26 values.
-
-The later gate must bind its results to the exact candidate tree. It must run the
-complete [XY-1402 deferred acceptance matrix](../specs/execution-coordinator-authority.md#deferred-acceptance-matrix).
-That matrix includes clean and populated migration, drain, historical
-cross-link, and ambiguity falsifiers, S0/R1/R2 manifests, ACL closure, both
-consumer shapes, route causes, quota separation and aging, RuntimeSession
-continuity, ProcessGeneration fencing, ProviderAttempt capability consumption
-and ambiguity, same-UID transport, concurrency, hostile cross-links, and reverse
-production isolation.
-
-## Vstyle audit authority
-
-Vstyle is an explicit read-only audit and is not part of the blocking `lint` or `check`
-aggregates. The ordinary `lint-fix` aggregate contains only Clippy fixing; the repository
-provides no Vstyle mutation task. Run the governed audit directly:
-
-```sh
-cargo make audit-vstyle-rust
-```
-
-`config/vstyle-rust-audit.json` pins `vibe-style` 0.2.3 to source commit
-`3a0959eac5363c4c427382bae1d80d87ecadb702`, attests the complete implemented Rust rule
-inventory, and records the reviewed current baseline of 184 findings, including seven
-manual findings. Supported hosts install that exact revision:
-
-```sh
-cargo install --git https://github.com/hack-ink/vibe-style.git \
-  --rev 3a0959eac5363c4c427382bae1d80d87ecadb702 \
-  --locked --force vibe-style
-```
-
-The audit fails closed when the executable version, source revision, build target, rule
-inventory, output grammar, or governance deadline differs from the contract. It also fails
-when normalized finding counts increase. Resolved baseline findings are reported without
-blocking so maintainers can refresh the baseline through review.
-
-Vstyle 0.2.3 does not expose structured curate output. The smallest repository-owned
-boundary therefore accepts only its exact finding and summary line grammar and rejects
-every unexpected nonempty line. Finding identity is normalized by path, rule, message,
-fixability, and multiplicity; line and column numbers are deliberately excluded so an
-unrelated line shift does not appear as a regression. The baseline owner is the Decodex
-repository maintainers. It must be reevaluated by 2026-08-15, whenever executable or rule
-identity changes, whenever the accepted baseline changes, and before any scope is promoted
-to blocking.
-
-The current CLI matrix builds the real `decodex` binary and uses the fixed owner-only Unix
-namespace. It proves status/doctor, stable identity mismatch,
-disconnection, malformed/missing profile configuration, unsafe server-host paths,
-database unavailability, plugin/vault/blob unknown states, and redaction. Protocol unit
-fixtures separately force wrong major/minor, malformed/oversized response, timeout, and
-untrusted server-text cases.
-
-Run the focused reset-card PostgreSQL crash/reclaim contract in its own disposable
-PostgreSQL 18 cluster:
-
-```sh
-python3 scripts/vnext/postgres_store_test.py --focus-reset-cards
-```
-
-This contract proves generic-claim isolation, private exact-ID binding, effect fencing,
-lease expiry and reclaim, same-key receipt survival, reconciliation, and terminal status.
-
-PostgreSQL authority digest changes use an explicit derivation phase followed by one acceptance
-phase:
-
-```sh
-# Run the one-shot R1 prerequisite gate only when the Manager authorizes this exact clean tree.
-python3 scripts/vnext/postgres_store_test.py \
-  --capture-authority-restore-prerequisite-v2 \
-  /absolute/private/directory/postgres-restore-prerequisite-r1.json
-
-# Run Phase A from one clean committed repaired pre-digest tree.
-python3 scripts/vnext/postgres_store_test.py \
-  --capture-authority-candidate /absolute/private/directory/postgres-authority-candidate.json
-
-# Follow the receipt's zero-, one-, or two-array transition, then run Phase B.
-python3 scripts/vnext/postgres_store_test.py \
-  --accept-authority-candidate \
-  /absolute/private/directory/postgres-authority-candidate.json \
-  /absolute/private/directory/postgres-authority-acceptance.json
-```
-
-`--capture-authority-restore-prerequisite-v2` is the only spelling for the replacement gate. The v1
-spelling has no alias. This gate is not a focused mode, Phase A, Phase B, or the aggregate. Its
-output path must be absolute, outside the source tree, in an exact operator-owned private directory,
-and absent before the command starts. The Manager authorizes one invocation on one exact clean HEAD
-and tree. The gate does not provide cross-process once-only state.
-
-One state owner records this ordered execution prefix: `cli`, `output_contract`,
-`source_binding_preflight`, `temporary_root`, `tool_discovery`, `toolchain_preflight`,
-`private_work`, `cluster_init`, `cluster_start`, `role_setup`, `source_binding_gate_start`,
-`toolchain_gate_start`, `server_version`, `definition_binding`, `source_database_created`,
-`source_migrated`, `source_provisioned`, `source_populated`, `source_semantic_authority`,
-`source_archive_created`, `archive_declaration_guarded`, `restore_database_fresh_template0`,
-`restore_pgcrypto_absent`, `restore_prerequisite_created`, `restored_once`,
-`restored_once_semantic_authority`, `semantic_authority_equal`, `invocation_policy`,
-`source_binding_gate_end`, `toolchain_gate_end`, `privacy_validation`, and
-`stopped_after_restored_once`. A receipt cannot claim a checkpoint until its action succeeds.
-
-The separate lifecycle owners are `cluster_stop`, `private_work_cleanup`, `cleanup_finalization`,
-`receipt_validation`, `receipt_source_binding`, and `receipt_publication`. Actual lifecycle state
-derives the ordered required cleanup sequence. `cluster_stop` is present only after cluster stop
-becomes applicable. `private_work_cleanup` is present only after private work exists. The only valid
-sequences are empty, `private_work_cleanup`, or `cluster_stop` then `private_work_cleanup`. Each
-required owner has pending, active, or completed state. `cleanup_finalization` is always an explicit
-fail-closed transition after that sequence.
-
-The exact reason set is `contract_invalid`, `authority_unavailable`, `changed`, `operation_failed`,
-`archive_declaration_invalid`, `target_not_fresh`, `duplicate_invocation`,
-`invocation_policy_failed`, `semantic_authority_changed`, `cleanup_failed`, `receipt_invalid`,
-`publication_failed`, `interrupted`, and `harness_corruption`. The definition binds the exact
-allowed checkpoint and reason pairs. The expected pairs are:
-
-- `cli`, `output_contract`, `temporary_root`, `definition_binding`, `privacy_validation`, and
-  `stopped_after_restored_once` use `contract_invalid`.
-- `source_binding_preflight`, `tool_discovery`, `toolchain_preflight`, and `server_version` use
-  `authority_unavailable`.
-- `source_binding_gate_start`, `source_binding_gate_end`, `toolchain_gate_start`, and
-  `toolchain_gate_end` use `authority_unavailable` or `changed`.
-- `private_work`, `cluster_init`, `cluster_start`, `role_setup`,
-  `restore_database_fresh_template0`, `restore_prerequisite_created`, and `restored_once` use
-  `operation_failed`.
-- `source_database_created`, `source_migrated`, `source_provisioned`, `source_populated`,
-  `source_semantic_authority`, `source_archive_created`, and `restored_once_semantic_authority` use
-  `operation_failed` or `duplicate_invocation`.
-- `archive_declaration_guarded` uses `archive_declaration_invalid` or `duplicate_invocation`.
-- `restore_pgcrypto_absent` uses `operation_failed` or `target_not_fresh`.
-- `semantic_authority_equal` uses `semantic_authority_changed`.
-- `invocation_policy` uses `duplicate_invocation` or `invocation_policy_failed`.
-- `cluster_stop` and `private_work_cleanup` use `cleanup_failed`.
-- `cleanup_finalization` has no expected operation failure.
-- `receipt_validation` uses `receipt_invalid`; `receipt_source_binding` uses
-  `authority_unavailable` or `changed`; and `receipt_publication` uses `publication_failed`.
-
-Every owner also permits `interrupted` and `harness_corruption`. An unexpected assertion, type,
-key, or invariant failure is `harness_corruption` at the active owner. The first primary failure is
-immutable. Before the first action, after an action before transition, between actions, and during
-finalization, one active or pending cleanup owner remains authoritative. Cleanup has fixed status and
-can become primary only when no execution primary exists. An execution primary keeps only the fixed
-secondary `cleanup_failed` reason. `cleanup_status=passed` proves that the completed cleanup sequence
-equals the required sequence and that finalization completed. Publication cannot relabel an earlier
-primary.
-
-The gate creates S0 once with the unchanged authority-mode setup. It migrates, provisions,
-populates, and runs the complete Rust semantic-authority owner once. It creates one custom dump.
-Before it creates R1, it uses the selected PostgreSQL 18 `pg_restore` to inspect the private TOC.
-The closed PostgreSQL 18 list parser requires one active `pgcrypto` `EXTENSION` declaration. It
-rejects an absent, duplicate, disabled, malformed, or ambiguous declaration. The guard does not
-retain or publish a TOC line, owner, ACL, OID, role, SQL, connection, path, or discovered object.
-
-After the guard passes, the shared restore helper creates R1 from `template0`. It connects as the
-canonical migration role and proves that `pgcrypto` is absent. It then executes exactly
-`CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public VERSION '1.4';`. The ordinary
-`pg_restore --exit-on-error` command stays under the bootstrap identity. It does not use `--role`,
-`--use-set-session-authorization`, `--no-owner`, or `--no-acl`. The helper does not run a migration
-or runtime provisioning after restore. The full Rust semantic-authority owner runs once at R1.
-The same guard and helper own each future Phase A R1 and R2 target.
-
-The gate stops after R1 for every outcome. It does not create R2, derive a manifest digest, publish
-an authority candidate, run Phase B, or run the aggregate. A pass publishes one immutable,
-create-only, mode-0600, file-fsynced and directory-fsynced
-`decodex/postgres-restore-prerequisite-r1-gate/2` receipt. The receipt has `acceptance=false`. It
-contains the exact source binding, PostgreSQL toolchain fingerprint, definition fingerprint
-`53bb20b8e43a6199c3aa578269cee8b941ed549fd8f10db0dce361a03016524a`, the complete validated
-checkpoint prefix, the exact required and completed cleanup-owner sequences, completed cleanup
-finalization, and fixed invocation-policy Booleans. The definition schema is
-`decodex/postgres-restore-prerequisite-r1-definition/2`.
-
-A failure uses `decodex/postgres-restore-prerequisite-r1-diagnostic/2`. It contains the validated
-source binding, or null before source validation, the immutable primary checkpoint and reason, the
-validated completed prefix, fixed cleanup status, and the optional fixed secondary cleanup reason.
-It also carries the exact required and completed cleanup-owner sequences, completed finalization,
-and the fixed `failure_document_repaired` Boolean. It includes the existing closed
-semantic-authority diagnostic only when a semantic owner has the primary failure. It cannot contain
-raw exception text, a command, child output, environment, path, selected tool name, database, role,
-owner, ACL, OID, SQL, connection, TOC content, catalog row, count, or discovered identity. Failure
-document construction and repair belong to `receipt_validation`. Incomplete or corrupt cleanup
-state produces one fixed privacy-safe repaired diagnostic and preserves a valid earlier primary.
-When the output contract is valid, the owner tries to publish one create-only failure receipt after
-cleanup. It also writes the same canonical diagnostic to standard error for publication-failure
-recovery. A fixed `receipt_validation/harness_corruption` fallback remains available if normal
-construction or durable publication fails. The raw-error `StageOrchestrator` remains separate.
-
-The v1 gate ran once and returned ownerless `gate/stage_failed` evidence. That result did not prove
-that candidate 3 reached the archive guard, prerequisite, restore, or R1 semantic owner. Candidate 3
-remains frozen and unadjudicated. The three-rejected-candidate threshold is not crossed unless one
-source-bound replacement result exercises and rejects candidate 3. A v2 pass authorizes only a
-later decision about revised Phase A. This v2 source is unexecuted, and it makes no acceptance
-claim.
-
-Phase A must start from one clean committed repaired tree. Its mismatch array is the exact ordered
-subset of `schema`, then `configured_authority`: it may be empty, contain either one component, or
-contain both in that canonical order. No unrelated component, duplicate, or reordered mismatch is
-valid. For one or two mismatches, the operator creates one clean direct single-parent child that
-changes exactly the reported digest array or arrays in `authority.rs`; every unreported digest and
-every other path remains byte-identical. For zero mismatches, Phase B uses the same clean HEAD and
-tree without an intervening commit. No particular commit hash is prescribed: the receipt and Phase
-B consumer bind and verify the actual Phase A commit/tree, candidate-receipt hash, clean Phase B
-commit/tree, exact mismatch set/order, and the corresponding same-tree or digest-only-child shape.
-
-The capture-only mode migrates and provisions an isolated PostgreSQL 18 database, captures raw
-source S0, first-restore R1, and second-restore R2 evidence, and separately proves the exact
-V13-to-V22 one-grantee runtime ACL delta from raw catalogs. The same immutable
-semantic-authority contract used by production readiness must pass at S0, R1, and R2 before the
-command atomically publishes
-`decodex/postgres-authority-candidate/3`; the Phase A mismatch set must be exactly the canonical
-zero-, one-, or two-component subset described above, while complete, unique, resolved manifests,
-migration ledger,
-semantic state, population, runtime-authority shape, and semantic evidence satisfy both restore
-edges. Raw manifests
-and temporary cluster state are not retained in the receipt. Capture, PostgreSQL shutdown/removal,
-and final source binding complete before publication. A complete fsynced mode-0600 temporary receipt
-is published by one create-only hard link; that link is the commit point and never overwrites or
-rolls back the final path. Directory fsync completes the normal-success durability claim, but any
-failure or interruption after the link is an ambiguous producer outcome resolved by reading the
-immutable receipt. Exit status and stdout are not evidence. The receipt has `acceptance=false`; it
-never substitutes for the normal aggregate. Phase B alone validates the exact immutable receipt,
-its hash and Phase A HEAD/tree, and the exact transition authorized by the mismatch array. It then
-repeats S0→R1→R2. Each checkpoint must contain the Rust-owned versioned definition, its ordered
-Boolean observations, and its emitted fingerprint. Python independently recomputes the
-domain-separated, length-prefixed SHA-256 fingerprint and compares it with the emitted value and
-the one supported value. It rejects malformed, missing, duplicate, extra, reordered, non-Boolean,
-false, or checkpoint-divergent evidence without a copied predicate inventory or Rust source
-inspection. Phase B requires every semantic predicate and restore edge to pass with zero digest
-mismatches, and publishes
-the only `acceptance=true` receipt bound to both trees and the Phase A receipt hash. Existing
-malformed, substituted, duplicate, or mismatched receipts fail closed. A zero-mismatch acceptance
-receipt is freshly emitted from the unchanged clean Phase A HEAD/tree and is explicitly bound to
-the Phase A receipt; existing receipts remain provenance only and cannot attest a source outside
-their recorded binding. For one or two mismatches, any unreported array change or other source
-delta invalidates the candidate.
-
-Phase A candidate capture uses a dedicated semantic parser path. It first validates the complete
-artifact shape, component structure, database binding, Rust-emitted definition, ordered Boolean
-observations, emitted fingerprint, independently recomputed fingerprint, and supported fingerprint.
-If one or more observations are false, it raises the exception-only
-`decodex/postgres-semantic-authority-diagnostic/2` diagnostic. The diagnostic has only `schema`,
-`source_binding`, `checkpoint`, `definition_fingerprint`, and `failures`. The source binding has
-only the exact lowercase 40-hex `head` and `tree`. The checkpoint is `source`, `restored_once`, or
-`restored_twice`. The nonempty failure array is complete and uses definition order. Each item has
-only the fingerprint-bound `predicate` and its fixed Rust-defined `failure_policy`. Canonical JSON
-uses sorted keys, compact separators, and ASCII escaping. The diagnostic does not contain passed
-observations, a concrete runtime-derived failure class, SQL, catalog or role data, counts, paths,
-raw evidence or errors, candidate mismatches, or schema, configured-authority, manifest, or
-mismatch digest values. The supported `definition_fingerprint` is its only digest. This branch
-stops before semantic summary hashing, digest derivation, mismatch construction, and receipt
-publication. Malformed evidence remains `artifact_malformed` and does not echo attempted
-predicate text. The shared retained-title loader keeps its immediate all-pass requirement.
-
-The current [XY-1368 retained-title validation](xy-1368-retained-title-validation.md) documents the
-two historical V22-era partial-boundary command surfaces that still exist in source. Neither
-command authorizes full-check publication or production enablement, and neither implements the
-retired private-artifact delivery contracts above.
-
-The normal aggregate uses one explicit stage report. Configuration and cluster preflight are fatal:
-mode/argument validation, clean source binding, temporary-root validation, PostgreSQL tool
-discovery, temporary cluster initialization/start, and base-role creation must all pass before
-semantic work is scheduled. Phase A/B instead validate their private output and receipt/source
-lineage directly, outside the aggregate scheduler. Meaningful aggregate suites then report `passed`,
-`failed`, or `blocked`. Ordinary `TestFailure` leaves independent branches schedulable but blocks
-every declared consumer of the failed prerequisite. RoleProfile, RuntimeSession, ManagedRun V26,
-migration-boundary,
-blob-restart, primary-store, managed-repository, account-composition, bootstrap/doctor, collation,
-authority safety, hostile-search-path, primary restore, redaction, default-ACL restore,
-authority-drift, and final-evidence work are all represented. A restore-owning suite cannot pass
-when one of its required nested captures, restores, parity checks, or production checks failed or
-became unavailable, so its consumers are blocked truthfully. One private live-doctor mutation SQL
-executor owns the ordinary, role-as, and secret-bearing mutation subprocesses, their dispatch and
-completion facts, output handling, and cleanup; the coordinator owns doctor readiness and the
-doctor child only. Every mutation and doctor child receives bounded terminate, kill-fallback, and
-reap attempts on every exit; an indeterminate or unreaped child is harness corruption. The probe
-and fixture restoration are separate stages. A failed ordinary `Popen` is pre-dispatch and blocks
-restoration; successful `Popen` owning SQL in argv makes delivery possible, so every later failure
-remains restoration-eligible. A secret mutation completes its fail-closed logging prelude before
-dispatch, becomes may-have-dispatched immediately before the first mutation-frame payload write,
-and remains eligible after any later write, flush, timeout, protocol, exit, or cleanup failure.
-Successful exit means only command acknowledged, not exact server receipt or non-vacuous mutation
-application; an optional postcondition query is separate evidence. The scheduler consumes exactly
-one restoration claim per shared-fixture attempt: pre-dispatch probe failure blocks restoration,
-eligible probe failure still attempts it, and the next shared-fixture probe depends on successful
-restoration. Assertion/type/key failures, invalid stage/report state, source-binding failures,
-redaction failures, and other unexpected exceptions are harness corruption and stop new scheduling.
-A private work directory is
-created with mode 0700 under `/private/tmp` by default on macOS; the existing validated
-`DECODEX_TEST_TEMP_ROOT` override remains available. Before cluster initialization, the harness
-rejects any resolved workspace whose final `.s.PGSQL.<port>` pathname plus terminating NUL exceeds
-the portable 104-byte Unix-socket bound. The directory is cleaned directly when preflight fails
-before cluster start, with cleanup failure remaining subordinate. If `pg_ctl start` fails, its
-primary `TestFailure` includes a bounded, secret-marker-redacted tail of `postgres.log` before the
-stopped cluster is removed; no log or cluster retention is introduced. After PostgreSQL has
-started, teardown and final stage-report emission still run. The semantic/stage failure is selected
-before aggregate output and report emission, so cleanup or emission failures are recorded without
-replacing it. The normal aggregate emits `decodex/postgres-aggregate-stage-report/1`. The focused
-ManagedRun mode emits `decodex/postgres-managed-run-v26-stage-report/1`. Other focused modes and
-Phase A/B capture modes preserve their direct output or receipt behavior.
-
-An unavailable or incomplete raw schema/authority component publishes no receipt. Before its private
-cluster is removed, the capture emits a versioned, bounded diagnostic to the operator-owned combined
-log containing the exact source/database binding, component status, manifest hash and row count when
-present, and at most eight unresolved dependency kind/identity/reference records. In this mode only,
-database failures contain SQLSTATE and primary message; non-database failures use fixed generic text.
-Malformed artifacts report only classification, expected binding, byte length/hash when readable,
-and a bounded parser error. Diagnostic text and identities are length-bounded and secret-marker
-redacted; full manifests and raw contracts are never emitted.
-Semantic `/2` diagnostics contain only the schema, exact source binding, canonical checkpoint,
-supported definition fingerprint, and complete definition-ordered failure objects. Each failure
-contains only its false canonical predicate name and fixed failure policy. These diagnostics never
-contain SQL, ACL bodies, object identities, connection data, paths, or other digest values.
-
-The PostgreSQL integration command uses an isolated PostgreSQL 18 cluster and fixture-only roles.
-Its authority matrix contains 28 unsafe roots and six incompatible roots. The new unsafe root adds
-a migration-owned, runtime-executable `public` `SECURITY DEFINER` routine. Direct runtime
-ManagedRun mutation is rejected first. The routine then performs one valid ManagedRun
-revision/divergence mutation, while the Decodex relation, routine, trigger, rule, and policy
-inventories stay unchanged. Production verification must reject this unexpected runtime entry.
-
-Runtime entry closure evaluates the login identity and every inherited or `SET ROLE`-reachable
-identity. Effective privileges include `PUBLIC` and column grants. The verifier rejects unexpected
-privileges on non-system relation-like objects and unexpected runtime-executable non-system
-security-definer normal functions, procedures, or window functions. Aggregate rows are excluded
-because PostgreSQL `CREATE AGGREGATE` has no `SECURITY DEFINER` capability. The one external
-execution dependency is exact `public.digest(bytea,text)` from `pgcrypto` 1.4, including extension
-membership, namespace, owner relationship, metadata, and ACL. Existing scenarios continue to cover
-direct and indirect authority, DDL, relation/ledger/sequence mutation, grant options, trigger drift,
-extension control, canonical-function drift, external cascades, ledger tampering, and absent
-`pgcrypto`.
-
-The following historical V9 detail remains part of the retained test surface.
-The XY-1267/XY-1307 integration command and XY-1264 storage proof are intentionally separate because they require an intended macOS host with one PostgreSQL 18 distribution. Each creates and removes its own isolated temporary checksummed cluster with TCP disabled and never enumerates or changes an existing service. The PostgreSQL command provisions fixture-only migration/runtime roles, proves least-privilege daemon bootstrap, and rejects 27 unsafe roots covering direct, inherited, NOINHERIT/SET-only, and membership-admin paths to forbidden role attributes, PostgreSQL 18 namespace-object ownership (including distinct collation, conversion, operator, and text-search cases), DDL, table/ledger/sequence mutation, grant options, `session_replication_role` SET/ALTER SYSTEM, retention bypass, trigger drift, extension-member control, an indirect public-function trigger, and a genuinely additional function. It closes every runtime-callable Decodex function over exact signatures, overloads, metadata, settings, and canonical source. At the frozen V9 boundary, all 72 shipped functions have the exact secure `pg_catalog, decodex` function-local search path, and all 52 non-internal shipped trigger bindings—including deferred constraint triggers—have exact catalog attestations. The 16 shipped security definers comprise three V3 cursor/history functions, eleven V5-V7 Project/Policy/Program/Objective command entrypoints, and two V9 RoleProfile command entrypoints; runtime cannot insert cursors or execute capture directly. The additional fixture-only seventy-third function is migration-owned, runtime-executable, `SECURITY DEFINER`, configured with an unsafe setting, and is invoked as runtime to perform owner-authority trigger DDL before fixture restoration and independent rejection. The separate substitution fixture replaces a shipped safety body without changing its signature. The indirect-trigger fixture proves runtime DML executes a public definer function despite direct `EXECUTE`, protected-table `UPDATE`, and `TRIGGER` all being denied. The extension fixture proves a public runtime-owned extension can transactionally drop it. Six incompatible roots cover missing ledger SELECT, canonical-function drift, a dropped credential constraint with demonstrated credential insertion, an external child cascade with demonstrated runtime-mediated deletion, a same-count tampered migration ledger, and absent `pgcrypto`. The canonical PostgreSQL 18 schema manifest closes defaults, constraints on both foreign-key sides, indexes, enums, and internal constraint-trigger semantics. Descriptor-pinned socket unit fixtures reject a same-UID pre-planted endpoint in a world-writable configured directory, a mismatched operator UID pin, replaced ancestors, replaced endpoints, and deterministic replacement between precheck and failed connect; an unchanged secure stale socket maps to unreachable. An isolated daemon fixture starts Ready, replaces the configured endpoint, and proves a fresh V1.3 doctor query becomes unsafe-host-path without migration or repinning. The runtime protocol tests keep mutation receipt lookup/capacity independent across V1.2/V1.3 and prove repeated, ordered, concurrent live queries neither replay nor consume receipts. The adapter contract tampers a ledger name at constant row count, proves read-only live revalidation reports it as incompatible, restores the ledger, and revalidates successfully; a terminal direct-adapter fixture removes `pgcrypto` in its own disposable database and proves the missing extension is incompatible without restoration. The harness also exercises an in-flight Rust BlobSession across an immediate PostgreSQL restart: the old session loses its hash lock and transaction-B connection, its stale claim cannot complete, and a reassigned exact retry verifies already-published bytes before committing metadata. It also proves `setval` denial, same-signature callable hostile-`search_path` safety, Turkish ICU credential behavior, and populated dump/restore. The XY-1264 proof additionally exercises rollback, blob, and cache behavior (`crates/decodex-postgres/src/socket.rs`, `crates/decodex-runtime/tests/bootstrap_doctor.rs`, `scripts/vnext/postgres_store_test.py`, `spikes/vnext-storage/proof.py`, `spikes/vnext-storage/README.md`).
-
-The V10 extension raised the closed production inventory to 80 functions, 59 non-internal
-triggers, and 18 security definers. The two additional definers are the command-complete
-RuntimeSession creation and transition owners; the other three new private/builder routines and
-three new trigger routines are security invokers. Runtime receives EXECUTE only on the two command
-owners and SELECT-only access to RuntimeSessions and their profile/account snapshots. The
-additional privileged-function fixture is therefore the eighty-first function at V10. The frozen
-XY-1337 fixtures cover exact request substitution and replay, stable rejection replay, profile and
-duplicate races, hostile DML/helper/audit namespaces, five atomic rollback boundaries, V9-to-V10
-identity-preserving upgrade, and populated restore. The manager-owned final PostgreSQL 18 run adds
-clean V1-to-V10 bootstrap, classified zero-state and blocked-old-writer cutover, whole-transaction
-retry, crash/restart, dump/restore, and stress schedules; those live gates are deliberately not run
-during candidate construction.
-
-V11 adds canonical PostgreSQL WorkItems without introducing execution ownership. The closed
-inventory is 98 functions, 69 non-internal triggers, and 23 security definers. Runtime can execute
-four exact WorkItem command owners plus one inert future running/resume guard, and receives
-SELECT-only access to five normalized WorkItem relations. Readiness re-reads and locks the current
-WorkItem, Project, canonical Lead, Program/Objectives, dependency/blocker graph, lifecycle, and
-revision state in one transaction before recording typed blockers or entering `ready`. Lead
-acceptance snapshots exact-review-revision criteria, evidence provenance, and database chronology
-without changing lifecycle or revision; completion remains unowned. The focused V11 harness mode
-covers exact replay and concurrent convergence, cycle rollback, readiness blocker persistence,
-guard inertness, acceptance immutability and non-completion, clean V1-to-V11 bootstrap, and populated
-dump/restore.
-
-V12 adds only inert blocked/waiting ManagedRuns and one safety consumer transaction. At the
-historical V12 boundary, the closed inventory was 107 functions, 84 non-internal triggers, and 24
-security definers. Runtime receives
-SELECT-only access to six ManagedRun/effect/readback relations and EXECUTE on one command-complete
-safety entrypoint; it has no ManagedRun creation, acquisition, activation, progress, completion,
-assignment, submitted-receipt production, or effect-lineage writer authority. Task and Reviewer
-assignments bind exact RuntimeSessions and cannot encode Advisor, Lead, or durable Agent identity.
-The barrier has only fail-closed `guarded` and `closed` states. V26 removes the drained V12 local
-barrier authority and adds execution-coordinator readback. One `managed_run_v26_suite` stage owns
-the focused ManagedRun mode and the normal PostgreSQL aggregate. The stage owns its database,
-migration, runtime provisioning, baseline capture, V26 behavior, post-behavior capture, dump,
-restore, restored capture, and restored behavior. Exact nextest selection must fail when it selects
-zero tests. Final aggregate evidence depends on this stage. Source parsing, copied predicate
-inventories, regular-expression control-flow proofs, and AST reachability proofs are not part of
-this validation boundary.
-The final schema produced by every migration version must be a PostgreSQL 18 dump/restore fixed
-point so the one exact full-manifest digest remains identical before and after logical restore.
-Cross-database manifest identity is semantic rather than catalog-local: every relation, column,
-constraint, function signature, trigger, dependency, ACL/default ACL, and sequence is keyed by
-stable schema/name/owner-column/principal tuples. Catalog OIDs and presentation renderers are join
-mechanics only and never enter emitted identity or ordering. Sequence definitions and stable
-ownership belong to the schema manifest; mutable sequence values are a separate restore-state
-receipt. Every manifest checkpoint binds an explicit requested database to both configured URLs
-and both observed `current_database()` values, while that binding evidence is excluded from
-cross-database digest equality. The canonical harness collects source, post-command, populated
-RoleProfile restore, and final primary restore evidence before one terminal report.
-
-XY-1353 reset the earlier catalog-presentation model after two canonical-boundary falsifiers: the
-normalized source schema changed from the stale `5b546036...` digest to `79fc7a15...`, then the
-same committed candidate restored as `b3984125...`. Those failures reject the identity model, not
-PostgreSQL logical restore, and prohibit repairing another individual OID or mechanically rebinding
-a digest before semantic source/restore parity is established.
-
-The XY-1345 command is a separate non-production architecture proof. It requires exactly
-PostgreSQL 18.4, creates a private temporary cluster with TCP disabled, installs only fixture
-roles/objects, exercises the deterministic and 50-by-32 stress schedules, performs populated
-`pg_dump`/`pg_restore`, stops the cluster, and removes its temporary root on success or failure. Its
-JSON output is the command receipt; any `FAILED` result or nonzero anomaly count falsifies the gate.
-It does not run the production migration ledger and cannot substitute for the V9 clean-bootstrap,
-V8-to-V9 upgrade, authority-manifest, hostile SQL, crash/recovery, focused concurrency/idempotency,
-and populated-restore tests owned by XY-1346. The canonical final PostgreSQL harness runs the V9
-upgrade, concurrency, crash/recovery, and populated-restore scenarios in isolated databases; it
-also injects admin-only receipt/domain/activity/outbox aborts and database-executed
-serialization/deadlock failures to prove whole-transaction rollback, retry, and convergence through
-the production RoleProfile API. The V9 proof runs once only after the exact candidate is frozen;
-active implementation uses targeted Rust compilation, parser/unit contracts, and migration/protocol
-syntax checks. See
-[the durable evidence page](../evidence/xy-1345-exact-command-authority.md).
-
-The PostgreSQL integration harness bootstraps the shipped V1-V12 migration history, from the `V1`
-foundation through the forward-only `V12` ManagedRun safety authority, and verifies
-transaction/idempotency/revision behavior, Conversation-lock serialization with append-only history-derived
-positions, snapshot high-water, and immutable item-version sequence with no writable stored next-position counter, page-only opaque
-issued-cursor pagination with never-issued/expired/cross-Conversation/edited-chain rejection,
-fixed chain page size, 512-per-Conversation/4,096-global durable limits, serialized concurrent
-capacity, exact-boundary expired-chain pruning, runtime direct-root denial, and the canonical
-receipt-before-statement-level-hierarchy/cursor/row lock order under same- and cross-Conversation
-history-versus-Artifact races, mutation-stable snapshot replay, canonical
-insert-time lifecycle timestamps, immutable RuntimeSession Codex-thread and
-last-known-turn correlations across lifecycle transitions, scoped foreign-key and terminal-state
-counterexamples, contiguous Artifact revision history and exact parent/current-revision coherence,
-receipt-first fenced claims, exact stored-response replay, and cross-operation/entity conflict before
-effects, large history and Context Pack blob offload, canonical media-type rejection before authority commit,
-missing/tampered/retried direct and transitive blob behavior, sorted session hash/per-shard admission
-locks, concurrent shard-capacity enforcement, bounded grace-aged resumable orphan reclamation with
-metadata-commit-before-byte-removal crash ordering, two-connection parent/child serialization races,
-writer/reclaimer exclusion, complete Context Pack provenance/readback/determinism/truncation, sealed
-source-manifest append/update/delete/gap rejection, a real PostgreSQL-backed WebSocket history path,
-and hard-disabled transition dispatch. A hostile-search fixture supplies same-signature callable
-shadows and proves canonical media validation and trigger timestamps still use catalog semantics.
-It also verifies collation-independent credential rejection in
-a Turkish ICU database, dumps the populated primary database, restores it into a fresh
-database, and reruns the restored contract. The primary contract also exercises
-caller-shifted lease/retry/retention anchors, early and due delivered-row deletion, and
-forbidden outbox truncation. Intermediate schemas from unshipped branches are not
-compatibility targets.
-
-## Managed repository frozen-tree validation
-
-This section describes the managed-repository and historical V22 frozen-tree boundary. It does not
-define or satisfy the retired private-artifact unified validation protocol.
-
-Managed-repository stage-two work has no pre-freeze execution gate. Do not run compile, test,
-check, Clippy, format, migration, wrapper, matrix, doctest, behavioral, app, or benchmark commands
-while its parallel owners construct the candidate. After serial integration freezes one exact
-tree, run one complete unified validation on that tree only. Keep the resulting evidence categories
-concise: pure semantics; PostgreSQL authority, concurrency, restore, and retention; accepted
-Git/filesystem execution and operation-specific readback; first shared-saga composition; provider
-and repository integration; and final digest/manifest agreement. Partial runs, expanded early test
-matrices, and results from any other tree are not acceptance evidence.
-
-The managed-repository deferred cases are the
-[XY-1353 deferred acceptance matrix](../specs/vnext-gates.md#xy-1353-deferred-acceptance-matrix).
-For the V22 retained-title bridge, the
-[XY-1367 V22 deferred acceptance matrix](../specs/vnext-gates.md#xy-1367-v22-deferred-acceptance-matrix)
-is historical acceptance context. It does not grant current command authority or define the
-future package validation protocol.
-The repository has no standalone XY-1353 artifact generator: migration, configured-authority, and
-schema inventories plus their expected/actual digests are emitted and checked by the canonical
-PostgreSQL frozen-tree harness during that one unified gate. Do not run it as integration-time
-code generation or create parallel manifest authority.
-
-## Manual V22 retained-title experiment
-
-The manual runner is not a validation command. Run it only under separate live-effect authority.
-Do not run it during XY-1367 or XY-1368.
-
-The runner requires the `retained-title-experiment` feature. No default feature enables it.
-The `decodexd` application does not depend on this feature or binary.
-
-```sh
-cargo run -p decodex-runtime \
-  --features retained-title-experiment \
-  --bin decodex-retained-title-experiment -- REQUEST.json
-```
-
-`REQUEST.json` has one closed JSON object. It contains these fields:
-
-- `identity`: The complete V14 experiment identity.
-- `creation_attempt_id`: The UUID for the one start fence.
-- `title_attempt_id`: The UUID for the one title-set fence.
-- `attestation_id`: The UUID for the exact-ID retained-title attestation.
-- `observation_id`: The UUID for the positive read observation.
-- `timeout_milliseconds`: A value from 1000 through 60000.
-
-The runner fixes the app-server request IDs to 3, 4, and 5. They identify start, title set, and
-read. It derives each database idempotency key from the experiment ID and operation name.
-
-The runner first verifies configuration, database readiness, executable identity, schema, and
-account identity. It then permits only this effect sequence:
-
-1. Prepare the experiment.
-2. Commit the creation fence.
-3. Send one `thread/start` request after a fresh fence.
-4. Bind the exact start request and response immediately.
-5. Commit the title-set fence.
-6. Send one `thread/name/set` request after a fresh title fence.
-7. Read only the exact bound thread ID.
-8. Commit the retained-title attestation.
-9. Commit the positive observation.
-
-A creation-fence replay can only read the exact durable start receipt. An absent receipt is
-terminally ambiguous. A title-fence replay can only read the exact bound thread.
-
-A lost title-set response can only continue to exact-ID readback. No path retries an external
-request. Database transport can retry only the same key and byte-equivalent envelope.
-
-## Validation scope selection
-
-Use the aggregate gate before broad readiness, landing, or release-readiness claims. During iteration, choose the smallest command that covers the touched contract, then name that scope in handoff notes. A narrow validation result is useful evidence, but it is not equivalent to the broad gate unless the change is truly limited to that surface.
-
-Good targeted scopes are contract-shaped rather than file-shaped: CLI parsing/output, runtime state transitions, tracker comments, GitHub status and merge behavior, app-server payloads, site type/build behavior, or plugin/generated-artifact sync. If a change crosses scheduler, review/landing, state, or public/private projection boundaries, start with the relevant focused tests and finish with a broader Rust or repo gate when feasible.
+These commands are current source checks. They do not replace the new database gates
+below. Do not cite a migration-era PostgreSQL subcommand, numbered-ledger result, or
+historical restore receipt as latest-schema evidence.
+
+## Latest-schema command boundary
+
+The exact command names for empty-target bootstrap, current-authority validation, and the
+operator-only local reset are implementation-owned. They are not yet authoritative.
+Implementers must add or rename commands and task-runner entries together with their
+source and contract tests. Do not invent aliases in documentation or preserve old names
+for compatibility.
+
+There are three separate operations:
+
+1. **Empty-target bootstrap** resolves the schema-owner credential, proves a clean
+   target, executes `crates/decodex-postgres/schema.sql` once in one transaction, verifies
+   the result, and commits.
+2. **Current-authority validation** is read-only and verifies the live catalog and
+   configured runtime authority. It resolves no schema-owner credential and executes no
+   DDL.
+3. **Local database reset** is one reviewed operator-only action that stops the daemon,
+   preserves the complete credential-negative account and routing tuple, including each
+   enabled state and the mode-valid fixed target, replaces or directly transforms the
+   local database, bootstraps when needed, rebinds the exact tuple to unchanged
+   host-vault records, proves exact readback, and starts the daemon.
+
+Normal `decodexd` serve is not any of these commands. It uses only the runtime credential,
+executes zero DDL, and invokes current-authority validation before it retains the store.
+
+The current hidden `provision-local` behavior and any daemon path that applies numbered
+SQL are superseded implementation. They do not define the future command spelling or
+contract.
+
+## Source-freeze validation order
+
+After the implementation source is frozen, use this order:
+
+1. reverse scan retired schema names, paths, dependencies, credentials, and commands;
+2. bootstrap one fresh PostgreSQL 18 empty target;
+3. run the same bootstrap again and prove nonempty refusal with no change;
+4. start `decodexd` with only runtime credentials and prove zero DDL/no schema owner;
+5. run exact current catalog/configured-authority and adversarial negative checks;
+6. parse and execute every changed adapter SQL path against the fresh database;
+7. run Candidate-5 domain, transport, and account-observation checks;
+8. run the direct local reset/rebind/readback scenario; and
+9. run the applicable repository aggregate, UI, package, and live exact-build checks.
+
+Do not add Phase A/B, a preparation pass, a digest-only child, a schema receipt, or a
+second aggregate. No historical upgrade or migration proof belongs in this order.
+
+## Reverse scan
+
+The reverse scan is read-only and must find no active executable or acceptance reference
+to:
+
+- `crates/decodex-postgres/migrations` or numbered `V<integer>__*.sql` files;
+- Refinery dependency, macro, runner, target version, or error type;
+- `public.refinery_schema_history` or another schema-history relation;
+- latest-version constants, `run_through_*`, prefix checks, upgrade branches, or
+  migration-source includes/parsers;
+- schema-owner credentials in normal daemon configuration/startup;
+- migration receipts, finalizers, rollback/fallback code, Phase A/B schema flows, or
+  S0/R1/R2 acceptance;
+- `SchemaManager`, schema registry, generator pipeline, bootstrap facade, or cutover
+  coordinator;
+- executable schema ownership in `spikes/vnext-storage`; or
+- tests, scripts, task-runner entries, docs, and manifests that require any retired
+  mechanism.
+
+The scan may find explicit negative/supersession text in active authority documents and
+clearly labeled historical evidence. Classify those hits; do not treat them as executable
+drift.
+
+## Empty-target bootstrap validation
+
+Use one isolated PostgreSQL 18 target with data checksums and TCP disabled unless a
+separate accepted test requires it. The command must verify the configured Unix-socket
+directory, endpoint descriptor identity, expected server UID, and kernel peer UID before
+it sends authentication data.
+
+Prove all of these outcomes:
+
+- only the explicit operator invocation resolves the schema-owner credential;
+- a clean target matches the accepted fresh-database catalog baseline, apart from
+  externally provisioned login roles, with no user-created schema, relation, function,
+  type, extension, or other product object;
+- `pgcrypto` and the complete latest schema execute in one transaction;
+- SQL, verification, disconnect, and injected failure before commit leave no partial
+  Decodex schema;
+- final enums, relations, constraints, indexes, functions, triggers, dependencies,
+  owners, grants, `schema_fingerprint`, and runtime authority are exact;
+- every accepted runtime function has the required safe settings and body;
+- every accepted trigger is enabled and bound to its final function; and
+- the second invocation fails before DDL and leaves the exact catalog unchanged.
+
+Do not run the executable storage spike as bootstrap or proof.
+
+## Runtime-only startup validation
+
+Instrument the database boundary or use an equivalent independent oracle. Start
+`decodexd` with the schema-owner credential absent and prove:
+
+- runtime credential resolution only;
+- zero DDL and zero extension/schema creation;
+- no access to latest schema bytes for execution, numbered SQL, or a schema-history table;
+- exact current catalog, dependency, ownership, ACL, function, trigger, semantic, and
+  configured-authority checks;
+- typed unavailable results for missing, extra, changed, unsafe, unreachable, or
+  authentication-failed authority; and
+- bounded doctor/status revalidation with no mutation or endpoint repinning.
+
+Adversarial cases cover PUBLIC/runtime grants, inherited and `SET ROLE` paths, object
+ownership, DDL, `TRUNCATE`, grant options, trigger bypass, unsafe search path/function
+settings, overloads, default ACLs, extension membership, external cascades, rules,
+policies, RLS, sequence mutation, trigger/body drift, and fingerprint forgery.
+
+## Adapter SQL validation
+
+Every SQL statement in adapters and tests must target the final schema. Parse and execute
+the affected commands against the fresh bootstrapped database. Cover exact request and
+response construction, stable rejection, replay, rollback, serialization/deadlock retry,
+concurrency, strict readback, and hostile identity cross-links.
+
+Do not keep old/new query branches or fixtures for an old catalog. Remove tests whose only
+claim is migration order, upgrade compatibility, or schema-history integrity. Preserve
+and retarget tests that protect current domain semantics, ACLs, crash behavior,
+reconciliation, or exact readback.
+
+## Candidate-5 validation
+
+The complete boundary is in
+[vNext Gates](../specs/vnext-gates.md#candidate-5-quick-task-gate) and
+[vNext Authority](../specs/vnext-authority.md#quick-task-thread-establishment).
+
+Validation must prove:
+
+- exact `L0`/`L6` lineage and complete routing evidence;
+- one sole Routing Decision account selector;
+- atomic first account/profile/session/plan cluster;
+- atomic one-winner first Turn and first Message admission;
+- selected-account HostCredentialStore pre-spawn fence without re-selection;
+- exact Turn locks across ProcessGeneration, thread, and ProviderAttempt effects;
+- `Fresh`/`Replayed`/`Rejected`/`Unknown` behavior and definite pre-effect refusal;
+- final exact trigger bodies/bindings without a broad starting-session bypass;
+- existing same-thread and Context Pack behavior;
+- positive-only ProcessGeneration and ProviderAttempt reconciliation;
+- same-UID transport ordering, completion, and shutdown; and
+- preservation of current-main account observations and cache reads.
+
+For account observation preservation, prove different accounts progress concurrently;
+Reset Card work precedes profile observation within one account; repeated wakes coalesce;
+publication is revision/cache-generation fenced; and Reset Card/profile queries read
+daemon cache or persisted projection without joining, waiting for, or starting provider
+refresh work.
+
+## Local database reset validation
+
+Use disposable local state and a test HostCredentialStore. The reviewed operator action
+must:
+
+1. stop the daemon;
+2. capture only credential-negative Account UUID, enabled state, account revision,
+   provider binding, credential version/fingerprint, and store binding for every retained
+   account, plus routing revision, mode, fixed target, and complete order;
+3. replace or directly transform the database;
+4. bootstrap the latest schema when the target was recreated;
+5. restore or rebind the exact captured tuple against unchanged host-vault records;
+6. prove exact Account Registry and `HostCredentialStore` agreement, every retained
+   account's enabled state, revision, and binding, and the routing
+   revision/mode/fixed-target/order tuple; and
+7. start the daemon only after current-authority verification passes.
+
+For `fixed` mode, require one non-null target that belongs to the retained account set
+and complete order. For `balanced` mode, require a null target. Require the order to be a
+duplicate-free permutation of all retained accounts, including disabled accounts.
+Readback must compare each enabled value and the exact mode, target, order, revision, and
+membership as one tuple.
+
+Instrument the existing `HostCredentialStore` owner boundary. For credential agreement
+only, that owner may perform a confined in-process exact read, recompute and compare the
+credential fingerprint and binding, and return only a typed credential-negative
+agreement result. The operator action and result must not expose, serialize, copy, log,
+persist, rotate, delete, or return token bytes. The check must create no public product
+or migration API, generic attestation framework, metadata sidecar, generic import API,
+migration state, backup/rollback, receipt/finalizer, or fallback. A failed readback
+leaves the daemon stopped.
 
 ## Owner path source map
 
-Use the owner path to choose the first validation surface:
-
-- `crates/decodex-core/`: vNext domain/application contracts and authority ports plus
-  the typed `~/.decodex` root, bounded/redacted config, stable server identity,
-  integrity-verifying blobs, and disposable bounded cache. For managed repositories it
-  owns only mechanism-neutral values, facts, descriptors, evidence, and pure deciders;
-  these are not durable authority.
-- `crates/decodex-protocol/`: version, same-UID Unix namespace authority, and bounded
-  typed WebSocket client transport shared by CLI and future UI clients.
-- `crates/decodex-postgres/`: explicit PostgreSQL product-state adapter and isolated
-  real-PostgreSQL integration tests; XY-1307 runtime composition supplies only typed
-  explicit configuration and retains unavailable on every bootstrap failure. XY-1349 is
-  the sole V13 owner for managed-repository projection, generation/tip, global operation
-  assignment, append-only evidence, compare-and-swap, transaction completeness, receipt
-  provenance, retention, and restart loads.
-- `crates/decodex-codex/`: typed shared-home Codex adapter foundation; live dispatch is
-  disabled in current source. Slice 1 may enable only fenced initial fixed/balanced
-  selection; XY-1304 remains the later automatic fallback/wake gate.
-- `crates/decodex-runtime/`: `decodexd` lifecycle assembly over the four narrow owners;
-  for managed repositories it sequences accepted owners but creates no state or receipt
-  authority. XY-1351 owns the first shared saga path.
-- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/`: active vNext composition roots.
-- `apps/decodex/`: frozen v0.2 source excluded from the workspace; provenance only.
-- `apps/radar/`: Radar auxiliary tool for upstream evidence, release deltas, signal rendering, artifact validation, and ledger workflows.
-- `apps/decodex-publisher/`: Publisher auxiliary tool for social candidate, reservation, post validation, and publication handoff workflows.
-- `plugins/decodex/`: installable Decodex runtime/operator plugin source, including planning, runtime ops, commit, and landing skills/hooks.
-- `automations/radar/` and `automations/decodex/`: repo-local Codex App automation sources; generated Radar and Publisher artifacts stay under `.agent/automations/**/cache`.
-- `site/`: Astro/TypeScript public static site and app download entry; validate with site type/build commands rather than runtime checks.
-- `apps/decodex-app/`: current native SwiftPM macOS account UI. It contains one
-  daemon-protocol account surface under
-  [Account Lifecycle Authority](../specs/account-lifecycle-authority.md), with no
-  local account pool, helper/server workflow, or dual authority.
-- `spikes/vnext-storage/`: isolated XY-1264 PostgreSQL, blob, and bounded-cache feasibility proof; validate it with `cargo make test-vnext-storage-proof` and use [the evidence record](../evidence/vnext-storage-feasibility.md) for accepted choices and boundaries.
-- `scripts/`: repository helpers; `scripts/assets/` owns checked-in asset generation,
-  and `scripts/macos/` owns macOS app packaging checks and the source-install local
-  service installer.
-- `.github/`: repository automation such as CodeQL code scanning ruleset support.
+- `crates/decodex-core/`: domain/application contracts, typed paths/configuration, blobs,
+  cache, and pure decision values.
+- `crates/decodex-protocol/`: exact-current same-UID local protocol and clients.
+- `crates/decodex-postgres/schema.sql`: sole executable latest schema.
+- `crates/decodex-postgres/src/schema.rs` or the final equivalent module: clean-target
+  bootstrap transaction and post-execution verification. The exact file name is an
+  implementation choice; its ownership contract is fixed.
+- `crates/decodex-postgres/`: current PostgreSQL adapters and read-only authority
+  verification.
+- `crates/decodex-codex/`: typed app-server adapter and exact-build capability profiles.
+- `crates/decodex-runtime/`: daemon service assembly, Account Service,
+  ProcessSupervisor, ProviderAttemptService, account observations, and stateless execution
+  coordination.
+- `apps/decodexd/`: server composition and implementation-owned operator command surface.
+- `apps/decodex-cli/` and `apps/decodex-gpui/`: protocol clients.
+- `apps/decodex-app/`: credential-negative native account client.
+- `apps/decodex/`: frozen v0.2 provenance only.
+- `spikes/vnext-storage/`: historical feasibility source only; no executable schema or
+  validation owner.
+- `site/`, Radar, Publisher, plugins, and automations: auxiliary surfaces with their own
+  checks.
 
 ## Targeted Rust checks
 
-Common targeted commands:
+Common current source checks include:
 
 ```sh
 cargo check --all-features --all-targets --workspace
@@ -713,36 +272,17 @@ cargo nextest run --workspace --all-targets --all-features
 cargo make test-vnext-architecture
 cargo test -p decodex-core --all-targets --all-features
 cargo test -p decodex-core -p decodex-protocol -p decodex-postgres -p decodex-codex -p decodex-runtime
-cargo test -p radar <filter>
-cargo test -p decodex-publisher <filter>
 ```
 
-The remaining test map on this page describes frozen v0.2 provenance and remains useful
-only when later removal work audits preserved behavior. It is not an active vNext test
-surface.
+After implementation, the task runner must expose one canonical latest-schema/bootstrap
+gate and one canonical current-authority/runtime gate. Their names remain
+implementation-owned. A test that still initializes through numbered SQL is not evidence
+for this reset.
 
-## Test map
+## CLI discovery
 
-Use source placement over stale historical test counts; current high-value areas are:
-
-- `apps/decodex/src/orchestrator/tests/`: intake, retry, review/landing, runtime cleanup, operator status, repo gates, Program dispatch, reconciliation.
-- `apps/decodex/src/agent/tracker_tool_bridge/tests/`: dynamic tracker tools, continuation guards, review handoff, review repair, closeout, terminal finalize, public/private projections.
-- `apps/decodex/src/agent/app_server/tests/` and `apps/decodex/src/agent/json_rpc/tests/`: app-server JSON-RPC parsing, dynamic tools, phase goals, thread/turn runtime, transport failures.
-- `apps/decodex/src/state/tests/`: SQLite persistence, leases, run-control channels, protocol replay, schema migrations, runtime records.
-- `apps/decodex/src/cli/tests/`: CLI parsing and command contract checks.
-- `apps/decodex/src/mcp/tests/`: MCP resources, HTTP transport, CORS/auth, capability profiles, lane/project control tools.
-- `apps/decodex/src/config/tests/` and `apps/decodex/src/workflow/tests/`: config and workflow policy parsing.
-- `apps/decodex/src/manual/tests/`, `apps/decodex/src/github/tests/`, `apps/decodex/src/worktree/tests/`, `apps/decodex/src/recovery/tests/`: Git, PR, landing, worktree, and recovery helpers.
-- `tests/scripts/test_sync_installable_plugins.py`: Python test for installable plugin sync and repo-local global skill cleanup.
-
-When adding tests, protect an externally visible contract: CLI output, status JSON, tracker comments, runtime DB state, app-server protocol payloads, Git commands, or public/private boundary behavior. Behavior families that deserve focused tests include scheduler/intake/retry transitions, review and landing classification, tracker mutation writebacks, app-server JSON-RPC payloads, SQLite state and leases, MCP resources/tools, config/workflow parsing, recovery/retained-worktree flows, and Radar/Publisher artifact validation. Prefer table-driven cases when inputs vary only by spelling or equivalent invalid values; keep separate tests when the state-machine outcome, persisted lifecycle marker, authority boundary, process boundary, or observable public surface differs.
-
-Non-Rust validation matters when the touched surface is not in the Cargo workspace: use `npm --prefix site run check` or `npm --prefix site run build` for the Astro site, the plugin and automation Python commands for generated installable artifacts, and the Swift/macOS staging commands for `apps/decodex-app/`. Do not treat `cargo test` as coverage for those surfaces.
-
-## CLI and operator command discovery
-
-The active vNext CLI starts in `apps/decodex-cli/src/lib.rs`. Use these commands for
-the shared reset-card service:
+The active vNext CLI source starts in `apps/decodex-cli/src/lib.rs`. Current supported
+account and Reset Card discovery includes:
 
 ```sh
 decodex account list
@@ -761,124 +301,15 @@ decodex reset-card use \
 decodex reset-card status --idempotency-key KEY
 ```
 
-`account profile` uses the fixed daemon-owned ChatGPT profile endpoint. It is independent
-from Reset Card inventory. The default JSON result reports
-`email.visibility = "redacted"`. `--include-email` permits one bounded current credential
-email in that response. Current and cached results carry one profile snapshot. An
-unavailable result carries one typed error, the same explicit email visibility, and an
-optional current credential `plan_type` claim. PostgreSQL stores only the latest non-secret
-profile snapshot and at most 36 daily usage facts. It stores no email, plan claim, token,
-or provider body.
+Account profile and Reset Card list are daemon-owned reads. They do not contact the
+provider or join account observation work. Create and persist a Reset Card key before
+`use`; after a potentially dispatched result, query status with the same key rather than
+creating another effect.
 
-`fast-mode status` reads the canonical Codex `[features].fast_mode` Boolean.
-`fast-mode set --enabled BOOL` atomically replaces `~/.codex/config.toml` after changing
-only that key. It preserves unrelated TOML, creates no backup, and introduces no second
-configuration authority.
+No public schema-administration, database migration, or local reset API is implied by
+these commands.
 
-Create and persist the key before `use`; the CLI does not generate it. The account registry and
-reset-card inventory responses retain the selected profile and stable server authority. Retain
-that authority when a selection or pending operation crosses commands:
-
-```sh
-decodex \
-  --profile NAME \
-  --expected-server-id SERVER_UUID \
-  --output json \
-  reset-card list --account ACCOUNT_UUID
-```
-
-Use the same two global options for `use` and `status`. Reset-card commands reject a
-remote profile before connection. Current remote profile data is not an authenticated
-mutation transport.
-
-Each `use` invocation sends the consume command at most once and then polls durable
-status. If output remains `prepared`, use `status`; do not submit a new key for the same
-selected card. A recovery client may invoke `use` again only after `status` reports
-`not_found`, and it must reuse the exact persisted request and key. Add `--output json`
-for the stable `decodex/reset-card-cli/1` projection.
-After key creation, every `use` JSON result repeats `idempotency_key` and includes one
-closed `dispatch_state`:
-
-- `definitely_not_dispatched`: The CLI did not attempt the protocol send. Retain the key.
-- `potentially_dispatched`: The send may have reached the daemon. Query `status` with the
-  same key before a same-key resume.
-- `durably_accepted`: The daemon returned a durable accepted operation state.
-- `rejected_before_acceptance`: The daemon rejected the command before durable
-  acceptance.
-
-The Rust service and CLI run on supported macOS and Linux hosts. The native SwiftUI
-client is the only macOS-specific reset-card surface.
-
-Run the focused durable reset-card store proof after changes to preparation, effect
-fencing, reconciliation, retention, or recovery:
-
-```sh
-python3 scripts/vnext/postgres_store_test.py --focus-reset-cards
-```
-
-The excluded v0.2 runtime command surface starts in `apps/decodex/src/cli.rs`. For its
-preserved command details, prefer:
-
-```sh
-decodex --help
-decodex <subcommand> --help
-```
-
-Important source modules:
-
-- `apps/decodex/src/cli/control_commands/run.rs`: `decodex run`.
-- `apps/decodex/src/cli/control_commands/serve.rs`: `decodex serve`.
-- `apps/decodex/src/cli/control_commands/status.rs`: `decodex status`.
-- `apps/decodex/src/cli/control_commands/lane.rs`: lane inspect/steer/interrupt.
-- `apps/decodex/src/cli/control_commands/project.rs`: project registry.
-- `apps/decodex/src/cli/control_commands/mcp.rs`: MCP gateway.
-- `apps/decodex/src/cli/research_intake_commands/intake.rs`: Program Intake.
-- `apps/decodex/src/cli/recovery_commands.rs`: recovery command families.
-- `apps/decodex/src/cli/manual_commands.rs`: commit and land.
-- `apps/decodex/src/cli/account_commands.rs`: account pool.
-- `apps/decodex/src/cli/verify_commands.rs`: validation status publishing.
-
-## Local validation status gate
-
-Frozen v0.2 projects choose `[github].landing_mode` in their `project.toml`. The current
-`decodex.example.toml` is the vNext global path/config template and no longer models this
-frozen project setting.
-The default `standard` mode waits for GitHub's status rollup and ordinary merge
-gates. `fast` mode trusts the Decodex local full-check status
-`decodex/local-full-check`, requires `landing_actors`, and allows those actors to
-execute ruleset bypass landing after local validation passes. The publish command
-attaches the local validation status to the exact PR head and base evidence
-(`apps/decodex/src/cli/verify_commands.rs`):
-
-```sh
-cargo make check
-HEAD_SHA="$(git rev-parse HEAD)"
-BASE_REF=main
-git fetch origin "$BASE_REF"
-BASE_SHA="$(git rev-parse "origin/$BASE_REF")"
-decodex verify publish-status \
-  --config /path/to/project.toml \
-  --pr https://github.com/OWNER/REPO/pull/NUMBER \
-  --context decodex/local-full-check \
-  --state success \
-  --expected-head "$HEAD_SHA" \
-  --expected-base-ref "$BASE_REF" \
-  --expected-base-oid "$BASE_SHA" \
-  --description "cargo make check passed"
-```
-
-Success requires head/base preconditions, preventing stale green statuses after PR or target branch movement. Publish only after the cited command has passed on the exact tree, and include a description that lets a later operator connect the GitHub status back to the local evidence packet. In fast landing mode, the local status is a merge authority boundary, so a moved PR head, moved base branch, wrong context, or unapproved status creator should stop landing rather than be worked around manually.
-
-## Code scanning
-
-GitHub rulesets for this repository require CodeQL code scanning before merge.
-The checked-in workflow is `.github/workflows/codeql.yml` and runs on pushes to
-`main`, pull requests targeting `main`, and a weekly schedule. It
-analyzes Rust and JavaScript/TypeScript with no-build CodeQL mode so the
-required code-scanning tool is configured for PR heads without adding a second
-repository build gate.
-
-## App-server compatibility checks
+## App-server checks
 
 For app-server integration work:
 
@@ -889,82 +320,24 @@ cargo test -p decodex-runtime macos_attested_spawn --lib
 cargo test -p decodex-runtime live_read_only_probe_negotiates_without_dispatch -- --ignored
 ```
 
-Runtime's private supervisor validates the accepted receipt, captures and protects the exact
-executable snapshot, then structurally validates canonical generated-schema digests before
-app-server spawn. Linux executes the sealed snapshot. macOS runs preflights from the immutable
-snapshot, then starts the canonical final image suspended and checks its full source digest,
-snapshot-rooted CDHash, dynamic path, session, and process group before resume. Private FIFO
-endpoints are atomic close-on-exec and have no live names before user code starts. This canonical
-macOS image preserves process-attributed network-extension routing without moving Reset Card
-ownership into Swift. The child receives only the fixed `HOME`, system `PATH`, and
-`CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` projection. The Codex adapter owns the typed
-schema/capability contracts but exposes no launch surface.
-Markers are not capability promises. Focused tests cover the golden, exact-build cache
-conflicts, scripted fake server, structural history/collaboration-schema rejection, fixed
-production command construction, bounded executable/preflight/schema/frame/queue/result
-inputs, timeout and descendant/orphan cleanup, typed or hashed untrusted event strings,
-shared-home/account re-attestation, redacted debug surfaces, and default-disabled dispatch.
-The accepted marker now binds Codex CLI `0.146.0-alpha.9.2` to
-`ClientRequest.json` digest
-`6ffc593d603d21a051840539a4dbfad95cad2e7fec315e252b6722bd71bf37b4`,
-`ServerNotification.json` digest
-`abbb54060ea6a6005e63267bc6996eacd70cbb7954a7e0d61f50ea02af4acf02`, and
-aggregate v2 schema digest
-`e554a74bd59d38d16acb1744750b2999156ee3d65d0fe906b22ab52edf17fbbc`.
-It also pins `ServerRequest.json`, `v2/LoginAccountParams.json`, both root refresh schemas,
-`v2/ThreadReadResponse.json`, and `v2/ThreadStartParams.json` to the digests in the
-[exact image receipt](../evidence/xy-1422-codex-0146-account-callback.md).
-Codex CLI release `rust-v0.145.0` is rejected as an obsolete exact build. Its
-`ClientRequest.json`, `ServerNotification.json`, and aggregate v2 schema digests are
-`92085c18742dd355e5afa7d570170c74629635082e8e3341a952068735dc28b2`,
-`97c6bf194b9edfa1e2ffe62547e4497fa5ea8a1af5c94687956b69966ac6f9e2`, and
-`27f8d983f19d8e1a5548d52176de0a460fb05aaf2a72110f913c6f4af2bd4f27`.
-Codex CLI prerelease `rust-v0.146.0-alpha.11` is also rejected as an incompatible exact
-build. Its three digests are
-`6755a5eb5fcc0502a9d3b56c8ebd43a857f2c22820cf9cfa12e2dd0d5d48234c`,
-`28fd2f3e9020a1a26503facff7038f84137c2a0139df8443eab6d63a71deb240`, and
-`5ff4540622e002308ad5e6bac6df49b7ab5d52d79c8f71537b1098951b946b2d`.
-No compatibility shim for either release is retained. The previously accepted
-three-digest set is also rejected as an incompatible build.
-The ignored live test is strictly read-only: `initialize`, `initialized`, `account/read`, and
-bounded `thread/list(useStateDbOnly=true)` with a fixed nonmatching search term. It sends optional
-exact-ID `thread/read(includeTurns=false)` only if the filtered list unexpectedly returns a thread.
-The exact `alpha.9.2` schema advertises `thread/search`, but the method did not return during the
-bounded live check. The test does not invoke it and records it as `not_probed`. These probes do not
-establish global title discovery. Do not replace the live test with excluded v0.2
-`decodex probe stdio://`, which starts a proof turn.
+The exact-build supervisor verifies executable identity and generated schema before
+spawn. Raw protocol handles do not leave ProcessSupervisor. The live probe remains
+read-only and does not establish global title discovery or product dispatch.
 
 ## Plugin and automation checks
 
-Installable plugin sync:
-
 ```sh
 python3 scripts/config/sync_installable_plugins.py
-python3 scripts/config/sync_installable_plugins.py --apply --clean-repo-local-skills
 python3 -m unittest tests/scripts/test_sync_installable_plugins.py
-```
-
-The Decodex plugin manifest declares runtime package include/exclude patterns.
-`scripts/config/sync_installable_plugins.py` must honor that contract when
-installing to `$CODEX_HOME/plugins/cache/hack-ink/decodex/<version>`, so
-source-only plugin tests are not copied into installed packages.
-
-Codex App automation rendering and evaluation:
-
-```sh
 python3 automations/decodex/scripts/config/render_automation_plan.py --json
 python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json
 cargo make test-automations
 ```
 
-`automations/portfolio.toml` declares exactly three upstream roles and two content
-roles. The renderer and evaluator cannot write scheduler state. Apply definitions only
-with the native Codex automation lifecycle tool, then read back every field. Codex App
-owns machine-local timestamps.
+Rendering and evaluation do not write scheduler state. Apply automation definitions only
+through their owning lifecycle tool and read back every field.
 
 ## Static site checks
-
-The site is an Astro/TypeScript static surface (`site/package.json`). Commands:
 
 ```sh
 npm --prefix site install
@@ -973,12 +346,7 @@ npm --prefix site run build
 npm --prefix site run dev
 ```
 
-Use `site/README.md`, `site/src/`, `site/package.json`, and `openwiki/integrations/plugins-automations-and-auxiliary-tools.md` for the current static-site boundary and validation commands.
-
 ## Native macOS app checks
-
-The app is outside the Cargo workspace (`Cargo.toml`). Commands from
-`apps/decodex-app/README.md`:
 
 ```sh
 swift build --package-path apps/decodex-app -c release
@@ -988,43 +356,41 @@ scripts/macos/test_decodex_app_stage.sh
 python3 -m unittest tests.scripts.test_install_decodex_local_service
 ```
 
-The Swift suite covers one all-account list, UUID-keyed progressive Reset Card rows,
-strict native-client decoding, second-click confirmation, bounded startup recovery,
-and durable use replay. The staged package contains only the Swift app, in-process Rust
-client library, and resources. It contains no CLI, daemon, legacy `decodex`, app helper,
-loopback server, `:8192` client, account-pool reader, or migration tool. The separately
-installed and signed local service owns the daemon wrapper and PostgreSQL generation.
-
-The local-service installer test starts from a fresh empty product database and verifies
-credential-negative config, the signed wrapper, one `supervise-local` LaunchAgent,
-doctor readiness, and an empty account list. The installer never reads, copies, or
-deletes an old account pool. Local credentials are imported afterward with the ordinary
-public account command, followed by one restart for exact-build callback attestation.
+The staged app contains no daemon, legacy account pool, helper, loopback server,
+`:8192` client, schema owner, or database migration tool. The local-service installer
+must use the accepted empty-target operator bootstrap for a new database and must start
+normal `decodexd` only after bootstrap completes. It does not read an old account pool.
 
 ## Radar and Publisher checks
-
-Radar:
 
 ```sh
 radar --help
 radar validate .agent/automations/radar/cache/site-content/signals
 cargo test -p radar
-```
-
-Publisher:
-
-```sh
 decodex-publisher validate-social
 cargo test -p decodex-publisher
 ```
 
-Generated Radar artifacts belong under `.agent/automations/radar/cache`; generated Publisher social artifacts belong under `.agent/automations/decodex/cache/social` (`automations/radar/README.md`, `automations/decodex/README.md`).
+## Historical command surfaces
 
-## Practical change checklist
+Frozen v0.2 commands, old migration harness modes, retained-title freeze commands,
+numbered-schema tests, storage-spike execution, and private-artifact validation phases are
+historical provenance. Do not run them as latest-schema, Candidate-5, or release
+acceptance. A still-useful current domain test must be moved or retargeted to the latest
+schema owner.
 
-- CLI option or parsing change: add/adjust `apps/decodex/src/cli/tests/**` and run `cargo test -p decodex cli::tests` or relevant filter.
-- Runtime scheduler/lifecycle change: run targeted orchestrator tests, then `cargo nextest run -p decodex` if feasible.
-- State schema change: add migration/schema tests and run state tests.
-- Public projection change: test redaction and public/private split.
-- Plugin hook or installer change: run Python plugin sync tests.
-- Site/App change: run the site or Swift checks, not only Rust checks.
+## Practical checklist
+
+- Schema change: edit only the one latest schema and substantive schema/verification
+  owner; run fresh bootstrap, second refusal, runtime-only startup, and current-authority
+  gates.
+- Adapter SQL change: parse and execute against a fresh latest-schema database; add no
+  compatibility branch.
+- Candidate-5 change: prove sole selection, atomic admission, exact fences, ambiguity,
+  account observation/cache preservation, and transport shutdown.
+- Account change: test secret-negative storage/protocol and Registry/store/service
+  authority.
+- Public projection change: test bounds, redaction, and public/private split.
+- Plugin, automation, site, or app change: run that surface's own checks.
+- Completion claim: name exact source revision, exact implemented command names, gate
+  scope, and any remaining source drift.

--- a/openwiki/operations/xy-1368-retained-title-validation.md
+++ b/openwiki/operations/xy-1368-retained-title-validation.md
@@ -1,52 +1,63 @@
 # XY-1368 retained-title validation
 
-This document owns the bounded validation commands for the V14-V22 retained-title core.
+> **Superseded historical provenance.** This document records the former V1-V32
+> migration-based validation boundary. Its commands and results are non-executable
+> historical evidence. They are not current command or gate authority and must not be
+> run for vNext acceptance. Current authority is
+> [Commands and validation](commands-and-validation.md) and the
+> [vNext gate manifest](../specs/vnext-gates.md).
 
-## Preparation command
+This document formerly owned the bounded validation commands for the V14-V22
+retained-title core.
 
-Run this command once after the source boundary freezes:
+## Historical preparation command
+
+The former boundary instructed operators to run this command once after source freeze:
 
 ```console
 cargo make check-vnext-retained-title-preparation
 ```
 
-The command uses one private PostgreSQL 18 cluster. It reports three complete stages:
+The command used one private PostgreSQL 18 cluster and reported three complete stages:
 
-1. It checks the full V1-V32 migration syntax, applies and canonically provisions a fresh
-   full ledger, and separately verifies the closed migration-only authority delta from V24
-   through V32. V28, V29, V30, V31, and the V32 exact-release repair do not derive or grant a runtime
-   principal. The one configured
-   post-migration provisioner owns the final runtime ACL.
-2. It parses and prepares all 30 changed V22/V27/V28 embedded PostgreSQL statements in one Rust process.
-3. It verifies the generated schema and configured-authority digests, including the exact 28
+1. It checked the full V1-V32 migration syntax, applied and canonically provisioned a
+   fresh full ledger, and separately verified the closed migration-only authority delta
+   from V24 through V32. V28, V29, V30, V31, and the V32 exact-release repair did not
+   derive or grant a runtime principal. The one configured post-migration provisioner
+   owned the final runtime ACL.
+2. It parsed and prepared all 30 changed V22/V27/V28 embedded PostgreSQL statements in
+   one Rust process.
+3. It verified the generated schema and configured-authority digests, including the exact 28
    migration-owned function sources and 201 final function contracts in `authority.rs`.
 
-The command does not execute the prepared statements.
+The command did not execute the prepared statements.
 
-## Semantic boundary command
+## Historical semantic boundary command
 
-Stage the complete source candidate before you run this command:
+The former boundary instructed operators to stage the complete source candidate before
+running this command:
 
 ```console
 cargo make test-vnext-retained-title-core
 ```
 
-The command requires an index-only candidate. It binds the base commit and staged tree.
-It reuses the accepted PostgreSQL continuation contract and the V22 production-inert check.
+The command required an index-only candidate. It bound the base commit and staged tree.
+It reused the accepted PostgreSQL continuation contract and the V22 production-inert check.
 
-The receipt records these accepted pinned protocol facts for `codex-cli 0.145.0-alpha.18`:
+The receipt recorded these accepted pinned protocol facts for `codex-cli 0.145.0-alpha.18`:
 
 - A `thread/start` result can contain a null thread name.
 - `thread/name/set` is a separate title mutation.
 
-The versioned primary source is the OpenAI Codex tag `rust-v0.145.0-alpha.18`.
-The relevant source is `codex-rs/app-server-protocol/src/protocol/v2`.
+The versioned primary source was the OpenAI Codex tag `rust-v0.145.0-alpha.18`.
+The relevant source was `codex-rs/app-server-protocol/src/protocol/v2`.
 
-Do not start an app-server thread for this boundary. Do not use Desktop for this boundary.
+The historical boundary did not start an app-server thread or use Desktop.
 
-## Command authority
+## Historical command scope
 
-These commands are partial-boundary commands. They do not replace the trusted full check.
-Do not publish `decodex/local-full-check` from either command.
+These commands were partial-boundary commands. They did not replace the trusted full
+check and did not publish `decodex/local-full-check`.
 
-XY-1304 owns aggregate validation, production enablement, full-check publication, and landing.
+XY-1304 owned aggregate validation, production enablement, full-check publication, and
+landing for that historical boundary.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,392 +1,205 @@
 # OpenWiki Quickstart
 
-Decodex is cutting over to the accepted vNext agent-workspace architecture. The active
-Rust workspace currently contains the ownership skeleton and explicitly unavailable
-composition roots; it does not provide the old Linear/SQLite runtime. The v0.2 source is
-preserved under `apps/decodex/` as frozen provenance and is excluded from the active
-workspace. Radar, Publisher, the static site, plugins, and automation source remain
-outside the runtime rewrite until their owners adopt them.
+Decodex is resetting its vNext PostgreSQL architecture before deployment. There are no
+external or deployed users, and current local PostgreSQL data is disposable development
+state. The accepted target has one canonical unversioned latest schema, no database
+migration system, and runtime-only daemon startup.
 
-OpenWiki is the repo-local project knowledge surface for agents and maintainers. Runtime authority lives in source, project contracts, tests, manifests, and local runtime state; OpenWiki explains where to start and what to watch before editing.
+This is target authority, not a claim about current source. Existing numbered SQL,
+Refinery integration, schema-history checks, upgrade tests, and the executable storage
+spike are implementation drift to remove. Historical files that describe those paths are
+superseded provenance only.
 
-XY-1403 retires the private-artifact lane at the exact repository effective point
-defined in the [retirement decision](specs/private-artifact/decision.md#repository-effective-point).
-The [private-artifact archive](specs/private-artifact/README.md) is historical
-evidence only after that point. It is not a runtime or future-work input.
+OpenWiki is the repository knowledge entrypoint. Source, tests, the one latest schema,
+configuration, and accepted contracts remain executable authority.
 
 ## Start here
 
-- [Runtime architecture](architecture/runtime-architecture.md): process topology, CLI bootstrap, app-server runs, operator HTTP/MCP, and state ownership.
-- [Design rationale](decisions/design-rationale.md): why Decodex keeps loop graphs internal, autonomy authority typed, MCP/skills split, the site static, and Radar/Publisher bounded.
-- [vNext authority decision](decisions/vnext-authority.md): the accepted product,
-  ownership, state-authority, cutover, delivery, and private-artifact retirement
-  decision.
-- [vNext authority contract](specs/vnext-authority.md): normative entities, runtime boundaries,
-  protocol, account continuity, non-goals, clean-cutover contract, and retained-title
-  Git evidence boundary.
-- [Account lifecycle authority](specs/account-lifecycle-authority.md): the three-owner
-  PostgreSQL/HostCredentialStore/Account Service boundary, MacDogfoodReady, final
-  readiness, refresh/recovery, ordinary import, and clean startup.
-- [XY-1400 ProcessGeneration authority](specs/process-generation-authority.md): durable
-  pre-spawn fencing, opaque exact-build launch attestation, macOS positive-death quarantine,
-  exact process identity, ProviderAttempt ambiguity handoff, restore safety, and the deferred
-  adversarial acceptance matrix.
-- [XY-1401 ProviderAttempt authority](specs/provider-attempt-authority.md): generic
-  Conversation/ManagedRun consumer binding, exact V16/V17/ProcessGeneration lineage,
-  positive-only reconciliation, restore projection, duplicate-risk fencing, and the deferred
-  acceptance matrix.
-- [XY-1402 stateless execution coordination](specs/execution-coordinator-authority.md):
-  closed Conversation/ManagedRun consumer integration, exact cause projection, V12
-  retirement, production isolation, and the deferred unified acceptance matrix.
-- [vNext gate manifest](specs/vnext-gates.md): ordered feasibility and implementation gates,
-  downstream issue ownership, private-artifact retirement, and decision-changing
-  falsifiers.
-- [Private-artifact design archive](specs/private-artifact/README.md): frozen historical
-  decision, semantic modules, protected authority data, receipts, and retirement
-  controls. It contains no executable or future vNext obligation.
-- [XY-1262 Codex runtime proof](evidence/vnext-codex-runtime-proof.md): shared-home, ownership, schema, collaboration, cross-account, fallback, crash, and typed-quota evidence for the Codex feasibility gate.
-- [XY-1345 exact-command authority proof](evidence/xy-1345-exact-command-authority.md): corrected pure-PostgreSQL command authority, deterministic/concurrency schedules, privilege/catalog closure, restore receipt, and V9/V10 ownership order.
-- [XY-1372 private-artifact capability evidence](evidence/xy-1372-private-artifact-capabilities.md): historical accepted APFS, OrbStack overlayfs, and OrbStack virtiofs feasibility provenance; it authorizes no current platform or delivery gate.
-- [Lane Authority v2](decisions/lane-authority-v2.md): superseded historical target retained as architecture and incident provenance; C1-C7 are frozen and must not be implemented.
-- [Drift audits](evidence/drift-audits.md): public-safe evidence notes, current MCP remote-control watched claims, reverse checks, validation commands, and stop conditions.
-- [v0.2 freeze receipt](evidence/v0.2-freeze.md): exact trusted tag, cold-config and automation inventory, frozen legacy work, preserved incident evidence, cleanup ownership, and the unresolved SQLite-backup gap.
-- [GPUI feasibility evidence](evidence/gpui-feasibility.md): accepted pinned XY-1263 foundation/toolchain, macOS runtime and package probes, bounded-history measurements, preserved negative provenance, and the independently reviewed normalized current-main 40/40 PID-bound accessibility receipt landed in PR #1109.
-- [Runtime operator workflows](workflows/runtime-operator-workflows.md): project registry, run/serve/status, lane control, recovery, intake, commit/land, accounts, and MCP workflows.
-- [Contracts and data](specs/contracts-and-data.md): current v0.2 project config, SQLite, Decision Contract, Program Intake, tracker, review, and commit behavior; superseded for vNext target work.
-- [Runtime contracts](specs/runtime-contracts.md): current v0.2 state, app-server, tracker, evidence/privacy, and recovery contracts; superseded for vNext target work.
-- [Runtime lifecycle](specs/runtime-lifecycle.md): current v0.2 lane, app-server, tracker, review, and autonomy lifecycle; superseded for vNext target work.
-- [Lane Authority v2 target contract](specs/lane-authority-v2.md), [effect registry](specs/lane-authority-v2-effects.md), [gate manifest](specs/lane-authority-v2-gates.md), and [checkpoint ledger](evidence/lane-authority-v2-checkpoints.md): superseded provenance only, not active implementation authority.
-- [Commands and validation](operations/commands-and-validation.md): task runner, tests, targeted checks, status publishing, app/site/Radar/Publisher validation.
-- [Operator runbooks](operations/operator-runbooks.md): lane-control recovery, review handoff recovery, release readiness, GitHub operations, and control-plane workflows.
-- [Codex upstream automation](operations/codex-upstream-autopilot.md): agent-led
-  upstream research, deterministic PR creation, independent review and landing, and
-  portfolio management without the Decodex server.
-- [Plugins, automations, and auxiliary tools](integrations/plugins-automations-and-auxiliary-tools.md): installable plugin lifecycle, hook guardrails, automation sync, Radar, Publisher, native App, and site boundaries.
-- [Radar, Publisher, and site contracts](integrations/radar-publisher-site.md): Radar artifacts, upstream review, release deltas, social publishing, site contract, and retention.
-- [Radar Publisher contracts](integrations/radar-publisher-contracts.md): evidence separation, Publisher hard boundaries, static-site boundary, retention, and stop conditions.
+- [vNext authority decision](decisions/vnext-authority.md): the accepted no-migration
+  reset, Candidate-5 continuity, product shape, and supersession boundary.
+- [vNext authority contract](specs/vnext-authority.md): normative entities, PostgreSQL
+  schema ownership, runtime boundaries, Candidate-5 Quick Task, account continuity, and
+  delivery contract.
+- [vNext gate manifest](specs/vnext-gates.md): source-freeze, latest-schema, runtime,
+  Candidate-5, account, and local cutover gates.
+- [Runtime architecture](architecture/runtime-architecture.md): process topology,
+  PostgreSQL bootstrap/runtime separation, service ownership, and current-state drift.
+- [Commands and validation](operations/commands-and-validation.md): implementation-owned
+  bootstrap and authority command boundaries plus current repository checks.
+- [Account lifecycle authority](specs/account-lifecycle-authority.md): Account Registry,
+  HostCredentialStore, Account Service, current account observations, and the local
+  credential-negative rebind.
+- [ProcessGeneration authority](specs/process-generation-authority.md): durable pre-spawn
+  fencing, exact process identity, positive-only death evidence, and account-local
+  quarantine.
+- [ProviderAttempt authority](specs/provider-attempt-authority.md): one external-turn
+  attempt owner, positive-only outcome evidence, and replay prohibition.
+- [Stateless execution coordination](specs/execution-coordinator-authority.md): closed
+  Conversation/ManagedRun consumer integration and Candidate-5 owner sequencing.
+- [Design rationale](decisions/design-rationale.md): retained product design choices.
+- [Runtime operator workflows](workflows/runtime-operator-workflows.md): current operator
+  workflows; treat any schema-upgrade text there as stale until its owner aligns it.
+- [Private-artifact archive](specs/private-artifact/README.md): historical evidence only.
+- [v0.2 freeze receipt](evidence/v0.2-freeze.md): frozen legacy provenance only.
+
+## Schema authority
+
+`crates/decodex-postgres` owns exactly one executable schema source:
+`crates/decodex-postgres/schema.sql`. It contains final object definitions directly. It
+does not contain an ordered history, upgrade branch, compatibility DDL, drain, backfill,
+or old-state cleanup.
+
+One explicit operator bootstrap runs only against an empty PostgreSQL 18 target. It:
+
+1. resolves the schema-owner credential;
+2. proves that the target is clean;
+3. executes the complete latest schema in one transaction;
+4. verifies the exact resulting catalog and configured authority; and
+5. commits only after every check passes.
+
+A second bootstrap against that nonempty target fails closed. Bootstrap is not
+`decodexd` startup. Exact command spelling is implementation-owned and is not yet
+authoritative.
+
+Normal `decodexd` startup resolves only the runtime database credential. It executes zero
+DDL and verifies the exact current catalog and authority. It never resolves a schema-owner
+credential, runs an upgrade, repairs a catalog, or consults a schema-history relation.
+
+The reset preserves PostgreSQL 18, data checksums, `pgcrypto`, verified Unix-socket and
+peer-UID checks, full schema/function/trigger/dependency/ownership/ACL/semantic
+attestation, and negative PUBLIC/runtime checks. It removes history and upgrade
+predicates only.
+
+Exact-command receipts, account operations, ProcessGeneration, ProviderAttempt,
+`schema_fingerprint`, runtime authority, activity, outbox, and repository-effect evidence
+remain domain integrity records. They are not schema migration records.
 
 ## Repository map
 
-- `crates/decodex-core/` owns domain/application authority contracts, including logical
-  Conversation/RuntimeSession/history and deterministic inspectable Context Pack types, plus the XY-1306
-  typed `~/.decodex` root, bounded/redacted config profiles, stable server identity,
-  content-addressed blobs, and disposable bounded cache foundation.
-- `crates/decodex-protocol/` owns the vNext version and the owner-only, same-UID Unix
-  transport contract shared with clients.
-- `crates/decodex-postgres/` owns the PostgreSQL product-state adapter: explicit
-  connection configuration, embedded immutable migrations, optimistic transactions,
-  leases, append-only activity, transactional outbox delivery, inert account/window
-  metadata, bounded history pagination, immutable snapshots, blob references, Context Pack
-  revisions, inert rollover/fallback proposals, exact in-transaction receipts, and immutable
-  global RoleProfile revisions. V14 additionally owns revisioned complete routing policies,
-  database-timestamped ordinary Codex compatibility evidence, and immutable complete routing
-  fact snapshots; it performs no selection or dispatch. V15 adds the uncomposed causal Codex
-  experiment persistence protocol. Forward-only V22 repairs its retained-title authority for the
-  pinned two-effect protocol. It stores the exact nullable-name `thread/start` request and response.
-  It then fences one `thread/name/set`. Only exact-ID `thread/read` can attest the prepared title.
-  Positive observations and V17 same-thread authority require that attestation. Forward-only V23
-  adds durable ProcessGeneration intent, exact identity, append-only positive death evidence, and
-  account-local quarantine. Runtime has function-only ProcessSupervisor authority and no relation
-  DML. Forward-only V24 adds one generic ProviderAttempt authority for Conversation Turns and
-  ManagedRun executions, append-only transition and positive-evidence histories, restore
-  projection, and bounded positive-only reconciliation. Runtime has function-only
-  ProviderAttemptService authority and no relation DML. Forward-only V25 adds the
-  closed route and wait enum vocabulary in its own transaction. Forward-only V26 removes the
-  drained V12 ManagedRun-local submitted-turn and effect-barrier authority. It makes V14,
-  V16, and V17 generic over an ordinary Conversation Turn or one ManagedRun execution,
-  adds exact route-cause and reconciliation projection, and retains V16, V17,
-  ProcessSupervisor, and ProviderAttemptService as the sole writers of their accepted
-  decisions. Its zero-sized ExecutionCoordinator stores no state and is not connected to
-  a production root. V16 adds inert
-  atomic routing decisions over a
-  PostgreSQL-authored locked universe, exact evidence references, duration-typed depletion
-  exclusions, and pure-kernel readback. No production root reaches either boundary and they enable no
-  live execution. XY-1307 wires the typed connection data through runtime composition into the
-  existing verification/migration boundary; every bootstrap failure remains fail-closed.
-  V18 adds XY-1362's uncomposed ledger-first `waiting_usage` wake authority. Append-only transitions
-  own operation results, historical readback, lease/reclaim history, cancellation, supersession,
-  and the one fired fresh-routing request; a mutable head is only the exact-tip scheduler index and
-  fence. Cross-key operation replay reads the immutable transition result and never reconstructs a
-  success from the head. Fired transitions contain no old candidates, quota evidence, eligibility,
-  exclusions, or account choice and structurally disable prior-decision reuse and production
-  enablement. Forward-only V19 reopens the core freeze only to repair deterministic wake-time
-  acceptance authority: the four unchanged public commands still select PostgreSQL time after the
-  same locks, while four migration-owner-only internals accept a bounded explicit instant for the
-  deferred acceptance gate. Runtime cannot execute those internals, inject time, or reach V18/V19
-  through another API. No runtime or application composition root imports the wake adapter.
-  Forward-only V20 recreates only nine named CHECK constraints with equivalent explicit lower/upper
-  predicates so their exact definitions are stable across restoration. Phase A authority capture
-  requires the source S0, first restore R1, and second restore R2 to satisfy both S0=R1 and R1=R2.
-  Forward-only V21 repairs the RuntimeSession event classifier without rebinding its triggers:
-  scalar RuntimeSession/profile/account snapshot identities are cross-domain provenance, while
-  RuntimeSession aggregate/event/kind markers, complete session or snapshot objects, and outbox
-  links to activity carrying those ownership shapes remain migration-owner-only.
-- `crates/decodex-codex/` owns typed app-server contracts, exact-build capability profiles, redacted normalized events, fixed and bounded read-only launch/probe behavior, and immutable one-account process supervision. Current dispatch is disabled. Slice 1 can enable only the fenced initial-selection path; XY-1304 remains later automatic fallback/wake acceptance.
-- `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner that composes protocol and infrastructure adapters.
-- `apps/decodexd/`, `apps/decodex-cli/`, and `apps/decodex-gpui/` are composition
-  roots. The client roots depend only on the protocol crate. GPUI opens a real shell and
-  window. Health is the only bounded live destination. Every other destination remains a
-  placeholder. The Quick Task and WorkItem contracts do not make their shell
-  destinations live. GPUI is not generally usable. Remaining Slice 1 UI work is Accounts
-  and Conversation. Slice 2 owns Project/Work/Run; Slice 3 owns the Mac package.
-- `apps/decodex/` is the frozen v0.2 package. It remains in Git for provenance but is excluded from Cargo workspace membership and must not be used by vNext.
-- `apps/radar/` is the Radar auxiliary tool for upstream review queues, release deltas, artifact validation, signal rendering, and bundle generation (`apps/radar/README.md`, `apps/radar/src/lib.rs`).
-- `apps/decodex-publisher/` validates and reserves Decodex-owned social artifacts (`apps/decodex-publisher/README.md`, `apps/decodex-publisher/src/lib.rs`).
-- `apps/decodex-app/` is the current native macOS account UI. It is a
-  credential-negative client of the daemon-owned
-  [Account Lifecycle Authority](specs/account-lifecycle-authority.md) and does not
-  contain a local account pool, helper/server path, credential authority, or service
-  lifecycle owner (`apps/decodex-app/README.md`).
-- `crates/decodex-app-client-ffi/` owns the app's credential-negative in-process
-  protocol client and private `decodex/app-native-client/1` ABI. Its only child
-  process is one user-requested, finite official Codex device-login session in an
-  owner-private temporary home. It exposes no credential bytes or file path to
-  Swift and does not start the Decodex CLI, helper, app-server, or legacy account
-  process. It does not own credentials, account state, or daemon lifecycle.
-- `site/` is the static Astro product site; it must not depend on live daemon state (`site/package.json`, `openwiki/integrations/plugins-automations-and-auxiliary-tools.md`).
-- `plugins/decodex/` contains the installable Decodex plugin, narrow routing skills, and lifecycle guardrail hooks (`plugins/decodex/.codex-plugin/plugin.json`).
-- `automations/upstream/` contains the current standalone Codex App upstream
-  adaptation loop. `automations/decodex/` contains the current Content Manager and
-  xurl Publisher tasks plus shared config and Publisher assets.
-  `automations/radar/` owns reusable Radar assets and has no separate schedule. The
-  old multi-task content schedules remain deleted (`automations/upstream/README.md`).
-- `scripts/` contains repo maintenance helpers including plugin sync and macOS app staging.
-- `tests/scripts/test_vnext_architecture.py` enforces the exact vNext dependency graph, client isolation, and exclusion-with-preservation of the legacy package.
+- `crates/decodex-core/` owns domain and application contracts, typed `~/.decodex`
+  paths/configuration, content-addressed blob contracts, and disposable cache contracts.
+- `crates/decodex-protocol/` owns the exact-current owner-only same-UID Unix WebSocket
+  protocol used by clients.
+- `crates/decodex-postgres/` owns `schema.sql`, empty-target transactional bootstrap,
+  current catalog/authority verification, PostgreSQL adapters, exact commands, leases,
+  activity/outbox, account state, routing state, Conversation history, RuntimeSession,
+  managed repositories, ProcessGeneration, and ProviderAttempt persistence.
+- `crates/decodex-codex/` owns typed app-server contracts, exact-build capability
+  profiles, redaction, and one-account-per-process adapter behavior.
+- `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner
+  that composes infrastructure adapters.
+- `apps/decodexd/` is the sole server composition root. Its normal serve path is
+  runtime-only.
+- `apps/decodex-cli/` and `apps/decodex-gpui/` are protocol clients. They do not read
+  PostgreSQL, credentials, rollout files, blobs, or repositories directly.
+- `apps/decodex-app/` is a credential-negative native account client. It has no local
+  account pool, helper/server authority, or daemon lifecycle owner.
+- `apps/decodex/` is frozen v0.2 provenance outside the active Cargo workspace.
+- `spikes/vnext-storage/` is retired as an executable schema owner. Historical feasibility
+  evidence may remain, but no product or validation path may execute its schema.
+- `site/`, Radar, Publisher, plugins, and automations remain separate auxiliary surfaces.
 
-## Runtime in one minute
+## Runtime summary
 
-`apps/decodexd` composes the PostgreSQL and Codex adapter boundaries through
-`decodex-runtime` and serves the exact-current typed V2.0 protocol at the fixed
-`~/.decodex/server/decodex.sock` endpoint. The active local profile must set
-`policy = "same_uid"` and the exact service-owner effective UID. The server directory
-has mode 0700. The persistent `decodex.lock`, fixed `decodex.sock.stage`, and published
-`decodex.sock` entries have owner-only mode 0600 and exactly one link whenever present.
-Publication binds the staging name and uses same-directory descriptor-relative `renameat`
-while the one-link lock is held.
-It opens a Codex app-server process only for an admitted manual reset-card request;
-conversation dispatch remains disabled. It attempts only
-the explicitly configured PostgreSQL Unix socket and otherwise retains a typed unavailable
-adapter. The protocol accepts only V2.0 and provides typed command receipt/result and
-event envelopes, bounded snapshots/queues/wire text, fixed-capacity in-lifetime
-idempotency in its one exact-current namespace,
-publication-epoch-bound cursor resume,
-snapshot fallback, stable
-server-identity pinning, bounded doctor/status results, and a bounded typed Conversation-history
-query, plus a read-only immutable execution-decision query. The `decodex` and GPUI roots
-compile against `decodex-protocol` only. `decodex status` and `decodex doctor` are active
-API-only V2.0 diagnostic clients. `decodex reset-card` is the active manual reset-card
-client. `decodex account profile` is the independent bounded account-profile client.
-GPUI opens its real shell and window. Health is the only bounded live destination. Every
-other destination remains a placeholder. The Quick Task and WorkItem contracts do not
-make their shell destinations live. GPUI is not generally usable. Remaining Slice 1 UI
-work is Accounts and Conversation.
+`decodexd` serves the exact-current protocol at the fixed owner-only
+`~/.decodex/server/decodex.sock` endpoint. Both sides verify kernel peer UID and stable
+server identity. Remote and cross-UID control remain disabled until their security gate.
 
-The reset-card service uses only configured vNext account UUIDs. A durable terminal
-receipt replays before current account gates. New admission and the pre-effect fence both
-require enabled state, AccountLifecycle readiness, no unsettled account operation, and
-exact Registry/store revision, credential fingerprint/version, and provider agreement.
-Clients select a card by its public grant and expiry timestamps and send the exact account
-revision. `decodexd` alone reads the credential
-vault, starts and attests the Codex process, resolves the opaque provider credit ID,
-persists that exact ID and the logical-command idempotency key before the effect, consumes
-the card, and reconciles fresh provider state. Restart recovery reuses the same exact ID
-and key; it never selects a replacement card. Both `account/rateLimits/read` and
-`account/rateLimitResetCredit/consume` must be present in the generated app-server schema.
+When PostgreSQL is available, startup verifies the pinned socket, PostgreSQL 18 and data
+checksums, `pgcrypto`, the exact latest catalog, closed dependencies, object ownership,
+function and trigger bodies/settings/bindings, ACLs, configured runtime authority, and
+negative PUBLIC/runtime conditions. Any drift produces typed unavailability. Startup
+does not mutate the database.
 
-Each client reconnect captures the current socket identity and verifies the daemon kernel
-peer UID. Each server admission verifies the client kernel peer UID and the current
-directory, lock, and socket identities. There is no startup self-connect challenge and no
-continuous endpoint watchdog. One lifecycle task owns the listener. One `JoinSet` owns all
-session and command tasks with stable spawn IDs and kinds. The same lifecycle directly
-owns daemon service futures. Shutdown first closes Reset Card provider-work admission,
-then creates one absolute session/command deadline and harvests `join_next_with_id` until
-empty. Already registered provider work keeps its own bounded process deadline and must
-settle before exact endpoint cleanup and lock release. This boundary serializes legitimate
-daemons. It does not claim confinement against hostile code that already has the same UID.
+The runtime identity has only the exact relation, sequence, and function authority needed
+by current adapters. It cannot own Decodex objects, execute DDL, bypass triggers or
+retention, use grant options, reach schema-owner authority through role membership, or
+control a Decodex extension member. Hostile `search_path`, overload, trigger, rule,
+policy, RLS, external-cascade, and default-ACL paths fail closed.
 
-When PostgreSQL is ready, daemon bootstrap projects restored nonterminal
-ProcessGenerations to `death_unknown`, performs one positive-only reconciliation pass, and
-continues background reconciliation. Same-boot uncertainty remains local to its account. The
-runtime exposes an exact diagnostic/reconciliation/owned-termination port, but no protocol,
-CLI, routing, or production spawn path.
+`decodexd` starts the account observation service independently from client queries. It
+refreshes different accounts concurrently. Within one account it settles Reset Card work
+before profile observation, coalesces successor rounds, and publishes only to a matching
+account revision/cache generation. Account and Reset Card/profile queries read the
+daemon-owned cache or persisted projection without contacting the provider, joining a
+refresh, or starting refresh work. Candidate 5 must preserve this current-main behavior.
 
-Daemon bootstrap also projects every present nonterminal ProviderAttempt to `unknown`, performs
-one bounded positive-only reconciliation pass, and continues background reconciliation. A
-replacement can reconcile the original attempt but cannot replay it. Process death, boot change,
-EOF, timeout, restart, missing results, and negative search cannot prove `not_submitted`. The
-runtime exposes bounded redacted diagnostics and exact positive-receipt reconciliation, but no
-provider gateway or live dispatch path.
+ProcessSupervisor projects restored nonterminal ProcessGenerations to `death_unknown`
+and performs positive-only reconciliation. Uncertainty quarantines only the affected
+account. ProviderAttemptService projects prepared or dispatch-authorized attempts to
+`unknown` after restore and performs positive-only reconciliation. Process death, EOF,
+timeout, restart, absence, or negative search never proves provider non-submission.
 
-The crate-private stateless ExecutionCoordinator can sequence one persisted V16 decision, one V17
-plan, one ProcessSupervisor-owned live fence, and one ProviderAttempt preparation. It consumes
-the fresh prepared capability and returns only an inert projection. It has no retained service,
-lifecycle, retry state, receipt, or durable relation. Its only protocol surface is a read-only
-immutable execution-decision query. No protocol command, CLI, scheduler, application service,
-Codex adapter, credential owner, UI, or daemon composition root can start the sequence or authorize
-dispatch.
+ExecutionCoordinator is crate-private and stateless. It sequences accepted route,
+continuation, process, and provider-attempt owners. It stores no receipt or lifecycle and
+cannot authorize dispatch by itself.
 
-When PostgreSQL is ready, daemon bootstrap also opens the accepted pinned repository executor,
-retains the single PostgreSQL/executor/saga composition, and completes bounded readback-only
-restart reconciliation before serving. No managed-repository or GitHub mutation is exposed by the
-current protocol; the GitHub PR/check reconciler remains sealed until the later provider and
-PostgreSQL effect-lineage owner connects it.
+## Candidate-5 Quick Task
 
-The PostgreSQL adapter persists its XY-1267 foundation and forward-only XY-1271 history schema when `decodexd` receives one explicit
-PostgreSQL 18 Unix-socket endpoint, an operator-pinned expected server UID, and distinct migration
-and runtime identities. The socket directory must be owned by that UID and not group/other-writable.
-The adapter retains descriptor identities for the directory and socket, rejects replacement, and
-verifies the connected kernel peer UID before sending either identity's authentication data. Optional,
-separate environment-variable references supply their credentials without entering config,
-wire data, logs, or ordinary PostgreSQL rows. The migration identity is used only for forward
-migration and migration verification and is closed before the live adapter retains the runtime
-pool. The runtime identity must have the exact adapter DML/function/sequence contract. The audit
-covers the login role and every NOINHERIT or inherited role reachable with `SET ROLE`, rejecting
-membership admin option, ownership of any PostgreSQL 18 object class in the Decodex namespace,
-superuser/BYPASSRLS, database/schema/table DDL, TRUNCATE,
-grant options, trigger authority, `session_replication_role` SET/ALTER SYSTEM, or any other
-retention bypass. The effective login value must be `origin`. Readiness requires a closed inventory
-of every runtime-callable Decodex function with exact signatures, overloads, metadata, settings, and
-source bodies matching the canonical embedded migrations. The 146 expected safety/state/retention
-triggers must also remain enabled, correctly shaped, and bound to their canonical functions; no
-additional user trigger, rule, policy, RLS mode, or noncanonical expression dependency may add an
-indirect execution path on a runtime relation. The accepted V22 canonical PostgreSQL 18 schema
-manifest attests its complete historical relation/column, default, constraint, index, enum-label, and internal
-constraint-trigger binding together with each stable catalog dependency identity. It includes
-foreign keys whose Decodex relation is either the child or
-the referenced parent, so external cascades and internally generated execution paths fail closed.
-Extension authority follows `pg_depend` membership,
-not extension schema, so a runtime-controlled extension cannot own or drop a Decodex member.
-`public.refinery_schema_history` is always schema-qualified and must have table SELECT only. Its
-ordered versions, names, and checksums must exactly equal the embedded migration inventory;
-missing SELECT is incompatible, while ownership, SET-reachable authority, table/column grant
-options, writes, and table DDL privileges are unsafe. All canonical database functions have an exact
-function-local `pg_catalog, decodex` search path. Exactly seventy-nine narrowly scoped functions are
-security definers: three history cursor/version functions, eleven Project/Agent/Policy/Program/Objective
-commands, two command-complete exact RoleProfile entrypoints, two command-complete exact
-RuntimeSession entrypoints, four command-complete exact WorkItem entrypoints, one inert future
-running/resume guard, twelve inert V14/V15/V22
-routing and causal-experiment entrypoints, the inert V16 exact routing-decision entrypoint, V17's inert
-exact continuation command plus strict readback, and V18's four exact wake commands plus strict
-readback, plus V23's eight ProcessSupervisor fence, transition, projection, evidence, and read
-entrypoints, plus V24's seven ProviderAttemptService preparation, transition, positive-evidence,
-projection, and read entrypoints, one trigger-only Turn-reservation helper, and V26's immutable
-execution-decision and ManagedRun execution-projection read functions, plus V27's sixteen exact
-account lifecycle, routing, quota, store, and capability functions, V28's two exact profile
-observation/read functions, and V29's PostgreSQL 18 array-zip repair for profile observation.
-The helper has a
-fixed search path, runs as the migration owner, and grants no direct runtime or PUBLIC execution.
-The historical V24 boundary has an exact semantic inventory overlay for its 84-relation,
-184-function, 75-safety-function, 154-trigger, 69-runtime-function, and ten-post-V22-enum
-shape. V26 has the current 80-relation, 182-function, 74-safety-function, 146-trigger,
-70-runtime-function semantic inventory. Full S0/R1/R2 V26 manifest capture and digest refreeze
-remain in the deferred unified gate.
-A selected V16 decision commits either one positive-evidence-bound same-thread plan or one Context
-Pack, fallback RuntimeSession, and plan in the same transaction. Runtime cannot insert
-cursor, exact-receipt, RoleProfile, RuntimeSession, RuntimeSession snapshot, WorkItem, ManagedRun,
-assignment, routing-decision, decision-member, decision-quota,
-decision-capability, decision-blocker, decision-exclusion, continuation-plan, waiting-usage wake
-transition, waiting-usage wake head, ProviderAttempt, provider-attempt evidence, or
-provider-attempt transition rows or execute trigger/private helpers directly.
-The two bound identity sequences require
-USAGE only; UPDATE/`setval`, SELECT, ownership, grant options, and SET-reachable surplus authority
-are unsafe. Explicit qualification keeps bootstrap correct under a hostile runtime `search_path`.
-Missing, malformed, unsafe,
-unreachable, authentication-failed, and incompatible inputs remain typed unavailable with no
-fallback.
-Host repository paths reject symbolic links at any component. PostgreSQL socket paths additionally
-use descriptor-pinned component traversal, immutable directory/socket identity checks, explicit
-operator UID authority, and kernel peer credentials rather than trusting an observed pathname.
-`~/.codex` remains Codex-owned shared continuation state. `decodex-core` owns the typed
-`~/.decodex` layout for `config.toml`, logs, SHA-256 blobs, disposable cache, and atomic
-server identity.
+Candidate 5 remains the product target and is not yet accepted implementation. It is one
+ordinary multi-turn Conversation. The initial authority order is:
 
-Doctor/status is a V2.0 read-only query served only by `decodexd`. Queries have client observation
-identities but no mutation receipt, deduplication, replay, event, or receipt-capacity effect. Its closed report
-covers configuration, database, protocol and version, stable server identity, shared
-Codex home, each typed app-server capability, aggregate server-host repository readiness,
-blob integrity, credential-vault readiness, and plugin readiness. It carries no repository
-path/name, credential text, parser detail, database/socket/user text, or raw app-server
-payload. Checks that are not yet safely probed report `unknown`; they never imply ready.
-Every doctor read revalidates the pinned socket, a live runtime connection, the closed database
-authority contract, and immutable migration history without rerunning migration or repinning the
-endpoint. A secure stale listener is database-unreachable; endpoint replacement is unsafe-host-path.
-PostgreSQL socket recreation requires restarting `decodexd` so bootstrap can establish a new explicit
-operator-authorized pin.
-The legacy `~/.codex/decodex` SQLite/config layout is frozen provenance, not a vNext
-input or fallback.
+```text
+Conversation creation
+-> prospective Turn intent
+-> complete routing snapshot
+-> one route decision
+-> first snapshots + starting RuntimeSession + inert initial plan
+-> atomic first Turn + first Message admission
+-> selected-account pre-spawn fence
+-> fresh ProcessGeneration
+-> exact RuntimeSession thread start and bind
+-> ProviderAttempt
+```
 
-The daemon history query is read-only, uses opaque PostgreSQL-issued cursors whose persisted rows bind
-the Conversation, high-water snapshot, page size, positive position, exact item, and issued-parent chain, returns
-at most eight items per WebSocket result, and verifies referenced blob bytes before returning
-metadata. Only the page-level next cursor is exposed; page size is fixed for its chain. Cursor rows
-expire after one hour, subsequent issuance prunes expired chains, and serialized hard limits cap
-storage at 512 rows per Conversation and 4,096 globally. Never-issued, expired, cross-Conversation,
-changed-size, and edited tokens fail closed; capacity refusal is typed. Domain, PostgreSQL, adapter
-read/write, and wire boundaries enforce one canonical bounded
-`type/subtype` media-type invariant. Wire decode bounds page cardinality, blob length, SHA-256 text,
-media type, and a core-owned flat credential-negative metadata projection of at most 32 fields
-(64-byte keys; string or boolean values; 256-byte string limit). Credential-bearing key suffixes and
-concrete authorization/token/assignment/key patterns are rejected; ordinary text such as `secret
-sauce`, `token budget`, and `session summary` remains valid. Inline and offloaded entries both carry
-the same media type and projection. Bounded grace-aged orphan reclamation is deterministic and resumable, treats only
-history, Artifact revisions, and Context Packs as live references, commits metadata deletion before
-a lock-coordinated live-reference recheck and byte removal, and coordinates with writers through
-PostgreSQL. Cursor issuance follows the canonical lock order: command receipt for mutations,
-statement-level hierarchy coordinator 1271 before executor tuple selection, cursor coordinator
-1272, then the Conversation and child rows. Hash-scoped blob coordination uses namespace 1273 and
-never nests an outer hierarchy/cursor lock around filesystem I/O. Row-level hierarchy triggers do
-not acquire the outer coordinator; their statement-level `BEFORE` guards run before PostgreSQL can
-lock an update tuple.
-RuntimeSession and Turn insert triggers author their creation/update timestamps, clear terminal
-timestamps for legal nonterminal creation, and reject direct terminal creation, so runtime SQL cannot
-persist a lifecycle state that typed services cannot represent.
-Clients
-cannot query PostgreSQL or local blob paths directly. No client mutation or artifact-download route
-is exposed by this slice.
+Routing Decision is the sole account selector. Account Service fences only that selected
+account immediately before spawn. Initial planning has no source RuntimeSession and no
+sticky member. It creates the first session; it is not same-thread reuse, explicit
+successor, or Context Pack fallback.
 
-Artifact parents are transactionally coherent with one exact immutable current revision through a
-deferred composite foreign key and state guard. Revision 1 must exist before an advance, and every
-later immutable revision requires its exact legal predecessor, preventing direct-SQL gaps. Context
-Pack source manifests are staged under the
-writer lock and sealed by the immutable parent with an exact contiguous source count; runtime SQL
-cannot append, alter, delete, or commit an incomplete source manifest after persistence.
+The final latest schema contains both closed routing lineage shapes: all six source
+lineage fields absent for the initial operation (`L0`), or all six present with positive
+revisions for existing-session work (`L6`). Conversation work permits `L0` or `L6`.
+ManagedRun work permits only `L6`. The latest schema creates the final constraints,
+functions, and trigger bindings directly.
 
-The API-only diagnostic CLI operations `decodex status` and `decodex doctor` are active.
-The `decodex account` lifecycle operations and the `decodex reset-card list`, `use`, and `status`
-operations are active clients of the common daemon service. Other unsupported product CLI
-operations remain unavailable in current source. Delivery proceeds through exactly three slices:
-Accounts/Quick Task/minimal Accounts-Conversation-Health GPUI; then the bounded managed-work
-flow and Project-Work-Run GPUI; then the two-account restart E2E and Mac package. A general
-PostgreSQL administration plane, authenticated HTTP artifact path, and remote or cross-UID
-binding remain later work.
-Kernel same-UID credentials are the complete local V2.0 principal. Application PKI and remote
-TLS remain outside this boundary and belong to the later remote-security gate.
+Every process, thread, and provider fence locks the exact selected active revision-1
+Turn. Only a fresh ProcessGeneration result can spawn. Replayed, rejected, or uncertain
+state cannot spawn, substitute an account, create a successor, duplicate an attempt, or
+terminalize the Turn. Only positive definite pre-effect refusal can let Conversation
+authority move that Turn to failed revision 2.
 
-The macOS source-install path is narrower than a general administration plane.
-`scripts/macos/install_decodex_local_service.py` initializes one same-UID PostgreSQL
-18 cluster, provisions the exact Decodex roles and grants, and installs one user
-LaunchAgent. `decodexd supervise-local` owns the PostgreSQL and daemon process
-generations. A PostgreSQL generation change stops the daemon and makes the
-supervisor exit; launchd then starts one new coherent generation. An atomic
-credential-file replacement restarts only the daemon when its injected credential
-projection changes. The LaunchAgent restarts only unsuccessful exits and retains a
-60-second final stop timeout. When the installed job has that exact contract, the
-installer first signals the loaded supervisor, waits for its bounded daemon and
-PostgreSQL drain to leave the job inactive, and only then removes the job. If the loaded
-job does not match the exact installed service contract, the installer removes that exact
-job directly before replacement. Both paths bind observed processes by PID and full start
-time and wait at most 300 seconds before provisioning a replacement. Reset Card
-discovery, account binding, provider access, and typed results remain Rust runtime work.
-On macOS, the runtime starts the final canonical Codex image suspended and verifies it
-against its immutable snapshot before resume so process-aware network extensions can apply
-the correct route. Swift remains a client and owns none of these effects.
+Automatic cross-account same-thread fallback and all-depleted wake remain disabled under
+XY-1304.
+
+## Local database reset
+
+One reviewed operator-only local action may stop the daemon and capture the complete
+credential-negative reset tuple. For every retained account, the tuple contains Account
+UUID, enabled state, account revision, provider binding, credential version/fingerprint,
+and host-store binding. It also contains the routing revision, mode, fixed target, and
+complete account order. The action may then replace or directly transform the disposable
+local database, bootstrap the latest schema when needed, restore or rebind that exact
+tuple against unchanged host-vault records, prove exact readback, and start the daemon.
+
+For `fixed` mode, the fixed target is non-null and belongs to the retained account set
+and order. For `balanced` mode, it is null. The order remains a complete duplicate-free
+permutation of retained accounts whether each account is enabled or disabled.
+
+Credential agreement may invoke only the existing `HostCredentialStore` owner. That
+owner performs a confined in-process exact read, recomputes and compares the credential
+fingerprint and binding, and returns only a typed credential-negative agreement result.
+The operator action and its result never expose, serialize, copy, log, persist, rotate,
+delete, or return token bytes. The action creates no public product or migration API,
+generic attestation framework, metadata sidecar, backup/rollback path,
+receipt/finalizer, or fallback. Normal startup and installation do not read an old
+database or account source.
 
 ## First commands
 
-Use these as discovery and validation entrypoints:
+Current repository discovery and source-validation entrypoints include:
 
 ```sh
-cargo run -p decodexd
 cargo run -p decodexd -- --version
 cargo run -p decodex-cli -- status
 cargo run -p decodex-cli -- doctor --output json
@@ -394,72 +207,24 @@ cargo run -p decodex-cli -- account list
 cargo run -p decodex-gpui
 cargo test -p decodex-core --all-targets --all-features
 cargo make test-vnext-architecture
-cargo make test-vnext-postgres-store
 cargo make check
 ```
 
-`decodexd` with no arguments, or with `serve`, starts the same-UID Unix WebSocket
-service and runs until stopped. `decodexd --version` prints the version and does
-not start a service. `decodexd supervise-local --help` describes the bounded
-Unix service supervisor used by the macOS source installer. The CLI selects
-the configured active profile by default; `--profile NAME` selects an explicit declared
-profile and `--root PATH` selects a typed Decodex root. Human output is the default and
-diagnostic `--output json` emits `decodex/cli-diagnostics/1`; reset-card JSON emits
-`decodex/reset-card-cli/1`. GPUI opens a real shell and window. Health is the only
-bounded live destination. Every other destination remains a placeholder. The Quick Task
-and WorkItem contracts do not make their shell destinations live. GPUI is not generally
-usable. Remaining Slice 1 UI work is Accounts and Conversation.
-For a targeted Rust gate,
-prefer
-`cargo check --all-features --all-targets --workspace` or
-`cargo nextest run --workspace --all-targets --all-features` (`Makefile.toml`,
-`openwiki/operations/commands-and-validation.md`).
+Do not use current schema-provisioning or migration commands as acceptance for this
+reset. The future latest-schema bootstrap and current-authority validation command names
+are implementation-owned. See [Commands and validation](operations/commands-and-validation.md).
 
-XY-1399 A-prime is the historical source-only ancestor of the integrated same-UID
-transport. The current tree must run the commands in this section. It also runs the
-focused namespace, WebSocket lifecycle, daemon signal, CLI process, Reset Card
-PostgreSQL, Swift, and signed app-staging checks described in
-[vNext gates](specs/vnext-gates.md).
+## Safety rules
 
-## Authority and safety rules
-
-- Do not read `.env` files or live secret-bearing config. `decodex.example.toml` is the
-  bounded vNext setup model and stores only a PostgreSQL credential environment-variable
-  name, never its value.
-- Do not route vNext product state through `apps/decodex`, legacy SQLite, Linear
-  lanes, or the legacy operator transport. A legacy macOS account watcher or
-  daemon-environment projection is not Mac dogfood authority. Old local credentials can enter vNext only through temporary private files and the
-  ordinary public account import command. This finite operator action is not an installed
-  migration feature. Startup and packaging must not use a watcher, environment bridge,
-  helper/`:8192` service, mapping, or fallback.
-- Use `decodex commit` and `decodex land` for Decodex-owned commit/landing authority; the installable plugin hook blocks raw `git commit` and `gh pr merge` inside Decodex scope (`plugins/decodex/scripts/decodex_lifecycle_hook`).
-- PostgreSQL is the vNext product-state authority when explicitly configured; unavailable is the only supported service state otherwise, with no fallback authority.
-- For project knowledge work, update OpenWiki directly and keep it aligned with source, tests, and manifests.
-
-## Recent development context
-
-XY-1265 established compile-time ownership and composition. XY-1266 established the
-historical loopback protocol foundation. XY-1399 A-prime replaces its active production
-transport with the same-UID Unix WebSocket authority; XY-1270 implements the bounded Codex adapter foundation
-without live dispatch. XY-1267 established PostgreSQL-backed product state and durable
-transactions. XY-1306 established the typed `~/.decodex` path/config/blob/cache child of
-XY-1268; XY-1307 supplied daemon bootstrap/doctor; XY-1308 supplies the API-only CLI and
-end-to-end diagnostic matrix.
-Limited initial account routing and minimal GPUI are Slice-1 work. Automatic fallback and
-wake remain with XY-1304; remote security, HTTP artifacts, and broader GPUI remain with
-their later owners and gates.
-The private-artifact API and runtime composition are not implemented and are no
-longer vNext targets. At and after the XY-1403 repository effective point, the
-[private-artifact archive](specs/private-artifact/README.md) preserves the complete
-former design and receipt anchors as historical evidence. Its rules, A0/A1/B/D0a/C/D
-delivery graph, CORE-FREEZE, ACC, preparation tasks, mechanical pass, and unified
-validation are historical and non-executable. They do not define dependencies or
-future work.
-
-XY-1369 and XY-1370 keep their bounded operator checks and produce canonical
-privacy-safe Git attestations and digests for XY-1363. XY-1363 consumes the exact
-accepted receipt identities and uses the accepted V22 one-shot title path. This
-replacement creates no service, schema, storage system, runtime route, platform
-layer, issue, compatibility path, or product Artifact. The existing
-Artifact/BlobStore boundary remains unchanged, and production dispatch remains
-disabled.
+- Do not read `.env` files or secret-bearing live configuration.
+- Do not route vNext product state through frozen v0.2 SQLite, Linear lanes, the old
+  account watcher, an environment token projection, helper/`:8192`, or a compatibility
+  fallback.
+- Do not add numbered SQL, Refinery, a schema ledger, a schema generator, or a second
+  executable schema owner.
+- Do not make daemon startup resolve schema-owner credentials or execute DDL.
+- Keep current-main account observation and cache-read isolation unchanged while adding
+  Candidate-5 behavior.
+- Treat historical migration evidence as superseded provenance, not current authority.
+- Update OpenWiki directly for this reset; the user prohibited OpenWiki generation for
+  this task.

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -6,6 +6,14 @@ boundary and the later complete account lifecycle.
 The immediate target is `MacDogfoodReady`. Final `AccountLifecycleReady` has more
 requirements. A component-first global gate is not the delivery order.
 
+There are no external or deployed users. The current local database is disposable.
+Account lifecycle has no product account-migration mode. The one local database reset
+may preserve only the complete credential-negative reset tuple defined below, including
+each enabled state, the existing revisions and bindings, and exact routing
+mode/fixed-target/order. Only the existing `HostCredentialStore` owner may read a
+credential in process to recompute agreement. The operator action and its result never
+expose, serialize, copy, log, persist, rotate, delete, or return token bytes.
+
 ## Fixed boundaries
 
 The account system has exactly three owners:
@@ -21,8 +29,9 @@ arguments, logs, or a long-lived daemon or child environment.
 
 This boundary adds no event sourcing, generic distributed transaction coordinator,
 new process or provider-effect ledger, per-account daemon, or permanent per-account
-or per-run Codex home. V13 remains the repository-effect saga. V23 remains the
-ProcessGeneration owner. V24 remains the ProviderAttempt owner.
+or per-run Codex home. Managed-repository effect authority remains separate.
+ProcessSupervisor remains the ProcessGeneration owner. ProviderAttemptService remains
+the ProviderAttempt owner.
 
 One Codex process has one immutable Account UUID and provider binding for its
 complete lifetime. A refresh callback can return a newer credential for that same
@@ -172,8 +181,9 @@ commands and then submits a new task. It does not rebind or replay an existing t
 
 Automatic cross-account same-thread fallback and all-depleted scheduler wake are not
 Slice 1 requirements. An all-depleted result exposes the exact reset evidence and waits
-for an explicit retry. V14 and V16 remain the policy/snapshot and decision authorities;
-their broader automatic-routing behavior is accepted later.
+for an explicit retry. Routing Snapshot remains the complete policy/evidence owner, and
+Routing Decision remains the sole selection owner. Their broader automatic-routing
+behavior is accepted later.
 
 ## Explicit Use in Codex
 
@@ -269,7 +279,7 @@ is safe, and ambiguous store state becomes `RecoveryRequired`.
 ## ProcessGeneration binding
 
 The owning [ProcessGeneration authority](process-generation-authority.md) must extend
-its existing V23 intent, launch-manifest identity, prepare command, and strict readback
+its intent, launch-manifest identity, prepare command, and strict readback
 with the canonical initial account revision, credential version, credential fingerprint,
 provider binding, and exact-build account-capability profile. These fields are immutable
 launch facts. Same-account callback rotation does not rewrite them.
@@ -279,6 +289,13 @@ metadata and compare every field with the ProcessGeneration intent and Account R
 Any mismatch stops before spawn. The existing ProcessGeneration and ProviderAttempt
 state machines own crash and effect ambiguity. No account-specific process or effect
 ledger is added.
+
+For Candidate-5 Quick Task, Account Service receives the account selected by the one
+accepted Routing Decision. It repeats the exact account revision, `enabled` state,
+AccountLifecycle and exact-build capability, provider binding, credential version and
+fingerprint, and HostCredentialStore binding immediately before spawn. It cannot
+preselect, substitute, fall back to, or wake another account. Drift fails closed without
+a second route decision.
 
 ## Reset Card fencing
 
@@ -337,6 +354,11 @@ account value and advances its cache generation before requesting observation. A
 older in-flight generation cannot republish after that invalidation. No credential or
 provider-private Reset Card ID enters this cache.
 
+Query handling is isolated from refresh work. A query does not join, await, register with,
+or inject work into an observation owner. It cannot convert a read into provider access or
+make a slow refresh hold the request path. Candidate-5 Quick Task work must preserve this
+current-main cache-read and observation behavior unchanged.
+
 ```mermaid
 sequenceDiagram
     participant Timer as Daemon timer or wakeup
@@ -369,7 +391,7 @@ quota durability while Reset Card descriptors live only for the daemon lifetime.
 
 ## Bounded account profile
 
-Protocol V2.0 provides one independent `GetAccountProfile` query per Account UUID. It does
+The exact-current protocol provides one independent `GetAccountProfile` query per Account UUID. It does
 not run as part of account listing or Reset Card inventory. The query reads the latest
 persisted projection and the daemon observer's revision-scoped refresh status. One failed
 background profile observation affects only that account row.
@@ -381,11 +403,11 @@ total timeouts, no redirects, and a bounded response body. The daemon sends the 
 token and provider account ID only to that endpoint. It does not log or return the token,
 provider body, or raw error.
 
-V28 stores one latest non-secret profile snapshot and at most 36 unique ascending daily
-usage facts. Persistence uses the exact account revision, provider binding, tombstone
-state, and a monotonic observation time. A response is `current` only after persistence.
-V29 replaces only the profile observation function so PostgreSQL 18 zips the two bounded
-daily arrays through `ROWS FROM`; it adds no relation, authority, or compatibility path.
+The latest schema stores one latest non-secret profile snapshot and at most 36 unique
+ascending daily usage facts. Persistence uses the exact account revision, provider
+binding, tombstone state, and a monotonic observation time. The final PostgreSQL 18
+profile-observation function zips the two bounded daily arrays through `ROWS FROM`. A
+response is `current` only after persistence.
 A previous exact snapshot can return as `cached` with one typed refresh error. Otherwise,
 the row is `unavailable` with one typed error.
 
@@ -407,24 +429,43 @@ fields are absent when the provider or current credential does not supply them.
 
 ## Clean latest-architecture cutover
 
-The product has no legacy-account migration mode. Normal startup and installation do
-not read an old account pool, mapping, helper, environment projection, migration
-manifest, or migration receipt. V27 is the landed clean-break account schema in the
-current V1–V32 migration ledger and accepts only an empty Account Registry. A populated
-older registry requires a fresh local product database.
+The product has no legacy-account or database migration mode. Normal startup and
+installation do not read an old database, account pool, mapping, helper, environment
+projection, migration manifest, or migration receipt. The one latest schema creates an
+empty Account Registry on an empty PostgreSQL target.
 
-An operator can move credentials once by creating owner-private
-`decodex/account-credential-import/1` files and calling the ordinary versioned account
-import command for each account. Each successful command writes the same PostgreSQL
-Account Registry, HostCredentialStore, account-operation journal, and routing order
-used by every later import. The product contains no source parser, bridge, bulk
-importer, finalizer, migration state machine, receipt, or compatibility fallback.
+One reviewed operator-only local action may preserve credential-negative account,
+routing, and binding metadata while replacing or directly transforming the disposable
+development database. It stops the daemon and captures, for every retained account, only
+Account UUID, enabled state, account revision, provider binding, credential
+version/fingerprint, and host-store binding. It also captures the routing revision, mode,
+fixed target, and complete account order. It bootstraps the latest schema when needed and
+restores or rebinds that exact tuple to the unchanged `HostCredentialStore` records.
 
-After every imported account and routing control is verified through the public
-protocol, the operator deletes each temporary import file and the old local account
-pool. That finite local procedure is not an installed product capability. Failure
-before verification leaves the old source untouched; success has no rollback or
-legacy-runtime path.
+For `fixed` mode, the fixed target is non-null and belongs to the retained account set
+and complete order. For `balanced` mode, it is null. The order is one duplicate-free
+permutation of all retained non-tombstoned accounts, including disabled accounts. Exact
+readback proves every retained Account UUID and enabled value, every revision and
+binding, and the routing mode, target, and order together. It rejects an omitted or
+extra account, changed enabled value, invalid target nullability, or order mismatch.
+
+For credential agreement only, the operator action may invoke the existing
+`HostCredentialStore` owner. The owner performs a confined in-process exact record read,
+recomputes the domain-separated fingerprint, compares the Account UUID, provider
+binding, credential version, fingerprint, and host-store binding, and returns only a
+typed credential-negative agreement result. The operator action and result never expose,
+serialize, copy, log, persist, rotate, delete, or return token bytes.
+
+The action must prove exact Account Registry and `HostCredentialStore` agreement for
+every retained account before the daemon starts. It is not a public account or migration
+API, generic attestation framework, metadata sidecar, product importer, source parser,
+bridge, bulk operation, backup/rollback mechanism, state machine, receipt/finalizer,
+compatibility branch, or fallback.
+
+Ordinary enrollment and explicit credential import remain account lifecycle operations
+for credentials that a user deliberately adds. They are not used to move existing host
+vault secrets during this local database reset and do not become a product migration
+surface.
 
 ## Readiness levels
 

--- a/openwiki/specs/execution-coordinator-authority.md
+++ b/openwiki/specs/execution-coordinator-authority.md
@@ -1,260 +1,271 @@
-# XY-1402 stateless execution coordination
+# Stateless Execution Coordination
 
-## Status and authority
+Status: normative current owner composition plus the accepted Candidate-5 Quick Task
+target. Candidate-5 implementation and integrated acceptance remain pending.
 
-This page records the source projection for XY-1402. Linear issue XY-1402 is the
-complete scope and acceptance contract. The following accepted records supply the
-composed authority:
-
-- parent decision XY-1398;
-- product authority comment `099fb36d-9a48-407e-abdd-80dd56d13051`;
-- skeptic authority comment `02d37443-f3cf-4c11-a462-e3da80c40481`;
-- decision memo `134844d5-ad31-484f-9409-4591638c966d`;
-- accepted XY-1399 R2 receipt `4afabdfc-a694-4d16-ba61-6cb016f38fe9`;
-- accepted XY-1400 R2 receipt `e9509cd9-fb60-43ab-a9ab-d235a8e14e7f`; and
-- accepted XY-1401 cycle-2 R2 receipt `8a784c0a-2e2f-4675-adba-d3baaaddb3f1`.
-
-The XY-1396 and XY-1397 candidates are rejection evidence. They do not supply
-implementation authority.
-
-This candidate is source-only work before the unified core-freeze gate. No
-formatter, build, compiler, lint, static analysis, migration parser, SQL parser,
-test, fixture, generator, service, VM, UI check, live Codex experiment, account
-operation, or provider effect is part of this candidate evidence.
+The coordinator is not a schema owner. Its domain records are not schema migration
+records. The one latest schema contains only final current relations and omits the retired
+ManagedRun-local submitted-turn/effect-barrier machinery.
 
 ## Owner composition
 
-`ExecutionCoordinator` is a zero-sized, stateless sequencer. It does not persist
-state. It does not own a lifecycle, retry machine, receipt, effect barrier,
-ambiguity ledger, account decision, RuntimeSession decision, process state, or
-ProviderAttempt state.
+`ExecutionCoordinator` is a zero-sized, stateless sequencer. It does not persist state or
+own a lifecycle, retry machine, receipt, effect barrier, ambiguity ledger, account
+decision, RuntimeSession decision, process state, or ProviderAttempt state.
 
-| Owner | Sole authority retained |
+| Owner | Sole authority |
 | --- | --- |
-| Conversation owner | Ordinary Conversation and Turn lifecycle. Quick Task stays an ordinary multi-turn Conversation. |
-| ManagedRun owner | ManagedRun lifecycle, execution assignment, wait state, and acceptance. |
-| V14 and V16 | Complete account universe, eligibility facts, account selection, and immutable route decision. |
-| V17 | Exact same-thread RuntimeSession reuse or atomic Context Pack plus fallback RuntimeSession creation. |
-| ProcessSupervisor | ProcessGeneration intent, live fence, positive death evidence, and account-local quarantine. |
-| ProviderAttemptService | Atomic prepared binding, provider-effect state, positive evidence, restore projection, and reconciliation. |
-| Reviewer | Execution-scoped, read-only review. Missing or ambiguous output grants no approval or completion. |
-| ExecutionCoordinator | One in-memory sequence across the accepted owners. It grants no dispatch authority. |
+| Conversation authority | Ordinary Conversation and Turn lifecycle, including Candidate-5 atomic first Turn/history admission and legal Turn finalization. |
+| ManagedRun authority | ManagedRun lifecycle, execution assignment, wait state, review, acceptance, and completion. |
+| Routing Snapshot | Complete account universe, policy order, account/evidence revisions, capability/quota facts, and blocker completeness. |
+| Routing Decision | Sole account selection, exact cause projection, and immutable route result. |
+| Continuation Plan | First-session planning, exact same-thread reuse, atomic Context Pack plus fallback RuntimeSession, and PostgreSQL-only explicit-successor evidence. |
+| RuntimeSession Thread Establishment | Exact thread request fence, start binding, activation, and acknowledgement. |
+| ProcessSupervisor | ProcessGeneration intent, live fence, positive-only death evidence, and account-local quarantine. |
+| ProviderAttemptService | Atomic attempt binding, dispatch authorization, provider-effect state, positive evidence, restore projection, and reconciliation. |
+| Reviewer | Execution-scoped read-only review; missing or ambiguous output grants no approval or completion. |
+| ExecutionCoordinator | One in-memory sequence across accepted owners; no independent authority. |
 
-The coordinator first consumes one V16 decision. A selected decision can consume
-one V17 plan. The coordinator then consumes one ProcessSupervisor-owned live
-fence and asks ProviderAttemptService to prepare the exact attempt. The
-coordinator consumes the fresh prepared capability and returns only an inert
-attempt projection. It cannot authorize dispatch. No production composition
-root can call this sequence.
+The coordinator consumes typed results in owner order and returns an inert projection
+unless a separately accepted production dispatch root consumes the complete fence chain.
+It cannot reconstruct a fresh fence from durable readback.
 
 ## Closed execution consumer
 
-V14, V16, and V17 use one closed consumer union:
+Routing, continuation, and ProviderAttempt use one closed consumer union:
 
-- `conversation_turn` binds the Conversation identity and revision, source
-  RuntimeSession identity and revision, and reserved Turn identity; and
-- `managed_run_execution` binds the ManagedRun identity and revision and one
-  distinct managed execution identity.
+- `conversation_turn` binds Conversation identity/revision, optional source
+  RuntimeSession identity/revision, and one prospective or existing Turn identity; and
+- `managed_run_execution` binds ManagedRun identity/revision and one distinct managed
+  execution identity.
 
-The ordinary variant does not contain a ManagedRun identity. The Conversation
-owner can materialize its reserved Turn after ProviderAttempt preparation.
-ProviderAttempt does not create or rewrite a RuntimeSession or a Turn.
+The Conversation variant contains no ManagedRun identity. Quick Task remains an ordinary
+multi-turn Conversation. Conversation authority materializes its reserved Turn only after
+the accepted first-session plan or for an existing-session intent. ProviderAttempt cannot
+create or rewrite a Turn or RuntimeSession.
 
-The managed variant does not move ManagedRun lifecycle authority. The ManagedRun
-read model consumes all ProviderAttempt result projections. It does not copy
-provider-effect authority into a second ledger.
+The ManagedRun variant does not move ManagedRun lifecycle authority. Its read model can
+consume ProviderAttempt projections, but it cannot copy provider-effect authority into a
+second ledger or synthesize acceptance.
 
-## V25 and V26 forward cutover
+## Final latest-schema cut
 
-`V25__execution_route_enum_expansion.sql` adds only the route and wait vocabulary.
-PostgreSQL requires that transaction to commit before a later transaction uses a
-new value from an existing enum.
+The latest schema includes the final closed route and wait vocabulary and the final
+consumer-generic routing, continuation, and ProviderAttempt definitions directly. It does
+not contain the retired ManagedRun-local submitted-turn receipts, safety inputs, effects,
+or barriers. It contains no compatibility or fallback writer for those shapes.
 
-`V26__execution_coordinator_cutover.sql` is the forward-only coordinated cutover.
-It takes exclusive locks on the retired V12 relations and their current
-integration relations before it changes authority.
+There is no data conversion or historical backfill. Current local data is disposable. If
+old local state cannot satisfy the latest schema, the operator replaces the local
+database or directly transforms that one development database under the reviewed local
+action. Product runtime never interprets an old shape.
 
-The migration stops if any V12 effect barrier, effect, submitted-turn receipt,
-safety input, or V12 exact-command receipt remains live. It also stops when
-historical routing or continuation data maps one accepted ManagedRun revision to
-more than one managed execution identity. V24 could represent an ordinary
-ProviderAttempt over its then-ManagedRun-only V17 plan. V26 stops if such a
-historical row exists because it cannot convert that lineage into a direct
-ordinary consumer without inventing authority. These conditions require an
-external cutover decision. The migration does not invent compatibility
-authority.
+The latest schema retains sole writers:
 
-After the checks pass, V26:
-
-- removes the V12 safety command, helper, effect ledger, submitted-turn ledger,
-  and barrier relations;
-- removes V12 runtime grants;
-- makes V14, V16, and V17 consumer-generic;
-- backfills one unambiguous historical managed execution identity;
-- adds exact Conversation and ManagedRun consumer completeness constraints;
-- adds exact route-cause and reconciliation projection;
-- keeps V16 as the only account decision writer;
-- keeps V17 as the only RuntimeSession continuation writer;
-- keeps ProviderAttempt as the only provider-effect writer; and
-- adds least-privilege read functions for immutable execution decisions and
-  ManagedRun execution projections.
-
-There is no live, latent, compatibility, or fallback V12 writer after V26.
-Rollback means restore of a pre-V26 database. It does not mean reverse SQL or a
-dual-writer interval.
+- Routing Decision for account choice and route causes;
+- Continuation Plan for RuntimeSession continuation/creation;
+- ProcessSupervisor for ProcessGeneration;
+- ProviderAttemptService for provider effects; and
+- Conversation or ManagedRun for their own lifecycle.
 
 ## Route projection
 
-V16 loads and locks the complete V14 account universe. The caller supplies no
-account list and cannot select an account.
+Routing Decision loads and locks the complete Routing Snapshot. The caller supplies no
+account list, policy order, eligibility, exclusion, or account choice.
 
-Selection and pure-wait classification use only independently eligible included
-members. Policy-excluded members never become eligible and do not participate in
-quota or reconciliation wait classification. A `no_route` projection instead
-uses the complete persisted policy-member universe. Each excluded member retains
-`excluded_by_policy` and every other persisted blocker, while each included
-member retains its exact blockers. An all-excluded universe therefore produces a
-cause-complete `no_route`. A cause-free `no_route` is invalid.
+Selection and pure-wait classification use only independently eligible included members.
+Policy-excluded members never become eligible and do not participate in quota or
+reconciliation wait classification. A `no_route` projection uses the complete persisted
+policy-member universe. Every excluded member keeps `excluded_by_policy` plus every other
+blocker. Every included member keeps its exact blockers. An all-excluded universe is a
+cause-complete `no_route`; cause-free `no_route` is invalid.
 
-The 300-minute and 10,080-minute quota facts stay independent. Each fact keeps
-its duration, source identity, observation revision, exact raw timestamp,
-microsecond value, confidence, and reset instant. V16 applies sticky affinity
-only after it proves independent eligibility. V16 classifies both duration-typed
-facts again at its own database-authored decision instant. A fact that becomes
-stale or reset-expired after V14 keeps that exact new cause.
+The 300-minute and 10,080-minute quota facts remain independent. Each retains duration,
+source identity, observation revision, exact raw timestamp, exact microsecond value,
+confidence, and reset instant. Routing classifies both again at its database-authored
+decision instant. A fact that ages after snapshot creation keeps the exact stale or
+reset-elapsed cause.
 
-V16 uses these exact projection rules:
+Sticky affinity applies only after independent account, capability, quota, process, and
+attempt eligibility. Route results are:
 
-- `selected` names one independently eligible account.
-- `waiting_usage` is valid only when every otherwise eligible account is blocked
-  only by current positive quota depletion. It contains the complete exact
-  depletion causes and the earliest account-ready instant.
-- `waiting_reconciliation` is valid only when every otherwise eligible path is
-  blocked only by an unresolved ProcessGeneration or ProviderAttempt.
-- `no_route` keeps every exact cause for mixed or non-wake conditions. It grants
-  no quota wake and does not fail the task.
+- `selected`: one independently eligible account;
+- `waiting_usage`: every otherwise eligible account is blocked only by current positive
+  quota depletion; includes complete depletion causes and earliest ready instant;
+- `waiting_reconciliation`: every otherwise eligible path is blocked only by unresolved
+  ProcessGeneration or ProviderAttempt state; and
+- `no_route`: complete mixed or non-wake causes; it grants no wake and does not fail the
+  task by itself.
 
-Authentication, plugin, disabled-account, unknown-capability, dependency,
-approval, user, external, and Reviewer causes do not become quota or
-reconciliation causes. Missing timestamp provenance becomes `usage_unproven`.
-ManagedRun reconciliation without an exact unresolved process or attempt becomes
-`reconciliation_unproven`.
+Authentication, plugin, disabled account, unknown capability, dependency, approval,
+user, external, and Reviewer causes do not become quota or reconciliation causes. Missing
+quota provenance becomes `usage_unproven`. Reconciliation without an exact unresolved
+process or attempt becomes `reconciliation_unproven`.
 
-V16 adds a process cause to a path that is otherwise eligible except for positive
-quota depletion. Therefore, an unresolved process and quota depletion produce a
-mixed `no_route`, not a quota wake.
+An unresolved process plus positive depletion is mixed `no_route`, not a quota wake.
+Separate account quotas are never pooled, merged, summed, averaged, or caller-ranked.
 
-## RuntimeSession and thread continuity
+## Candidate-5 initial operation
 
-For an ordinary Conversation, V17 permits same-thread reuse only when the
-original ProviderAttempt has positive exact-thread readback evidence. The
-evidence must bind the same Conversation, source RuntimeSession, account, and
-Codex thread. The reserved current Turn remains a new Conversation-owned intent.
+Candidate 5 adds no coordinator state or new owner. The exact order is:
 
-For a ManagedRun, V17 retains the accepted V15/V22 causal experiment path. An
-exact accepted experiment and positive `thread/read` attestation must bind the
-same source RuntimeSession thread.
+1. Conversation authority creates the Conversation.
+2. The routing request supplies one prospective Turn UUID as intent only. No Turn row or
+   Turn foreign key exists yet.
+3. Routing Snapshot proves the exact initial zero-source lineage and complete locked
+   account universe.
+4. Routing Decision selects one account exactly once.
+5. Continuation Plan atomically creates selected account/profile snapshots, the first
+   revision-1 unfenced `starting` RuntimeSession, inert `initial_thread` plan, exact
+   receipt, activity, and outbox.
+6. Conversation authority atomically admits the exact active revision-1 sequence-1 user
+   Turn and exactly one ordinal-0 completed Message.
+7. Account Service fences only the selected account immediately before spawn.
+8. ProcessSupervisor can spawn only from a fresh ProcessGeneration outcome.
+9. RuntimeSession Thread Establishment fences, starts, binds, and activates the exact
+   thread.
+10. ProviderAttemptService prepares and authorizes the exact attempt.
 
-If same-thread evidence is absent, stale, negative, incomplete, ambiguous, or
-cross-linked, V17 uses its atomic fallback path. The transaction creates the
-Context Pack, account snapshot, starting fallback RuntimeSession, continuation
-plan, activity, outbox, and exact receipt as one authority cluster. V17 does not
-write ProviderAttempt state. ProviderAttempt does not write RuntimeSession state.
+There is no second route decision, alternate account, initial fallback, wake, or account
+re-selection. Initial planning has no source RuntimeSession and no sticky member. It is
+first-session creation, not same-thread reuse, explicit successor, or Context Pack
+fallback.
 
-The shared Codex home stays visible. Exact thread identity, supported same-thread
-resume, and the accepted Context Pack fallback stay intact.
+### Initial lineage
+
+`L0` has all six RuntimeSession, account-snapshot, and profile-snapshot
+identity/revision fields absent. `L6` has all six present with positive revisions.
+Conversation work permits `L0` or `L6`; ManagedRun work permits only `L6`.
+
+The final schema keeps all foreign keys and one exact all-null/all-present check. `L0`
+requires an open exact-revision Conversation, no RuntimeSession or Turn, zero sticky
+members, and exact complete locked membership/order/account/two-window quota/eight
+capability/blocker facts. Partial lineage, source fields, sticky `L0`, existing session or
+Turn, closed/stale Conversation, source-less ManagedRun, and missing, extra, duplicate,
+cross-linked, or reordered evidence reject.
+
+One Conversation lock permits one cross-key initial decision to be fresh. Exact-key replay
+is read-only. Continuation planning accepts only the selected `L0` result and rolls back
+the complete first-session authority cluster on any failure.
+
+### Initial admission
+
+Conversation authority creates the first Turn and history item in one one-winner
+transaction. Required Turn values are the prospective UUID, sequence 1, `user`,
+`possible_side_effects=unknown`, `active`, revision 1, and the exact Conversation/new
+RuntimeSession cross-link. The only first history item is ordinal 0, Message, `completed`,
+revision 1.
+
+The fresh/replay/refusal result, Turn, history, receipt, activity, and outbox are one
+atomic owner result. A competing key commits none of those effects. Wrong identity,
+sequence, role, status, revision, side-effect state, history ordinal/kind/status, second
+item, or cross-link rejects the complete transaction.
+
+### Exact fences and replay
+
+Every process, thread, and provider-effect owner locks and rechecks the exact selected
+Turn as active revision 1. ProcessGeneration and thread establishment through bind require
+the applicable `starting` RuntimeSession revision. ProviderAttempt preparation and
+authorization require the exact post-bind `active` revision plus exact thread fence/bind
+receipts.
+
+Only a fresh ProcessGeneration outcome can spawn. Replay, rejection, and uncertainty use
+durable ProcessGeneration, RuntimeSession, ProviderAttempt, and Conversation readback.
+They cannot spawn, replace, adopt, create a successor, duplicate an attempt, or
+terminalize the Turn.
+
+Conversation authority can move the Turn to failed revision 2 under a starting session
+only after positive proof of definite pre-effect refusal. The proof excludes every process
+state that may have created a child, thread fence/start/bind, and prepared, authorized, or
+unknown ProviderAttempt. Ambiguous work remains active and returns `Unknown`.
+
+Explicit successor remains PostgreSQL-only non-dispatch evidence. Before any write it
+locks the Turn named by the selected route and requires the same Conversation/source
+RuntimeSession, `failed`, revision 2. It has no protocol field, command, runtime grant,
+facade, fallback, or wake path.
+
+## RuntimeSession continuity
+
+For an existing ordinary Conversation session, same-thread reuse requires positive exact
+thread evidence from the original ProviderAttempt. Evidence must bind the same
+Conversation, source RuntimeSession, account, and Codex thread.
+
+For ManagedRun, same-thread reuse requires the accepted causal experiment and positive
+exact-thread attestation bound to the source RuntimeSession.
+
+When accepted existing-session same-thread evidence is absent, stale, negative,
+incomplete, ambiguous, or cross-linked, Continuation Plan uses its atomic Context Pack
+path. It creates the Context Pack, account snapshot, starting fallback RuntimeSession,
+plan, activity, outbox, and exact receipt as one authority cluster.
+
+Candidate-5 initial planning cannot enter either existing-session branch. Continuation
+Plan never writes ProviderAttempt state, and ProviderAttempt never writes RuntimeSession
+state.
 
 ## Effect ambiguity and isolation
 
-An authorized ProviderAttempt remains `unknown` until positive evidence proves a
-terminal result. Process death, timeout, missing events, EOF, restart, negative
-search, and absent rows do not prove non-submission. These observations do not
-authorize replay.
+An authorized ProviderAttempt remains `unknown` until positive evidence proves a terminal
+result. Process death, timeout, missing events, EOF, restart, negative search, and absent
+rows do not prove non-submission and do not authorize replay.
 
-Late positive evidence stays bound to the original attempt. A replacement
-process can reconcile that attempt. It cannot replay the attempt.
+Late positive evidence remains bound to the original attempt. A replacement process can
+reconcile that attempt but cannot replay it.
 
-An existing exact attempt blocks only its exact Conversation Turn or managed
-execution intent. A process cause blocks only the affected account path. Other
-consumers, accounts, dependencies, and routes remain eligible.
+An attempt blocks only its exact Conversation Turn or managed execution. Process
+uncertainty blocks only the affected account path. Other consumers, accounts,
+dependencies, and routes remain independently eligible.
 
 ## Transport and production isolation
 
-The protocol exposes one read-only immutable execution-decision query. The query
-returns the closed consumer, route kind, exact causes, and independent positive
-quota exclusions. It cannot create a route, RuntimeSession, process,
-ProviderAttempt, wake, retry, receipt, or dispatch fence.
+The exact-current protocol may expose one read-only immutable execution-decision query.
+It returns the closed consumer, route kind, complete exact causes, and independent quota
+exclusions. It cannot create a route, RuntimeSession, process, ProviderAttempt, wake,
+retry, receipt, or dispatch fence.
 
-The service uses the accepted XY-1399 owner-only same-UID local transport. It
-does not restore unauthenticated loopback admission. Remote and cross-UID
-authority remains deferred to XY-1299.
+The service uses the owner-only same-UID Unix transport. It has no TCP or loopback
+fallback. Remote and cross-UID authority remains separately gated.
 
-Live provider dispatch and production routing stay structurally disabled. The
-coordinator method is crate-private. It accepts only a crate-private live
-`FencedProcess`. No protocol, CLI, scheduler, application, Codex adapter,
-credential owner, UI, or daemon composition root can acquire the coordinator
-sequence or a dispatch authorization.
+The coordinator method remains crate-private and accepts only crate-private owner
+capabilities. No protocol, CLI, scheduler, UI, credential owner, Codex adapter, or client
+can construct the sequence or mint dispatch authority. Product dispatch remains disabled
+until the Candidate-5 gate accepts the complete composition.
 
-## Deferred acceptance matrix
+## Acceptance
 
-The later unified core-freeze gate must bind every result to the exact candidate
-tree. It must execute the complete matrix below. This source candidate does not
-execute any row.
+After source freeze, validation must cover:
 
-| Boundary | Representative deferred acceptance cases and required evidence | Residual risk before execution |
-| --- | --- | --- |
-| Rust source quality | Compile all affected crates and run the accepted formatter, lint, static, and documentation checks on the exact tree. | Type, visibility, warning, and formatting defects are not excluded by source inspection. |
-| Migration paths | Prove clean V1-to-V26 and populated V24-to-V25-to-V26 migration. Prove that V25 commits enum vocabulary before V26 uses it. Prove transaction rollback for each V26 cutover checkpoint. | PostgreSQL syntax, lock order, and catalog behavior are not executed. |
-| Cutover drain | Prove that every live V12 row or V12 exact-command receipt stops V26 without partial change. Prove that a drained cutover removes all V12 writers and grants. | A latent historical writer or unexpected production row can still falsify the cutover. |
-| Historical ambiguity | Prove that zero or one accepted managed execution identity backfills exactly. Prove that two identities stop the migration. Prove that every historical ordinary ProviderAttempt over the old ManagedRun-only V17 lineage stops the cutover. | Existing data can contain an unobserved ambiguous or cross-linked lineage. |
-| Authority manifests | Capture S0, R1, and R2 manifests. Verify the V26 migration ledger, relation, function, trigger, enum, ACL, dependency, and security-definer inventories. | The schema and configured-authority digests remain intentionally unfrozen until the aggregate gate. |
-| ACL closure | Prove runtime can execute only the required exact functions and read only the required projections. Prove PUBLIC and runtime cannot use private helpers or relation DML. | A catalog or default-ACL drift can add an authority path. |
-| Ordinary Conversation | Route and plan an ordinary Turn without a ManagedRun, WorkItem, Reviewer, or second effect ledger. Prove Quick Task stays a multi-turn Conversation. | No end-to-end ordinary execution was run. |
-| Conversation Turn owner | Prepare one reserved Turn, then materialize it only through the Conversation owner. Reject a cross-Conversation, cross-session, changed, or duplicate Turn. | Conversation-owner integration is source-inspected only. |
-| ManagedRun | Route one exact managed execution and consume ProviderAttempt results without changing ManagedRun lifecycle ownership. | ManagedRun lifecycle and acceptance integration are not executed. |
-| Account authority | Supply no account list. Prove V16 loads the full persisted V14 universe and rejects policy, member, revision, and evidence drift. | A query or trigger error can weaken full-universe closure. |
-| All-excluded policy | Exclude every persisted policy member. Require one `no_route` containing `excluded_by_policy` for every member and every other persisted member blocker. | Database trigger and Rust-kernel cause completeness are not executed. |
-| Mixed included/excluded policy | Combine excluded members with included members carrying quota, reconciliation, and non-wake blockers. Require pure waits to use only included members; require every excluded and included cause when the result is `no_route`. | Mixed policy-disposition and blocker schedules are not executed. |
-| Cause-free NoRoute | Remove all causes or one required excluded-member cause from a `no_route` projection. Require PostgreSQL integrity, exact-command readback, read-only adapter, runtime projection, and protocol decoding to fail closed. | Cross-layer malformed-projection cases are source-inspected only. |
-| Quota separation | Exercise 300-minute and 10,080-minute facts independently and together. Prove duration, source, revision, raw value, precision, and reset identity stay separate. | SQL and Rust ordering parity are not executed. |
-| V14-to-V16 quota aging | Place each duration just before, at, and after its freshness and reset boundaries between snapshot and decision. Require the exact stale or reset-elapsed cause and never an empty, selected, or pure-depletion projection. | Cross-transaction clock boundaries are not executed. |
-| Sticky affinity | Prove sticky selection only after independent account, capability, quota, process, and attempt eligibility. | A data-dependent ordering defect can select too early. |
-| Pure usage wait | Prove `waiting_usage` only when all otherwise eligible accounts have only positive current depletion. Verify the exact earliest account-ready instant. | Boundary timestamps and provenance comparisons are not executed. |
-| Pure reconciliation wait | Prove `waiting_reconciliation` only when all otherwise eligible paths have only unresolved ProcessGeneration or ProviderAttempt causes. | Process/attempt race schedules are not executed. |
-| Mixed causes | Combine quota with process, authentication, plugin, disabled, unknown-capability, dependency, approval, user, external, and Reviewer causes. Require `no_route`, every exact cause, no wake, and no task failure. | Cross-product cause schedules are not executed. |
-| Missing quota provenance | Remove each duration, source, revision, raw timestamp, precision, confidence, or reset field. Require `usage_unproven` or the exact existing typed cause, never a quota wake. | Malformed and boundary timestamp fixtures are deferred. |
-| RuntimeSession reuse | For Conversation work, require original positive ProviderAttempt thread evidence. For ManagedRun work, require accepted causal experiment evidence. Reject stale, negative, missing, duplicate, or cross-linked evidence. | Same-thread evidence queries are not executed. |
-| Atomic fallback | Inject failures before and after each Context Pack, snapshot, RuntimeSession, plan, activity, outbox, receipt, and commit step. Require zero or one complete authority cluster. | Transaction and blob crash behavior are deferred. |
-| Process fence | Accept only a live ready ProcessGeneration with an unretired execution epoch. Reject dead, starting, stopping, death-unknown, cross-account, stale-revision, and retired-epoch generations. | Host and database races are not executed. |
-| ProviderAttempt preparation | Prove one atomic binding to the exact consumer, V16 decision, V17 plan, RuntimeSession, account, process generation, epoch, request identity, and provider keys. Prove that the coordinator consumes the fresh prepared capability and returns only an inert projection. | V24 replacement-function behavior and capability consumption are not executed. |
-| Exact-intent replay | Prove same-key replay returns stored authority. Prove a new attempt for the same Turn or managed execution cannot change account or replay an effect. | Concurrency and response-loss schedules are deferred. |
-| Lost supervision | Inject process death, timeout, EOF, restart, missing events, negative search, and absent result rows after authorization. Require `unknown`, not `not_submitted`. | Provider and host adapters are not exercised. |
-| Late positive evidence | Reconcile a late positive result to the original attempt after process loss. Reject attribution to a replacement attempt. | Provider evidence adapters are not exercised. |
-| Smallest-scope isolation | Block one attempt, dependency, account, and route in turn. Prove unrelated work remains eligible. | Large concurrent account and consumer schedules are deferred. |
-| ManagedRun projection | Read every exact ProviderAttempt state, positive terminal evidence identity, and unknown reason through the ManagedRun view. Prove it cannot mutate ProviderAttempt or synthesize acceptance. | Read-model completeness is not executed. |
-| Reviewer | Exercise unavailable, failed, missing, ambiguous, and positive output. Require missing or ambiguous output to grant neither approval nor completion. | Reviewer integration remains read-only and unexecuted. |
-| Coordinator statelessness | Inspect object layout and run repeated, concurrent, crash, and restart calls. Prove no coordinator relation, receipt, task, retry state, or durable projection exists. | Runtime memory and concurrency behavior are not executed. |
-| Protocol projection | Query selected, usage-wait, reconciliation-wait, mixed, missing, malformed, and incompatible decisions. Require complete causes without truncation or mutation authority. | V1.2/V1.1 wire compatibility and response-size limits are not executed. |
-| Same-UID transport | Prove fixed owner-only Unix endpoint, client and server peer-UID checks, and no TCP or loopback fallback. | XY-1399 host matrix remains deferred. |
-| Shared Codex home | Prove the exact configured home, account visibility, thread identity, supported resume, and Context Pack fallback across restart. | No live Codex experiment is part of this candidate. |
-| Production isolation | Reverse-scan every composition root. Prove no routing, coordinator, process spawn, provider dispatch, credential, remote transport, UI, packaging, or release path is enabled. | A dependency or feature-flag change can invalidate source isolation. |
-| Replay and concurrency | Run same-key, cross-key, response-loss, rollback, serialization, deadlock, restore, and concurrent-consumer schedules for V16, V17, and V24. | Exact-command convergence is not executed on the integrated tree. |
-| Hostile cross-links | Substitute every Conversation, Turn, ManagedRun, managed execution, RuntimeSession, account, process, attempt, plan, evidence, operation, and idempotency identity. Require fail-closed rejection. | The full hostile matrix is deferred. |
-| Documentation alignment | Compare the final source, Linear authority, manifests, OpenWiki, and accepted parent receipts on the exact tree. | Later changes can cause documentation or authority drift. |
+- fresh PostgreSQL 18 latest-schema bootstrap, second-bootstrap refusal, and runtime-only
+  daemon startup with zero DDL and no schema-owner credential;
+- exact current catalog/authority for all routing, continuation, Conversation,
+  ProcessGeneration, ProviderAttempt, and read-only projection objects;
+- both consumer shapes and rejection of every partial or cross-linked identity;
+- complete route universe, all-excluded and mixed policies, cause-free rejection,
+  independent quota facts, aging, sticky eligibility, and exact pure-wait rules;
+- Candidate-5 `L0`/`L6`, sole account selection, atomic first-session cluster, atomic
+  first Turn/history admission, exact effect fences, fresh/replay/reject/unknown behavior,
+  and definite pre-effect refusal;
+- existing-session same-thread and atomic Context Pack paths;
+- positive-only process/attempt reconciliation, late evidence, smallest-scope isolation,
+  and no replay after lost supervision;
+- ManagedRun and Reviewer authority isolation;
+- stateless coordinator layout and restart behavior;
+- same-UID transport and complete read-only protocol projection; and
+- reverse scans proving no old barrier writer, second ledger, alternate selector,
+  unauthorized dispatch root, or schema upgrade machinery remains.
+
+No historical upgrade, populated cutover, schema-ledger, migration, or restore-digest
+proof is part of acceptance.
 
 ## Architecture falsifiers
 
-Stop integration and return to the authority owner if any of these conditions is
-true:
+Stop and return to the authority owner if:
 
 - ordinary Conversation execution requires a ManagedRun;
-- ProviderAttempt must create or rewrite a RuntimeSession;
-- V17 must write ProviderAttempt state;
-- the coordinator must persist durable authority;
-- V12 cannot be retired without a second live, latent, compatibility, or fallback
-  writer;
-- the accepted parent contracts cannot compose without a change to accepted
-  authority;
-- route projection must collapse a mixed cause into a quota or reconciliation
-  wait; or
-- lost supervision must authorize replay without positive evidence.
+- ProviderAttempt must create or rewrite RuntimeSession state;
+- Continuation Plan must write ProviderAttempt state;
+- ExecutionCoordinator must persist authority;
+- the retired ManagedRun effect path requires a second live or compatibility writer;
+- mixed route causes must collapse into a pure wait;
+- lost supervision must authorize replay without positive evidence; or
+- Candidate-5 requires a second account selector, pre-admission Turn row, generic
+  recovery framework, or alternate dispatch owner.

--- a/openwiki/specs/process-generation-authority.md
+++ b/openwiki/specs/process-generation-authority.md
@@ -1,317 +1,256 @@
-# XY-1400 ProcessGeneration authority
+# ProcessGeneration Authority
 
-## Authority and scope
+Status: normative current domain authority. Candidate-5 Quick Task composition is an
+accepted target and remains subject to its integrated gate.
 
-This page records the checked-in implementation projection for Linear issue XY-1400.
-The parent product decision is XY-1398. Product authorization V3 comment
-`099fb36d-9a48-407e-abdd-80dd56d13051`, architecture skeptic receipt
-`02d37443-f3cf-4c11-a462-e3da80c40481`, and implementation authorization
-`a0f34b3e-033e-4106-9007-c9b21d23ae57` are the accepted issue authority. Cycle-2
-review receipt `1afe3710-e9f5-4d0f-84d0-9c0732923b07` and repair authorization
-`2b0937ac-48b6-40e7-b301-3d074223b1c0` correct the local protocol and lifetime
-boundaries without changing V3.
+## Scope
 
-V3 supersedes V2 comment `30ca36d4-8b94-4f6b-9a79-93c06561ec57`. V2 and rejected
-commit `4789f7f6bcf4377ff8da02d2a781575f9ff150a3` are provenance only. Rejected
-XY-1396 and XY-1397 guardian and takeover designs supply no implementation authority.
-
-This slice adds durable fenced ProcessGeneration intent, an opaque attested launch,
+ProcessGeneration owns durable fenced provider-process intent, opaque attested launch,
 exact process identity, positive-only death reconciliation, account-local quarantine,
-and a narrow runtime diagnostic and control port. XY-1423 extends that same intent and
-readback with non-secret account credential binding. It does not add a second ledger,
-routing, account selection, RuntimeSession creation, ProviderAttempt storage, remote
-authentication, UI, packaging, release, provider effects, or production dispatch.
+and a narrow runtime diagnostic/control port.
+
+It does not own routing, account selection, RuntimeSession creation, thread creation,
+ProviderAttempt state, provider effects, remote authentication, UI, packaging, release,
+or product dispatch. It adds no second process ledger.
+
+ProcessGeneration is a current domain integrity record. It is not schema history,
+bootstrap authority, or a database migration mechanism. The one latest schema creates
+its final relations, functions, constraints, indexes, and triggers directly.
 
 ## Owner and durable model
 
-`ProcessSupervisor` is the only product component that writes ProcessGeneration state.
-The PostgreSQL runtime role has no relation privilege on the four V23 relations. It can
-execute only eight closed `SECURITY DEFINER` ProcessGeneration functions. PUBLIC has no
-type, relation, or function authority. The migration identity owns the relations and
-functions.
-
-V23 adds these durable concepts:
+`ProcessSupervisor` is the only product writer. The runtime PostgreSQL identity has no
+relation DML for ProcessGeneration state. It can execute only the closed
+ProcessGeneration command/read functions. PUBLIC has no type, relation, or function
+authority. The PostgreSQL schema owner owns the objects but is not available to normal
+daemon startup.
 
 | Concept | Contract |
 | --- | --- |
-| Execution epoch | An external restore authority supplies an epoch UUID and matching SHA-256 authorization digest. Runtime cannot read the digest from PostgreSQL. |
-| ProcessGeneration | One immutable generation, account, initial account revision, canonical credential version and fingerprint, provider binding, exact-build account-capability profile, epoch, attested launch-manifest identity, intended boot, control kind, isolation kind, optional exact process identity, state, revision, and timestamps. It stores no credential material. |
+| Execution epoch | An external restore authority supplies an epoch UUID and matching SHA-256 authorization digest. Runtime cannot recover the digest from PostgreSQL. |
+| ProcessGeneration | One immutable generation, account, initial account revision, credential version/fingerprint, provider binding, exact-build capability profile, epoch, launch-manifest identity, intended boot, control kind, isolation kind, optional exact process identity, state, revision, and timestamps. It stores no credential bytes. |
 | Death evidence | One append-only positive receipt for an exact generation and source revision. |
-| Transition history | One append-only row for each revision. |
+| Transition history | One append-only row for each accepted revision. |
 
 The durable states are `starting`, `ready`, `stopping`, `dead`, and
-`death_unknown`. A partial process identity is invalid. A bound identity contains the
+`death_unknown`. A partial process identity is invalid. A complete identity contains the
 boot identity, PID, process-start identity, process-group ID, and session ID. The child
-must be the leader of its process group and session.
+must lead its process group and session.
 
-One partial unique index permits at most one non-`dead` generation for an account.
-Thus, uncertainty quarantines only that account. Quarantine is a derived projection
-from a nonterminal generation. It is not another durable writer or a lease.
+At most one non-`dead` generation may exist for one account. Uncertainty therefore
+quarantines only that account. Quarantine is a derived projection, not a lease or a
+second writer.
 
 ## Opaque attested launch
 
-`AttestedAppServerLaunch` is a private, non-clone launch authority with no public
-constructor. The existing account-launch owner constructs it only after all of these
-facts agree:
+`AttestedAppServerLaunch` is private, non-clone launch authority with no public
+constructor. The account-launch owner creates it only after these facts agree:
 
-- the capacity permit names the same account as the immutable account binding and carries
-  a positive account revision;
-- the canonical Account Service snapshot, HostCredentialStore version, credential
-  fingerprint, and provider identity agree at that exact account revision;
-- version and canonical generated schema come from the retained executable snapshot;
-- the executable digest, derived `BuildId`, fixed `app-server --stdio` arguments, and
-  exact-build capability match one accepted profile;
-- the exact-build capability profile positively supports the typed
-  `account/chatgptAuthTokens/refresh` callback and its response shape;
-- the environment policy is clear-then-set with exact `HOME`, `PATH`, and
-  `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` startup-state values;
-- the exact-build profile derives one macOS private-stdio lifetime capability; and
-- the working directory, protected reference snapshot, and canonical macOS execution identity
-  remain inside the opaque authority.
+- the capacity permit, immutable account binding, and positive account revision;
+- Account Registry, HostCredentialStore version/fingerprint, and provider binding;
+- version and canonical generated schema from the retained executable snapshot;
+- executable digest, derived `BuildId`, fixed `app-server --stdio` arguments, and one
+  accepted exact-build profile;
+- positive support for the typed account refresh callback and response shape;
+- a clear-then-set environment with exact `HOME`, `PATH`, and
+  `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` values;
+- the accepted platform lifetime capability; and
+- working directory, protected executable snapshot, and execution identity.
 
-The launch-manifest SHA-256 binds its schema, macOS canonical-suspended execution policy,
-platform, control and session-isolation kinds, `BuildId`, exact image digest, command identity,
-ordered arguments, working directory, complete sanitized environment, account, initial account
-revision, canonical credential version and fingerprint, provider binding, and exact-build account
-capability. `ProcessSupervisor` derives durable `runner_identity` from this object. Its spawn API
-accepts no caller-supplied runner digest, raw `Command`, command arguments, environment, account, or
-control kind. After a fresh fence, the object re-attests the retained profile and constructs the
-command internally. On macOS, version and schema preflights execute the protected snapshot. The
-final app-server executes the canonical image while suspended, and it resumes only after the
-snapshot-rooted dynamic code identity, canonical path, session, and process group match.
-Unsupported platform, argument, and image profiles reject before a profile-dependent version or
-schema preflight can spawn a child.
+The launch-manifest SHA-256 binds the schema identity, platform execution policy,
+control/session isolation, `BuildId`, image digest, command and ordered arguments,
+working directory, complete sanitized environment, account, initial account revision,
+credential version/fingerprint, provider binding, and exact-build account capability.
+
+`ProcessSupervisor` derives durable runner identity from the opaque launch. Its spawn API
+accepts no caller runner digest, raw command, arguments, environment, account, or control
+kind. After a fresh fence, the launch re-attests the retained profile and constructs the
+command internally.
+
+On macOS, preflights execute the protected snapshot. The final app-server starts
+suspended and resumes only after snapshot-rooted dynamic code identity, canonical path,
+session, and process group agree. Unsupported platform, image, version, argument,
+environment, or capability rejects before a provider app-server can start.
 
 The current accepted profile is intentionally narrow:
 
 | Field | Accepted value |
 | --- | --- |
-| Platform evidence | macOS arm64 |
+| Platform | macOS arm64 |
 | Version | `codex-cli 0.146.0-alpha.9.2` |
 | Executable SHA-256 | `d96ae1ca1ff6fc8587842fa04c92d3ee4d31651a811c2f89b65fcfd9c28473e2` |
-| Command | canonical Codex path as both executable and argv0, suspended before user code, with fixed `app-server --stdio` arguments |
-| Startup state | `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1` selects `DisabledEphemeral`; no remote-control argument |
-| Protocol boundary | Child stdin and stdout remain private to `ProcessSupervisor`; `FencedProcess` returns no protocol handle |
+| Command | Canonical Codex path as executable and argv0, suspended before user code, with fixed `app-server --stdio` arguments |
+| Startup state | `CODEX_INTERNAL_APP_SERVER_REMOTE_CONTROL_DISABLED=1`; no remote-control argument |
+| Protocol boundary | Child stdin/stdout remain private to `ProcessSupervisor`; `FencedProcess` returns no protocol handle |
 | Capability | `codex-app-server-private-stdio-disabled-ephemeral-startup-v1` |
-| Account callback readiness | Accepted only after the generated schema, callback shape, and exact image preflights pass. |
+| Account callback | Ready only after exact-image, generated-schema, and live callback preflights pass |
 
-The current exact image and callback receipt is
-[the Codex 0.146 account-callback receipt](../evidence/xy-1422-codex-0146-account-callback.md).
-For the same exact tag, Codex reads the marker at startup and selects
-`DisabledEphemeral` for stdio without a remote-control argument in the upstream
-[CLI selection](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.9.2/codex-rs/cli/src/main.rs)
-and
-[remote-control transport module](https://github.com/openai/codex/blob/rust-v0.146.0-alpha.9.2/codex-rs/app-server-transport/src/transport/remote_control/mod.rs).
-The marker is startup-state evidence only. It is not a permanent denial policy: the
-same exact build can process an alternate-control enable RPC if a protocol writer can
-send one. This pre-dispatch slice therefore returns no raw stdin, raw stdout, generic
-protocol access, or protocol writer from `FencedProcess` or the retained child
-capability. `ProcessSupervisor` keeps both channels private only for lifetime ownership.
+The startup marker is exact-build startup-state evidence only. The same build can accept
+an alternate-control enable RPC if a protocol writer can send one. Therefore no raw
+stdin/stdout, generic protocol access, or protocol writer can leave ProcessSupervisor.
+A future live-dispatch gateway must source-reject alternate-control RPCs before product
+dispatch can be accepted.
 
-No Linux executable or lifetime receipt is accepted in this source slice. Linux
-identity and read-only exit-observation mechanics remain available, but generic
-session and descriptor setup does not install `PR_SET_PDEATHSIG`. A future Linux
-parent-death primitive must be reachable only from a separately accepted exact Linux
-lifetime capability. Linux ProcessGeneration launch fails closed before its
-profile-dependent preflights. Every other version, image, argument shape, environment,
-or capability also fails closed. A version string or protocol `CapabilityProfile`
-alone cannot mint launch authority.
-
-MacDogfoodReady requires an exact-build account-capability receipt for the callback.
-Version text, generated request types, or upstream implementation presence alone is not
-proof. The current exact `codex-cli 0.146.0-alpha.9.2` profile handles the root refresh
-request and response, but it mints readiness only after the exact-image, generated-schema,
-and live callback preflights pass. An unsupported build or callback shape fails closed
-before account launch. The private-stdio lifetime profile does not independently claim
-AccountLifecycle readiness.
+No Linux ProcessGeneration profile is accepted. Generic Linux identity/read-only exit
+observation does not install `PR_SET_PDEATHSIG`. A future Linux parent-death primitive
+requires a separately accepted exact lifetime capability. Unsupported Linux launch fails
+before profile-dependent preflights.
 
 ## Fence and child control
 
 The launch sequence is:
 
-1. An account-launch owner rejects an unsupported platform, image, argument, or account
-   callback profile. It reads one canonical account revision plus credential
-   version/fingerprint/provider binding and creates one opaque attested launch. Only an
-   accepted profile can run the read-only executable preflights. No provider app-server
-   can start.
-2. The caller supplies only a new generation ID and external execution authorization.
-3. `ProcessSupervisor` derives account, initial account revision, credential
-   version/fingerprint/provider binding, runner identity, current boot, accepted control
-   kind, and session isolation from trusted owners. It re-reads the Account Service and
-   HostCredentialStore before the fence; any version, fingerprint, provider, or enabled
-   mismatch rejects the launch.
-4. PostgreSQL serializes the account, locks the active external execution epoch
-   through transaction commit, and commits revision 1 in `starting`.
-5. Only a fresh commit returns the non-clone `FreshProcessGenerationFence`. Replay is
-   readback and cannot authorize another spawn.
-6. The opaque launch constructs and spawns the protected `app-server --stdio` image as
-   a new session and process-group leader. Non-stdio descriptors close on exec. Raw
-   stdin and stdout stay inside the supervisor-owned child.
-7. The current exact lifetime capability is macOS private stdio with best-effort EOF.
-   macOS has no claimed parent-death primitive. This source has no accepted Linux
-   lifetime capability and does not install `PR_SET_PDEATHSIG`.
-8. The supervisor reads and persists the exact boot, PID, process-start, process-group,
-   and session identity before it can mark the generation `ready`. Ready readback
-   includes the immutable initial account revision, credential version/fingerprint,
-   provider binding, and account-capability profile.
+1. Account launch rejects unsupported platform, image, callback, or argument profile.
+2. It reads the canonical account revision and credential-negative binding and creates
+   the opaque launch.
+3. The caller supplies only a new generation ID and external execution authorization.
+4. ProcessSupervisor derives all launch facts from trusted owners and rechecks Account
+   Service and HostCredentialStore immediately before the database fence.
+5. PostgreSQL serializes the account, locks the active execution epoch through commit,
+   and creates revision 1 in `starting`.
+6. Only a fresh commit returns the non-clone `FreshProcessGenerationFence`. Replay is
+   readback and cannot authorize spawn.
+7. The opaque launch starts the protected child as a new session/process-group leader;
+   non-stdio descriptors close on exec and raw stdio remains private.
+8. ProcessSupervisor persists complete process identity before it can mark the
+   generation `ready`.
 
-The daemon-local in-flight reservation prevents background reconciliation from
-projecting an active fence, bind, or exact termination as restored authority. It is
-per generation, so it does not serialize unrelated accounts. The opaque child retains
-the original unreaped `Child` and the account capacity permit. Its owned-drop path uses
-the existing bounded process-group cleanup and quarantine only while this daemon still
-owns that child. It does not create restored-process authority.
-The cleanup owner and reaper revoke signaling authority when a child wait reaps the
-leader or returns an uncertain error. They never signal a numeric process group after
-that point.
+The daemon-local in-flight reservation prevents background reconciliation from treating
+an active fence, bind, or owned termination as restored authority. It is per generation
+and does not serialize unrelated accounts.
 
-The supervisor can close its private owned channels without transferring either
-handle. Closing stdin sends EOF. On macOS, EOF is only a best-effort shutdown request.
-It is not death evidence and does not imply process exit, credential loss, or effect
-cancellation. `decodexd` remains the only product daemon.
+The opaque child retains the original unreaped `Child` and account capacity permit.
+Cleanup and reaper ownership revoke signaling authority when the leader is reaped or a
+wait returns uncertainty. No path signals a numeric process group after that point.
+Closing stdin is best-effort shutdown on macOS. It is not death evidence, credential
+revocation, or effect cancellation.
 
 ## Positive-only reconciliation
 
 The closed death-evidence kinds are:
 
-- spawn did not create a child;
-- positive wait of the original owned child, followed by process-group quiescence;
-- Linux pidfd exit for an exact persisted identity, followed by process-group
-  quiescence;
-- macOS exact kqueue `EVFILT_PROC/NOTE_EXIT`, followed by process-group quiescence;
-- exact owned termination followed by positive child exit and group quiescence; and
-- a current boot identity that differs from the generation boot.
+- positive proof that spawn created no child;
+- positive wait of the original owned child plus process-group quiescence;
+- exact Linux pidfd exit plus process-group quiescence;
+- exact macOS kqueue `EVFILT_PROC/NOTE_EXIT` plus process-group quiescence;
+- exact owned termination plus positive exit and group quiescence; and
+- current boot identity different from the generation boot.
 
-PID absence, process-group absence by itself, PID or PGID reuse, timeout, lease expiry,
-row absence, EOF, restart, identity mismatch, and negative search are not evidence.
+PID absence, process-group absence by itself, PID/PGID reuse, timeout, lease expiry, row
+absence, EOF, restart, identity mismatch, and negative search are not death evidence.
 They cannot transition a generation to `dead`.
 
-On startup, PostgreSQL projects every present nonterminal generation to
-`death_unknown` before replacement authority is available. Runtime performs one
-positive-only reconciliation pass. The server lifecycle then owns and polls bounded
-background reconciliation until shutdown. One item error does not stop later items or
-unrelated work.
+On startup, every present nonterminal generation becomes `death_unknown` before
+replacement authority is available. Runtime performs one bounded positive-only pass and
+continues background reconciliation until shutdown. An item error does not stop later
+items or unrelated accounts.
 
-For a same-boot restored process, runtime first checks every persisted identity field.
-On macOS, it then registers a one-shot kqueue process filter and performs a final exact
-identity recheck. On Linux, it opens a pidfd and performs the same final recheck. A
-mismatch or absence at either exact comparison supplies no proof. The retained witness
-is read-only. Runtime does not create a `Child`, adopt, proxy, reacquire, signal,
-terminate, or otherwise control the restored process.
+For a same-boot restored process, runtime checks every identity field, attaches one
+read-only platform witness, and performs a final exact identity recheck. Mismatch or
+absence supplies no proof. Runtime does not create a `Child`, adopt, proxy, reacquire,
+signal, terminate, or otherwise control a restored process.
 
-On macOS, replacement requires an exact `NOTE_EXIT` from the retained witness and
-process-group quiescence. If the process exits before witness attachment, the event is
-not reconstructed. Same-boot quarantine then remains until boot change. A boot change
-is positive proof that the prior boot ended.
+On macOS, exact `NOTE_EXIT` and group quiescence are required. If the process exits before
+witness attachment, same-boot quarantine remains until boot change. A boot change is
+positive proof that the prior boot ended.
 
-The exact termination operation accepts only a generation whose original unreaped
-`Child` remains owned by this supervisor. It rechecks durable revision and exact
-identity before signaling the owned process group. It never signals a restored child
-or signals after leader reap. If bounded termination cannot prove exit and group
-quiescence, the generation becomes `death_unknown`; timeout is not death proof.
+Exact termination accepts only a generation whose original unreaped child remains owned
+by this ProcessSupervisor. It rechecks durable revision and identity before signaling the
+owned group. If bounded termination cannot prove exit and group quiescence, the state is
+`death_unknown`; timeout is not death proof.
 
 ## Restore and continuity
 
-The execution-epoch authorization digest comes from outside the restored database.
-Runtime cannot read the epoch relation or reconstruct the digest from a generation. A
-restored or replayed generation never returns a fresh spawn fence. A backup or rollback
-is not launch authority.
+The execution-epoch authorization digest comes from outside the database. Runtime cannot
+read it from an epoch or generation row. Restored or replayed state never returns a fresh
+spawn fence. Database contents alone are not launch authority.
 
-The restore owner must prove interval quiescence or establish the accepted external
-monotonic anchor or a new safe execution epoch. An ambiguous restore must not supply
-the external digest. Every present nonterminal generation becomes `death_unknown`.
-Row absence does not prove process death and cannot authorize reconstruction,
-takeover, or launch.
+An authorized restore owner must prove interval quiescence, use an accepted external
+monotonic anchor, or establish a new safe epoch. Ambiguous restore supplies no digest.
+Every present nonterminal generation becomes `death_unknown`; row absence does not prove
+death or authorize reconstruction, takeover, or launch.
 
-Conversation continuity remains bound to persisted Codex thread identity. A
-replacement can use exact-thread resume when positively supported or the accepted
-Context Pack fallback when resume is positively unsupported. Process survival is not
-conversation continuity. ProcessGeneration creates neither a RuntimeSession nor a
-fallback.
+Conversation continuity remains bound to persisted Codex thread identity. A replacement
+may use exact-thread resume when positively supported or the accepted Context Pack path
+when resume is not supported. Process survival is not Conversation continuity.
+ProcessGeneration creates neither a RuntimeSession nor a continuation plan.
 
 ## ProviderAttempt handoff
 
-XY-1401 owns ProviderAttempt persistence. XY-1400 preserves this exact boundary:
+ProcessGeneration protects replacement integrity. ProviderAttempt protects external
+effect integrity. The handoff requires:
 
-- one pre-dispatch transaction must bind a prepared attempt to its consumer intent,
-  accepted RuntimeSession, exact ProcessGeneration, request identity, and correlation
-  or idempotency key;
-- an unproved `dispatch_authorized` attempt becomes or remains `unknown` after lost
-  supervision;
-- process death, kqueue exit, boot change, EOF, timeout, restart, missing events, row
-  absence, or negative search never proves `not_submitted`;
-- a late positive result remains attributable to the original attempt after generation
-  death;
-- a replacement may reconcile the attempt but cannot replay it; and
-- a successor is a distinct user-authorized effect with explicit duplicate-risk
-  acknowledgement.
+- one atomic pre-dispatch binding to the exact consumer intent, RuntimeSession,
+  ProcessGeneration, request identity, and provider key;
+- an unproved authorized attempt to remain or become `unknown` after supervision loss;
+- no inference of `not_submitted` from process death, kqueue exit, boot change, EOF,
+  timeout, restart, missing events, row absence, or negative search;
+- late positive results to remain attributable to the original attempt;
+- replacement reconciliation without replay; and
+- a distinct successor effect to require new user authorization and explicit duplicate
+  risk acknowledgement.
 
-ProcessGeneration quarantine protects replacement integrity. ProviderAttempt protects
-effect integrity. A macOS orphan can retain credentials and finish an in-flight effect;
-this slice does not claim cancellation, credential revocation, or effect containment.
+A macOS orphan can retain credentials and finish an in-flight effect. ProcessGeneration
+does not claim provider cancellation, credential revocation, or effect containment.
 
-## Diagnostics and production isolation
+## Candidate-5 boundary
 
-`ServiceBootstrap` exposes independent ProcessGeneration readiness and an
-authority-bound borrowed runtime control port. The port is not cloneable and cannot
-escape its bootstrap owner. It provides one exact or bounded diagnostic read, one exact
-positive-only reconciliation request, and one exact owned-child termination request with
-an expected revision.
+Candidate-5 initial thread establishment adds no ProcessGeneration state or owner. Before
+ProcessGeneration preparation and again before spawn, ProcessSupervisor must lock and
+prove the exact routing-selected Turn remains active at revision 1 under the same
+Conversation and first `starting` RuntimeSession.
 
-Diagnostics distinguish prior-boot proof, owned or in-flight supervision, pending
-positive spawn non-creation, an attached positive-exit observer, an observed positive
-exit with its exact kernel witness kind and current process-group quiescence, exact
-same-boot presence, same-boot absence, identity mismatch, unbound identity, and
-observation failure. Identity-mismatch output includes the observed boot, PID,
-process-start, process-group, and session facts.
+Account Service repeats the exact selected Account revision, `enabled` state,
+AccountLifecycle and exact-build capability, provider binding, credential version and
+fingerprint, and actual HostCredentialStore binding. It cannot select another account.
 
-The current spawn and ready methods remain crate-private and have no caller.
-`decodexd` retains `CodexAdapter::unavailable()`. Current source has no Account Service
-binding at ProcessGeneration spawn and rejects all inbound child requests. It is
-therefore not Slice-1 ready. The Mac dogfood implementation may add only the canonical
-non-secret account/credential metadata read and typed refresh-callback gateway defined
-above. No credential material enters V23 or the public protocol. Scheduler,
-RuntimeSession, ProviderAttempt, remote-auth, and UI do not gain ProcessGeneration
-write authority. The V22 retained-title runner remains an explicit nonproduction feature
-and grants no ProcessGeneration or dispatch authority.
-A future live-dispatch protocol gateway is a separate typed authority. Before dispatch
-can be enabled, that gateway must source-reject `remoteControl/enable` and every other
-alternate-control RPC. XY-1400 does not implement that gateway.
+The create envelope has four typed outcomes:
 
-## Deferred XY-1400 V3 adversarial acceptance matrix
+- `Fresh`: returns the sole non-clone spawn authority;
+- `Replayed`: returns durable readback and no spawn authority;
+- `Rejected`: returns durable refusal/readback and no spawn authority; and
+- `Unknown`: bounded readback cannot prove a safe local result.
 
-The integrated core is not frozen. XY-1400 authorizes source implementation and source
-review only. The later unified gate must run this matrix against the exact committed
-tree without enabling provider effects or production dispatch.
+Only `Fresh` may spawn. Every other outcome keeps the Turn active and cannot replace,
+adopt, create a successor, duplicate a ProviderAttempt, or prove pre-effect refusal.
+Positive spawn noncreation is required before a fresh path can become a definite
+pre-effect refusal.
 
-| Boundary | Deferred acceptance cases |
-| --- | --- |
-| Rust quality gate | Run repository-owned formatting, compile, static analysis, lint, documentation, unit, integration, and nextest gates on macOS and Linux. Add and run ProcessGeneration tests only after the integrated freeze permits test changes. |
-| Migration edges | Prove clean V1-to-V23 initialization and V22-to-V23 forward upgrade. Prove immutable ledger names, versions, checksums, and supported rollback posture. |
-| Manifest refreeze | Capture PostgreSQL 18 source S0, restore R1, and second restore R2. Require S0=R1 and R1=R2. Regenerate and accept complete V23 schema and configured-authority digests. Remove the temporary `process_generation` exclusion that keeps the accepted V22 digest base during this source-only slice. |
-| ACL and catalog hostility | Prove the expected 81 relations, 172 functions, 70 safety functions, 147 triggers, 62 runtime-callable functions, five new enums, exact ownership, no PUBLIC authority, no runtime relation DML, no grant option, closed dependencies, hostile `search_path`, overload/default-ACL rejection, and populated restore parity. |
-| State machine | Exercise every legal transition. Reject every illegal transition, combined bind/state transition, identity rewrite, partial identity, history rewrite, deletion, truncation, explicit-null or stale revision, cross-generation evidence, and malformed evidence shape. |
-| Opaque launch mismatch | Prove that callers cannot mismatch runner identity, executable image, command, argv0, fixed arguments, working directory, environment, account, initial account revision, credential version/fingerprint, provider binding, BuildId, or exact-build capability. Prove that macOS preflights execute only the retained protected snapshot and that the final app-server executes only the canonical path after snapshot-rooted suspended dynamic attestation. |
-| Credential binding and readback | Rotate, remove, replace, disable, or change the provider between prepare, fence, spawn, callback, and ready. Every stale combination rejects or quarantines without a second launch. Intent, manifest, V23 row, transition readback, and diagnostics agree on the canonical non-secret binding. No credential material is stored. |
-| Exact-build private stdio | For each accepted profile, prove fixed `app-server --stdio`, environment clearing, the exact startup marker, absence of a remote-control argument, `DisabledEphemeral` startup selection, no raw stdin/stdout or generic protocol writer in any returned capability, and rejection of changed images, versions, arguments, environment, or capability. Prove the exact `account/chatgptAuthTokens/refresh` callback round trip and reject unknown callback methods or shapes. Unsupported profiles reject before version/schema preflight spawn. The gateway source-rejects alternate-control RPCs before enablement. |
-| Fence concurrency | Exercise replay, changed-intent conflict, same-account competitors, credential rotation, provider disagreement, different-account progress, epoch retirement, account deletion, transaction abort, deadlock, serialization failure, lost commit result, and restart. Only one fresh fence can authorize spawn. |
-| Crash cuts | Cut before fence, after fence before spawn, during spawn, after spawn before identity capture, after capture before bind, after bind before result, before ready, after ready before result, during stopping, after evidence insert, after generation update, and after commit with lost response. Require absence, recoverable owned authority, or account-local `death_unknown`; never permit replacement without positive death. |
-| Linux identity and liveness | Prove current generic retained-title and preflight children receive session/descriptor setup without ProcessGeneration lifetime authority. Prove unsupported Linux ProcessGeneration profiles reject before version/schema preflight spawn. After an exact Linux lifetime profile is separately accepted, prove its capability-gated `PR_SET_PDEATHSIG`, parent-race closure, boot ID and `/proc/<pid>/stat` start ticks, stdio close, pidfd attachment-before-recheck, positive pidfd events, child and descendant exit, group quiescence, PID/PGID reuse, and daemon death. |
-| macOS identity and liveness | Prove the versioned stable `kern.bootsessionuuid`, fail-closed quarantine for an incomparable persisted boot-identity scheme, `proc_pidinfo` start time, session leadership, EOF as best effort only, a surviving orphan, credential/effect residual risk, exact match before kqueue registration, registration before final exact recheck, exact `NOTE_EXIT`, child and descendant exit, group quiescence, and boot change. |
-| Exit before macOS witness | Exit the child after daemon loss but before witness attachment. Prove that absence supplies no receipt, the account stays quarantined for the rest of the boot, and unrelated accounts continue. |
-| Identity hostility | Exercise stale start identity, wrong boot, PID and PGID reuse before and after attachment, mismatched group/session, missing identity, process absence, and observation errors. None can create death evidence. |
-| Same-boot isolation | Prove that one uncertain generation quarantines only its account. Continue diagnostics, repositories, reconciliation, and eligible work for unrelated accounts without starvation. |
-| Restore and rollback | Restore active, retired, missing, wrong-digest, duplicated, and rollback-ambiguous epochs. Prove present nonterminal rows become `death_unknown`, database contents cannot return the external digest, replay cannot return a fresh fence, and row absence cannot authorize launch. |
-| Exact termination | Prove owned versus restored behavior, revision and identity checks, TERM/KILL only while the original child is unreaped, no signal after reap, positive wait plus group quiescence, descendant persistence, timeout-to-unknown, and cancellation. Restored children always return `NotOwned`. |
-| Background progress | Prove bounded paging, repeated reconciliation, idempotent evidence replay, item-error isolation, daemon-control drop, witness cleanup, and no starvation from one uncertain account. Prove restart performs observation only, without adoption or signaling. |
-| Forbidden topology | Prove no guardian, wrapper authority, second daemon, adoption, proxy, takeover, reacquisition, restored-process signaling, lease-as-death, or negative-proof recovery path. |
-| Conversation continuity | Prove that generation death or replacement does not change persisted thread identity. Prove exact-thread resume when positively supported and accepted fallback only when resume is positively unsupported. ProcessGeneration must create neither path. |
-| ProviderAttempt handoff | Exercise late success, ambiguous submission, generation death, replacement reconciliation without replay, and a distinct acknowledged successor intent. Prove process evidence never changes an attempt to `not_submitted`. |
-| Production isolation | Before Slice 1, prove no default or production caller of `spawn_fenced`, no raw ProcessGeneration protocol writer, no available Codex adapter, and no enabled dispatch flag. For Slice 1, prove the only new account paths are the canonical non-secret binding read and typed refresh callback; no credential material, alternate-control RPC, scheduler authority, RuntimeSession creation, ProviderAttempt storage, remote-auth, or UI write path enters V23. |
+ProviderAttempt preparation after thread bind must lock the same Turn as active revision
+1 under the exact post-bind active RuntimeSession. ProcessGeneration never writes that
+Turn or RuntimeSession.
 
-No formatter, compiler, build, static check, migration or SQL parser, migration
-execution, test, fixture, validation wrapper, generator, service, VM, UI or
-accessibility check, live Codex experiment, account operation, or provider effect ran
-in XY-1400 V3. No new test or fixture is part of this candidate. The only retained
-test-file edit is the smallest existing `authority.rs` manifest inventory exception
-needed to describe V23. All executable acceptance remains deferred.
+## Diagnostics and isolation
+
+Runtime exposes an authority-bound borrowed ProcessGeneration control port. It cannot
+escape its bootstrap owner. It provides bounded diagnostics, exact positive-only
+reconciliation, and exact owned-child termination with an expected revision.
+
+Diagnostics distinguish prior-boot proof, owned/in-flight supervision, pending positive
+spawn noncreation, attached exit observation, positive exit and group quiescence,
+same-boot presence/absence, identity mismatch, unbound identity, and observation failure.
+Credential material is not representable.
+
+No protocol, CLI, scheduler, UI, remote-auth path, or client gains ProcessGeneration
+relation or spawn authority. Live provider dispatch remains separately gated.
+
+## Acceptance
+
+After source freeze, validation must cover:
+
+- fresh PostgreSQL 18 empty-target latest-schema bootstrap and second-bootstrap refusal;
+- exact current catalog, ownership, ACL, dependency, function/trigger, and negative
+  PUBLIC/runtime checks for ProcessGeneration objects;
+- opaque-launch mismatch for every image, account, credential-negative binding, command,
+  argument, environment, and capability field;
+- fresh/replay/reject/unknown fences, response loss, crash cuts, concurrency, epoch
+  retirement, and restart;
+- macOS process identity, orphan, exit-before-witness, boot-change, group-quiescence, and
+  exact owned termination behavior;
+- unsupported Linux launch and any later exact Linux lifetime profile independently;
+- positive-only death evidence, account-local quarantine, bounded background progress,
+  and restore safety;
+- Candidate-5 exact Turn and selected-account fences; and
+- ProviderAttempt ambiguity handoff plus reverse production-isolation scans.
+
+No historical upgrade, schema-ledger, or migration proof is part of acceptance.

--- a/openwiki/specs/provider-attempt-authority.md
+++ b/openwiki/specs/provider-attempt-authority.md
@@ -1,72 +1,73 @@
-# XY-1401 ProviderAttempt authority
+# ProviderAttempt Authority
 
-Status: source-only implementation candidate. Executable acceptance is deferred by the core
-freeze.
+Status: normative current external-turn effect authority. Candidate-5 initial-thread
+binding is an accepted target and remains subject to its integrated gate.
 
-The accepted XY-1401 decision memo
-`134844d5-ad31-484f-9409-4591638c966d`, V3 product authorization
-`099fb36d-9a48-407e-abdd-80dd56d13051`, V3 skeptic receipt
-`02d37443-f3cf-4c11-a462-e3da80c40481`, and XY-1400 implementation authorization
-`a0f34b3e-033e-4106-9007-c9b21d23ae57` define this boundary.
+ProviderAttempt is a current domain integrity record. It is not a schema-history ledger,
+bootstrap receipt, or database migration mechanism. The one latest schema creates its
+final objects directly.
 
-## Architecture result
-
-One authority serves both consumer types. V24 uses one `provider_attempts` relation and one
-atomic preparation command. The consumer is a closed union:
-
-- one existing Conversation and one reserved exact Turn identity; or
-- one ManagedRun revision and one distinct execution identity.
-
-The union does not make a Conversation depend on ManagedRun. It does not give
-ProviderAttemptService authority to change either domain. It lets the same external-effect
-machine retain one exact consumer reference. A V24 Turn guard rejects later materialization that
-does not match the reserved Conversation and RuntimeSession identities. The guard does not write
-the Conversation domain. It runs as the migration owner with a fixed search path because runtime
-owns Turn DML but has no ProviderAttempt relation privilege. Runtime and PUBLIC cannot execute
-the trigger helper directly. Unreserved Turn writes pass the empty lookup.
+## Owner boundary
 
 `ProviderAttemptService` is the sole product writer for external Codex turn attempts.
-`ExecutionCoordinator` remains stateless. V16 continues to own account selection. V17
-continues to own the accepted existing RuntimeSession or the atomic Context Pack and fallback
-RuntimeSession. ProcessSupervisor continues to own ProcessGeneration. ProviderAttemptService
-consumes those accepted records. It creates none of them.
+One authority serves two closed consumer shapes:
 
-This result does not trigger the architecture falsifier. One PostgreSQL transaction can bind
-all required authorities without a second writer or coordinator ledger.
+- `conversation_turn`: one existing Conversation plus one exact reserved Turn identity;
+  or
+- `managed_run_execution`: one exact ManagedRun revision plus one distinct managed
+  execution identity.
+
+The union does not make Conversation depend on ManagedRun. ProviderAttemptService cannot
+change either consumer domain. It retains one exact consumer reference while Conversation
+and ManagedRun keep their own lifecycle authority.
+
+A Turn-reservation trigger rejects later materialization that does not match the reserved
+Conversation and RuntimeSession. It does not write Conversation state. The final trigger
+helper has a fixed safe search path and runs with schema-owner authority because runtime
+owns Turn DML but has no ProviderAttempt relation privilege. Runtime and PUBLIC cannot
+execute that helper directly. An unreserved Turn follows the ordinary Conversation path.
+
+Routing Decision remains the sole account selector. Continuation Plan remains the sole
+owner of an accepted existing RuntimeSession, first RuntimeSession, or atomic Context Pack
+and fallback RuntimeSession. ProcessSupervisor remains the ProcessGeneration owner.
+ProviderAttemptService consumes these accepted records and creates none of them.
+
+ExecutionCoordinator remains stateless. It adds no attempt relation, receipt, lifecycle,
+or second provider-effect ledger.
 
 ## Durable data
 
-Forward-only migration `V24__provider_attempt_authority.sql` adds:
+The latest schema defines:
 
 | Relation | Purpose |
 | --- | --- |
 | `provider_attempts` | Current immutable authority binding and optimistic state. |
-| `provider_attempt_positive_evidence` | Append-only positive provider proof for an original attempt. |
+| `provider_attempt_positive_evidence` | Append-only positive provider proof for the original attempt. |
 | `provider_attempt_transitions` | Append-only state history. |
 
-A prepared row binds these values in one transaction:
+One preparation transaction binds:
 
 - one exact consumer intent;
-- one immutable V17 continuation plan and its V16 routing decision;
+- one immutable Continuation Plan and its Routing Decision;
 - the accepted RuntimeSession identity and revision;
-- the V16-selected account;
-- one live ready ProcessGeneration, its exact ready transition revision, and execution epoch;
+- the selected account;
+- one live ready ProcessGeneration, exact ready revision, and active execution epoch;
 - one request identity and SHA-256 request digest;
 - at least one provider idempotency or correlation key; and
-- an original-intent disposition or one exact unknown predecessor plus a durable
+- original-intent disposition, or one exact unknown predecessor plus a durable
   duplicate-risk acknowledgement digest.
 
-The service never accepts a caller-selected account or RuntimeSession. PostgreSQL derives them
-from the accepted V16 and V17 records. It verifies that the ready ProcessGeneration belongs to
-that account and that its execution epoch is active. A Conversation consumer reserves a canonical
-Turn identity in the accepted RuntimeSession. If the Conversation owner has already materialized
-that Turn, it must be active and match the same Conversation and RuntimeSession. This prospective
-identity permits V17's accepted fallback RuntimeSession to remain `starting`; XY-1402 owns later
-Turn materialization and must consume the reserved identity. A ManagedRun consumer must reference
-the exact V17 ManagedRun revision.
+The service never accepts a caller-selected account or RuntimeSession. PostgreSQL derives
+both from accepted route and plan records, then verifies that the ready generation belongs
+to that account and its execution epoch is active.
 
-One provider idempotency key can belong to only one attempt for an account. Correlation keys are
-indexed but are not unique because one provider thread can correlate several turns.
+A Conversation consumer reserves a canonical Turn identity in the accepted
+RuntimeSession. If Conversation authority already materialized that Turn, the row must be
+active and match the same Conversation and RuntimeSession. A ManagedRun consumer must
+reference its exact accepted revision and managed execution identity.
+
+One provider idempotency key can belong to only one attempt for one account. Correlation
+keys are indexed but not unique because several turns may use one provider thread.
 
 ## State authority
 
@@ -78,104 +79,119 @@ dispatch_authorized -> succeeded | failed_definitive | not_submitted | unknown
 unknown -> succeeded | failed_definitive | not_submitted
 ```
 
-The last transition group requires positive evidence. `canceled`, `succeeded`,
-`failed_definitive`, and `not_submitted` are terminal. An `unknown` attempt has no automatic
-retry transition.
+`canceled`, `succeeded`, `failed_definitive`, and `not_submitted` are terminal. Every
+terminal transition after dispatch authorization requires positive evidence. `unknown`
+has no automatic retry transition.
 
-Restore has one explicit fail-closed projection. It changes every present `prepared` or
-`dispatch_authorized` row to `unknown` with reason `restore_projection`. This exceptional
-projection is required because a restored prepared row can be older than a dispatch
-authorization that occurred after the backup. It does not authorize dispatch or claim that a
-request was submitted.
+Restore has one fail-closed projection. It changes every present `prepared` or
+`dispatch_authorized` row to `unknown` with reason `restore_projection`. A restored
+prepared row can be older than authorization that happened after the restored point.
+The projection therefore grants no dispatch and makes no non-submission claim.
 
-The preparation and dispatch-authorization commands share the existing restore advisory gate.
-The restore projection takes the exclusive gate. Consumer-scoped serialization prevents a new
-intent from racing an unknown transition and bypassing duplicate-risk acknowledgement.
+Preparation and dispatch authorization share the restore advisory gate. Restore
+projection takes the exclusive gate. Consumer-scoped serialization prevents a new intent
+from racing an unknown transition and bypassing duplicate-risk acknowledgement.
 
 ## Positive-only reconciliation
 
-The closed evidence sources are:
+The closed positive evidence sources are:
 
 - exact provider terminal receipt;
 - positive idempotency lookup;
-- exact turn readback;
-- exact thread and turn readback; or
+- exact Turn readback;
+- exact thread and Turn readback; or
 - positive non-submission receipt.
 
-Evidence binds the original attempt, pre-transition attempt revision, request identity, one
-retained provider key, outcome, positive identities, and a SHA-256 witness digest. Exact thread
-readback must match the accepted RuntimeSession thread. A missing RuntimeSession thread identity
-is inconclusive.
+Evidence binds the original attempt, pre-transition revision, request identity, one
+retained provider key, outcome, positive identities, and SHA-256 witness digest. Exact
+thread readback must match the accepted RuntimeSession thread. Missing thread identity is
+inconclusive.
 
-There is no timeout, absence, negative-search, exhausted-list, missing-event, process-death,
-kqueue, boot-change, EOF, restart, lease-expiry, or row-absence evidence type. Those observations
+Timeout, absence, negative search, exhausted list, missing event, process death, kqueue,
+boot change, EOF, restart, lease expiry, and row absence are not evidence kinds. They
 cannot produce `not_submitted` or another terminal state.
 
-A late positive result updates its original attempt even after the bound ProcessGeneration is
-dead. A replacement service reads and reconciles the original row. It cannot recreate the fresh
-prepared capability or the one-time dispatch fence, so it cannot replay the request.
+A late positive result updates the original attempt after generation death. A replacement
+service can read and reconcile that row. It cannot recreate the fresh prepared capability
+or one-time dispatch fence and therefore cannot replay the request.
 
-The runtime performs the restore projection and one bounded reconciliation pass during startup.
-The server lifecycle then owns and polls bounded background passes until shutdown. Each pass reads
-at most one page for each reconcilable state and advances a persistent state-specific cursor, so
-a large unresolved prefix cannot exclude later attempts. One evidence-source error affects only
-that item. The current composition installs an inconclusive source and also exposes an exact
-positive receipt operation. It installs no provider gateway.
+Runtime performs restore projection and one bounded reconciliation pass during startup.
+The server lifecycle then owns bounded background passes until shutdown. Each pass pages
+each reconcilable state and advances a persistent state-specific cursor so an unresolved
+prefix cannot starve later attempts. One evidence-source error affects only that item.
+
+## Candidate-5 initial thread
+
+Candidate-5 preparation and dispatch authorization add one exact `initial_thread`
+binding. The transaction must lock and require:
+
+- the selected initial Routing Decision and its complete zero-source lineage;
+- the inert first-session Continuation Plan;
+- selected account and copied RoleProfile snapshots;
+- the ready ProcessGeneration revision and live execution epoch;
+- the exact completed RuntimeSession thread fence and bind receipts;
+- the exact post-bind `active` RuntimeSession revision; and
+- the selected Turn under that Conversation/session, still `active` at revision 1.
+
+The thread-binding protocol and idempotency-key identities are immutable attempt fields.
+Every non-initial plan keeps those fields absent and retains its existing same-thread,
+Context Pack, ManagedRun, predecessor, and positive-lineage predicates.
+
+The dispatch-authorization command must perform the same exact Turn lock itself. A
+deferred trigger cannot replace the pre-write lock. An absent, terminal,
+changed-revision, wrong, or cross-linked Turn fails before provider dispatch.
+
+Lost results at prepare or authorize remain bound to the original Turn and attempt.
+They cannot create a duplicate attempt, terminalize the Turn, or authorize replay.
 
 ## Authority and observability
 
-Runtime has no relation DML on the three V24 relations. It receives enum `USAGE` and only seven
-closed `SECURITY DEFINER` entry points: prepare, authorize dispatch, cancel, mark unknown,
-record positive evidence, restore projection, and bounded read.
-The Turn-reservation trigger is one additional migration-owner `SECURITY DEFINER` function.
-Its fixed search path and direct-execution revokes let runtime mutate Turns without receiving
-ProviderAttempt relation access.
+Runtime has no relation DML on ProviderAttempt relations. It can execute only the closed
+prepare, authorize, cancel, mark-unknown, positive-evidence, restore-projection, and
+bounded-read functions. PUBLIC has no ProviderAttempt authority. The trigger-only Turn
+helper is not directly executable.
 
-Current diagnostics expose consumer identity, V17 plan, V16 decision, accepted RuntimeSession
-and revision, selected account, bound ProcessGeneration revision and execution epoch, request
-identity, key-presence flags, state, reason, evidence identity, revision, and update time.
-Provider keys and request digests are not representable in the diagnostic type. Core and
-PostgreSQL debug projections redact exact provider keys.
+Diagnostics expose consumer identity, plan, route decision, RuntimeSession/revision,
+selected account, ProcessGeneration/revision/epoch, request identity, key-presence flags,
+state, reason, evidence identity, revision, and update time. Provider keys and request
+digests are not representable in the diagnostic type. Debug projections redact exact
+provider keys.
 
-The fresh dispatch fence contains no provider transport, credentials, request bytes, retry
-operation, or public consumer. The current `CodexAdapter` remains unavailable. No protocol, CLI,
-scheduler, UI, remote-auth, or live provider-effect path can consume the fence.
+The fresh dispatch fence contains no provider transport, credentials, request bytes,
+retry operation, or public consumer. No protocol, CLI, scheduler, UI, remote-auth, or
+client path can obtain it before a separately accepted dispatch composition exists.
 
-## V12 and XY-1402 boundary
+## Consumer isolation
 
-V24 does not consult V12 submitted-turn receipts, safety inputs, or effect barriers to establish
-attempt submission or outcome. ProviderAttempt is the only external-turn authority after this
-cutover. The existing V12 relations can remain as inert historical ManagedRun data until XY-1402.
-They are not a second ProviderAttempt ledger.
+Conversation and ManagedRun consume the same attempt authority. ManagedRun does not copy
+provider-effect state into a submitted-turn receipt, effect barrier, or second ledger.
+ProviderAttempt does not create routing decisions, Continuation Plans, RuntimeSessions,
+Turns, or ManagedRun lifecycle transitions.
 
-XY-1402 owns consumer integration and V12 retirement. It can adapt the currently
-ManagedRun-specific V16 and V17 inputs for ordinary Conversation lineage. It must not move
-attempt persistence into ManagedRun, add a submitted-turn receipt, add coordinator persistence,
-or let ProviderAttempt create routing decisions or RuntimeSessions.
+Quick Task remains an ordinary Conversation. A ManagedRun remains the owner of execution
+assignment, wait state, review, acceptance, and completion. Provider outcome alone cannot
+synthesize ManagedRun or WorkItem acceptance.
 
-## Deferred acceptance matrix
+## Acceptance
 
-The integrated core is not frozen. XY-1401 runs no executable validation. The later unified gate
-must run these cases against the exact committed tree:
+After source freeze, validation must cover:
 
-| Boundary | Deferred acceptance cases |
-| --- | --- |
-| Rust quality | Run repository formatting, compile, static analysis, lint, documentation, unit, integration, and nextest gates on supported hosts. |
-| Migration | Prove clean V1-to-V24 initialization and V23-to-V24 forward upgrade. Prove exact migration ledger identity and checksum. |
-| Manifest refreeze | Capture PostgreSQL 18 source S0, restore R1, and second restore R2. Require S0=R1 and R1=R2. Regenerate and accept the complete V24 schema and configured-authority digests. Remove the temporary `process_generation` and `provider_attempt` exclusions. |
-| Catalog and ACL | Prove the expected 84 relations, 184 functions, 75 safety functions, 154 triggers, 69 runtime-callable functions, ten post-V22 enums, 60 security definers, exact ownership, no PUBLIC authority, no runtime relation DML, no grant option, closed dependencies, hostile `search_path`, overload rejection, direct Turn writes with trigger-only reservation reads, and populated restore parity. |
-| Atomic binding | Exercise both consumer shapes, every partial or cross-linked shape, stale V16/V17/RuntimeSession/generation/epoch authority, transaction rollback, lost response, replay, changed-intent conflict, and concurrent preparation. |
-| State machine | Exercise each ordinary transition and the restore-only projection. Reject every other transition, immutable-authority rewrite, stale revision, history rewrite, delete, and truncate. |
-| Positive evidence | Exercise every positive source and outcome shape, exact request/key/thread binding, evidence replay, late success, late definitive failure, positive non-submission, evidence-ID conflict, and malformed witness. |
-| Negative observations | Prove that process death, kqueue, boot change, EOF, timeout, restart, lease expiry, row absence, missing events, exhausted lists, and negative search cannot produce a terminal attempt state. |
-| Replacement | Prove startup projection, replacement reconciliation without replay, original-attempt attribution after generation death, and persistence across repeated restart and restore. |
-| Duplicate risk | Exercise one unknown predecessor, exact acknowledgement, an unrelated predecessor, multiple unresolved predecessors, concurrent unknown transition, a distinct successor intent, and no mutation of the original unknown attempt. |
-| Background progress | Prove bounded paging, repeated passes, item-error isolation, control drop, unrelated-account progress, and no automatic retry. |
-| Production isolation | Prove no live dispatch consumer, available Codex adapter, protocol/CLI/UI writer, routing or RuntimeSession creation, second ledger, coordinator persistence, credential path, remote-auth path, provider effect, or enabled dispatch flag. |
-| XY-1402 handoff | Prove that Conversation and ManagedRun consume the same attempt authority and that retained V12 turn ledgers are not authoritative or writable through a second product path. |
+- fresh PostgreSQL 18 latest-schema bootstrap and second-bootstrap refusal;
+- exact ProviderAttempt catalog, function, trigger, ownership, ACL, dependency, and
+  negative PUBLIC/runtime authority;
+- both consumer shapes and every partial, stale, cross-linked, or ambiguous binding;
+- atomic prepare/authorize behavior, rollback, lost response, exact replay,
+  changed-intent conflict, and concurrency;
+- every legal state edge and rejection of illegal transitions, identity rewrites,
+  deletes, truncation, and history rewrites;
+- every positive evidence source, evidence replay, late result, positive
+  non-submission, and malformed witness;
+- rejection of every negative observation as terminal evidence;
+- restore projection, replacement reconciliation without replay, duplicate-risk
+  acknowledgement, and bounded background progress;
+- Candidate-5 exact route/plan/process/thread/Turn binding; and
+- reverse scans proving no second ledger, credential path, provider replay, remote path,
+  or unauthorized production dispatch root.
 
-No formatter, compiler, build, static check, migration or SQL parser, migration execution, test,
-fixture, validation wrapper, generator, service, VM, UI or accessibility check, live Codex
-operation, account operation, or provider effect is part of this source-only candidate. The only
-test-file changes allowed in this slice are existing authority-manifest inventory updates required
-to describe V24.
+No historical upgrade, numbered-schema, schema-ledger, or migration proof is part of
+acceptance.

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -7,6 +7,21 @@ in the [retirement decision](private-artifact/decision.md#repository-effective-p
 Owner: [vNext authority decision](../decisions/vnext-authority.md). Gates:
 [vNext gate manifest](vnext-gates.md).
 
+There are no external or deployed users. The current local PostgreSQL database is
+disposable development state. This contract has no supported schema-upgrade path.
+
+Decodex has exactly one canonical unversioned latest schema source:
+`crates/decodex-postgres/schema.sql`. Numbered SQL, Refinery, schema-history ledgers,
+upgrade prefixes, compatibility DDL, migration receipts/finalizers/fallback, Phase A/B
+schema receipts, schema generators, and second executable schema owners are rejected.
+The former schema labels, including V14, V16, V17, V33, and V34, are superseded
+provenance and are not current owner names.
+
+One explicit operator bootstrap owns clean-target precondition, one transactional schema
+execution, and exact post-execution verification. A second bootstrap against a nonempty
+target fails closed. Normal `decodexd` startup resolves no schema-owner credential,
+executes zero DDL, and verifies only the exact current catalog and configured authority.
+
 ## Product entities
 
 | Entity | Contract |
@@ -27,7 +42,7 @@ Owner: [vNext authority decision](../decisions/vnext-authority.md). Gates:
 | Artifact | Content-addressed large output/evidence with PostgreSQL metadata; `active`, `expired`, or `deleted`. |
 
 There is no Domain Agent, automatic multi-Lead topology, arbitrary durable role, or Goal
-product entity in V1. Task and Reviewer agents are execution-scoped. Codex-native
+product entity in the first release. Task and Reviewer agents are execution-scoped. Codex-native
 subagents are run-local runtime actors normalized into the same activity/message graph;
 durable cross-run and cross-project routing belongs to Decodex.
 
@@ -76,28 +91,17 @@ reviewer, PR, harness, or Goal. A ManagedRun separates:
 - wait reason: `usage`, `auth`, `plugin`, `dependency`, `approval`, `user`, `external`,
   `reconciliation`, `reviewer_unavailable`, `reviewer_failed`, `reviewer_ambiguous`.
 
-Before V26, the inert V12 boundary persisted only `waiting` ManagedRuns that remained blocked.
-Every run was foreign-key bound to its exact Project, canonical WorkItem, and authoritative
-RuntimeSession revision. Task and Reviewer assignments remain exact-run RuntimeSession identities.
-Their closed role type cannot represent Advisor or Lead and contains no durable Agent identity.
-V12 effect lineage was foreign-key bound to one run and one barrier. Barrier states were `guarded`
-or permanently `closed`; both denied effects.
+The latest schema contains no ManagedRun-local submitted-turn receipt, safety-input,
+effect, or barrier authority. Those old shapes have no compatibility writer and no data
+conversion path. Current local data is disposable.
 
-The historical V12 mutation consumed a positively observed unknown exact turn, a Decodex-owned
-exact submitted-turn receipt, or an explicit inconclusive observation. It preserved a blocked
-waiting run and recorded divergence only from positive unknown-turn evidence. Missing, empty,
-exhausted, not-found, scan-exhaustion, no-event, or method-result absence never authorized
-progress.
-
-V26 removes the drained V12 submitted-turn, safety-input, effect, and barrier relations and their
-exact writer. The cutover stops if any live row or V12 exact-command receipt remains. It does not
-create a compatibility or fallback writer. The V3 Turn and HistoryItem invoker-rights repairs that
-V12 introduced remain current and independent of the retired ManagedRun-local effect authority.
-
-V24 cuts external-turn authority over to the generic ProviderAttempt owner. V12 submitted-turn
-receipts, safety inputs, and effect barriers are not inputs to ProviderAttempt submission or
-outcome. V25/V26 adapt V14, V16, and V17 for both consumer paths and retire the old V12 shapes.
-ProviderAttempt remains the sole external-turn attempt, receipt, and ambiguity authority.
+Task and Reviewer assignments remain exact-run RuntimeSession identities. Their closed
+role type cannot represent Advisor or Lead and contains no durable Agent identity.
+ManagedRun owns run lifecycle, wait state, review, acceptance, and completion.
+ProviderAttempt is the sole external-turn attempt, receipt, ambiguity, and positive
+outcome authority for both ordinary Conversation Turns and ManagedRun executions.
+Missing, empty, exhausted, not-found, scan-exhaustion, no-event, or method-result absence
+never authorizes progress or proves non-submission.
 
 Project/Program policy is versioned authority over allowed repositories, tools, paths, merge
 behavior, parallelism, budgets, approvals, and quiet periods. Commands use expected
@@ -117,15 +121,48 @@ replayed.
 | GPUI local state | bounded disposable cache only; SQLite is permitted only here |
 | Account product state | PostgreSQL Account Registry; it stores credential-negative identity, independent enabled state, observed health, routing mode/order, quota, usage/profile/history, credential-version evidence, and finite operation receipts |
 | Credentials | narrow versioned HostCredentialStore; PostgreSQL and clients never store or receive credential bytes |
-| v0.2 state | final vNext runtime and installer read none; an operator can copy local credentials once through ordinary vNext account imports and then delete the frozen account pool |
+| v0.2 state | Final vNext runtime and installer read none. The reviewed local database reset may preserve the complete credential-negative account/routing/binding tuple, including each enabled state and the mode-valid fixed target, and rebind it to unchanged host-vault records. Only the existing HostCredentialStore owner may perform a confined in-process read for typed credential-negative agreement; no token bytes leave that owner. |
 
 PostgreSQL is not event sourced and no graph database is used. Stable IDs plus correlated
 activity derive graph/timeline projections. `decodexd` is the sole product scheduler,
 app-server child owner, mutation coordinator, and repository-side-effect owner. GPUI,
 SwiftUI menubar, CLI, and MCP are clients/adapters over common application services; they
-never read PostgreSQL, rollout files, blobs, or repositories directly. V1 is single-host
+never read PostgreSQL, rollout files, blobs, or repositories directly. The first release is single-host
 and has no worker registry or distributed mesh. Remote UI may be added only through the
 protocol security gate.
+
+### PostgreSQL latest-schema authority
+
+`crates/decodex-postgres/schema.sql` is the only executable schema owner. It contains the
+final accepted enums, relations, constraints, indexes, functions, triggers,
+dependencies, ownership, and ACLs directly. It contains no old-state branch, drain,
+backfill, compatibility operation, or reverse operation.
+
+An allowed Rust `schema` module must own clean-target verification, one transaction that
+executes the complete schema, and post-execution current-authority verification before
+commit. A wrapper around `include_str!` alone is prohibited. There is no schema manager,
+registry, version constant, generator pipeline, bootstrap facade, or cutover coordinator.
+
+The explicit operator bootstrap resolves the schema-owner credential for that invocation
+only. It requires an empty PostgreSQL 18 target with data checksums, runs the complete
+schema once, verifies `pgcrypto`, exact catalog shape, stable dependencies, ownership,
+ACLs, function/trigger bodies and settings, `schema_fingerprint`, and configured runtime
+authority, and commits only after all checks pass. A second bootstrap fails because the
+target is no longer empty.
+
+Normal `decodexd` startup resolves only the runtime credential. It runs zero DDL and
+performs the same read-only current-catalog/configured-authority checks. It never creates,
+upgrades, repairs, or finalizes a schema and never reads a schema-history relation.
+
+The verifier rejects any extra, missing, changed, unsafe, or unreachable schema,
+relation, column, enum, constraint, index, function, trigger, rule, policy, RLS setting,
+sequence, dependency, owner, or grant. It closes inherited and `SET ROLE` authority,
+PUBLIC access, grant options, DDL, `TRUNCATE`, trigger bypass, unsafe function settings,
+hostile `search_path`, overloads, external cascades, and extension-member control.
+
+Exact-command receipts, account operations, ProcessGeneration, ProviderAttempt,
+`schema_fingerprint`, runtime authority, activity, outbox, and repository-effect records
+remain current domain integrity. They are not schema history or bootstrap permission.
 
 The account ownership, refresh, recovery, platform-store, clean-cutover, and readiness
 contract is [Account Lifecycle Authority](account-lifecycle-authority.md). An account's
@@ -248,7 +285,7 @@ infer persistence freshness, COMMIT success, or global operation history. No sna
 caller-supplied projection, generic observation, operation view, or reconstructed state
 can be supplied back as mutation authority.
 
-Within the trusted single-host V1 boundary:
+Within the trusted single-host first-release boundary:
 
 - `decodexd` is the sole owner of repository and worktree effects. No client, provider,
   validation child, second daemon, or distributed worker acquires a parallel mutation
@@ -270,7 +307,7 @@ Within the trusted single-host V1 boundary:
   working directory, and repository discovery never grant authority.
 - Project validation is supervised for process lifecycle, bounded output, timeout and
   cancellation, and repository mutation detection. Deliberately hostile same-UID code is
-  outside V1 confinement. Hostile-project or multi-tenant operation requires a separate
+  outside first-release confinement. Hostile-project or multi-tenant operation requires a separate
   UID or sandbox owner and an independently accepted feasibility and authority gate.
 
 Every external operation is assigned one complete canonical descriptor. The descriptor
@@ -334,24 +371,22 @@ imports external state. Generic observations cannot complete any operation.
 
 Authorized whole-cluster restore is inside the trusted PostgreSQL-administrator boundary
 and may remove or resurrect assignments, checkpoints, and results together, thereby
-redefining current authority. V1 has no external monotonic anchor and no automatic
+redefining current authority. The first release has no external monotonic anchor and no automatic
 full-cluster rollback detection. The accepted trusted single-daemon/same-UID boundary,
 XY-1354 descriptor-assisted symlink-free persisted absolute-path reacquisition, and
 pinned Git 2.54 mechanism remain unchanged.
 
-XY-1349 solely owns V13 physical persistence, transaction mechanics, privileges,
-retention, migration, and frozen database evidence. XY-1350 may proceed in parallel only
-against this accepted contract and owns read-only acquisition plus executor/readback
-mechanics, not persistence, receipt minting, saga, or hidden allocation mutation. XY-1351
-owns the first shared path that composes preparation, fresh receipt consumption, execution,
-readback, and terminal reconciliation. Rejected candidate trees
+Managed Repository Persistence owns the final physical relations, transaction mechanics,
+privileges, retention, and current database evidence. Repository Executor owns read-only
+acquisition plus executor/readback mechanics, not persistence, receipt minting, saga, or
+hidden allocation mutation. Repository Saga owns the shared path that composes preparation,
+fresh receipt consumption, execution, readback, and terminal reconciliation. Rejected candidate trees
 `6e20e9b3cf1415cce9b399da173b0410cc4c80dc`,
 `6979e3831da772fca3fe0f0e0b4699df642d3a65`, and
-`e42212add13af3f702e0ec8966ce3d6a7b682d12` are superseded evidence only. This contract
-creates no compatibility or history migration path.
+`e42212add13af3f702e0ec8966ce3d6a7b682d12` are superseded evidence only.
 
 Pure PostgreSQL commands use a different, exact in-transaction authority. Each operation has one
-command-complete migration-owner `SECURITY DEFINER` function. PostgreSQL constructs the complete
+command-complete schema-owner `SECURITY DEFINER` function. PostgreSQL constructs the complete
 request JSONB from the same typed values the function consumes; runtime supplies only a
 protocol-scoped idempotency key and typed operation inputs, never an authoritative
 caller-supplied request hash, claim token, lease, committed pending claim, or split-phase reserve.
@@ -400,12 +435,12 @@ failpoint, and incomplete-row probe present in the candidate, with only command-
 runtime-executable. Effect evidence decodes the stored response bytes and joins their effect envelope
 to the returned domain row and actual canonical activity/outbox identities.
 
-This authority is implemented vertically: XY-1345 records and proves the protocol; XY-1346
-implements the separate relation and RoleProfile bootstrap/update in V9; re-bounded XY-1337 owns authoritative
-RuntimeSession snapshot creation/transition in V10. Candidate 3 is superseded code and may supply
-only independently re-derived invariants and hostile-test ideas.
+XY-1345 records the exact-command protocol. RoleProfile Authority owns the separate
+receipt relation and RoleProfile bootstrap/update. RuntimeSession Authority owns
+authoritative RuntimeSession snapshot creation/transition. Candidate 3 is superseded
+code and may supply only independently re-derived invariants and hostile-test ideas.
 
-V9 persists exactly the `advisor`, `lead`, `task`, and `reviewer` identities in
+RoleProfile Authority persists exactly the `advisor`, `lead`, `task`, and `reviewer` identities in
 `role_profiles`, keeps every configuration in immutable `role_profile_revisions`, and advances one
 current-revision pointer per role. `bootstrap_role_profiles_exact` accepts four fixed
 advisor/lead/task/reviewer scalar groups and creates all four revision-one profiles atomically.
@@ -445,12 +480,176 @@ and unsupported, oversized, or credential-shaped forms are rejected.
 `thread/read(includeTurns=true)` and paginated/list evidence are lossy reconciliation sources.
 They may support positive observations, but never authorize a negative `Present`, `Complete`, or
 context-free `Absent` conclusion. Missing, truncated, or unobserved evidence remains unknown.
-Experiment intent and the first creation fence belong to XY-1358/V15. XY-1367/V22 binds the exact
-nullable-name start response. It fences the separate name-set effect. It requires exact-ID
-retained-title attestation before positive observations or V17 same-thread authority. Production
+Experiment Authority owns intent and the first creation fence. Retained-title Authority binds the exact
+nullable-name start response, fences the separate name-set effect, and requires exact-ID
+retained-title attestation before positive observations or same-thread authority. Production
 Quick Task creation belongs to XY-1276. External Codex activity may be provenance-imported for ordinary
 Quick/Advisor/Lead conversations; on an active ManagedRun it marks the session `diverged` and blocks
 side effects until tool/repository readback reconciles them.
+
+### Quick Task thread establishment
+
+Status: Candidate 5 is approved target architecture. Implementation and integrated
+acceptance remain pending. Candidate-4 tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance.
+
+Quick Task remains an ordinary multi-turn Conversation. Candidate 5 uses existing owners
+in this exact order:
+
+1. Conversation authority creates the Conversation.
+2. Routing receives a prospective Turn UUID as intent. It creates no Turn, and no routing
+   column has a foreign key to `turns` for that intent.
+3. Routing Snapshot loads and locks the complete account universe without a source
+   RuntimeSession or sticky member.
+4. Routing Decision selects the account exactly once.
+5. Continuation Plan consumes that selected decision and atomically creates the selected
+   account snapshot, copied RoleProfile snapshot, one revision-1 unfenced `starting`
+   RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and outbox.
+6. Conversation authority admits the exact prospective Turn and first history item in one
+   transaction.
+7. Every establishment fence locks and rechecks that Turn as active revision 1 under the
+   same Conversation and new RuntimeSession.
+8. Account Service fences only the selected account immediately before spawn.
+9. Only a fresh ProcessGeneration fence may spawn.
+10. RuntimeSession Thread Establishment owns thread request fencing, exact start binding,
+    activation, and acknowledgement.
+11. ProviderAttemptService owns preparation, authorization, ambiguity, positive evidence,
+    and reconciliation.
+
+There is no second route decision, fallback, wake, alternate account, or account
+re-selection in the initial operation. Initial planning creates the first session. It is
+not explicit successor, same-thread reuse, or Context Pack fallback. Automatic
+cross-account fallback and wake remain disabled under XY-1304.
+
+| Owner | Candidate-5 authority |
+| --- | --- |
+| Account Registry and Routing Snapshot | Complete lifecycle, control, capability, quota, blocker, and routing facts; no selection. |
+| Account Service | Account operations and exact selected-account readiness/credential/provider/HostCredentialStore pre-spawn fence; no selection. |
+| Routing Decision | Sole Quick Task account selector and immutable route-decision writer. |
+| Continuation Plan | Initial snapshots, first starting RuntimeSession, inert initial plan, existing same-thread/Context Pack planning, and PostgreSQL-only explicit-successor evidence. |
+| Conversation authority | Conversation creation, atomic initial Turn/history admission, legal Turn finalization, and exact Turn lock/read proof. |
+| RuntimeSession Thread Establishment | RuntimeSession state/thread fields, exact thread fence and bind, and acknowledgement. |
+| ProcessSupervisor | ProcessGeneration intent, fresh spawn authority, exact readback, positive death evidence, and account-local quarantine. |
+| ProviderAttemptService | Attempt preparation, dispatch authorization, ambiguity, positive evidence, and reconciliation. |
+| ExecutionCoordinator | Crate-private stateless sequencing only. |
+
+Account Service can report and fence facts for the selected account. It cannot preselect,
+substitute, fall back to, or wake another account. If account A passes an Account Service
+subset but fails a complete routing capability while B is fully eligible, Routing
+Decision selects B. Continuation Plan creates only B's snapshots and RuntimeSession.
+Later B drift fails closed before spawn without a second decision or account A.
+
+#### Closed initial lineage
+
+For `routing_snapshots`:
+
+- `L0` means all six source lineage fields are null: `runtime_session_id`,
+  `runtime_session_revision`, `account_snapshot_id`,
+  `account_snapshot_source_revision`, `profile_snapshot_id`, and
+  `profile_snapshot_source_revision`.
+- `L6` means all six fields are present and the three revisions are positive.
+
+The latest schema keeps the existing foreign keys and defines one closed
+all-null/all-present shape check. The only valid combinations are
+`conversation_turn AND (L0 OR L6)` and `managed_run_execution AND L6`. Half-null
+lineage and a source-less ManagedRun reject.
+
+`decodex.enforce_routing_completeness()` has one narrow `L0` branch. It accepts only the
+exact prospective Conversation Turn intent when the locked Conversation is open at the
+expected revision, has no RuntimeSession or Turn, and every candidate member has
+`sticky=false`. Candidate membership, policy positions, account revisions, both quota
+observations, all eight capability observations, and blocker rows must exactly equal the
+locked Routing Snapshot universe. Missing, extra, duplicate, cross-linked, or reordered
+evidence rejects. The existing `L6` branch keeps exactly one sticky member.
+
+The supporting current owners obey these predicates:
+
+- `resolve_routing_snapshot_exact` accepts source RuntimeSession identity/revision only
+  when both are present or both absent. The absent branch proves initial predicates and
+  zero sticky members, then writes exact `L0`.
+- `route_account_exact` applies the same pair rule, selects in policy order, and replays
+  only its stored decision. The Conversation lock permits one competing initial key to be
+  fresh; exact-key replay is read-only.
+- `plan_initial_thread_continuation_exact` consumes only selected `L0` and creates the
+  complete first-session authority cluster in one transaction.
+- Routing codecs/readbacks represent the source pair as jointly optional and permit zero
+  sticky members only for `L0`.
+- Continuation-plan completeness proves selected `L0` and the new account/profile/session
+  lineage.
+- Routing-decision completeness remains unchanged.
+
+#### Atomic initial admission
+
+Conversation authority admits exactly one Turn with:
+
+- the prospective UUID bound by the selected route;
+- sequence 1 and role `user`;
+- `possible_side_effects=unknown`;
+- status `active` and revision 1; and
+- the exact Conversation and new starting RuntimeSession cross-link.
+
+The same transaction inserts exactly one ordinal-0 completed Message history item. The
+fresh/replay/refusal result, Turn, history item, exact receipt, activity, and outbox form
+one atomic owner result. Exact-key replay is read-only. Every competing key commits no
+Turn, history, activity, or outbox effect. Wrong identity, role, sequence, side-effect
+state, status, revision, ordinal, kind, second item, or cross-link rejects the transaction.
+
+#### Process, thread, and effect replay
+
+Before ProcessGeneration prepare/spawn, thread fence/start/bind, and ProviderAttempt
+prepare/authorize, the effect owner locks the selected Turn and requires it to remain
+active revision 1 under the same Conversation and first RuntimeSession.
+
+ProcessGeneration and thread establishment through bind require the applicable
+`starting` RuntimeSession revision. ProviderAttempt preparation and authorization require
+the exact post-bind `active` revision and exact completed thread fence/bind receipts. A
+terminalization race loses before effect execution.
+
+ProcessGeneration has four typed outcomes: `Fresh`, `Replayed`, `Rejected`, and
+`Unknown`. Only `Fresh` returns non-clone spawn authority. All other outcomes use durable
+readback or refusal and cannot spawn, replace, adopt, create a successor, duplicate an
+attempt, or terminalize the Turn. The same rule applies after result loss at every thread
+and ProviderAttempt fence.
+
+Conversation authority may transition the exact Turn to `failed` revision 2 under the
+starting RuntimeSession only when positive readback proves definite pre-effect refusal.
+The proof excludes every process state that may have created a child, every thread
+fence/start/bind, and every prepared, authorized, or unknown ProviderAttempt. Ambiguous
+work remains active and returns `Unknown` for manual recovery.
+
+Explicit successor remains PostgreSQL-only non-dispatch evidence. It has no protocol
+field, product command, runtime execution grant, facade, fallback, or wake path. Before
+any write, it locks the Turn named by the route and requires the same Conversation/source
+RuntimeSession, status `failed`, and revision 2.
+
+#### Final trigger functions
+
+The latest schema creates these seven final trigger-function bodies and bindings directly:
+
+| Trigger function | Exact Candidate-5 predicate |
+| --- | --- |
+| `decodex.enforce_routing_completeness()` | Preserve complete existing policy/evidence/`L6` behavior and add only the exact zero-sticky `L0` branch above. |
+| `decodex.enforce_runtime_session_state()` | Preserve revision-one insert, identity, timestamps, terminal immutability, legal terminal edges, and ended-session active-Turn rules. Permit only: unfenced `starting` to request-fenced `starting` by setting the complete request ID/digest pair; that exact row to `active` by preserving the request, matching response ID, and setting exact response digest/thread ID; and `active` to `active` only for exact last-Turn acknowledgement. Reject generic `starting` to `active`, partial receipts, combined edges, or unrelated drift. |
+| `decodex.enforce_turn_state()` | Preserve active-session behavior. Under `starting`, permit only exact first-Turn insertion and active-revision-1 to failed-revision-2 after positive definite pre-effect refusal. Reject every other starting-session write. |
+| `decodex.enforce_history_item_state()` | Preserve active-session behavior. Under `starting`, permit only the admission transaction's ordinal-0 completed Message for the exact first Turn; reject update, second item, other ordinal/kind/status, wrong Turn, or cross-link. |
+| `decodex.enforce_provider_attempt_transition()` | Keep the accepted state algebra, unknown reasons, positive terminal-evidence rule, and immutable tuple; include immutable RuntimeSession thread-binding protocol/key identities. |
+| `decodex.enforce_provider_attempt_binding()` | For `initial_thread`, require exact selected route/plan/account snapshot, ready ProcessGeneration/live epoch, completed thread fence/bind receipts, active post-bind RuntimeSession revision, and active revision-1 selected Turn. Preserve all non-initial branches. |
+| `decodex.enforce_continuation_plan_completeness()` | For `initial_thread`, require selected `L0`, prospective Turn intent, selected account/profile snapshots, one revision-1 unfenced starting RuntimeSession, and inert plan. Preserve same-thread and Context Pack branches; explicit-successor completeness also requires the exact failed revision-2 Turn. |
+
+The dispatch-authorization command performs its own exact Turn lock. A deferred trigger
+does not replace this pre-write fence. The continuation-rejection helper derives only the
+operation from an already-reserved receipt and adds no transport or idempotency mechanism.
+
+No other trigger function changes. Trigger bindings and ACLs remain closed. Every
+unrelated write keeps existing active-only semantics. The narrow first-session permissions
+are not a generic starting-session bypass.
+
+Candidate 5 adds no module, fixed hierarchy, schema phase, ledger, generic transaction or
+recovery framework, transport/idempotency mechanism, wrapper, runner, scheduler, or
+explicit-successor product surface. It must preserve current-main independent account
+observations, Reset Card-before-profile ordering within an account, concurrent progress
+across accounts, revision-fenced cache publication, and query paths that do not join or
+start refresh work.
 
 Long-term context consists of immutable Project, Advisor, and Program revisions. Project
 context records decisions, constraints, repository facts, active Programs/Objectives,
@@ -458,7 +657,7 @@ unresolved risks, and accepted handoffs. Advisor briefs compact cross-project st
 risk. Program context records metrics/signals, recent decisions, quiet periods, and next
 review. A Context Pack contains the current revision, recent raw window, relevant
 artifacts, and repository instructions/OpenWiki. Summaries never silently replace
-sources; users can inspect pinned memory and provenance. V1 uses structured PostgreSQL
+sources; users can inspect pinned memory and provenance. The first release uses structured PostgreSQL
 queries and full-text search, not vectors.
 
 AgentMessage carries logical endpoints, project, correlation and causal parent, dedupe
@@ -497,7 +696,7 @@ nanoseconds. The product-valid interval is `0..=253402300799999999` Unix microse
 RFC3339 ingress normalizes offsets to UTC and must be exactly microsecond-aligned before it
 constructs that type. Sub-microsecond, pre-Unix, post-year-9999, infinity, overflow or carry,
 leap-second, parser-unsupported, and otherwise unsupported values fail before command-receipt
-reservation. No application, adapter, database, or migration path rounds or truncates a quota
+reservation. No application, adapter, database, or persistence path rounds or truncates a quota
 timestamp. Freshness uses checked integer-microsecond subtraction: an age of exactly 300 seconds
 is accepted, while 300 seconds plus one microsecond is stale.
 
@@ -508,34 +707,20 @@ canonical serialization. The receipt binds the resulting SHA-256 digest and byte
 completed-response replay returns the stored response bytes. Retaining the complete request
 document is not required.
 
-V8 is one atomic zero-state migration. In canonical writer order it takes `ACCESS EXCLUSIVE` locks
-on `command_receipts`, `quota_windows`, `activity`, and `outbox`, then uses closed structural
-classification to reject every pre-V8 quota fact: any `quota_windows` row; every receipt whose
-operation is `mutate_quota_window` or whose scope is `quota_windows`, regardless of lifecycle
-state; activity classified by aggregate kind, event kind, or structured payload; outbox classified
-by aggregate fields or structured activity envelope; every outbox link to classified activity; and
-every malformed or orphaned combination of those facts. Correlation-key or aggregate-ID string
-patterns are not evidence classification. The assertion and all DDL occur in the same transaction.
-Only after zero state is proven may V8 alter `quota_windows` in place, preserving its table identity,
-ACLs, account foreign key, unchanged observation-index identity, and migration atomicity while
-replacing only changed constraints and adding the typed enums, exclusion relation, indexes, and
-authority inventory.
-
-There is no populated V7 conversion or quarantine, hand deletion, retention bypass, table
-drop/recreation, dual schema, compatibility read/write, or hidden fallback. Any classified state
-aborts V8 with a stable incompatibility result. The supported recovery is to stop Decodex and
-recreate the whole disposable pre-release database. XY-1302 owns the final whole-ledger
-squash/reset, production baseline, privileges, recreation runbook, cutover/rollback readback, and
-proof that no pre-release database becomes production state.
+The latest schema defines the final typed quota-window and exclusion enums, relations,
+constraints, indexes, account foreign keys, observation index, receipts, and authority
+directly. There is no old quota shape, conversion, quarantine, drain, backfill, table
+replacement, dual schema, compatibility read/write, or hidden fallback. Local pre-release
+state is disposable and is never converted into production state.
 
 Separate typed 300-minute and 10080-minute observations remain mandatory. This persistence
 boundary enables no account assignment, fallback, `waiting_usage` registration, wake scheduling,
 continuation, replay of external effects, or live dispatch. Ingress retains the exact raw provider
 timestamp value. Construction of UTC Unix microseconds must be exact; any conversion that would
-round or truncate is rejected. V14 through V16 consume only exact values, remain otherwise
-precision-agnostic, and fail closed. XY-1357 owns the one natural precision receipt in the unified
-post-freeze gate. An incompatible receipt leaves production routing disabled and reopens only the
-ingress authority; it does not require a moving-core schema or decision rewrite.
+round or truncate is rejected. Routing Snapshot and Routing Decision consume only exact
+values, remain otherwise precision-agnostic, and fail closed. XY-1357 owns the natural
+precision evidence after source freeze. Incompatible evidence leaves production routing
+disabled and reopens only ingress authority.
 
 The dormant manual account observation path checks an exact PostgreSQL account revision in the
 `available` state before mechanics and checks the same predicate again after cleanup. Each check
@@ -565,15 +750,15 @@ restart launch permission.
 
 ### Durable ProcessGeneration authority
 
-XY-1400 implements the accepted XY-1398 V3 contract in
+XY-1400 implements the accepted ProcessGeneration contract in
 [the ProcessGeneration authority specification](process-generation-authority.md).
 `ProcessSupervisor` is the sole product writer. A private opaque launch authority retains one
 protected executable snapshot and derives the durable launch-manifest identity and exact command.
 The manifest binds the image and BuildId, fixed `app-server --stdio` arguments, working directory,
 sanitized environment, account, initial account revision, canonical credential version and
 fingerprint, provider identity, and exact-build startup/lifetime/account-callback capability. No
-caller can pair an independent digest with a raw command. The supervisor commits this intent in
-V23 before a fresh fence can authorize one spawn. Intent, launch manifest, prepare fence, ready
+caller can pair an independent digest with a raw command. The supervisor commits this intent
+before a fresh fence can authorize one spawn. Intent, launch manifest, prepare fence, ready
 transition, and readback carry the same non-secret binding. No new process or effect ledger is
 added. The supervisor then binds the exact PID, process-start identity, process group, and session.
 
@@ -613,10 +798,10 @@ Persisted Codex thread identity carries Conversation continuity; process surviva
 or continue a RuntimeSession.
 
 ProcessGeneration proves replacement safety only. It does not prove provider non-submission,
-effect cancellation, or credential revocation. V24 keeps an unproved authorized ProviderAttempt
+effect cancellation, or credential revocation. ProviderAttempt keeps an unproved authorized attempt
 `unknown`; process exit or boot change cannot make it `not_submitted`, a replacement cannot replay
 it, and any successor is a distinct user-authorized effect with duplicate-risk acknowledgement.
-The generic attempt transaction consumes one accepted V16 decision, V17 RuntimeSession, and ready
+The generic attempt transaction consumes one accepted Routing Decision, Continuation Plan, and ready
 ProcessGeneration without creating or changing them. XY-1400 adds no account selection, routing,
 ProviderAttempt storage, remote authentication, UI, packaging, release, or live dispatch.
 A future live-dispatch protocol gateway must be a separate typed authority that source-rejects
@@ -632,9 +817,8 @@ or a preclassified candidate array.
 
 The current `decodex-core::PolicySnapshot` remains a bounded inert value inside one accepted
 Project Policy revision. It neither enumerates the account inventory nor establishes routing
-completeness, eligibility, evidence provenance, or persistence freshness. V14 must introduce the
-distinct database-owned complete routing snapshot rather than widening a Rust wrapper into
-authorization authority.
+completeness, eligibility, evidence provenance, or persistence freshness. Routing Snapshot is the
+distinct database-owned complete value; a Rust wrapper cannot become authorization authority.
 
 One snapshot binds, under the database locks that establish its revision boundary:
 
@@ -660,7 +844,7 @@ blockers. An all-excluded universe is an explicit cause-complete `no_route`; a c
 `no_route` is invalid.
 
 `decodex-core` is a pure deterministic decision kernel over this database-produced snapshot. It
-does not establish provenance or completeness. PostgreSQL atomically persists the resulting V16
+does not establish provenance or completeness. PostgreSQL atomically persists the resulting Routing
 decision, its complete normalized exclusions, and every evidence reference. Runtime consumes one
 exact persisted decision and sequences effects only; it cannot substitute a decision. Codex is a
 positive-evidence capability adapter and cannot determine membership, policy, or eligibility.
@@ -672,7 +856,7 @@ snapshot. Eligibility requires the independent versioned `enabled=true` fact; ob
 not imply enablement. Every known depleted window excludes its account until reset. Unknown, stale,
 incompatible, disabled, authentication-failed, missing-duration, low-confidence, or precision-
 incompatible evidence blocks eligibility. When every otherwise eligible account is excluded only
-by usage, V16 persists `waiting_usage` and the exact earliest-ready time. XY-1362 owns one
+by usage, Routing Decision persists `waiting_usage` and the exact earliest-ready time. XY-1362 owns one
 restart-safe scheduler wake and always re-enters fresh authoritative resolution; routing owns no
 wake lifecycle.
 
@@ -683,12 +867,13 @@ positive readiness evidence and does not change an account to ready. XY-1336 rem
 passive-receipt tracking. Host-owned before/after receipts prove causal no-mutation integrity only
 and cannot establish account-owned readiness.
 
-XY-1358 owns the original causal experiment ledger. XY-1367/V22 repairs its two-effect retained-title
-authority without changing V15. After an exact V16 decision, V17 owns same-thread continuation
-when exact positive account/profile/build evidence permits it. Otherwise, V17 owns one atomic
-Context Pack plus fallback RuntimeSession. V25/V26 preserve this authority for ordinary
-Conversation Turns and ManagedRun executions. The stateless ExecutionCoordinator sequences V16,
-V17, one live ProcessGeneration fence, and ProviderAttempt preparation. Current production
+Experiment Authority owns the original causal experiment record. Retained-title Authority owns its
+two-effect title bridge. After an exact Routing Decision with an existing source RuntimeSession,
+Continuation Plan owns same-thread continuation when exact positive account/profile/build evidence
+permits it. Otherwise, it owns one atomic Context Pack plus fallback RuntimeSession. These owners
+serve ordinary Conversation Turns and ManagedRun executions. The stateless ExecutionCoordinator
+sequences one Routing Decision, one Continuation Plan, one live ProcessGeneration fence, and
+ProviderAttempt preparation. Current production
 dispatch stays structurally disabled until its applicable slice gate passes. Ambiguous-turn
 replay remains blocked by ProviderAttempt. ManagedRun
 consumes the attempt result and keeps only domain lifecycle authority.
@@ -722,7 +907,7 @@ non-routing evidence.
 Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
 reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a
 user-owned desired inventory only as intent. Until a stable passive account-owned receipt
-exists, V1 reports plugin readiness as `unknown`; that unknown is blocking only when the exact
+exists, the first release reports plugin readiness as `unknown`; that unknown is blocking only when the exact
 accepted routing policy requires the corresponding capability, and is non-applicable when the
 required-capability set is empty. Host facts never become positive account-readiness evidence or
 guide mutation from such a conclusion.
@@ -976,21 +1161,38 @@ Acceptance is limited to:
 User-visible warm history is not an acceptance claim until the Conversation destination
 consumes `HistoryPager`.
 
-## Clean cutover and delivery
+<a id="clean-cutover-and-delivery"></a>
 
-Cutover has no availability requirement. Stop v0.2 and start vNext with empty PostgreSQL
-execution and control-plane state. Import each local account once through the ordinary
-versioned account-import command from an owner-private temporary file. Verify the
-PostgreSQL account and routing readback, the exact HostCredentialStore binding, and the
-per-account Reset Card readback. Then delete the temporary import files and the retired
-local account source.
+## Local reset and delivery
 
-The product has no account-migration manifest, bulk importer, migration receipt,
-migration state machine, migration finalizer, compatibility fallback, or dual account
-authority. It imports no quota, usage/profile projection, account history, Codex
-sessions, SQLite execution state, Linear lanes, or Codex-created tasks. Normal startup
-reads only vNext PostgreSQL and HostCredentialStore authority. Recreate selected Projects
-explicitly from reviewed inventory.
+The local reset has no availability requirement. One reviewed operator-only action stops
+the daemon and captures, for every retained account, only Account UUID, enabled state,
+account revision, provider binding, credential version/fingerprint, and host-store
+binding. It also captures routing revision, mode, fixed target, and the complete account
+order. It may replace or directly transform the disposable local database. A recreated
+database receives the one empty-target latest-schema bootstrap.
+
+The operator restores or rebinds that exact tuple against unchanged
+`HostCredentialStore` records. `fixed` mode requires one non-null target in the retained
+account set and complete order; `balanced` mode requires a null target. The order is a
+duplicate-free permutation of all retained accounts, including disabled accounts. Exact
+readback proves every Account UUID, enabled value, revision, binding, and the routing
+mode, target, and order together. The daemon starts only after exact current-authority
+and tuple readback pass.
+
+For credential agreement only, the action may invoke the existing
+`HostCredentialStore` owner. The owner performs a confined in-process exact read,
+recomputes and compares the credential fingerprint and binding, and returns only a typed
+credential-negative agreement result. The operator action and result never expose,
+serialize, copy, log, persist, rotate, delete, or return token bytes.
+
+The action is not a product account or migration API, manifest, generic attestation
+framework, metadata sidecar, bulk importer, generic migrator, state machine,
+receipt/finalizer, backup/rollback mechanism, compatibility branch, or fallback. It
+retains no quota, usage/profile projection, account history, Codex session, SQLite
+execution state, Linear lane, or Codex-created task. Normal startup reads only current
+PostgreSQL and `HostCredentialStore` authority. Recreate selected Projects explicitly
+from reviewed inventory.
 
 Delivery has exactly three dependencies: Accounts/Quick Task/Accounts-Conversation-Health
 GPUI, then the bounded Project/Lead/ManagedRun flow and Project-Work-Run GPUI, then the
@@ -1011,14 +1213,14 @@ PR #1092 is closed, unmerged, and frozen at historical head
 SQLite registry, lane/effect ledger, and C1-C7 orchestration are obsolete. The only relevant
 behavior classes are already replaced by vNext owners: explicit Project/repository identity by
 the Project and managed-repository admission contracts, frozen admitted-base and worktree
-continuity by the V13/executor/saga stack, and paginated positive GitHub readback by the sealed
+continuity by the Managed Repository Persistence/Executor/Saga owners, and paginated positive GitHub readback by the sealed
 GitHub effect boundary. It contributes no unique production behavior to the vNext candidate.
 
-## V1 non-goals
+## First-release non-goals
 
 - Pi as a second runtime; per-run/per-agent `CODEX_HOME`; Codex Project sync.
 - Linear import, projection, identity, lane authority, or compatibility.
-- SQLite product authority, dual writes, historical Codex/SQLite execution migration.
+- SQLite product authority, dual writes, or import of historical Codex/SQLite execution state.
 - Domain Agents, automatic multi-Lead, arbitrary durable roles, or Goal as general
   planning/review/development state.
 - Graph/vector databases, event sourcing, CRDT/DeltaDB worktrees, distributed workers.

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -1,1111 +1,367 @@
 # Decodex vNext Gate Manifest
 
-Status: normative sequencing and acceptance boundary. The XY-1403 private-artifact
-retirement takes effect only at the exact repository effective point in the
-[retirement decision](private-artifact/decision.md#repository-effective-point).
+Status: normative sequencing and acceptance boundary.
 
 Owner: [vNext authority decision](../decisions/vnext-authority.md). Contract:
 [vNext authority contract](vnext-authority.md).
 
-## Delivery slices
+## Changed decision
 
-XY-1260 establishes authority only. It does not implement PostgreSQL, app-server/Codex
-adapters, GPUI, protocol, runtime services, or migration. Delivery now follows three usable
-vertical slices. Issue ranges below are navigation and evidence provenance. They are not a
-component-first critical path.
+There are no external or deployed users. Local PostgreSQL state is disposable. Decodex
+has one canonical unversioned latest schema and no supported schema migration or upgrade
+path.
+
+The old numbered SQL, Refinery runner, schema-history ledger, migration credential on
+daemon startup, upgrade prefixes, migration receipts/finalizers/fallback, Phase A/B
+schema receipts, and second executable schema owners are rejected. The old V14, V16,
+V17, V33, and V34 labels do not name current owners. Their final accepted domain
+semantics must be present directly in the latest schema.
+
+Acceptance proves an empty-target bootstrap and exact current authority. It does not
+prove a historical upgrade, populated migration, version prefix, schema-history checksum,
+or source/restore migration receipt.
+
+## Delivery slices
 
 | Slice | Usable result | Entry condition |
 | --- | --- | --- |
-| 1. Accounts and Quick Task | The Slice-1 Mac account lifecycle subset, quota-aware initial fixed or balanced selection, explicit account order and manual recovery, Quick Task, and minimal Accounts/Conversation/Health GPUI. Normal startup has no legacy watcher, credential environment projection, helper, or `:8192` authority. | The Slice-1 subset of [MacDogfoodReady](account-lifecycle-authority.md#readiness-levels), including exact-build refresh-callback proof. |
-| 2. Managed work | Minimal Project, Lead, global Advisor entry, bounded Context Revision, WorkItem, ManagedRun, existing repository saga, Task-Reviewer result, explicit human acceptance, and Project/Work/Run GPUI. | Slice 1 is accepted. V13, V23, V24, bounded context, and the existing managed-work authority used by this flow pass their exact slice gates. |
-| 3. Self-hosting package | A representative two-account self-hosting repository flow across restart boundaries and one Mac package. Normal packaged startup proves that no legacy watcher, credential environment projection, helper, or `:8192` authority is present. | Slice 2 is accepted. Package, restart, repository-effect reconciliation, and representative E2E evidence pass on one exact build. |
-
-The dependency recommendation is `Slice 1 -> Slice 2 -> Slice 3`. A later issue can
-prepare inert foundations, but it cannot claim an earlier usable slice. Each acceptance
-records the exact source revision, evidence, contradictions, and outcome.
-
-## Downstream ownership
-
-| Range | Accepted downstream ownership |
-| --- | --- |
-| [XY-1261](https://linear.app/hack-ink/issue/XY-1261)-[XY-1264](https://linear.app/hack-ink/issue/XY-1264), with the failed live gate aggregated by [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | v0.2 freeze and PostgreSQL/blob/cache proof are accepted; the XY-1262 foundation is accepted, XY-1360 owns the still-disabled live-continuation and atomic Context-Pack fallback implementation after V16, XY-1304 owns only its later live-routing aggregate gate and enablement amendment, and XY-1263 accepts only the isolated pinned GPUI foundation. |
-| [XY-1265](https://linear.app/hack-ink/issue/XY-1265)-[XY-1269](https://linear.app/hack-ink/issue/XY-1269) | Workspace ownership boundaries, `decodexd` protocol, PostgreSQL persistence, `~/.decodex`/API-only CLI, and the GPUI client foundation consumed by the delivery slices. |
-| [XY-1270](https://linear.app/hack-ink/issue/XY-1270)-[XY-1276](https://linear.app/hack-ink/issue/XY-1276), [XY-1422](https://linear.app/hack-ink/issue/XY-1422), [XY-1423](https://linear.app/hack-ink/issue/XY-1423), plus [XY-1304](https://linear.app/hack-ink/issue/XY-1304) | Typed app-server, Conversation/RuntimeSession/history, shared-home, immutable runner binding, quota calculation, and profile foundations. XY-1423 corrects account authority; XY-1422 owns the Slice-1 subset of MacDogfoodReady and full MacDogfoodReady acceptance at Slice 3. Final AccountLifecycleReady is later. The XY-1355-XY-1363 chain retains broader routing authority and evidence. XY-1403 retires the private-artifact lane. XY-1304 owns only later automatic fallback/wake acceptance and enablement. |
-| [XY-1277](https://linear.app/hack-ink/issue/XY-1277)-[XY-1286](https://linear.app/hack-ink/issue/XY-1286) | Projects/Advisor/Lead, context, messages/collaboration, decision queues, Programs/Objectives, WorkItems, ManagedRuns, repository services, Task-owned independent review/repair/landing, and Project/Program authority policy. |
-| [XY-1287](https://linear.app/hack-ink/issue/XY-1287)-[XY-1290](https://linear.app/hack-ink/issue/XY-1290) | Automation definitions/firings, materiality/loop safety, removal of manager agents, and PubFi/SEO/GEO/Radar/Publisher dogfood. |
-| [XY-1291](https://linear.app/hack-ink/issue/XY-1291)-[XY-1297](https://linear.app/hack-ink/issue/XY-1297) | GPUI conversations, project/run workspace, graph/timeline, operational surfaces, multi-GB pagination/cache/search, thin menubar, and accessibility/interaction gates. |
-| [XY-1298](https://linear.app/hack-ink/issue/XY-1298)-[XY-1303](https://linear.app/hack-ink/issue/XY-1303) | Observability/retention, authenticated remote security/backups, E2E and fault injection, performance budgets, empty-state legacy cutover/removal, and package/dogfood/release reconciliation. |
-
-Each issue is accepted only for its own stated scope and blocked-by relations. The ranges
-are navigation, not permission to collapse tasks or skip gates. Linear relations are
-planning metadata, not product/runtime identity.
-
-## Readiness layers
-
-MacDogfoodReady is the three-slice target. It keeps PostgreSQL, outbox and leases, one
-daemon, shared `~/.codex`, typed same-UID transport, exact IDs, Keychain credentials,
-credential CAS and reconciliation, V13, V23, V24, separate 300/10080 windows, bounded
-context, and no history migration. Final AccountLifecycleReady retains broader product
-obligations without blocking the Mac dogfood.
-
-| Later-readiness obligation | MacDogfoodReady | Final authority |
-| --- | --- | --- |
-| Linux secret backend | Deferred | Required for supported Linux |
-| Explicit **Use in Codex** | One exact local account projection, separate from routing | Same fail-closed contract on every supported host |
-| Full usage, profile, and history presentation | Minimal health and quota only | Required |
-| Automatic same-thread fallback and all-depleted wake | Deferred to XY-1304 acceptance | Required before those paths are enabled |
-| Retained-title Desktop discovery | Deferred | Required only for the retained-title feature |
-| Broad compatibility/fault matrices, graph, automation, remote access, and polish | Deferred | Required by their owning final-product gates |
-
-Remote binding stays disabled until authentication, TLS, authorization, and redaction
-pass. Historical receipts remain accepted for their stated boundaries; this repair does
-not promote them into Slice-1 prerequisites.
-
-### XY-1262 foundation acceptance
-
-Manager accepted this split on 2026-07-13. The decision provenance is merged PR #1098 at
-`687605583817eca32cbdfb1107f3ee18d3106cea`; that proposal becomes authority only through
-this independently reviewed amendment. Repository authority is normative and Linear is
-planning metadata.
-
-The [Codex runtime proof](../evidence/vnext-codex-runtime-proof.md), including the merged
-reconciliation receipt, accepts the foundation gate for exactly these observed or pure
-evidence boundaries:
-
-- one shared normal `~/.codex`, with each app-server process bound to one account and no
-  credential switching under a live process;
-- Decodex ownership only from a durable creation receipt, never from arbitrary Codex
-  history;
-- generated typed schema plus negotiated live method results keyed by the Codex build;
-- persistent exact-ID, filtered-list, read, explicit archive, and restart readback;
-- lossy `thread/read` handling and a fail-closed ManagedRun `diverged` policy;
-- native collaboration/subagent events normalized only as run-local actors;
-- process-scoped authentication, redaction, and no-mutation integrity evidence; and
-- pure quota decisions keyed by duration 300/10080, including unknown, stale, reversed,
-  and all-depleted synthetic cases.
-
-Healthy-account same-thread continuation and a manually started Context-Pack session are
-mechanism evidence only. They do not accept automatic cross-account routing or fallback.
-No global Codex title-search contract is accepted: exact-ID and filtered-list ownership
-readback are the supported boundary.
-
-### Permitted foundation work
-
-Permission is issue-scoped and does not bypass each issue's own dependencies:
-
-| Issue | Permitted boundary |
-| --- | --- |
-| XY-1265 | Workspace ownership cutover and composition roots; no compatibility facade. |
-| XY-1266 | Loopback protocol, idempotency, reconnect, backpressure, and non-loopback refusal. |
-| XY-1267 | PostgreSQL transactions, leases, outbox, and inert account/window schemas. |
-| XY-1268 | Owned `~/.decodex` paths and API-only diagnostics that report unavailable/unknown honestly. |
-| XY-1269 | Retained GPUI transport/cache/client foundations. Slice acceptance is by the usable destination set, not by the former P/K/L/S component sequence. |
-| XY-1270 | Generated typed app-server contracts, live capability negotiation, redaction, and one-account-per-process supervision; no task scheduling or account choice. |
-| XY-1271 | Conversation/RuntimeSession/history and inspectable Context-Pack persistence; no automatic rollover, assignment, or fallback dispatch. |
-| XY-1272 | PostgreSQL configured-principal and ACL authority manifest/readiness closure against V8; no migration or Codex creation/reconciliation surface. Any future configured role must atomically extend configuration, bootstrap, manifest/readiness, and negative tests. |
-| XY-1273 | Credential-vault metadata and immutable runner/account binding; no sticky or policy assignment. |
-| XY-1274 | Exact-microsecond quota persistence, `/2` canonical mutation identity, atomic V8 zero-state migration, and durable exclusion transaction tests using synthetic fixtures only; no live exclusion, fallback assignment, or wake scheduling. |
-| XY-1275 | Umbrella for user-owned profile persistence and RuntimeSession snapshots. It closes only through the serial XY-1345 -> XY-1346 -> XY-1337 order. Account-owned plugin, skill, and MCP readiness remains typed `unknown`; XY-1336 neither closes nor blocks this issue. |
-| XY-1276 | Slice-1 Quick Task creation after the Slice-1 account and exact-build callback gates. It is not blocked by XY-1304. |
-| XY-1300 | Slice-3 representative E2E, restart, UI, packaging, and clean-startup acceptance. It is not globally blocked by XY-1304. |
-| XY-1304 | Later automatic cross-account same-thread fallback and all-depleted wake aggregate acceptance, followed by a separate reviewed enablement amendment. It is not a prerequisite for Quick Task, Project/Lead, ManagedRun, GPUI, or first Mac dogfood. |
-| XY-1345 | Accepted exact-command authority and isolated PostgreSQL 18 prototype only; no production migration or Rust command path. |
-| XY-1346 | PostgreSQL V9: separate exact receipts plus immutable global RoleProfile bootstrap/update. Starts only after XY-1345 lands. |
-| XY-1337 | Re-bounded RuntimeSession snapshot creation/transition migration, expected V10 after XY-1346. It does not own exact-receipt or RoleProfile redesign. |
-| XY-1343 | PostgreSQL V11 canonical WorkItems, transactional readiness blockers, and immutable Lead acceptance; no run execution or completion. |
-| XY-1338 | PostgreSQL V12 inert waiting ManagedRuns, exact-run Task/Reviewer assignments, exact RuntimeSession revision binding, FK-backed effect lineage, the fail-closed positive/inconclusive safety transaction, and the forward repair that removes illegal RuntimeSession row locks from V3 Turn/History invoker guards while preserving 1271 serialization. No producer, scheduler, acquisition, dispatch, progress, or completion path. |
-| XY-1284 | Accepted two-stage managed-repository authority reset; stage two is finalized by XY-1348 and consumes accepted XY-1354 unchanged. |
-| XY-1347 | One bounded macOS/Git feasibility spike for ordinary repositories and linked worktrees; evidence only, with no production source or schema. |
-| XY-1348 | Accepted mechanism-neutral transition contract and stage-two PostgreSQL/executor authority boundary; no V13 persistence. |
-| XY-1349 | Accepted sole V13 managed-repository PostgreSQL authority migration. |
-| XY-1350 | Read-only allocation evidence plus accepted Git/filesystem executor and readback only; may proceed in parallel against the accepted contract, with no persistence, receipt, saga, provider, or shared composition ownership. |
-| XY-1351 | First shared repository effect saga path, composing preparation, fresh receipt consumption, execution, readback, and terminal reconciliation; no migration, executor-internal, or provider ownership. |
-| XY-1352 | GitHub PR/check effect and reconciliation boundary with explicit provider identities and positive readback; no local repository discovery. |
-| XY-1353 | Serial integration, final authority/OpenWiki alignment, deferred-validation inventory, and exact-candidate freeze; it blocks XY-1285. |
-| XY-1355 | Normative live-routing authority and capability-applicability reset only; no executable implementation or validation. |
-| XY-1356 | Sole V14 migration owner for revisioned complete routing-policy and candidate-set authority. |
-| XY-1357 | One post-freeze natural provider timestamp-precision receipt; no deliberate quota consumption or routing enablement. |
-| XY-1358 | Sole V15 migration owner for causal positive-only Codex experiment authority. |
-| XY-1359 | Sole V16 migration owner plus pure routing kernel and atomic persisted decisions; no dispatch. |
-| XY-1360 | Sole V17 migration owner for same-thread continuation and one atomic Context-Pack/RuntimeSession fallback after V16; no dispatch. |
-| XY-1361 | Historical disabled runtime orchestration over persisted V16/V17 authorities. XY-1402 supersedes its wrapper without enabling dispatch. |
-| XY-1362 | Sole V18 migration owner for the inert `waiting_usage` wake lifecycle, plus its forward-only V19 deterministic time-authority repair; no selection or production scheduler authority. |
-| XY-1363 | Post-freeze retained-title Codex Desktop discovery evidence only. It consumes the exact accepted bounded Git receipt identities from XY-1369 and XY-1370 and uses the accepted V22 one-shot path. |
-| XY-1364 | Frozen-core integration and acceptance for the checked-in V14-V21 ledger, including the forward-only V20 restore canonicalization and V21 RuntimeSession event-reference repair; production routing remains disabled. |
-| XY-1367 | Sole V22 owner for the two-effect retained-title experiment bridge and inert manual Rust runner. It does not execute validation or live effects. |
-| XY-1368 | Historical mechanical, migration, semantic, authority-digest, and production-isolation acceptance for the exact XY-1367 V22 candidate; it is not current command authority. |
-| XY-1369 | Retained no-DDL read-only preflight gate. Its accepted output is one bounded canonical privacy-safe Git record and digest; it creates no private-artifact product Artifact. |
-| XY-1370 | Retained exact-build and bounded-schema attestation gate. Raw schema stays private; its accepted output is one bounded public-safe Git attestation and digest. |
-| XY-1373 | Historical private-artifact specification and moving-core integration work. Its former landing condition is non-executable. Its later cancellation preserves history and relations and does not claim completion. |
-| XY-1398 | Accepted V3 product decision for opaque attested launches, durable fenced provider-process generations, macOS positive-death quarantine, and ProviderAttempt ambiguity handoff; no guardian, takeover, or live dispatch. |
-| XY-1400 | Sole V23 and ProcessSupervisor implementation owner for opaque exact-build launch authority, ProcessGeneration fencing, exact supported-OS identity, account-local quarantine, positive-only death evidence, reconciliation, diagnostics, and exact owned termination. It adds no routing, RuntimeSession, ProviderAttempt, remote auth, UI, release, or live dispatch. |
-| XY-1401 | Sole V24 and ProviderAttemptService implementation owner for generic pre-dispatch consumer binding, exact V16/V17/ProcessGeneration lineage, positive-only evidence, restore projection, reconciliation, and redacted diagnostics. It adds no routing, RuntimeSession creation, consumer-domain mutation, second ledger, UI, release, or live dispatch. |
-| XY-1402 | Sole V25/V26 and stateless ExecutionCoordinator implementation owner for ordinary Conversation/ManagedRun consumer integration, exact cause projection, ProviderAttempt consumption, and drained V12 authority retirement. It adds no durable coordinator, account selection, RuntimeSession ownership, process ownership, provider-effect ownership, remote auth, UI, release, or live dispatch. |
-
-The [XY-1368 retained-title freeze](xy-1368-retained-title-freeze.md) is immutable V22 historical
-evidence. It preserves the historical V14-V21 acceptance and records the V22 receipt and deferred
-work as they existed at that freeze. It is not current command, task-runner, or V1-V23 delivery
-authority. The former private-artifact preparation and delivery contracts are also
-historical and non-executable. The only retained evidence transport is the bounded
-canonical privacy-safe Git contract in the
-[retirement decision](private-artifact/decision.md#smallest-retained-title-evidence-replacement).
-
-### XY-1400 deferred acceptance
-
-The [XY-1400 ProcessGeneration authority](process-generation-authority.md) records the complete
-source-only implementation boundary and deferred adversarial acceptance matrix. Its unified gate
-must cover V23 migration/ACL/catalog closure, S0/R1/R2 manifest refreeze, opaque launch mismatch,
-exact-build startup-state evidence plus absence of a returned protocol writer, future gateway
-alternate-control rejection, fence and crash concurrency, macOS orphan and exit-before-witness
-schedules, generic Linux preflight isolation, Linux parent-death behavior only after an exact
-lifetime profile is accepted, PID/PGID reuse, positive-only death proof, account-local same-boot
-uncertainty, restore rollback safety, exact owned termination, ProviderAttempt ambiguity handoff,
-conversation continuity, and reverse production-isolation evidence. XY-1400 runs none of that
-matrix and enables no provider effect or production dispatch.
-
-### XY-1401 deferred acceptance
-
-The [XY-1401 ProviderAttempt authority](provider-attempt-authority.md) records the source-only
-implementation boundary and deferred adversarial acceptance matrix. Its unified gate must cover
-V24 migration, ACL, and catalog closure; S0/R1/R2 manifest refreeze; both consumer shapes; exact
-V16/V17/RuntimeSession/ProcessGeneration binding; every state edge; positive-only evidence;
-negative-observation rejection; late results; replacement without replay; duplicate-risk
-acknowledgement and concurrency; restore rollback safety; bounded background progress; V12 and
-XY-1402 handoff; and reverse production-isolation evidence. XY-1401 runs none of that matrix and
-enables no provider effect or production dispatch.
-
-### XY-1402 deferred acceptance
-
-The [XY-1402 stateless execution-coordination authority](execution-coordinator-authority.md)
-records the source-only implementation boundary, forward V25 enum expansion and V26 cutover,
-architecture falsifiers, and complete deferred acceptance matrix. The unified gate must cover
-V25/V26 migration, drained and
-cross-linked or ambiguous cutover rejection, S0/R1/R2 manifest refreeze, V12 writer removal, both
-consumer shapes, exact V16 cause projection, independent quota windows and V14-to-V16 aging, V17
-same-thread and atomic fallback paths, live ProcessGeneration fencing, ProviderAttempt binding,
-fresh-capability consumption, and positive-only reconciliation,
-Conversation and ManagedRun owner isolation, Reviewer ambiguity, same-UID transport, and reverse
-production isolation. XY-1402 executes none of that matrix and enables no provider effect or
-production dispatch.
-
-XY-1336 is an upstream-blocked tracking issue outside the M2 critical path. A host file,
-manifest, configuration value, remote catalog entry, process binding, or user declaration
-cannot close the missing account-owned receipt. Existing doctor `unknown(plugin)` is the
-first-release result, and `plugin_unready` remains inert reserved state.
-
-### XY-1356 deferred V14 acceptance inventory
-
-V14 source review precedes executable validation. The frozen integration gate must execute the
-following as one coherent boundary, not as per-command repair loops:
-
-- fresh V1-to-V14 initialization and V13-to-V14 forward upgrade; exact migration ledger,
-  configured-principal ACL, 60-relation, 119-function, and 110-trigger inventories; derivation and
-  binding of the new schema/configured-authority digests; populated dump/restore parity;
-- policy replacement with empty, one-member, and multi-member inventories; every omission,
-  duplicate, foreign member, order gap, account-revision race, accepted-Policy race,
-  RoleProfile race, BuildId mismatch, and same-expected-revision/different-key schedule;
-- evidence publication with the exact eight-capability order and every closed state; account,
-  process, RoleProfile, BuildId, schema-fingerprint, and evidence-revision conflict schedules;
-  explicit rejection of timestamps and causal experiment, plugin, skill, MCP, marketplace,
-  OAuth/login-management, account-configuration, host-file, digest-only, and credential-shaped
-  sources;
-- snapshot resolution under the 1271 -> 1338 -> 1356 coordinator order and fixed SHARE bridge;
-  concurrent account, quota, Policy, RoleProfile, RuntimeSession, ManagedRun, evidence, and
-  inventory writers; resolution-clock capture only after the full lock/recheck set;
-- exact 300-second freshness acceptance and 300-seconds-plus-one-microsecond rejection for
-  account/evidence/quota facts; future facts; negative disabled/auth-failed facts independent of
-  age; exact raw quota timestamp preservation; separate ordered 300/10080 facts;
-- complete policy-order snapshots, one sticky source, exact account/profile snapshot lineage,
-  eight-cell capability matrices, explicit applicability, deterministic blocker arrays, and
-  deferred commit failure for every partial member, quota, matrix, blocker, or evidence child set;
-- byte-identical replay and lost-response recovery for all three operations; same-key changed
-  envelope/operation `DX001`; stable rejection replay after later state changes; rollback at every
-  receipt/domain/child/response boundary; no committed executing receipt;
-- runtime/PUBLIC direct relation, helper, receipt, activity, outbox, trigger, grant, ownership,
-  or DDL denial; EXECUTE only for the three public V14 functions; hostile search path, overload,
-  function-body, trigger-binding, ACL, default-privilege, and extension-dependency substitutions;
-- strict Rust rejection of malformed bytes, unknown/missing/null/defaulted fields, identity
-  duplication/reordering, position gaps, quota-pair or capability-matrix drift, blocker/disposition
-  inconsistency, cross-linked revisions/provenance, and effect-digest mismatch; and proof that V14
-  exposes no account selection, `waiting_usage`, continuation, wake, dispatch, or live enablement.
-
-### XY-1345 exact-command reset gate
-
-XY-1345 owns repository authority and a non-production PostgreSQL 18 proof, not a migration or
-Rust product API. Its accepted boundary is operation-specific, command-complete
-`SECURITY DEFINER` functions; PostgreSQL-built and -consumed typed request envelopes; a separate
-`exact_command_receipts` relation; no runtime receipt-table/private-helper/canonical-audit mutation
-authority; deferred commit closure for executing rows; immutable stored response bytes; and
-separate stable-domain, idempotency-conflict, and retryable-infrastructure outcomes. It changes no
-legacy `command_receipts` semantic.
-
-The isolated proof must pass all deterministic schedules for same-key waiting/replay, changed
-envelope and cross-operation conflict, rollback at receipt/domain/activity/outbox boundaries,
-precommit connection loss, postcommit lost result, stable rejection replay, deferred incomplete
-commit rejection, runtime receipt and canonical-audit denial, `READ COMMITTED`/`REPEATABLE
-READ`/`SERIALIZABLE`, opposite-order deadlock and whole-transaction retry, explicit nulls, exact
-text variants, typed numeric convergence, fixed scalar bootstrap groups, returned-row effect
-binding, catalog closure, and populated dump/restore. It must then pass 50 repetitions each of
-32-way identical and mixed-envelope concurrency with zero duplicate domain effects, duplicate
-activity/outbox pairs, response mismatches, committed executing rows, authority bypasses,
-unexplained rows, or unclassified SQLSTATEs. The durable receipt is
-[XY-1345 exact-command evidence](../evidence/xy-1345-exact-command-authority.md).
-
-Any anomaly falsifies the architecture and stops V9. A passing prototype permits only this serial
-order:
-
-```text
-XY-1345 authority/prototype and fresh exact-candidate review
--> XY-1346 V9 exact receipts plus RoleProfile bootstrap/update
--> XY-1337 V10 RuntimeSession snapshots, creation, and transition
-```
-
-V9 must re-prove the complete security-definer catalog/ACL/default-privilege/search-path/dependency
-closure, canonical audit namespace closure, clean V1-to-V9 bootstrap, V8-to-V9 upgrade, hostile SQL,
-crash/concurrency, and populated restore against the production migration. Candidate 3 SQL and Rust
-command code are superseded and cannot be transplanted; its valid invariants and hostile-test ideas
-remain provenance only.
-
-V10 must preserve the accepted V9 exact receipt and global RoleProfile contracts while adding only
-the two command-complete RuntimeSession entrypoints and their private builders/rejection helper.
-Acceptance requires zero-state V9-to-V10 fencing, clean V1-to-V10 bootstrap, exact creation and
-transition substitution conflicts, byte-identical success and stable-rejection replay, coherent
-old-or-new profile race binding, immutable account/profile history, direct-DML/helper/audit-namespace
-hostility, receipt/domain/activity/outbox/response rollback boundaries, whole-transaction retry,
-blocked-old-writer cutover, crash/restart convergence, concurrency, and populated dump/restore.
-These expensive PostgreSQL 18 gates run once against the frozen serial
-XY-1345 -> XY-1346 -> XY-1337 candidate; implementation work does not start a live database.
-
-### XY-1284 managed-repository authority gate
-
-Stage two is accepted. PostgreSQL owns durable projection, generation/tip, global
-complete-descriptor operation assignment, append-only evidence, exact compare-and-swap,
-atomic command completeness, and restart loads. Pure deciders/facts are mechanism-neutral
-and non-authoritative. Complete canonical equality yields
-`ExistingExact(OperationView, NoDispatch)`; any difference yields permanent
-`OperationIdConflict`. Only a same-control-path successful COMMIT acknowledgement may
-mint one fresh affine receipt. Unknown COMMIT outcome, persistence, repeat, readback,
-restart, and terminal state provide no receipt and authorize no external execution.
-
-Allocate and its evidence are strictly read-only outside PostgreSQL. `Register`,
-`WorktreeReady`, and `Commit` are distinct durably fenced `PossiblyEffected` operations with
-operation-specific positive readback and readback-only restart. They permit no retry,
-replay, adoption, repair, or import. `Register` requires exact reciprocal registration,
-`WorktreeReady` keeps the head unchanged, and `Commit` advances exact `H` to exact `H-prime`
-once. Authorized whole-cluster restore may redefine authority inside the trusted
-PostgreSQL-administrator boundary; V1 does not automatically detect it. The trusted
-single-daemon/same-UID boundary and accepted XY-1354 descriptor-assisted symlink-free
-absolute-path reacquisition plus pinned Git 2.54 remain unchanged.
-
-The replacement ownership and dependency graph is:
-
-```text
-XY-1284 accepted reset
-├── XY-1347 bounded macOS/Git feasibility ─┐
-└── XY-1348 pure transition/executor core ─┴─> stage-two authority
-                                               ├──> XY-1349 sole V13 persistence ─┐
-                                               └──> XY-1350 allocator/executor ───┤
-XY-1349 + XY-1350 ────────────────────────────────> XY-1351 effect saga/validation ─┤
-XY-1348 + XY-1349 ────────────────────────────────> XY-1352 GitHub reconciliation ──┤
-XY-1349 + XY-1350 + XY-1351 + XY-1352 ──────────> XY-1353 integration/freeze
-XY-1353 ─────────────────────────────────────────> XY-1285
-```
-
-The migration ledger is a singleton serial-writer domain. XY-1349's V13 is accepted on
-`main`. The checked-in order continues through XY-1356/V14 durable routing-policy authority,
-XY-1358/V15 causal experiment authority, XY-1359/V16 atomic routing decisions, and
-XY-1360/V17 continuation authority. XY-1362 owns the V18 inert `waiting_usage` wake lifecycle;
-V19 is its forward-only deterministic time-authority repair. XY-1364 frozen-core acceptance
-incorporates the forward-only V20 restore canonicalization and V21 RuntimeSession event-reference
-repair. XY-1367 adds only forward V22. XY-1368 owns its frozen acceptance. These versions are
-allocated in source. A later owner may allocate another migration only
-when then-current source inspection proves that additional durable state is required. XY-1350 and
-the remaining managed-repository children retain their accepted non-routing ownership.
-
-No managed-repository implementation executes validation before the integration tree is
-frozen. One complete unified validation runs once on that exact frozen tree. Its concise
-evidence categories are pure semantics; PostgreSQL authority, concurrency, restore, and
-retention; accepted Git/filesystem execution and operation-specific readback; the first
-shared saga; provider and repository integration; and final digest/manifest agreement.
-No partial run, detailed early matrix, or result from another tree is acceptance evidence.
-
-#### XY-1353 deferred acceptance matrix
-
-The Manager runs this matrix once against the exact frozen candidate. Every receipt must bind the
-candidate HEAD and tree; no result from an owner branch or earlier integration tree is reusable.
-
-| Boundary | Deferred acceptance cases |
-| --- | --- |
-| Integration and regression | Exact XY-1349/XY-1350/XY-1351/XY-1352 stack ancestry and exports; one runtime composition; no duplicate migration, executor, saga, provider, receipt, or authority owner; rejected candidate trees remain absent. |
-| Pure protocol and schema | Canonical admission/allocation/operation descriptors; global operation-ID conflict and exact-repeat/no-dispatch behavior; Register/WorktreeReady/Commit evidence-kind separation; protocol clients remain isolated from PostgreSQL, filesystem, and provider authority. |
-| PostgreSQL authority | Fresh V13 migration and rollback; exact ledger order; runtime ACL/function/trigger/catalog closure; compare-and-swap, immutable evidence, receipt provenance, retention, concurrency, populated dump/restore, and schema/authority digest agreement. |
-| Local repository effects | Ordinary and linked repositories; pinned executable/config/environment authority; read-only allocation acquisition; reciprocal registration; unchanged ready head; exact one-head commit advance; dirty, stale, foreign, replaced, symlinked, occupied, rollback, lost-response, and ambiguous readback. |
-| Saga and restart faults | COMMIT acknowledgement loss; receipt consumption at every dispatch boundary; dispatch serialization race; crash before/during/after effect and reconciliation; bounded restart enumeration; readback-only recovery; no receipt reconstruction, replay, adoption, repair, or duplicate effect. |
-| Restart backlog bound | Zero, below-limit, exact-256, and over-limit eligible restart backlogs; pending work after reconciliation; the one-item residual probe must distinguish exhaustion from residual work and prevent repository readiness without an unbounded loop. |
-| Startup failure observability | Missing/replaced pinned Git executable, executor integrity failure, incompatible restart row, and readback/store failure; typed bootstrap readiness, `ServerRepositories` doctor status, and product-state availability must all fail closed while retaining the startup failure classification. |
-| Validation supervision | Exact source fingerprint before/after; success, nonzero exit, signal, timeout, cancellation, output limits, drain bounds, descendant teardown, spawn/capture failure, and concurrent protected-worktree mutation. Same-UID hostile-code confinement is not claimed. |
-| GitHub effects | Explicit provider/repository/head/base/marker identities; create/update duplicates; lost mutation response; complete multi-page scans; cursor/snapshot/page drift; absent, stale, externally changed, ambiguous, and provider-fault outcomes; required check-run completeness; no CWD/local-Git inference or live mutation without later provider authority. |
-| End to end | PostgreSQL admission and allocation through Register, WorktreeReady, Commit, supervised validation, sealed GitHub reconciliation, daemon restart, and authoritative readback on one exact fixture; every failure remains unavailable, pending, or ambiguous rather than successful or replayable. |
-| Frozen artifacts | One final migration inventory, configured-authority inventory, class-specific semantic schema manifest, explicit database-binding evidence, separate mutable sequence-state receipt, expected digests, and source/tree binding produced by the canonical unified PostgreSQL gate; collect source, relevant post-command, RoleProfile-restored, and final primary-restored checkpoints, compare every expected/actual digest and row delta in the same invocation, run the existing production restore checks, and preserve restore parity without catalog OIDs or presentation text entering cross-database identity. |
-
-There is no separate checked-in XY-1353 manifest/digest generator. The existing canonical
-PostgreSQL harness produces and verifies those inventories only as part of the unified frozen-tree
-gate, so source-freeze work must not invent a second generator or execute the harness early.
-When the canonical semantic identity or closure model changes, final acceptance uses two exact
-phases. Phase A first proves dependency closure plus S0→R1→R2 source/restore parity and emits an
-immutable candidate receipt whose mismatch array is the exact canonical subset of schema then
-configured authority: zero, either singleton, or both. Phase B runs from the same clean HEAD/tree
-when that array is empty; otherwise it runs from one clean direct child that changes exactly the
-reported digest array or arrays and nothing else. Phase B verifies both source bindings, the
-candidate hash, clean state, mismatch order, and exact transition shape before repeating the full
-capture and emitting a fresh acceptance receipt explicitly bound to Phase A. A derivation or older
-receipt remains provenance only; malformed, substituted, duplicate, or out-of-binding evidence
-cannot attest the Phase B source.
-
-The bounded restore prerequisite has one separate R1-only replacement gate:
-`--capture-authority-restore-prerequisite-v2 ABSOLUTE_PRIVATE_RECEIPT_PATH`. The v1 spelling has no
-alias. The Manager authorizes one invocation on one exact clean HEAD and tree. This gate is not
-focused mode, Phase A, Phase B, or the aggregate. It creates S0 through the unchanged authority
-setup, migrates, provisions, populates, and runs the full Rust semantic owner once. It dumps once.
-A closed PostgreSQL 18 TOC parser then requires exactly one active `pgcrypto` extension declaration
-before R1 exists. The shared future R1/R2 restore helper creates fresh R1 from `template0`, proves
-that `pgcrypto` is absent, precreates version 1.4 in `public` as the migration role, and restores
-once as bootstrap with `--exit-on-error`. No migration or provisioning follows restore. The full
-semantic owner runs once at R1, and the gate stops.
-
-One privacy-safe state owner covers the exact ordered execution inventory from `cli` through
-`stopped_after_restored_once`. It also owns the separate `cluster_stop`, `private_work_cleanup`,
-`cleanup_finalization`, `receipt_validation`, `receipt_source_binding`, and `receipt_publication`
-lifecycle checkpoints. Completed execution checkpoints must be a successful prefix. Actual
-lifecycle state derives the exact required cleanup-owner sequence. `cluster_stop` is required only
-when cluster stop is applicable. `private_work_cleanup` is required only when private work exists.
-Each required owner is pending, active, or completed, and `cleanup_finalization` is an explicit
-fail-closed transition.
-
-The definition binds the complete checkpoint order, exact allowed checkpoint and reason matrix,
-cleanup-owner sequences, owner-state transitions, finalization proof, prefix rules, first-primary
-and cleanup precedence, pass schema, fixed failure-document fallback, PostgreSQL 18 toolchain
-boundary, restore identity and options, and semantic definition fingerprint. Expected cleanup
-operation failure uses `cleanup_failed`. Interruption uses `interrupted`. An unexpected assertion,
-type, key, or invariant failure uses `harness_corruption` at the active or pending owner. The first
-primary failure is immutable. Cleanup becomes primary only when no execution primary exists. An
-execution primary retains only the fixed secondary `cleanup_failed` reason. Cleanup can pass only
-when every required owner and finalization completed. Receipt validation, final source binding,
-cleanup, and publication cannot replace an earlier primary.
-
-The pass receipt schema is `decodex/postgres-restore-prerequisite-r1-gate/2`. It binds the clean
-source, selected PostgreSQL 18 toolchain, complete validated checkpoint prefix, fixed
-invocation-policy Booleans, and definition fingerprint
-`53bb20b8e43a6199c3aa578269cee8b941ed549fd8f10db0dce361a03016524a`. It also proves the exact
-required and completed cleanup-owner sequences and completed cleanup finalization. It is create-only,
-mode 0600, file-fsynced, directory-fsynced, privacy-safe, and has `acceptance=false`.
-The bound definition schema is `decodex/postgres-restore-prerequisite-r1-definition/2`.
-
-The failure schema is `decodex/postgres-restore-prerequisite-r1-diagnostic/2`. It contains only the
-validated source binding or null, immutable primary checkpoint and reason, validated completed
-prefix, exact required and completed cleanup-owner sequences, completed finalization, fixed cleanup
-status, optional fixed secondary cleanup reason, fixed failure-document repair state, and the
-existing closed semantic diagnostic when semantic authority owns the primary. It contains no raw
-operational or authority data. Failure-document construction and repair belong to
-`receipt_validation`. Incomplete or corrupt cleanup state becomes one fixed privacy-safe repaired
-diagnostic without replacing a valid earlier primary. If the output contract is valid and
-publication remains possible, the gate publishes one create-only failure receipt after cleanup. It
-writes the same canonical diagnostic to standard error for publication-failure recovery. A fixed
-`receipt_validation/harness_corruption` fallback remains available if normal construction or
-durable publication fails. The raw-error `StageOrchestrator` is outside this privacy boundary.
-
-The v1 gate ran once and returned ownerless `gate/stage_failed` evidence after 0.312 seconds. It did
-not prove that candidate 3 reached the archive guard, prerequisite, restore, or R1 semantic owner.
-Candidate 3 restore behavior remains frozen and unadjudicated. The three-rejected-candidate
-threshold is not crossed unless a source-bound v2 result exercises and rejects candidate 3. A v2
-pass authorizes only a later decision about revised Phase A. It does not authorize R2, digest
-derivation, candidate publication, Phase B, the aggregate, or final acceptance. The v2 source is
-unexecuted and no acceptance claim exists.
-
-The unified PostgreSQL aggregate is scheduled by one explicit top-level stage graph. Fatal
-configuration/cluster preflight covers mode and arguments, clean source binding, private
-temporary-root setup, PostgreSQL tool discovery, cluster init/start, and base-role creation. Phase
-A/B output and receipt-lineage validation remains direct and outside this graph. Every
-meaningful semantic suite has `passed`, `failed`, or `blocked` state. Expected `TestFailure` blocks
-only declared consumers and leaves independent branches schedulable; dependency consumers never
-run after failure. Required nested restore work is part of its owning suite's outcome: a failed or
-unavailable capture, restore, parity check, or production check prevents owner success and blocks
-its consumers. A private live-doctor mutation SQL executor alone owns ordinary, role-as, and
-secret-bearing mutation process spawn, dispatch/completion facts, output handling, and cleanup; the
-coordinator owns doctor readiness and the doctor child. Every mutation and doctor child receives
-bounded terminate, kill-fallback, and reap attempts across every exit; an unreaped or indeterminate
-child is harness corruption. Mutation probes and restorations are separate stages. Failed ordinary
-`Popen` and secret prelude failure are pre-dispatch and block restoration. Successful ordinary
-`Popen` owns the SQL payload in argv and makes delivery possible. A secret mutation becomes
-may-have-dispatched immediately before its first mutation-frame payload write. Every later write,
-flush, timeout, protocol, nonzero-exit, lost-acknowledgement, semantic, or cleanup failure remains
-restoration-eligible. Successful exit records command acknowledgement only, not exact server
-receipt or a non-vacuous catalog mutation; optional postcondition probes remain separate evidence.
-The scheduler consumes exactly one restoration claim from each shared-fixture attempt. An eligible
-failed probe still attempts restoration, and failed restoration blocks all subsequent shared-fixture
-probes and final evidence.
-Unexpected assertion/key/type failures, corrupt stage/report state, source-binding failure,
-redaction failure, or another unexpected exception stops new work as harness corruption. After a
-private directory is created, its outer cleanup owner covers every later exit and attempts direct
-removal if cluster start was never attempted, reporting removal failure without replacing an
-earlier primary. After a cluster starts, teardown and final report
-emission still run. Aggregate output/report failures are primary only when no earlier failure was
-selected; otherwise cleanup and emission failures are recorded as secondary. Only the normal
-aggregate emits `decodex/postgres-aggregate-stage-report/1`; focused and Phase A/B modes retain
-their direct output and receipt behavior.
-
-Falsifiers are evaluated in this fixed priority order: architecture, then
-stability/recoverability, security/authority, verification, integrity, and performance.
-An earlier class cannot be traded away for a later-class success.
-
-- **Architecture:** falsified if ordinary and linked repositories cannot preserve one
-  explicitly admitted authority without implicit mutable-path rediscovery; if the pure
-  contract cannot keep admission, allocation, mutable head, and effect authority
-  distinct; or if correctness requires another repository-effect owner beside
-  `decodexd`.
-- **Stability/recoverability:** falsified if restart or any `allocated`, `registered`,
-  `ready`, `PossiblyEffected`, or completion crash boundary cannot be read back without
-  retry, replay, adoption, repair, or import; or if unchanged-head worktree
-  readiness and exact-once commit head advancement cannot both be represented and
-  recovered.
-- **Security/authority:** falsified if stale, foreign, symlinked, replaced, dirty, or
-  ambiguous state can authorize an effect; if repository-controlled executable behavior
-  or path-bearing output cannot be disabled or exactly allowlisted; or if any supported
-  operation depends on CWD, ambient config, or implicit repository discovery. Same-UID
-  hostile-code confinement is explicitly not a V1 claim.
-- **Verification:** falsified if the unified frozen-tree evidence cannot distinguish
-  accepted completion from stale, duplicate, rollback, lost-response, or ambiguous
-  outcomes.
-- **Integrity:** falsified if a durable reservation can be bypassed, identity/revision
-  binding can drift, mutation can escape supervised detection, or positive external
-  readback cannot reconcile a possibly completed effect without duplication.
-- **Performance:** falsified only after the mechanism is otherwise acceptable if bounded
-  allocation, Git execution, recovery, or validation cannot meet the later explicit host
-  budgets without weakening an earlier guarantee.
-
-Rejected candidate trees `6e20e9b3cf1415cce9b399da173b0410cc4c80dc`,
-`6979e3831da772fca3fe0f0e0b4699df642d3a65`, and
-`e42212add13af3f702e0ec8966ce3d6a7b682d12` are superseded evidence, not current
-authority or compatibility/history migration inputs. Hostile same-UID or multi-tenant
-operation remains a separate future UID/sandbox feasibility and authority problem, not a
-stage-two residual or V1 promise.
-
-### GPUI foundation and usable destinations
-
-XY-1263 landed in PR #1109. Its reviewed candidate
-`de6d028405159a79f1c30a4eeebdae47481e6f25` had `NO_BLOCKING_FINDINGS`; merge commit
-`d85a808a88af96d50fb4471deb00d13f4301b07d` retains it as the second parent. The
-exact-PID cold-launch Accessibility result remains accepted only for the isolated GPUI
-foundation.
-
-Current source opens a real GPUI application shell and window. It is not print-and-exit.
-Health is the only bounded live destination. Every other destination remains a
-placeholder. The Quick Task and WorkItem contracts do not make their shell destinations
-live. GPUI is not generally usable. Remaining Slice 1 UI work is Accounts and
-Conversation. Slice 2 must make Project, Work, and Run
-usable. Slice 3 owns the exact Mac package gate. The former P/K/L/S component sequence
-and rejected combined XY-1269 candidate are historical planning provenance, not current
-delivery gates. Marked-text/IME, signing/notarization, VoiceOver, large-history rendering,
-graph behavior, and presented-frame evidence remain with their applicable later gates.
-
-### XY-1315 candidate-4 identity-ingress authority
-
-Candidate 3 remains frozen. Candidate 4 may start only after this amendment lands and the
-existing owner moves to the new base. The Project/Agent slice remains atomic and is
-limited to exactly the previously frozen candidate-3 twelve-path envelope below:
-
-```text
-crates/decodex-core/src/lib.rs
-crates/decodex-postgres/src/authority.rs
-crates/decodex-postgres/src/lib.rs
-crates/decodex-postgres/src/migrations.rs
-crates/decodex-postgres/src/types.rs
-crates/decodex-postgres/tests/postgres_store.rs
-scripts/vnext/postgres_store_test.py
-tests/scripts/test_vnext_architecture.py
-crates/decodex-core/src/agent.rs
-crates/decodex-core/src/project.rs
-crates/decodex-postgres/migrations/V5__project_agent_authority.sql
-crates/decodex-postgres/src/project_agents.rs
-```
-
-Candidate 4 may modify only this set. Any path-envelope change stops for scope review.
-The candidate requires bounded delta tests, the retained aggregate PostgreSQL harness,
-canonical validation, and a fresh exact-candidate review.
-
-The candidate-4 boundary is:
-
-1. One schema-qualified ingress-only checked text domain,
-   `decodex.canonical_uuid_v4_text`, owns exact lowercase hyphenated UUID-v4 boundary
-   spelling. It is not durable identity storage.
-2. The closed `pg_proc` inventory contains only these three externally executable
-   identity-bearing mutator signatures:
-
-   ```text
-   decodex.bootstrap_advisor(decodex.canonical_uuid_v4_text)
-   decodex.create_project(decodex.canonical_uuid_v4_text,pg_catalog.text,pg_catalog.text,pg_catalog.text,pg_catalog.jsonb,decodex.canonical_uuid_v4_text)
-   decodex.transition_project(decodex.canonical_uuid_v4_text,pg_catalog.int8,decodex.project_status)
-   ```
-
-   No `pg_catalog.text`, `pg_catalog.uuid`, polymorphic, or other identity-mutator
-   overload exists. Exact-domain, unknown-literal, explicit-`pg_catalog.text`, and
-   prepared/bound-`pg_catalog.text` expressions may resolve to these signatures. Every
-   non-null form must pass `canonical_uuid_v4_text_exact` before function execution.
-3. The domain is not universal NULL authority. Every mutator remains `CALLED ON NULL
-   INPUT` and rejects every null identity parameter in its first executable statement,
-   before casts, locks, reads, or writes. Every such rejection uses exactly SQLSTATE
-   `23514`, constraint name `canonical_uuid_v4_text_ingress`, and the fixed input-free
-   message `identity ingress requires canonical UUID-v4 text`. These literals are shared
-   by every identity mutator; parameter names and values never enter the error.
-4. Validated domain text converts locally to UUID. UUID table columns retain durable
-   semantic version/variant checks, PK/FK, uniqueness, lifecycle, revision, and restore
-   authority.
-5. Rust continues to bind the original typed ID string as wire text and spells every
-   identity argument `$n::pg_catalog.text::decodex.canonical_uuid_v4_text`; it never
-   binds a domain OID.
-6. Explicit caller normalization through
-   `uuid::text::decodex.canonical_uuid_v4_text` remains accepted. Lexical authority
-   begins after that explicit normalization, at the resulting domain text value;
-   discarded pre-boundary spelling is outside the contract. Under the attested catalog,
-   a bare `pg_catalog.uuid` expression must not resolve to a domain-bearing mutator and
-   returns SQLSTATE `42883`.
-7. Runtime retains SELECT-only Project/Agent table access and no direct DML.
-8. Readiness and every live revalidation reject any direct implicit
-   `pg_catalog.uuid` -> `pg_catalog.text` cast. That cast audit is not standalone
-   authority: the same pass retains the closed `pg_proc` inventory, schema ownership and
-   CREATE restrictions, extension/dependency checks, qualified calls and fixed
-   function-local search paths, domain/type ACLs, PUBLIC/default-privilege closure, the
-   exact runtime EXECUTE allowlist below, SELECT-only Project/Agent table access, and no
-   runtime Project/Agent DML.
-
-   At `ba09238b189da12ad60c2a6a3e10c0c60d1c5c52`, current-state audit evidence shows
-   the legacy runtime identity can execute 33 canonical signatures: the 15 required
-   non-trigger routines below plus 18 trigger-only routines. The nineteenth trigger-only
-   routine, `decodex.capture_history_item_version()`, is already non-executable. That
-   effective 33-signature set is evidence of legacy overgrant, not the target allowlist.
-
-   Candidate 4's target runtime EXECUTE allowlist contains exactly these 15 existing
-   non-trigger signatures required by current persistence behavior:
-
-   ```text
-   decodex.is_canonical_media_type(pg_catalog.text)
-   decodex.is_history_metadata_projection(pg_catalog.jsonb)
-   decodex.normalize_unicode_whitespace(pg_catalog.text)
-   decodex.ascii_lower(pg_catalog.text)
-   decodex.has_credential_material(pg_catalog.text)
-   decodex.has_credential_material(pg_catalog.jsonb)
-   decodex.is_meaningful_evidence(pg_catalog.jsonb)
-   decodex.rfc3339_utc(pg_catalog.timestamptz)
-   decodex.is_valid_operation_duration(pg_catalog.interval)
-   decodex.lease_ttl_milliseconds(pg_catalog.interval)
-   decodex.try_acquire_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.interval)
-   decodex.renew_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid,pg_catalog.interval)
-   decodex.release_lease(pg_catalog.text,pg_catalog.uuid,pg_catalog.uuid)
-   decodex.prune_history_snapshots()
-   decodex.issue_history_cursor(pg_catalog.uuid,pg_catalog.uuid,pg_catalog.int4)
-   ```
-
-   Candidate 4 adds its exact identity-mutator signatures as the additional nested
-   domain-only subset. It revokes runtime and PUBLIC EXECUTE from all 19 trigger-only
-   routines:
-
-   ```text
-   decodex.enforce_lease_operation_time()
-   decodex.enforce_outbox_operation_time()
-   decodex.forbid_mutation_of_activity()
-   decodex.enforce_outbox_terminal_retention()
-   decodex.forbid_outbox_truncate()
-   decodex.enforce_command_receipt_state()
-   decodex.acquire_hierarchy_coordinator()
-   decodex.canonicalize_created_at()
-   decodex.enforce_blob_object_state()
-   decodex.enforce_conversation_state()
-   decodex.enforce_runtime_session_state()
-   decodex.enforce_turn_state()
-   decodex.enforce_history_item_state()
-   decodex.capture_history_item_version()
-   decodex.enforce_artifact_state()
-   decodex.enforce_artifact_revision_state()
-   decodex.enforce_context_pack_state()
-   decodex.enforce_context_pack_source_state()
-   decodex.enforce_history_cursor_state()
-   ```
-
-   Broad `GRANT EXECUTE ON ALL FUNCTIONS` is prohibited. Rebase-time audit must preserve
-   the distinction between observed legacy grants and the required target authority.
-9. The migration revokes PUBLIC privileges on every existing protected routine and
-   type/domain. The migration owner also establishes global owner default-privilege
-   revocations for PUBLIC EXECUTE on future routines and PUBLIC USAGE on future types,
-   then applies only the exact required grants.
-10. The canonical schema manifest/digest, tamper checks, and populated logical restore
-    attest the domain base type, collation dependency, validated constraints,
-    `typnotnull`, owner, type ACL, function signatures/source/settings/ACL/dependencies,
-    relevant owner/default ACLs, exact runtime grants, and the exact NULL-rejection
-    constraint-name and message literals.
-11. SECURITY DEFINER relations and types are schema-qualified, the owner is unreachable,
-    and function settings are attested under a hostile search path. Null guards and
-    conversion precede advisory locks; Project writes precede Lead writes; propagated
-    exceptions preserve atomic rollback.
-12. Candidate 4 preserves the resolved credential/privacy, split-identity, concurrency,
-    dot/C0/DEL/C1 path, lifecycle, restart, collation, tamper, digest, rollback, and
-    populated-restore obligations.
-
-Candidate 4's ingress suite uses separately named cases for exact-domain,
-unknown-literal, explicit-text, prepared/bound-text, invalid-text, null, bare-UUID, and
-explicit-`uuid::text::decodex.canonical_uuid_v4_text` expressions. Every case carries
-its exact SQL expression in the assertion/report so text and UUID outcomes cannot be
-grouped or falsely attributed.
-
-These requirements are one authority boundary. A domain check does not replace durable
-UUID constraints, explicit NULL guards, function- and default-privilege closure, or
-logical-restore attestation.
-
-### Post-V4 authority order and writer map
-
-This amendment is based on landed `main` at
-`2f5e637a2c65ee88c1946df22d5c3649f664f467`. That tree contains the XY-1273
-`V4__account_readiness.sql` migration and no later migration. An unlanded migration
-name or number is not a reservation. Rebase each schema owner onto the then-current
-ledger and allocate its migration version only in the exact candidate that is ready to
-land.
-
-Repository decisions, specifications, migrations, source contracts, and tests are the
-normative authority. Linear issue descriptions and relations are executable planning
-metadata and must be kept aligned with that authority; they cannot amend it. The
-post-V4 serial schema and semantic order is:
-
-1. landed XY-1273/V4 account readiness and immutable runner binding;
-2. XY-1315 inert canonical Project and Agent identity, including one global Advisor
-   identity and one canonical Lead identity per active Project, without live
-   Conversation or Codex behavior;
-3. XY-1316 minimal Project-owned, versioned Policy identity and immutable accepted
-   revisions, without effective policy application;
-4. repaired XY-1281 Program and finite Objective persistence, importing the canonical
-   Project, Agent, and exact Policy revision authorities; and
-5. XY-1282 WorkItem identity and persistence plus its normalized, project-scoped
-   Objective-WorkItem association.
-
-Project, Agent, and Policy identity therefore precede Program persistence. WorkItem,
-not Program or Objective, owns the normalized association. Both sides must be
-foreign-key backed, must resolve to the same Project, and must reject cross-Project
-links. A `uuid[]`, JSON array, unconstrained UUID, placeholder identity, or equivalent
-denormalized shortcut is not authorized.
-
-XY-1281 owns the forward-only V7 schema after canonical V5 Project/Agent and V6 Policy.
-V7 contains no WorkItem identity or denormalized WorkItem relation. Program mutations
-verify the same active Project and canonical active Lead plus the exact accepted Policy
-revision. Objective achievement is not a bare lifecycle update: one immutable, exact
-prior-revision acceptance-and-validation record and the achieved revision are committed
-coherently. This evidence is Objective outcome authority only. Every new command reserves,
-mutates or records a typed deterministic rejection, appends activity/outbox when changed,
-and completes its exact response receipt in one transaction, so rollback cannot expose a
-pending receipt and exact retry/reopen returns the same typed result.
-ManagedRun may reach successful terminal completion only from explicit authoritative
-WorkItem acceptance and validation. Objective achievement or evidence and any external
-Codex Goal state cannot establish WorkItem acceptance or ManagedRun success; XY-1282 and
-later managed-execution owners must implement that positive authority.
-Mutation receipt scope comes only from the canonical Project ID in the request; a missing
-aggregate never substitutes an invented scope, and PostgreSQL independently compares that
-request scope with stored authority before mutation. Concurrent commands for one absent
-Program, Objective, or Objective evidence identity converge without leaking a uniqueness
-error: every command completes and replays while only the inserting command emits activity.
-Achievement chronology is anchored to the exact prior Objective revision `updated_at`, and
-all persisted Program/Objective timestamps share the closed `ProgramTimestamp` range.
-
-The executable dependency edges that mirror this order are XY-1273 -> XY-1314;
-XY-1314 -> XY-1315, XY-1317, and XY-1318; XY-1315 -> XY-1316; XY-1315 and XY-1316 ->
-XY-1281; the additional direct edge XY-1273 -> XY-1281; and XY-1315, XY-1316, and
-XY-1281 -> XY-1282. The direct XY-1273 block is recorded independently rather than
-treated as transitively satisfied through XY-1314. The repository order governs if
-planning metadata drifts. No fixed Domain Agent hierarchy is part of this order:
-additional agents remain a later policy/workload decision.
-
-#### Conflict domains and integration order
-
-PostgreSQL migrations, the embedded migration inventory, schema/authority digest,
-aggregate PostgreSQL test harness, and migration evidence are one non-commutative
-writer domain. Exactly one schema owner may be active: XY-1315, then XY-1316, then the
-repaired XY-1281 persistence slice, then the XY-1282 WorkItem/relation persistence
-slice. Pure application work may run beside that lane only when it does not edit or
-claim those surfaces.
-
-XY-1317's intended conflict domain is the Codex exact-ID/list/read/archive contract.
-On this landed tree, however, typed thread identity/projections are in
-`crates/decodex-codex/src/protocol.rs`, while request execution and the only scripted
-fake app-server fixture are in
-`crates/decodex-runtime/src/account_launch/process.rs`,
-`crates/decodex-runtime/src/account_launch/protocol.rs`, and
-`crates/decodex-runtime/tests/fixtures/fake_app_server.py`. Its current
-"Codex-adapter-only" brief does not authorize that runtime-owned production and fixture
-surface. XY-1317 is therefore not dispatch-ready until its planning metadata is
-rebriefed to name the runtime transport/fixture ownership or the acceptance contract is
-split so the adapter-only candidate is independently testable. Do not duplicate the
-fake server under `decodex-codex` to evade this boundary.
-
-XY-1318 owns only pure, side-effect-free quota value and decision contracts in
-`decodex-core`. It does not own PostgreSQL quota rows, exclusion receipts, app-server
-rate-limit decoding, account assignment, scheduling, wakeup, continuation, or any
-live-routing entry point. The existing
-`openwiki/evidence/fixtures/xy-1262-quota-matrix.json` is read-only accepted input for
-its tests, not a child-owned evidence file.
-
-### XY-1274 exact persistence and zero-state migration gate
-
-XY-1274 is the serial PostgreSQL storage, migration, receipt, activity, outbox, restore, and
-application-adapter owner for quota observations and inert exclusions. Its next implementation is
-candidate 1 of the materially redesigned exact-microsecond/zero-state boundary. It is not a fourth
-repair of the three rejected rounding/populated-conversion candidates preserved in
-[the runtime proof](../evidence/vnext-codex-runtime-proof.md).
-
-The implementation gate must prove all of the following on one exact candidate:
-
-- storage accepts only `QuotaTimestampMicros(i64)` in
-  `0..=253402300799999999`; raw RFC3339 offsets normalize to equivalent UTC integers, while
-  sub-microsecond, pre-Unix, post-year-9999, infinity, overflow/carry, leap-second, and unsupported
-  values fail before receipt reservation, with no rounding or truncation path;
-- checked integer-microsecond freshness accepts exactly 300 seconds and rejects 300 seconds plus
-  one microsecond, including overflow boundaries;
-- `decodex/quota-window-mutation/2` and `decodex/quota-exclusion-mutation/2` golden vectors use
-  typed logical values, integer timestamps, recursively sorted object keys, preserved array/scalar
-  distinctions, one serialized byte sequence, SHA-256 plus byte length, and exact completed-response
-  replay without requiring full request-document retention;
-- V8 takes `ACCESS EXCLUSIVE` locks on `command_receipts`, `quota_windows`, `activity`, and
-  `outbox` in canonical writer order before one transaction structurally rejects every pre-V8 quota
-  row; every `mutate_quota_window`/`quota_windows` receipt regardless of state; activity classified
-  by aggregate kind, event kind, or structured payload; outbox classified by aggregate fields or a
-  structured activity envelope; every outbox link to classified activity; and every malformed or
-  orphaned combination;
-- no correlation-key or aggregate-ID pattern substitutes for structural classification, and no
-  concurrent V7 writer can enter between the assertion and DDL;
-- the proven-empty `quota_windows` table is altered in place, preserving table identity, ACLs,
-  account foreign key, unchanged observation-index identity, and migration atomicity; the exact
-  PostgreSQL 18 authority/schema manifest and digest are regenerated by the later implementation;
-- empty V7 migrates, any classified pre-V8 state fails atomically with a stable incompatibility
-  result, and whole disposable-database recreation succeeds; no conversion, quarantine, hand
-  deletion, retention bypass, table drop/recreation, dual schema, or fallback is accepted; and
-- monotonicity, idempotency, exact replay, crash, retry, concurrency, dump/restore, credential
-  rejection, separate 300/10080 facts, and inertness pass without creating assignment, fallback,
-  scheduling, wakeup, continuation, external-effect replay, or live-dispatch consumers.
-
-XY-1302 alone owns the final whole-ledger squash/reset, production baseline, privilege
-provisioning, database-recreation runbook, cutover/rollback readback, and proof that no pre-release
-database becomes production state. Those operations are not XY-1274 acceptance work.
-
-The landed-tree path-and-contract ownership map for the post-amendment wave is below.
-Every concrete path named in it exists at the pinned snapshot. The map intentionally
-does not choose filenames for future Project, Agent, quota, PostgreSQL, or evidence
-modules. Each active child must re-derive and freeze its exact additions from the then-
-landed tree before dispatch; a proposed new filename has no authority merely because it
-fits the directory and contract owner recorded here.
-
-| Surface | XY-1315 Project/Agent identity | XY-1317 exact-ID adapter | XY-1318 pure quota algebra | Serial integration or exclusion |
-| --- | --- | --- | --- | --- |
-| Production domain source | Sole contract writer for canonical Project/Agent identity, lifecycle, validation, and repository ports added within the existing `crates/decodex-core/src/` owner directory; no account, quota, or Conversation contract. Exact additions require the child pre-dispatch re-derivation above. | Intended existing owner is `crates/decodex-codex/src/protocol.rs`, but no production path is active while the runtime execution gap above holds dispatch. | Sole contract writer for pure duration-typed quota values and policy algebra added within the existing `crates/decodex-core/src/` owner directory; no Project/Agent types or persistence. Exact additions require the child pre-dispatch re-derivation above. | `crates/decodex-core/src/lib.rs` is a shared crate export root: XY-1315 integrates its exports and lands first; only after that landing may rebased XY-1318 become the serial writer for its quota export. Neither child is finally acceptable before its own exact export is integrated and reviewed. |
-| PostgreSQL production source | Sole wave writer for Project/Agent persistence within the existing `crates/decodex-postgres/src/` owner directory, including required integration in the existing `lib.rs`, `types.rs`, `authority.rs`, and `migrations.rs`. Exact additions require the child pre-dispatch re-derivation above. | Excluded. | Excluded. | No other active task may edit any `crates/decodex-postgres/src/` file during the XY-1315 schema slice. |
-| Migration and schema contract | Sole owner of exactly one new migration under `crates/decodex-postgres/migrations/`, versioned only after rebase onto the landed ledger. | Excluded. | Excluded. | The directory, embedded ledger, runtime grants, schema/authority inventory, clean-install/restore contract, and migration number are one serial domain. |
-| Focused tests | Project/Agent core tests stay with the child-selected owning source under `crates/decodex-core/src/`; Project/Agent store cases belong in the existing `crates/decodex-postgres/tests/postgres_store.rs`. | Adapter-owned typed-result tests would belong beside its production owner; live request/response tests currently require the held runtime surface. | Pure table, boundary, fake-clock, overflow, ordering, and property-style tests stay with the child-selected owning source under `crates/decodex-core/src/`. | `crates/decodex-postgres/tests/postgres_store.rs` belongs exclusively to XY-1315 during this wave. Shared architecture acceptance remains serial. |
-| Fixtures | Project/Agent SQL/harness data only inside the PostgreSQL aggregate test or its existing harness. | `crates/decodex-runtime/tests/fixtures/fake_app_server.py` is required but not authorized by the present brief; no active writer until rebrief. | Reads, but must not edit, `openwiki/evidence/fixtures/xy-1262-quota-matrix.json`. | No child may repurpose another child's fixture or copy an existing fixture to create a nominally disjoint path. |
-| Migration harness | Sole writer for `scripts/vnext/postgres_store_test.py` and any Project/Agent assertions required by the existing PostgreSQL 18 harness. | Excluded. | Excluded. | Harness edits land with the schema candidate, never from a parallel pure-core or adapter branch. |
-| Evidence | Sole contract owner for any Project/Agent-specific receipt under the existing `openwiki/evidence/` directory, containing only commands actually run against its exact candidate; no new evidence filename is authorized until the child map is re-derived. Existing XY-1273 evidence remains immutable provenance. | No evidence path is active while dispatch is held. | Test output is validation; it must not rewrite XY-1262 evidence or claim natural-depletion/live acceptance. | Existing files under `openwiki/evidence/`, including `xy-1273-account-runner-binding.md` and `vnext-codex-runtime-proof.md`, are not wave integration scratch space. |
-| Contract surface | Canonical Project/Agent IDs, role uniqueness, lifecycle/revision, Project repository/root/default-cwd facts, and inert repository operations. | Exact-ID/list/lossy-read/archive typed facts only; no mapping persistence, divergence, protocol DTO, or live continuation. | Duration-typed 300/10080 observations, fail-closed pure eligibility/exclusion facts, and a hypothetical side-effect-free earliest-ready value. | Cross-domain application composition, runtime WebSocket, protocol, GPUI, and live behavior are excluded from this wave. |
-| Crate export roots | `crates/decodex-postgres/src/lib.rs` belongs solely to the active schema writer. | `crates/decodex-codex/src/lib.rs` and `crates/decodex-runtime/src/lib.rs` have no active writer while XY-1317 is held. | Becomes serial writer for its `decodex-core` export only after XY-1315 lands and this child rebases. | `crates/decodex-core/src/lib.rs` follows the XY-1315-then-XY-1318 landing sequence; `crates/decodex-protocol/src/lib.rs` is excluded from the wave. Any required runtime module-root edit must be named by a repaired XY-1317 brief before dispatch. |
-| Architecture registry | Serial writer for its Project/Agent guards in the first landing candidate. | No active writer while dispatch is held. | Becomes serial writer for its quota guards only after XY-1315 lands and this child rebases. | `tests/scripts/test_vnext_architecture.py` is a shared registry. Each landing candidate adds only its exact-owner guards, reruns the registry and full check, and receives fresh review before landing. |
-| Crate manifests | No dependency edit without separate authority. | No dependency edit without separate authority. | No dependency edit without separate authority. | `crates/decodex-core/Cargo.toml`, `crates/decodex-codex/Cargo.toml`, `crates/decodex-postgres/Cargo.toml`, and `crates/decodex-runtime/Cargo.toml` are excluded unless a separately reviewed serial change authorizes the exact dependency/feature contract. |
-| Root build graph | Excluded. | Excluded. | Excluded. | `Cargo.toml`, `Cargo.lock`, and `Makefile.toml` are serial shared integration surfaces. Opportunistic dependency, workspace, task, root-manifest, or lockfile edits are prohibited in the parallel wave. |
-| Normative OpenWiki | No child owns final authority edits. | No child owns final authority edits. | No child owns final authority edits. | `openwiki/decisions/vnext-authority.md`, `openwiki/specs/vnext-authority.md`, and this manifest are shared normative authority. A separately authorized serial authority step owns any required semantic amendment; ordinary evidence must not rewrite them. |
-
-Parallel implementation and landing are different gates. The landing order for the safe
-subset is XY-1315 first, then XY-1318. XY-1315 integrates its Project/Agent exports and
-architecture guards, passes fresh review, and lands as the sole schema writer. XY-1318
-then rebases onto that exact landing, integrates its quota export and architecture guard
-as the now-serial owner, reruns its focused tests plus canonical validation, receives a
-fresh exact-candidate review, and lands second. An excluded or deferred shared file may
-be absent during parallel implementation, but the affected child cannot claim final
-acceptance or landing readiness until its ordered serial integration is complete. Any
-upstream landing that changes a mapped path, crate boundary, schema ledger, fixture
-owner, contract, manifest, or test registry invalidates this table for the affected
-child and requires the map to be re-derived from the new landed tree before work
-resumes.
-
-At this snapshot, the maximum safe concurrent implementation subset is **XY-1315 and
-XY-1318**. Their owned production paths and contracts are disjoint once the core export
-root and architecture registry are deferred to serial integration. XY-1317 is excluded
-from dispatch until its adapter/runtime ownership contradiction is repaired. This is not
-permission to land XY-1315 and XY-1318 concurrently or to call either complete before
-the shared integration and fresh exact-candidate review.
-
-XY-1304 owns only later automatic cross-account same-thread fallback and all-depleted
-wake acceptance. Those paths, automatic Context-Pack fallback, and replay after an
-ambiguous provider effect remain disabled. Slice 1 can enable quota-aware initial fixed
-or balanced selection and explicit manual recovery after its own account, capability,
-and effect fences pass. Unknown or stale quota remains ineligible.
+| 1. Accounts and Quick Task | Mac account lifecycle subset, quota-aware initial fixed/balanced selection, explicit account order/manual recovery, Candidate-5 ordinary Quick Task, and minimal Accounts/Conversation/Health GPUI. | Latest-schema and runtime gates pass. The Slice-1 subset of MacDogfoodReady passes, including exact-build refresh callback, ProcessGeneration, ProviderAttempt, and Candidate-5 fences. |
+| 2. Managed work | Project, Lead, global Advisor, bounded Context Revision, WorkItem, ManagedRun, repository saga, Task-Reviewer result, human acceptance, and Project/Work/Run GPUI. | Slice 1 and the managed-repository/ManagedRun owner gates pass. |
+| 3. Self-hosting package | Representative two-account repository flow across restart boundaries and one Mac package. | Slice 2, package/restart/reconciliation, local database reset, and representative E2E evidence pass on one exact build. |
+
+The dependency is `Slice 1 -> Slice 2 -> Slice 3`. An inert foundation cannot claim a
+usable slice. Each acceptance records the exact source revision, evidence, contradictions,
+and outcome.
+
+Automatic cross-account same-thread fallback and all-depleted wake remain disabled under
+XY-1304. They do not block Candidate-5 initial selection or the first Mac dogfood flow.
+
+## Gate order
+
+After one source candidate is frozen, run gates in this order:
+
+1. reverse scan for all retired schema machinery and duplicate owners;
+2. fresh PostgreSQL 18 empty-target latest-schema bootstrap;
+3. refusal of a second bootstrap against the same nonempty target;
+4. runtime-only `decodexd` startup with zero DDL and no schema-owner credential;
+5. exact current catalog/configured-authority verification and adversarial negative cases;
+6. changed adapter SQL and domain behavior;
+7. Candidate-5 behavioral boundaries, including current-main account observation/cache
+   preservation;
+8. direct local database replacement/rebind and exact credential-negative reset-tuple
+   readback; and
+9. the applicable Rust, transport, UI, packaging, and slice checks.
+
+The exact bootstrap, current-authority validation, and local reset command names are
+implementation-owned. No command spelling is authoritative until its implementation and
+task-runner contract land together.
+
+## Latest-schema gate
+
+### Canonical source
+
+Acceptance requires exactly one executable schema source at
+`crates/decodex-postgres/schema.sql`. It contains final enum, relation, constraint, index,
+function, trigger, dependency, ownership, and ACL definitions directly.
+
+Reject the candidate if it contains:
+
+- a numbered SQL schema source or version allocation;
+- Refinery or another migration runner;
+- a schema-history relation, version constant, prefix verifier, or upgrade branch;
+- DDL that exists only to alter, drain, backfill, convert, rename, or drop old Decodex
+  state;
+- compatibility reads/writes, rollback schema, migration receipt/finalizer, or fallback;
+- a generated executable schema copy or parser-owned second schema;
+- `SchemaManager`, registry, bootstrap facade, cutover coordinator, or generator pipeline;
+  or
+- executable schema ownership under `spikes/vnext-storage`.
+
+The latest schema may include final required ownership/grant statements and current
+domain integrity records. Exact-command receipts, account operations,
+ProcessGeneration, ProviderAttempt, `schema_fingerprint`, runtime authority, activity,
+outbox, and repository-effect evidence are valid only for their current domain contracts.
+They must not be used as schema history.
+
+### Module boundary
+
+The `decodex-postgres` `schema` module passes only if it owns:
+
+- the clean-target precondition;
+- one transaction that executes the complete latest schema; and
+- post-execution current catalog/configured-authority verification before commit.
+
+A module that only exposes included SQL fails the gate. No caller may assemble partial
+schema steps or invoke schema creation through normal store connection/startup.
+
+### Empty-target bootstrap
+
+Run against one fresh PostgreSQL 18 target with data checksums and the accepted verified
+Unix-socket boundary. Prove:
+
+- schema-owner credentials resolve only in the explicit operator invocation;
+- endpoint directory, endpoint identity, expected server UID, and kernel peer UID are
+  verified before authentication data is sent;
+- the clean-target check requires the accepted fresh-database catalog baseline, apart
+  from externally provisioned login roles, and rejects every user-created schema,
+  relation, function, type, extension, or other product object;
+- `pgcrypto` and every final Decodex object are created in one transaction;
+- any SQL, catalog, authority, or verification failure rolls back the complete schema;
+- exact post-execution verification passes before commit; and
+- no source except `schema.sql` can create an accepted product catalog.
+
+### Second-bootstrap refusal
+
+Run the same bootstrap against the now initialized target. It must fail at the nonempty
+precondition, execute no DDL, change no object or fingerprint, and return no success
+receipt. There is no idempotent ensure/repair mode.
+
+### Runtime-only startup
+
+Start `decodexd` against the accepted target with only its runtime credential available.
+Prove:
+
+- no schema-owner credential is resolved, requested, inherited, or reachable;
+- no DDL or extension/schema creation executes;
+- no numbered SQL, migration source, schema-history relation, or bootstrap path is read;
+- startup verifies the exact current catalog and configured authority;
+- doctor/status performs the same bounded read-only revalidation;
+- missing, extra, changed, unsafe, authentication-failed, or unreachable authority keeps
+  product state typed unavailable; and
+- endpoint replacement requires daemon restart and never causes repinning or repair.
+
+## Current-authority gate
+
+The accepted candidate must attest the exact current PostgreSQL 18 catalog. It covers:
+
+- schemas, types/enums, relations, columns, defaults, constraints, indexes, sequences,
+  functions, triggers, rules, policies, RLS state, and internal constraint triggers;
+- all stable dependencies, including both sides of foreign keys and extension membership;
+- exact owners, normalized ACLs/default ACLs, grantors, grant options, and role membership;
+- function signatures, overloads, owner, language, security mode, volatility, parallel
+  safety, settings, source bodies, dependencies, and execution grants;
+- trigger names, bindings, timing/events, enabled state, constraint semantics, and bodies;
+- the exact current `schema_fingerprint` and configured runtime authority; and
+- semantic invariants for exact commands, history, blobs, accounts, routing,
+  RuntimeSessions, ProcessGeneration, ProviderAttempt, managed repositories, and
+  Candidate-5 first-session behavior.
+
+Adversarial negatives must reject:
+
+- PUBLIC authority or runtime relation/helper authority outside the closed contract;
+- direct, inherited, NOINHERIT, membership-admin, or `SET ROLE` paths to ownership, DDL,
+  `TRUNCATE`, trigger bypass, retention bypass, grant options, or role administration;
+- unsafe default ACLs, overloads, function settings, hostile `search_path`, body changes,
+  disabled/rebound/surplus triggers, rules, policies, or RLS drift;
+- extension-member control, external cascades, indirect execution paths, sequence
+  mutation, or extra grantees; and
+- changed or forged `schema_fingerprint`/runtime-authority facts.
+
+This gate derives the exact current inventory from the frozen latest candidate. It does
+not reuse historical object counts or schema digests as authority.
+
+## Adapter gate
+
+Every adapter query and command must target the final latest-schema shape. Acceptance
+covers:
+
+- static reverse scan for old relation/function/enum names and old compatibility paths;
+- prepared-statement parse and execution against the fresh latest-schema database;
+- exact command request/response, idempotency, stable rejection, rollback, and
+  concurrency behavior;
+- history cursors, blob references, Context Packs, account profiles/quotas, routing,
+  RuntimeSessions, ProcessGeneration, ProviderAttempt, managed repositories, and read-only
+  diagnostics;
+- startup/restart reconciliation that uses current domain records only; and
+- no adapter access to schema bootstrap or schema-owner credentials.
+
+Changed SQL is proved against the one fresh database and current catalog. There is no
+old/new adapter compatibility matrix.
+
+## Candidate-5 Quick Task gate
+
+Candidate 5 remains target architecture. Candidate-4 tree
+`f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance and cannot supply
+implementation evidence.
+
+The integrated gate covers seven bounded behavior groups. They are test responsibilities,
+not schema phases or separate authority frameworks.
+
+1. **Initial routing lineage.** Prove exact `L0` all-null source lineage, open
+   exact-revision Conversation, no RuntimeSession or Turn, zero sticky members, and exact
+   complete locked member/order/account/two-window quota/eight-capability/blocker facts.
+   Preserve exact `L6` all-present positive lineage and one sticky member. Reject every
+   partial, source-bearing/sticky `L0`, source-less ManagedRun, stale Conversation, or
+   missing/extra/duplicate/reordered/cross-linked fact. Under cross-key concurrency, one
+   initial Routing Decision is fresh; same-key replay is read-only.
+2. **First-session and admission atomicity.** Prove Continuation Plan creates only the
+   selected account/profile snapshots, first revision-1 unfenced starting RuntimeSession,
+   inert initial plan, receipt/activity/outbox in one transaction. Then prove Conversation
+   authority creates the exact active revision-1 sequence-1 user Turn and only ordinal-0
+   completed Message in one transaction. Every failure or competing key leaves no partial
+   domain effect.
+3. **Sole selection and exact fences.** Make one account pass a subset of Account Service
+   checks but fail complete routing capability while another is eligible. Routing Decision
+   must select only the eligible account, and Continuation Plan must create only that
+   account's lineage. Account Service later fences that selected account only. Prove exact
+   Turn locks at ProcessGeneration, thread, and ProviderAttempt boundaries and refusal on
+   drift without re-selection, fallback, or wake.
+4. **Replay, ambiguity, and terminalization.** At every process/thread/attempt lost-result
+   and restart cut, only a fresh ProcessGeneration can spawn. Replayed, rejected, and
+   unknown state cannot spawn, replace, adopt, create a successor, duplicate an attempt,
+   or fail the Turn. Only positive definite pre-effect refusal can move the exact Turn to
+   failed revision 2. Explicit successor locks only that failed revision-2 Turn and stays
+   PostgreSQL-only non-dispatch evidence.
+5. **Conversation and stream order.** Preserve result-before-stream order, one actor owner,
+   bounded deferred publication, one command/registration slot, explicit publication
+   source, non-reserving per-session acceptance, and no cross-session starvation.
+6. **Transport completion.** Preserve duplicate/conflict command order, disconnect and
+   reconnect, snapshot/cursor order, receiver-close outcomes, terminal result retention,
+   one-shot peer-close finalization, task wake, and leak-free accounting. A local write or
+   close does not prove peer receipt.
+7. **Service shutdown.** Preserve `Accepting -> DrainingApplication -> DrainingEgress ->
+   Closed`, one absolute deadline, admitted command completion, complete ordinal/transport
+   reconciliation, exact session admission bounds including handshakes, zero surviving
+   work, and cleanup only after closed accounting.
+
+The latest schema must create the final accepted bodies and bindings for exactly these
+affected trigger functions:
+
+- `decodex.enforce_routing_completeness()`;
+- `decodex.enforce_runtime_session_state()`;
+- `decodex.enforce_turn_state()`;
+- `decodex.enforce_history_item_state()`;
+- `decodex.enforce_provider_attempt_transition()`;
+- `decodex.enforce_provider_attempt_binding()`; and
+- `decodex.enforce_continuation_plan_completeness()`.
+
+Prove the exact predicates in
+[Quick Task thread establishment](vnext-authority.md#quick-task-thread-establishment).
+No other trigger behavior, binding, or ACL may change. There is no broad starting-session
+bypass.
+
+Candidate-5 acceptance must preserve current-main account behavior: deterministic
+one-word aliases, negative Reset Card counts as empty inventory, independent concurrent
+per-account observations, Reset Card-before-profile ordering within an account,
+coalesced successor rounds, revision-fenced publication, and query paths that read cache
+or persisted projection without joining or starting provider refresh work.
+
+## Domain-owner gates
+
+### ProcessGeneration
+
+Prove opaque launch identity, exact selected-account credential-negative binding, fresh
+fence only, complete process identity, positive-only death evidence, account-local
+quarantine, macOS exit-before-witness behavior, exact owned termination, restore epoch
+safety, bounded reconciliation, and ProviderAttempt ambiguity handoff. Unsupported Linux
+launch fails before profile-dependent preflights.
+
+### ProviderAttempt
+
+Prove both consumer shapes, atomic route/plan/session/process/Turn binding, every legal
+state edge, positive-only terminal evidence, late-result attribution, restore projection,
+replacement reconciliation without replay, duplicate-risk acknowledgement, bounded
+background progress, and no second provider-effect ledger.
+
+### Accounts
+
+Prove Registry/HostCredentialStore/Account Service separation; versioned enable/mode/order
+controls; exact credential CAS and reconciliation; exact-build refresh callback;
+one-account-per-process binding; Reset Card fencing/replay; bounded profile/quota storage;
+and current-main observation/cache-read isolation. No secret byte may enter PostgreSQL,
+protocol data, logs, process arguments, or the local reset metadata.
+
+### Managed repositories
+
+Prove complete canonical operation descriptors, global operation-ID conflict, fresh
+commit-acknowledged affine receipt, no receipt reconstruction, operation-specific read-only
+restart reconciliation, exact Git/filesystem readback, and no schema/history role for
+repository effect records.
+
+### Same-UID transport
+
+Prove fixed owner-only endpoint publication, descriptor identity, peer UID checks, stale
+recovery, replacement refusal, exact-current protocol, bounded session/command shutdown,
+zero survivors before cleanup, and no TCP/loopback fallback.
+
+## Local database reset gate
+
+One reviewed operator-only action may:
+
+1. stop the daemon;
+2. capture only credential-negative Account UUID, enabled state, account revision,
+   provider binding, credential version/fingerprint, and host-store binding for every
+   retained account, plus routing revision, mode, fixed target, and complete order;
+3. replace or directly transform the disposable local database;
+4. run empty-target latest-schema bootstrap when the database is recreated;
+5. restore or rebind the exact captured tuple against unchanged host-vault records;
+6. prove every retained account, enabled value, revision, binding, and the exact routing
+   revision/mode/fixed-target/order tuple; and
+7. start the daemon after current-authority verification passes.
+
+For `fixed` mode, the target is non-null and belongs to the retained account set and
+complete order. For `balanced` mode, it is null. The order is a duplicate-free
+permutation of all retained accounts, including disabled accounts. Readback must reject
+any changed enabled value, mode, target, order, revision, or membership.
+
+For credential agreement only, the existing `HostCredentialStore` owner may perform a
+confined in-process exact read, recompute and compare the credential fingerprint and
+binding, and return a typed credential-negative agreement result. Acceptance proves that
+the operator action and result do not expose, serialize, copy, log, persist, rotate,
+delete, or return token bytes. The action creates no public product or migration API,
+generic attestation framework, metadata sidecar, generic importer/migrator, backup,
+rollback, receipt/finalizer, compatibility path, or fallback. Failure before exact
+readback leaves the daemon stopped.
+
+## Mac dogfood gate
+
+MacDogfoodReady requires:
+
+- a fresh latest-schema PostgreSQL 18 database or the accepted local reset result;
+- the signed daemon wrapper, exact Keychain identity/access group, and same-UID transport;
+- Account Registry/HostCredentialStore exact bindings and routing controls;
+- exact-build account login/refresh callback proof;
+- independent 300-minute and 10,080-minute quota facts;
+- current-main account observations, Reset Card/profile readback, and terminal Reset Card
+  replay;
+- Candidate-5 initial routing/process/thread/attempt fences;
+- minimal Accounts/Conversation/Health GPUI; and
+- packaged startup with zero DDL, no schema-owner credential, no old watcher,
+  environment credential projection, helper, `:8192`, or old database input.
+
+Linux credential storage, broad profile/history presentation, automatic fallback/wake,
+retained-title Desktop discovery, remote access, graph/automation, and polish remain
+later obligations unless a slice explicitly names them.
 
 <a id="xy-1372-private-artifact-capability-and-consumption-gate"></a>
 
-### Private-artifact retirement projection
+## Historical evidence
 
-At and after the
-[repository effective point](private-artifact/decision.md#repository-effective-point),
-the [private-artifact archive](private-artifact/README.md) is historical evidence
-only. Its rules, owners, inventories, path sets, A0/A1/B/D0a/C/D graph,
-CORE-FREEZE, ACC, preparation tasks, mechanical pass, and unified validation
-protocol are non-executable. They are not gates, dependencies, or future vNext
-work. Current source has no private-artifact runtime or API composition, and this
-retirement creates none.
+Old migration-based PostgreSQL evidence, frozen schema manifests, S0/R1/R2 captures,
+Phase A/B receipts, numbered-ledger checks, version-specific matrices, private-artifact
+phases, Lane Authority v2, PR #1092, and v0.2 state are superseded provenance. They can
+suggest invariants and hostile cases only.
 
-The [XY-1372 capability evidence](../evidence/xy-1372-private-artifact-capabilities.md)
-remains historical feasibility provenance only. It cannot authorize a platform
-requirement, delivery start, or experiment. XY-1373's former moving-core condition
-is also historical and non-executable.
-
-XY-1371 and the XY-1378-XY-1391 private-artifact execution graph are inactive historical
-planning provenance. Repository authority already retired that program. These issue
-relations cannot gate a delivery slice or restore a private-artifact authority layer.
-
-XY-1369 and XY-1370 keep only their existing bounded operator checks and commit
-reviewed public-safe attestations and digests as canonical Git evidence. XY-1363
-consumes their exact accepted receipt identities. The accepted Artifact/BlobStore
-boundary remains unchanged, and no new product Artifact or compatibility path is
-added. No retained-title evidence gate enables production routing.
-
-### Account lifecycle and Mac dogfood gate
-
-The accepted Mac gate covers only the latest architecture. It starts a fresh V1–V32
-PostgreSQL database with an empty Account Registry, verifies the signed daemon wrapper
-and same-UID Unix transport, imports test accounts through the ordinary public account
-command, restarts once for exact-build callback attestation, and verifies list, routing,
-quota, Reset Card readback, use, and terminal replay.
-
-The source and installed package must contain no account-pool reader, mapping bridge,
-helper or `:8192` owner, token environment projection, migration manifest, migration
-receipt, migration-only command, finalizer, transition fixture, or compatibility
-fallback. Static reverse scans and package inspection enforce this closed set.
-
-The local operator moves existing credentials through temporary owner-private
-`decodex/account-credential-import/1` files and the same public import command. This
-finite host action is not a repository gate or installed product feature. The operator
-deletes temporary inputs and old account authority only after all destination accounts
-and Reset Cards verify.
-
-### Later automatic routing acceptance
-
-[XY-1304](https://linear.app/hack-ink/issue/XY-1304) remains failed and fail-closed only
-for automatic cross-account same-thread fallback and all-depleted wake. It is not a gate
-for Quick Task, Project/Lead, ManagedRun, GPUI, the limited Slice-1 initial selection, or
-the first Mac dogfood. Those flows use explicit fixed or balanced initial selection,
-quota-aware eligibility, deterministic account order, and manual recovery.
-
-The later XY-1304 evidence binds one exact tree and proves natural depletion, durable
-exclusion, exactly one supported continuation or atomic Context-Pack fallback, and one
-restart-safe fresh-resolution wake. Unknown, missing-duration, stale, or low-confidence
-quota never proves eligibility. Possibly side-effecting replay remains under V24
-ProviderAttempt and repository-effect reconciliation. Retained-title Desktop discovery
-is required only if that retained-title feature is enabled.
-
-The accepted V14-V22 receipts remain historical evidence for their stated boundaries.
-The dirty combined XY-1304/V14 candidates and caller-authored routing authority remain
-superseded. A separate reviewed repository amendment is still required before the later
-automatic paths can be enabled.
-
-#### XY-1399 same-UID Unix transport integration matrix
-
-XY-1399 A-prime implements the architecture reset authorized by
-`e27dfc31-c10c-470a-aa51-197abf22de99`. Its product boundary is V3 authority
-`099fb36d-9a48-407e-abdd-80dd56d13051`; the failure receipt is
-`1d8402ed-703d-469f-8ade-a6a8f3a380aa`; and the approved reset skeptic receipt is
-`221bdde4-71b0-46aa-84bf-3bccb05f108d`. Rejected commits
-`a5e5a42ae3cad39442a865a08a468de859fe72d1`,
-`188bf19b1b1333da61a10339f74159e2a9baca66`, and
-`c367a94bc83013715541147aafcf96975ee7c607` are read-only provenance. They are not
-implementation ancestry or compatibility authority.
-
-The A-prime commit is historical source-only ancestry. The current implementation is the
-integrated gate: it is ported onto exact-current protocol V2.0 and the shared Reset Card
-service. Results must bind to one exact tree and cover required macOS and Linux hosts.
-The transport does not add remote or cross-UID admission, use PostgreSQL credentials as
-end-user authentication, create local PKI, or add a production compatibility facade.
-
-| Boundary | Integrated acceptance cases |
-| --- | --- |
-| Policy and platform | `disabled` with no UID is a typed refusal. `same_uid` without an owner UID, `disabled` with a UID, a malformed policy, an owner UID different from the process effective UID, and an unsupported platform fail before endpoint use. `same_uid` plus the exact effective UID is the only enabled V2.0 state. |
-| Persistent namespace lock | The final server directory has the configured owner and exact mode 0700. Persistent regular `decodex.lock` has that owner, exact mode 0600, and one link. Symlink, wrong type, wrong owner, wrong mode, extra link, replaced directory, replaced lock path, lock conflict, overlong path, and ambiguous inspection fail closed. The exclusive nonblocking `flock` starts before stale inspection and remains held through cleanup, listener close, and release-last teardown. The lock file is not unlinked. |
-| Fixed staging recovery | Exercise absent, live, timed-out, exact refused, replaced, linked, wrongly typed, wrongly owned, and wrongly scoped `decodex.sock.stage` and `decodex.sock`. Only exact connection refusal from an unchanged secure socket under the verified lock permits descriptor-relative `unlinkat`. Success, timeout, another error, or any identity change preserves the entry and refuses startup. |
-| Atomic publication | Bind only fixed `decodex.sock.stage`, set exact mode 0600, capture its device/inode/owner/mode/link-count identity, require exactly one link, and validate the retained directory, lock, staging socket, and absent canonical name. Publish with same-directory descriptor-relative `renameat` to `decodex.sock` under the lock. Require the staging name to be absent and canonical name to have the captured identity before product admission. Inject ancestor, directory, lock, staging, and canonical replacement before and after each point. There is no self-connect challenge. |
-| Point-in-time identity | Publication, every server admission, every client connection or reconnect, and cleanup each re-open and validate the current no-follow directory path and exact socket identity against retained descriptors. Connect and accept races with parent rename, ancestor or final-component symlink, socket rename, inode replacement, and canonical replacement fail closed. There is no continuous 250-millisecond watchdog. Hostile same-UID mutation is an integrity-detection fixture, not a confinement claim. |
-| Kernel peer identity | Same-effective-UID client and daemon peers succeed on macOS and Linux. Wrong UID and unavailable or ambiguous kernel credentials return distinct closed refusals on both client connect and server admission. A wrong client peer is connection-local; namespace or listener drift invalidates the listener. Directory permissions and stable server identity do not substitute for kernel credentials. |
-| WebSocket continuity | Exact-current V2.0 continues at route `/v1/ws` over an already admitted Unix stream. V1.5 hello is refused as `major_mismatch`, and V2.1 is refused as `unsupported_minor`, before application payload handling. The exact `ws://localhost/v1/ws` constants are handshake metadata passed to `client_async_with_config`; they cannot resolve or dial. Doctor/status, Reset Card, hello, snapshot, event, command, query, refusal, frame, timeout, backpressure, and close behavior gain no TCP or Axum fallback. |
-| Single task owner | One top-level lifecycle owns the listener and lock. One `JoinSet` owns every session and command task. The same owner polls every daemon service future. Each session or command spawn receives a monotonic stable ID and closed kind before execution. Reset Card worker and heartbeat work are not detached. |
-| Shutdown and provider settlement | Requested shutdown, listener-invalidating refusal, child panic, or unexpected child failure creates one absolute non-extendable session/command deadline. Shutdown synchronously closes Reset Card provider-work admission and signals daemon services before session/command harvest. The closed command receiver drains through `None`, including buffered submissions and outstanding pre-close permits. On deadline, the owner aborts and harvests the task set through `None`. Already registered blocking provider work retains its separate bounded process deadline; the owner waits for exact settlement while it continues to hold the listener and namespace lock. |
-| Deterministic receipt | Terminate with no clients, incomplete handshake, active WebSocket, in-flight command, normal session completion, simultaneous completions, child panic, unexpected cancellation, and a non-quiescent task. Check exact session/command spawn counts, harvested and expected counts, panic/failure/forced/owner-integrity counts, and lowest stable abnormal identities. Primary rank is cleanup refusal, endpoint refusal, owner integrity, child panic, unexpected child failure, forced deadline, then requested shutdown. Task ties select the lowest spawn ID. |
-| Cleanup and daemon concurrency | Start two legitimate same-UID daemons against absent and stale names. Only the lock holder can inspect, remove, bind, publish, bootstrap PostgreSQL, project supervisor loss, start daemon-local mutation services, or clean. The refused daemon makes no PostgreSQL connection and performs no ProcessGeneration, ProviderAttempt, managed-repository, Reset Card, or other product-state mutation. The owner moves the one acquired listener and lock through bootstrap into the lifecycle task without cloning or reacquisition. During shutdown with active sessions, commands, and Reset Card service work, require zero survivors before cleanup and drain every lifecycle-owned service future. Remove only the retained canonical identity; a missing or different identity is a cleanup refusal and is preserved. SIGINT and SIGTERM use graceful cleanup. SIGKILL leaves a stale pathname that the next daemon recovers only after exact refusal and identity checks. Close the listener, then release the namespace lock last. A second legitimate daemon cannot publish until that release. Bootstrap failure after acquisition starts no background service future, removes the exact publication, and releases the lock only after constructed services drop. |
-| Profile disagreement | Run the daemon with its active local profile and select a different declared local profile in the client. Policy or owner-UID disagreement fails before WebSocket admission. Client selection cannot rewrite daemon authority, select TCP, or use the stable server ID as a transport credential. Remote profiles remain inert. |
-| Caller conversion | The protocol, runtime, core, CLI, GPUI, PostgreSQL wrapper, and CLI process fixtures use the fixed same-UID namespace. Local profile data contains policy and owner UID, not an address. Retained sessions receive a typed local authority, not a URL. |
-| Clean-break reverse scan | The active vNext local-daemon transport and its fixtures contain no `LoopbackEndpoint`, local-profile `address`, URL-based retained-session construction, transport-level `InvalidEndpoint`, product-local `TcpListener`/`TcpStream`, `BoundServer::address`, TCP V1 URI, fixed local port 49152, Axum serve/upgrade, self-connect, or watchdog fallback. Inert remote-profile port data and the GPUI `CompatibilityReason::InvalidEndpoint` display classification are not local transport implementations. The runtime Axum dependency and workspace edge are absent. |
-| Authority isolation | Reverse dependencies prove that no PostgreSQL client authentication/routing, `ProcessGeneration`, `RuntimeSession`, `ProviderAttempt`, account routing, scheduler, UI, packaging, release, remote transport, or cross-UID transport enters this owner. Existing Reset Card provider effects remain owned by the application service and are fenced by daemon lifecycle; the transport itself grants no new effect authority. Existing production dispatch remains structurally disabled. |
-
-Run the matrix on the integrated candidate. Focused executable owners are
-`local_transport_authority`, `websocket_protocol`, `bootstrap_doctor`,
-`signal_shutdown`, the real CLI diagnostics wrapper, the Reset Card PostgreSQL wrapper,
-the Swift suite, and signed macOS app staging.
-
-#### XY-1358 deferred acceptance matrix
-
-This source-only matrix is deferred to the XY-1364 unified frozen-core gate. It must run against
-one exact tree and may not enable a live experiment while collecting evidence.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Preparation and crash | Crash before preparation leaves no authority; crash after preparation leaves only `prepared`; a ManagedRun or RuntimeSession advance after preparation makes the pre-effect fence reject without revision 2; crash after the committed pre-effect fence leaves terminal `creation_possible` and cannot authorize another create. |
-| Lost response and replay | A discarded successful command response replays byte-identically, while replay of the pre-effect fence is typed only as ambiguity and cannot recreate its private fresh permission; a lost app-server creation response never retries creation, searches broadly, adopts a thread, or converts ambiguity to absence. |
-| Exact typed binding | Wrong attempt, experiment, marker, title, cwd, ephemeral flag, response ID, reused thread ID, or immutable V14 snapshot/run-revision lineage is rejected atomically; one exact response binds once. Later ManagedRun revision advances preserve that immutable historical provenance. |
-| Positive observations | Exact list/read/event/message facts append once with owned experiment, revision, thread, marker, source ID, digest, and database clock; malformed or cross-thread facts fail closed. |
-| Lossy readback | Empty pages, pagination exhaustion, list omission, missing events, truncated history, stale caches, and incomplete readback persist no negative fact and cannot prove absence, completion, failure, or recreate authority. |
-| Exact-command recovery | Same envelope/key replays stored bytes; changed envelope/key conflicts; aborts at receipt/domain/history completion roll back; no executing receipt commits. |
-| ACL and hostile catalog | Runtime has only the four V15 command entrypoints plus required enum usage; PUBLIC, direct table writes, helpers, trigger bypass, hostile search path, overloads, default ACL drift, and dump/restore authority drift fail closed. |
-| Production isolation | Reverse dependency inspection proves no production runtime or application reaches a V15 experiment execution root; Codex remains a typed fact adapter and dispatch remains disabled. |
-
-#### XY-1367 V22 deferred acceptance matrix
-
-This matrix is preserved as historical V22 acceptance context. XY-1368 executed its acceptance
-against one exact staged V22 candidate after XY-1367 deferred executable validation. It does not
-define a current command or a future package-defined V1-V23 retained-title task. The immutable
-[XY-1368 freeze](xy-1368-retained-title-freeze.md) and the retired
-[private-artifact delivery design](private-artifact/operations-delivery.md) are
-historical and non-executable.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Exact nullable-name start | The durable binding retains exact numeric request and raw response IDs, exact-frame SHA-256 digests, exact thread ID, cwd, marker, `ephemeral=false`, and nullable returned name. The pinned build accepts only raw null. A title read later cannot substitute for a start response field. |
-| Creation crash and replay | A fresh creation fence authorizes one start. Fence replay never authorizes another start. An exact same-experiment and same-attempt durable binding resumes with only its exact ID. Missing binding after response loss remains terminally ambiguous. Search, list, adoption, retry, and inferred absence remain unavailable. |
-| Title effect fence | Only a freshly committed title fence authorizes one exact `thread/name/set` request. The fence stores fixed request ID 4, the prepared title, and the exact-frame digest. Replay, response loss, method rejection, or any mismatch never authorizes another set. Database command replay retains the same derived key and byte-equivalent envelope. External RPC transport never retries. |
-| Exact-ID retained-title attestation | After fence replay or a lost set response, one bounded exact-ID read can attest an already-correct title. Attestation requires the prepared title, marker, cwd, and thread ID plus exact read request and raw response IDs and digests. Missing, null, changed, or cross-thread facts remain ambiguous. |
-| Observation and continuation gate | Only observations linked to an immutable retained-title attestation qualify as title evidence. V17 same-thread completeness requires that mapping and exact attestation lineage. Historical V15 rows remain readable but cannot satisfy the V22 title gate. |
-| ACL and catalog closure | Runtime cannot execute the obsolete V15 title-in-start binder or unattested observation command. It can execute only the V22 bind, exact start readback, title fence, attestation, and attested observation additions. PUBLIC, direct DML, overload, trigger, owner, dependency, default-ACL, and restore drift fail closed across 77 relations, 161 functions, 67 safety functions, 142 triggers, and the V1-V22 ledger. |
-| Inert runner reachability | The manual Rust runner requires its explicit Cargo feature and binary. Its only effect flow is prepare, creation fence, start, bind, title fence, name set, exact-ID read, attestation, and positive observation. `decodexd`, protocol handlers, scheduler, routing orchestration, production dispatch, and default features cannot reach it. It exposes no turn, list, search, archive, retry, adoption, account switch, plugin, or UI operation. |
-
-#### XY-1359 deferred acceptance matrix
-
-This source-only matrix is deferred to the XY-1364 unified frozen-core gate. It binds the V16
-source, migration, configured-authority inventory, schema manifest, and authority digests to one
-exact tree; no case may dispatch work or enable a production consumer.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Deterministic order | Policy order and canonical account identity produce the same selected result across caller reorder, map order, pagination, and timing variation; caller omission, substitution, duplication, or extra candidates cannot alter the PostgreSQL universe. |
-| Sticky eligibility | A sticky account wins only with the same current policy, identity/revision, capability, compatibility, blocker, and exact quota evidence required of every candidate; stale, disabled, auth-failed, incompatible, or depleted sticky accounts cannot bypass blockers. |
-| Duration and precision | 300-minute and 10080-minute facts remain distinct; missing/unsupported duration, unknown/low confidence, malformed raw provenance, non-microsecond precision, and any would-round or would-truncate timestamp fail closed. Exact raw observed/reset text, source identity, evidence revision, and UTC Unix microseconds round-trip unchanged. |
-| Selected exclusions | Every depleted predecessor ahead of the selected member has one normalized account/window exclusion tied to its immutable snapshot fact, observation revision, exact raw timestamps, source, precision, and deterministic `usage_depleted` reason; unrelated blockers are retained as references. |
-| Waiting versus blocked | All otherwise eligible accounts depleted produces only `waiting_usage`, complete per-account/per-window exclusions, per-account maximum readiness, and the exact minimum of those readiness instants. Mixed depletion with unknown, incompatible, disabled, auth-failed, missing-duration, stale, or precision-incompatible evidence produces `no_route`, never a wake-ready decision. |
-| Exact command replay | Same key and envelope replays byte-identical decision/evidence readback; changed operation or envelope conflicts; malformed input is a stable typed rejection; abort, lost response, deadlock, serialization failure, and restart never commit a partial decision, executing receipt, or duplicate effect. |
-| Concurrent authority | Policy, snapshot, account, RoleProfile, capability, compatibility, blocker, quota, or ManagedRun changes before or during resolution either serialize against the complete lock boundary or return a typed stale/concurrent rejection; no mixed-universe decision commits. |
-| Immutability and completeness | Decision, member, quota, capability, blocker, and exclusion rows commit together, are append-only after commit, retain the exact immutable V14 snapshot/run-revision lineage across later ManagedRun advances, and match strict Rust readback plus the pure kernel; missing, reordered, extra, cross-linked, or malformed fields fail closed. |
-| ACL and hostile catalog | Runtime has only the V16 command entrypoint; PUBLIC, direct table writes, private helpers, trigger bypass, hostile search path, overload/default-ACL drift, ownership drift, and dump/restore catalog drift fail closed. Regenerated schema/configured-authority digests match the integrated frozen tree. |
-| Production isolation | Reverse dependency inspection proves only the disabled XY-1361 runtime orchestration invokes exactly one V16 decision per request; no protocol, CLI, daemon, application, scheduler, Codex, credential, or UI production root constructs it. Selected alone may consume one exact V17 plan, while `waiting_usage` yields inert handoff facts for the separately uncomposed V18 wake authority. |
-
-#### XY-1360 deferred acceptance matrix
-
-This source-only matrix is deferred to the XY-1364 unified frozen-core gate. It binds V10, V12,
-V15, V16, V17, V21, the strict Rust adapter, schema/configured-authority inventories, and
-regenerated digests to one exact integrated tree; no case may dispatch work or enable a production
-consumer.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Decision consumption | Only one persisted `selected` V16 decision identity plus its exact immutable ManagedRun revision lineage is accepted; waiting/no-route, missing, stale, cross-run, substituted, or already-consumed decisions fail closed. Caller candidates, policy, exclusions, selection, evidence, and account facts cannot alter the database-derived lineage, and later ManagedRun advances do not rewrite or orphan the persisted plan. |
-| Same-thread evidence | Exact selected account/revision, build, RoleProfile and source RuntimeSession identity, bound thread, V14 schema/capability profile, and a fresh V22-attested positive thread-read observation permit exactly one same-thread plan. Unknown, unattested, stale, future, negative, mismatched, incomplete, duplicate-experiment, unsupported, noncanonical, or lossy absence evidence cannot authorize same-thread continuation. |
-| Atomic fallback | Crash before/after blob publication, exact-receipt reservation, source staging, Context-Pack seal, account snapshot, RuntimeSession, plan, activity, outbox, receipt completion, commit, or response loss leaves either no durable fallback state or one complete linked Context Pack + RuntimeSession + plan. No Context Pack-only, RuntimeSession-only, two-session, or V10/V16 two-command orphan is possible. |
-| Cross-domain event references | Canonical HistoryItem and other non-RuntimeSession activity/outbox may carry scalar `runtime_session_id`, `profile_snapshot_id`, or `account_snapshot_id` provenance. RuntimeSession aggregate/event/kind markers, complete RuntimeSession/profile/account snapshot objects under any wrapper, and outbox links to activity carrying those shapes remain migration-owner-only; direct forgery and immutable-authority updates fail, while delivery-only outbox updates remain permitted. A neutral array whose incomplete object elements only collectively contain a complete shape remains allowed; one genuinely complete snapshot object nested in an array remains reserved. |
-| Replay and concurrency | Same key replays exact bytes; a second key with the identical request reads the one stored plan; changed requests conflict or reject. Concurrent decision consumers, Context-Pack revisions, fallback identities, Conversation closure, ManagedRun revision change, and blob reclamation serialize or fail closed without duplicate state. |
-| ManagedRun safety | Conversation and ManagedRun identities remain unchanged. Guarded/closed barrier revision and submitted-turn receipt count are snapshotted; `replay_permitted=false` and `dispatch_enabled=false` remain immutable for no-receipt, stale-receipt, possible-side-effect, unknown-side-effect, diverged, and reconciled fixtures. No turn, tool, repository, worktree, Git, or artifact effect is replayed. |
-| Context-Pack hostile input | Canonical binary header, digest, manifest digest, source order, pinned source, disposition, represented-byte digest, bounds, credential-negative identities, Artifact revision/blob provenance, and inline/offloaded shape round-trip through strict readback. Truncated, reordered, forged, cross-Conversation, credential-shaped, oversized, malformed, and hash/length-conflicting inputs fail closed. |
-| ACL and catalogs | PUBLIC, direct plan DML, helper execution, activity/outbox lineage forgery, trigger bypass, hostile `search_path`, overload/default-ACL drift, ownership drift, restore drift, and surplus runtime privileges fail closed. The exact V17 function, relation, enum, constraint, trigger, dependency, migration, schema, and configured-authority inventories and regenerated digests match. |
-| End to end and isolation | One exact selected decision yields either one same-thread plan or one atomically verified fallback and survives restart readback byte-for-byte. Reverse dependency inspection proves only the disabled XY-1361 runtime orchestration reaches V17 and only after one selected V16 decision; no protocol, daemon, CLI, application, scheduler, credential, Codex, UI, or production composition root constructs it. |
-
-#### XY-1362 V18/V19 deferred acceptance matrix
-
-This source-only matrix is deferred to the XY-1364 unified frozen-core gate. It binds V10-V21, the
-strict Rust adapter, migration and configured-authority inventories, and regenerated digests to one
-exact integrated tree. It must not enable or compose a production scheduler.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Exact registration and hostile input | Only one persisted V16 `waiting_usage` identity and its exact ManagedRun revision are accepted. Database-derived `earliest_ready_at` round-trips at exact microseconds. Caller timestamps, candidates, quota facts, eligibility, exclusions, accounts, policy bodies, and replacement decisions are absent from the API; missing, selected/no-route, forged, cross-run, malformed, or stale lineage fails closed. |
-| Ledger-first registration and operation identity | One registered transition and one derived head bind the exact decision/run revision. Same-key replay returns stored receipt bytes; the same operation under a new key returns only its immutable registration result after canonical request equality. Retrying registration after later claim/fire cannot acquire later head state. A new operation ID targeting the registered decision, OR/non-strict identity lookup, conflicting reuse, concurrent registrar, or same-run competing decision rejects without aliasing or orphan state. |
-| Deterministic time authority and fairness | Owner-only explicit time proves before/equal/after-ready behavior, including exact-ready claim, equal readiness, microsecond boundaries, and reordered callers while preserving order by earliest-ready instant, registration time, and wake identity. Explicit values outside `0..=253402300739999999`, infinity, registration before locked decision/run authority, and successor time before the locked tip reject without committed mutation. Typed-`NULL` runtime wrappers retain PostgreSQL-authored post-lock sampling and provide no injectable time. Independent account quotas are never pooled, merged, summed, averaged, or caller-ranked. |
-| Transition chain and projection | Every accepted operation appends one immutable transition with the exact predecessor revision/tip and complete result, then atomically advances the head to that exact tip. Forged/skipped predecessors, direct head mutation, projection/ledger inequality, duplicate operation IDs, history rewrites, post-terminal successors, partial activity/outbox clusters, and mutable-head historical readback fail closed. |
-| Lease, crash, and restart | Crash or rollback before/after transition insertion, head advance, activity/outbox insertion, receipt completion, commit, or response loss yields complete cluster absence or one complete command, never a partial cluster. The fixed literal 60-second lease excludes concurrent holders; pre-expiry reclaim rejects, exact expiry appends a reclaim with a new fence, and the old fence and stale tip reject. Strict restart/readback preserves both lease transitions without rewriting history. |
-| Replay, concurrency, and exactly once | Same command key/envelope replays byte-identical bytes; changed envelopes conflict. Cross-key operation replay at a different valid explicit time, including after head movement, verifies the canonical domain request and returns only immutable result bytes. Duplicate fire, cancellation/fire, expiry/fire, and concurrent-holder schedules have the legal outcome multiset with at most one fired transition/request/effect. Stale fences and stale tips reject; no executing receipt or half-written transition/head/activity/outbox cluster commits. |
-| Fire, cancellation, and stale lineage | A valid unexpired leased tip fires once. Explicit cancellation and every ManagedRun, policy, or decision staleness case append the appropriate cause-bound terminal transition and advance the exact head before delivery. Terminal transitions cannot have successors or return to pending/leased, and a stale expected revision/tip or lost lease fence cannot mutate the head. |
-| Fresh resolution only | Fired readback contains one new routing-resolution request identity with `fresh_routing_resolution_only=true`, `prior_decision_reusable=false`, and `production_enabled=false`. Old member order, eligibility universe, quota/capability evidence, exclusions, selected account, V16 decision result, credential, continuation, dispatch, or retry authority cannot be reconstructed or reused from the effect. |
-| ACL, search path, and catalogs | PUBLIC, direct transition/head DML, runtime execution of any V19 internal, private replay/helper execution, inherited or `SET ROLE` time injection, forged predecessor or decision/run/policy lineage, activity/outbox namespace forgery, trigger bypass, hostile `search_path`, overload/default-argument/default-ACL drift, ownership or grant-option drift, relation/enum/constraint/index/function-dependency drift, dump/restore drift, and surplus runtime privileges fail closed. The four exact internal and four exact wrapper bodies/metadata/settings/ACLs, unchanged 51-function runtime allowlist, 73 relations, 67 safety functions, 138 triggers, V1-V21 migration ledger, transition-bound strict readback, and regenerated schema/configured-authority digests match. |
-| End to end and production isolation | Exact V16 wait -> registered transition/head -> claimed or reclaimed transition/head -> one fired transition with a fresh-resolution request survives restart and immutable strict readback; cancellation and every stale case emit no request. No command response is reconstructed from the head. Reverse dependency inspection proves no runtime, protocol, daemon, CLI, Codex, credential, continuation, dispatch, UI, or production composition root imports or invokes V18. XY-1304 remains the later automatic fallback/wake gate; it does not gate Slice-1 initial selection. |
-
-#### Integrated vNext core freeze deferred acceptance matrix
-
-The `fd1e351` core freeze was reopened for the forward V19 time-authority repair. Forward-only V20
-then canonicalized restore-unstable constraints, and V21 repairs only RuntimeSession event-reference
-classification and its final inventories without changing the trusted command or trigger boundary.
-XY-1367 reopened that tree only for forward V22. This matrix records the integrated source
-candidate used by the historical XY-1368 V22 acceptance. It is not the retired
-private-artifact CORE-FREEZE, ACC, preparation, or unified-validation contract.
-Those package terms remain frozen historical evidence in the
-[private-artifact delivery archive](private-artifact/operations-delivery.md) and
-cannot authorize work.
-
-| Boundary | Representative deferred acceptance cases |
-| --- | --- |
-| Scheduler timing and fairness | Before, equal, and after exact database-authored readiness; equal-ready deterministic ordering; clock-microsecond edges; bounded acquisition under a large independent-account inventory; no starvation introduced by caller order; and no pooling, merging, summing, averaging, or caller ranking of account quotas. |
-| Crash and partial-transaction boundaries | V22 start and title fences obey their distinct replay rules. Lost start response without a durable binding remains terminal. Lost title-set response permits only exact-ID readback. Database commands retain exact envelope replay. Existing V16-V18 transaction clusters remain atomic. |
-| Same-key and cross-key replay | Same protocol key and canonical envelope replays byte-identical stored bytes; changed envelopes conflict. A V17 decision cannot be consumed twice across keys. A V18 operation under a new key verifies canonical request equality and returns only its immutable transition result, never later mutable-head state. |
-| Concurrent lifecycle operations | Concurrent register/register, claim/claim, claim/reclaim, reclaim/reclaim, fire/fire, cancel/cancel, fire/cancel, expiry/fire, and supersede races serialize to one legal append-only chain and exact head tip. Same-run competing V16 decisions cannot alias a wake, and every losing stale tip, claim, fence, or operation identity fails closed. |
-| Lease expiry and restart reclaim | A fixed database-authored lease excludes concurrent holders; pre-expiry reclaim and stale-token fire reject; exact expiry and process restart append one reclaimed transition with a new fence while preserving the prior claim and lease history unchanged. |
-| Stale ManagedRun, decision, and policy lineage | Missing, cross-run, wrong-kind, replaced, or ambiguous V16 decisions; stale ManagedRun revision/lifecycle/wait reason/barrier state; divergence; changed policy head; and substituted requested policy/run provenance reject or append only the cause-bound V18 supersession allowed by the exact current tip. |
-| Terminal fencing | Fired, cancelled, and superseded tips admit no successor, reclaim, refire, recancel, or return to pending/leased. Lost leases, old transitions, forged predecessors, skipped revisions, and mutable-head/ledger inequality cannot mutate authority or reconstruct success. |
-| V17 barrier readback | Same-thread plans additionally require the exact V22 retained-title attestation and mapped observation. Same-thread and fallback plans round-trip the exact ManagedRun barrier facts. Stale or substituted values fail closed. Replay and dispatch remain structurally false. |
-| V16/V17/V18 provenance | Every disabled-orchestration outcome retains the exact requested routing policy and ManagedRun provenance. Exactly one V16 decision exists per request; selected alone consumes its one exact V17 plan; waiting exposes only its decision, ManagedRun revision, and exact earliest-ready handoff; V18 registration derives all remaining decision/policy/run lineage from PostgreSQL. |
-| ACL, search path, catalog, and hostile input | PUBLIC and runtime authority close exactly over the intended V16-V18 entrypoints and enum usage. Direct relation writes, private helpers, trigger bypass, overload/default-ACL/ownership drift, hostile `search_path`, malformed UUID/revision/time/JSON/digest input, forged lineage, relation/enum/constraint/index/dependency drift, and dump/restore drift fail closed. |
-| Exact effect, activity, outbox, and operation readback | Every accepted V17/V18 command binds immutable response/effect bytes, digest source, exact activity sequence/event, outbox identity/effect key, aggregate revision, operation identity, and transition/plan lineage. Missing, extra, reordered, cross-linked, half-written, or head-reconstructed values fail strict readback. |
-| Fresh-resolution behavior | One valid leased V18 fire emits exactly one opaque new routing-resolution request with no old candidate universe, selection, account, eligibility, quota/capability evidence, exclusion, credential, continuation, dispatch, or retry authority; old-decision reuse and production enablement remain structurally false. |
-| Production isolation and protocol vocabulary | Reverse dependencies prove no production root reaches the V22 runner. The runner requires its manual feature and binary. Existing V16/V17 orchestration and V18 remain disabled and uncomposed. No new V1 command exists. |
-| Regenerated schema and configured-authority digests | The canonical frozen derivation and final bound run agree on the immutable V1-V21 checksums plus V22, 77 relations, 161 functions, 67 safety functions, 142 triggers, exact source/metadata/signatures/ACLs, enums, constraints, indexes, dependencies, schema manifest, configured-authority inventory, and expected digests. |
-| Representative end-to-end flow | One request persists exactly one V16 result. Selected produces exactly one strict-readback V17 same-thread or atomic fallback plan and remains inert. Waiting produces only handoff facts, then an independently invoked V18 register -> claim or expiry/reclaim -> fire chain yields one immutable fresh-resolution request; cancellation and stale-lineage paths yield none. Restart preserves all readback and no production effect executes. |
-
-The table above is historical V22 evidence. Its V12 effect-barrier and ManagedRun-only V16/V17
-rows do not describe the current V26 source. The
-[XY-1402 deferred acceptance matrix](execution-coordinator-authority.md#deferred-acceptance-matrix)
-supersedes those current-state projections. The V26 matrix must run at the later unified
-core-freeze gate before any acceptance or enablement claim.
-
-
-## Cutover gate
-
-The Slice-3 Mac cutover requires XY-1422 MacDogfoodReady, replacement behavior evidence,
-the representative two-account E2E and restart evidence, one accepted Mac package, and
-the frozen v0.2 inventory. XY-1304 is not a cutover prerequisite while automatic
-fallback and wake remain disabled. Broader final-product cutover retains each later
-feature's own gate.
-
-The procedure stops v0.2, initializes empty PostgreSQL execution/control-plane state,
-imports each retained account once through the ordinary versioned account-import
-command, verifies the resulting PostgreSQL, HostCredentialStore, routing, and Reset Card
-readback, deletes the temporary import files and retired account source, explicitly
-recreates selected Projects, and starts only vNext. It creates no backup or rollback
-path. It imports no legacy execution or Codex thread history and enables no dual
-authority. Normal startup must not read a migration source or mapping and must not use
-the legacy watcher, credential environment projection, helper, `:8192`, or dual account
-UI. The product contains no generic account-migration runner, manifest, receipt,
-finalizer, compatibility branch, or migration gate.
-
-The repository-owned XY-1261 receipt is
-[the v0.2 freeze receipt](../evidence/v0.2-freeze.md). It is historical repository
-provenance, not a runtime input, migration authority, backup requirement, or rollback
-path. The local clean cutover validates only the retained vNext account and Reset Card
-state before it removes the retired source.
+No historical file can authorize a current command, schema source, upgrade proof, second
+owner, or acceptance claim. A retained invariant must be restated and pass against the
+one latest schema and current authority.
 
 ## Stop conditions
 
-Stop the owning gate on any contradiction with the authority contract, any unproven
-authority boundary, credentials entering ordinary PostgreSQL rows, a second mutation
-path around `decodexd`, possible side-effect replay without reconciliation, unbounded UI
-history loading, or attempted remote binding before security acceptance. Decision-level
-falsifiers are listed in the owning decision and require explicit architecture revision.
+Stop the owning gate on:
+
+- any second executable schema source or schema-creation path;
+- any daemon startup DDL or schema-owner credential resolution;
+- any accepted bootstrap on a nonempty target;
+- any current-authority check that depends on schema history or an upgrade prefix;
+- any secret byte in database/reset metadata, protocol data, logs, or process arguments;
+- a second account selector, provider-effect ledger, process owner, or coordinator state;
+- possible external-effect replay without positive reconciliation;
+- Candidate-5 partial lineage, partial admission, ambiguous terminalization, or account
+  observation/cache regression;
+- a second mutation path around `decodexd`;
+- unbounded UI history loading; or
+- remote binding before security acceptance.
+
+A decision-level contradiction requires an explicit architecture revision. It never
+authorizes a compatibility facade, silent fallback, generic migrator, or extra phase.


### PR DESCRIPTION
## Summary

- replace active V1-Vn migration authority with one unversioned latest PostgreSQL schema
- require runtime-only daemon startup and one operator-only empty-target bootstrap
- bound the one-time local credential-negative account reset/rebind
- mark migration-era commands and evidence as superseded provenance

## Review

Independent exact-tree review: APPROVED/READY, no P0/P1/P2.

Docs-only change; no compile, tests, PostgreSQL, or runtime commands were run.