### PR TITLE
Define independent runtime capability authority

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -152,6 +152,57 @@ It does not parse a sequence of SQL sources. Historical relation/function/trigge
 are not authority. The exact current candidate establishes its own reviewed closed
 inventory.
 
+## Runtime composition and readiness
+
+One `decodexd` and one owner-only same-UID endpoint remain authoritative. A Quick Task or
+ManagedRepository startup failure does not terminate the daemon when the transport and
+control plane can start. Diagnostics, account recovery, and available PostgreSQL-backed
+reads remain usable.
+
+Composition records these independent startup projections:
+
+| Surface | Startup projection | Owner boundary |
+| --- | --- | --- |
+| `ProductStore` | `Available(PostgresStore)` or `Unavailable(ProductStateReason)` | Exact runtime PostgreSQL connection and current-authority verification only. |
+| Quick Task | `Ready(QuickTaskRuntime)` or `Unavailable(QuickTaskUnavailableReason)` | Stateless Quick Task sequencing after all fallible dependencies are validated. |
+| ManagedRepository | `Ready`, `Disabled`, or `Unavailable(ManagedRepositoryUnavailableReason)` | Optional repository path, Git, executor, and reconciliation assembly. |
+
+`ProductStore` never contains Quick Task or repository readiness. A repository path,
+Git executor, reconciliation, or configuration failure cannot invalidate a verified
+PostgreSQL store. A Quick Task dependency failure cannot invalidate PostgreSQL or
+ManagedRepository.
+
+All fallible dependency owners finish their I/O, attestation, and startup work before
+Quick Task construction. `QuickTaskRuntime::new` or its final equivalent is infallible and
+performs no I/O. Service composition stores one immutable ready or unavailable projection
+for that daemon process. It does not poll, mutate, promote, or recover that projection.
+Every Quick Task command repeats the current Account Service, routing,
+ProcessGeneration, ProviderAttempt, app-server, and path fences before it can cause an
+effect.
+
+This structure has no capability-manager module. The startup projections own no durable
+state, receipt, task, channel, retry, or lifecycle. They only make the result of service
+assembly explicit. A deletion test must continue to hold: removing the Quick Task owner
+would spread sequencing and its closed error projection into callers; removing a wrapper
+that only forwards these values must remove no required behavior and is not allowed as a
+new module.
+
+Core configuration owns transport and PostgreSQL runtime configuration. It does not
+require a static repository path map. PostgreSQL owns repository identity, admission, and
+persisted path policy. If one concrete accepted host-only repository policy needs local
+configuration, that configuration has its own parser and validator. Missing or invalid
+repository configuration maps only to ManagedRepository `Disabled` or `Unavailable`; it
+cannot prevent core configuration parsing, endpoint binding, PostgreSQL verification, or
+Quick Task composition.
+
+Protocol and doctor return the three readiness projections independently. Quick Task
+execute, start, and resume return `QuickTaskUnavailable` with a closed redacted reason
+when Quick Task is unavailable. Persisted list and get operations return
+`ProductStateUnavailable` when PostgreSQL is unavailable. No optional setter, `.ok()`
+conversion, or omitted field can turn a startup error into silent feature absence.
+`AcceptanceUnknown` and recovery-required responses remain effect and recovery results;
+they are not startup readiness.
+
 ## State ownership
 
 | State or surface | Authority |
@@ -424,6 +475,11 @@ generation/tip, globally immutable operation assignment, append-only authority a
 operation evidence, exact compare-and-swap, transaction completeness, and restart loads.
 Git/filesystem execute admitted effects; GitHub supplies provider readback.
 
+ManagedRepository assembly is optional and independent from `ProductStore` and Quick
+Task. Absence is `Disabled`. A path, Git, executor, reconciliation, or isolated
+configuration failure is typed `Unavailable` and disables repository operations only.
+Neither state changes PostgreSQL readiness or prevents repository-free Quick Task work.
+
 Each external operation has one complete canonical descriptor. Exact equality with an
 existing assignment returns readback with no dispatch. Any difference is a permanent
 operation-ID conflict. A fresh affine execution receipt exists only after successful
@@ -441,6 +497,13 @@ identity, SHA-256 blobs, and disposable cache. Repository paths and PostgreSQL s
 paths reject symbolic links and replacement according to their owner-specific
 descriptor rules. Shared normal `~/.codex` remains Codex configuration, rollout, plugin,
 and thread-visibility authority.
+
+A requested Quick Task working directory is an input, not authority. Immediately before
+spawn, the runtime host adapter opens and validates the selected path by no-follow
+traversal, exact descriptor identity, directory type, ownership by the daemon effective
+UID, and the applicable PostgreSQL or accepted host-only path policy. Ambient current
+directory, repository discovery, and a caller-supplied path string cannot satisfy this
+check. A failure rejects only that Quick Task command.
 
 The exact-current protocol carries bounded command/result/event envelopes, snapshots,
 history pages, account queries, Reset Card operations, and read-only diagnostics.
@@ -493,6 +556,9 @@ path, compatibility mechanism, or executable schema owner.
   `schema` module. Do not add another SQL owner.
 - Runtime database changes must preserve zero-DDL startup and current-authority
   verification.
+- Runtime composition changes must preserve independent ProductStore, Quick Task, and
+  ManagedRepository projections. Do not add a mutable capability manager or silent
+  optional startup path.
 - Candidate-5 changes must preserve sole account selection, atomic first Turn/history
   admission, exact effect fencing, and current-main account cache-read isolation.
 - ProcessGeneration changes must preserve positive-only death and account-local
@@ -500,5 +566,7 @@ path, compatibility mechanism, or executable schema owner.
 - ProviderAttempt changes must preserve positive-only outcome evidence and no replay.
 - Account changes must preserve the Registry/store/service split and secret-negative
   database/protocol boundary.
+- Configuration changes must keep transport/PostgreSQL parsing independent from optional
+  repository configuration and must not restore duplicate repository-path authority.
 - Historical migration evidence is provenance only. No acceptance claim may depend on a
   historical upgrade or ledger proof.

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -118,6 +118,69 @@ generic migrator, an import API, a generic attestation framework, a metadata sid
 backup or rollback mechanism, a receipt/finalizer, or a fallback. Normal installation
 and startup do not read an old database or an old account source.
 
+## Runtime composition reset
+
+Three runtime-bootstrap candidates failed source review because they coupled unrelated
+owners, hid Quick Task startup failure, or left shared integration drift. The third
+candidate is a source donor only. It is not an accepted runtime candidate and it must not
+receive another runtime-lane-only patch.
+
+This reset keeps one `decodexd`, one owner-only same-UID endpoint, and one application
+surface. The daemon can start when Quick Task execution or ManagedRepository is not
+available. PostgreSQL-backed reads, diagnostics, account recovery, and the control plane
+remain available when their own owners are ready.
+
+Runtime composition has three independent startup results:
+
+1. `ProductStore` means verified PostgreSQL only. Its result is
+   `Available(PostgresStore)` or `Unavailable(ProductStateReason)`. Quick Task,
+   repository, Git, path, or reconciliation failure cannot replace or erase this result.
+2. `QuickTaskRuntime` construction is infallible and performs no I/O after all fallible
+   dependency owners return validated ready dependencies. Composition records one
+   immutable startup projection: `Ready(QuickTaskRuntime)` or
+   `Unavailable(QuickTaskUnavailableReason)`. The unavailable reason is closed and
+   redacted.
+3. ManagedRepository is an independent optional capability. Its startup projection is
+   `Ready`, `Disabled`, or `Unavailable` with a closed redacted reason. Repository path,
+   Git, reconciliation, or isolated configuration failure affects repository operations
+   only.
+
+These results are startup projections, not mutable authority. They create no capability
+manager, lifecycle, receipt, cached substitute, or recovery framework. Every command
+repeats the accepted checks of the PostgreSQL, Account Service, ProcessGeneration,
+ProviderAttempt, app-server, path, and repository owners that apply to that command.
+
+Core runtime, transport, and PostgreSQL configuration are independent from optional
+repository configuration. Remove the required static `server_host.repositories` path map
+unless a concrete accepted host-only policy consumes it. PostgreSQL remains authority for
+repository identity, admission, and persisted path policy. If a host-only repository
+policy remains, it has a separate parser and validator. Its absence or invalid content
+cannot block PostgreSQL verification or Quick Task assembly.
+
+Immediately before spawn, the runtime validates the selected Quick Task working directory
+by exact descriptor identity, directory type, ownership by the daemon effective UID,
+no-follow traversal, and the applicable accepted path policy. Ambient current directory
+and repository discovery grant no authority. One unrelated broken repository cannot
+disable all Quick Tasks.
+
+Protocol and doctor project `ProductStore`, Quick Task, and ManagedRepository readiness
+separately. Quick Task execute, start, and resume return typed
+`QuickTaskUnavailable(reason)` when the immutable startup projection is unavailable.
+Persisted Quick Task reads keep `ProductStateUnavailable` when PostgreSQL is unavailable.
+No `.ok()` conversion, optional setter, or absent field may hide a startup failure.
+`AcceptanceUnknown` and recovery-required results keep their existing meanings.
+
+The next source candidate has one integration owner after the Quick Task source freezes.
+That owner reconciles core configuration; runtime bootstrap, application, library,
+Quick Task, and managed-repository owners; protocol doctor, Quick Task, wire, and library
+surfaces; root Cargo/task-runner/lock files; deleted storage-spike references; and stale
+migration/configuration fixtures. This is integration acceptance-source work. It is not a
+fourth runtime-bootstrap patch.
+
+Daemon-fatal Quick Task startup, separate serve profiles, a mutable capability manager,
+duplicate repository-path authority, and another isolated runtime-lane candidate are
+rejected. This reset does not change the one-latest-schema or no-migration authority.
+
 ## Candidate-5 Quick Task
 
 Candidate 5 remains the accepted architecture for one ordinary Quick Task. It is a
@@ -247,6 +310,8 @@ work for an explicit decision.
   Decodex maps only threads that it created.
 - `decodexd` alone owns scheduling, app-server children, product mutations, repository
   side effects, and adapters. GPUI, SwiftUI, CLI, and MCP are clients.
+- `ProductStore` represents verified PostgreSQL only. Quick Task and ManagedRepository
+  startup projections are independent and cannot overwrite product-store readiness.
 - PostgreSQL Account Registry owns credential-negative account state. One
   HostCredentialStore owns secret bundles. Account Service coordinates account
   operations.
@@ -260,6 +325,8 @@ work for an explicit decision.
 - ExecutionCoordinator remains stateless and cannot authorize dispatch by itself.
 - Git/filesystem own repository bytes and worktrees. GitHub owns PR/check/merge
   readback. PostgreSQL owns the admitted repository-effect state and evidence.
+- Quick Task construction is I/O-free and infallible after validated dependencies exist.
+  Its startup projection is immutable, typed, and visible through protocol diagnostics.
 - Local content-addressed storage owns large bytes; PostgreSQL owns their metadata and
   references.
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -23,7 +23,8 @@ configuration, and accepted contracts remain executable authority.
 - [vNext gate manifest](specs/vnext-gates.md): source-freeze, latest-schema, runtime,
   Candidate-5, account, and local cutover gates.
 - [Runtime architecture](architecture/runtime-architecture.md): process topology,
-  PostgreSQL bootstrap/runtime separation, service ownership, and current-state drift.
+  PostgreSQL bootstrap/runtime separation, independent startup readiness, service
+  ownership, and current-state drift.
 - [Commands and validation](operations/commands-and-validation.md): implementation-owned
   bootstrap and authority command boundaries plus current repository checks.
 - [Account lifecycle authority](specs/account-lifecycle-authority.md): Account Registry,
@@ -87,7 +88,9 @@ remain domain integrity records. They are not schema migration records.
 - `crates/decodex-codex/` owns typed app-server contracts, exact-build capability
   profiles, redaction, and one-account-per-process adapter behavior.
 - `crates/decodex-runtime/` owns `decodexd` service assembly and is the only library owner
-  that composes infrastructure adapters.
+  that composes infrastructure adapters. It records independent immutable startup
+  projections for ProductStore, Quick Task, and ManagedRepository without adding a
+  capability manager.
 - `apps/decodexd/` is the sole server composition root. Its normal serve path is
   runtime-only.
 - `apps/decodex-cli/` and `apps/decodex-gpui/` are protocol clients. They do not read
@@ -104,6 +107,11 @@ remain domain integrity records. They are not schema migration records.
 `decodexd` serves the exact-current protocol at the fixed owner-only
 `~/.decodex/server/decodex.sock` endpoint. Both sides verify kernel peer UID and stable
 server identity. Remote and cross-UID control remain disabled until their security gate.
+
+One daemon and one endpoint remain available when Quick Task execution or
+ManagedRepository is unavailable. `ProductStore` means verified PostgreSQL only. Quick
+Task and ManagedRepository startup cannot overwrite it. Protocol and doctor report all
+three readiness results separately.
 
 When PostgreSQL is available, startup verifies the pinned socket, PostgreSQL 18 and data
 checksums, `pgcrypto`, the exact latest catalog, closed dependencies, object ownership,
@@ -133,6 +141,12 @@ timeout, restart, absence, or negative search never proves provider non-submissi
 ExecutionCoordinator is crate-private and stateless. It sequences accepted route,
 continuation, process, and provider-attempt owners. It stores no receipt or lifecycle and
 cannot authorize dispatch by itself.
+
+After fallible owners validate their dependencies, `QuickTaskRuntime` construction is
+infallible and performs no I/O. Composition records one immutable ready or typed
+unavailable result. Quick Task commands repeat all current owner fences. ManagedRepository
+is independently `Ready`, `Disabled`, or typed `Unavailable`; repository failure affects
+repository operations only.
 
 ## Candidate-5 Quick Task
 
@@ -168,6 +182,11 @@ Turn. Only a fresh ProcessGeneration result can spawn. Replayed, rejected, or un
 state cannot spawn, substitute an account, create a successor, duplicate an attempt, or
 terminalize the Turn. Only positive definite pre-effect refusal can let Conversation
 authority move that Turn to failed revision 2.
+
+Immediately before spawn, runtime validates the selected working directory by no-follow
+descriptor traversal, exact identity, directory type, ownership by the daemon effective
+UID, and accepted path policy. Ambient current directory and repository discovery are not
+authority. One broken repository cannot disable unrelated Quick Tasks.
 
 Automatic cross-account same-thread fallback and all-depleted wake remain disabled under
 XY-1304.
@@ -223,6 +242,10 @@ are implementation-owned. See [Commands and validation](operations/commands-and-
 - Do not add numbered SQL, Refinery, a schema ledger, a schema generator, or a second
   executable schema owner.
 - Do not make daemon startup resolve schema-owner credentials or execute DDL.
+- Do not make Quick Task or ManagedRepository startup failure fatal to an otherwise usable
+  daemon. Do not hide it through `.ok()`, an optional setter, or an omitted protocol field.
+- Do not add a mutable capability manager or duplicate PostgreSQL repository path
+  authority in core configuration.
 - Keep current-main account observation and cache-read isolation unchanged while adding
   Candidate-5 behavior.
 - Treat historical migration evidence as superseded provenance, not current authority.

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -154,6 +154,63 @@ Normal `decodexd` startup resolves only the runtime credential. It runs zero DDL
 performs the same read-only current-catalog/configured-authority checks. It never creates,
 upgrades, repairs, or finalizes a schema and never reads a schema-history relation.
 
+### Runtime composition and readiness
+
+One `decodexd` and one owner-only same-UID endpoint serve all product and diagnostic
+surfaces. Quick Task execution or ManagedRepository unavailability does not make daemon
+startup fail when the transport and control plane can start. Diagnostics, account
+recovery, and each available PostgreSQL-backed read remain reachable.
+
+`ProductStore` has exactly two startup results:
+
+- `Available(PostgresStore)` after exact runtime PostgreSQL and current-authority
+  verification; or
+- `Unavailable(ProductStateReason)` with no retained store.
+
+`ProductStore` means verified PostgreSQL only. Quick Task, repository, Git, path,
+reconciliation, and optional repository-configuration results cannot replace, erase, or
+change it.
+
+All fallible Quick Task dependencies must finish their own validation, I/O, attestation,
+and startup before composition constructs `QuickTaskRuntime`. Construction is infallible
+and performs no I/O. Composition records exactly one immutable process-lifetime
+projection:
+
+- `Ready(QuickTaskRuntime)`; or
+- `Unavailable(QuickTaskUnavailableReason)`, where the reason is closed and redacted.
+
+This projection is not a mutable capability manager, lifecycle, authority, cache,
+receipt, retry owner, or substitute for current evidence. Every execute, start, and resume
+command repeats all accepted owner fences before an effect. The projection never becomes
+ready without daemon restart.
+
+ManagedRepository has one independent optional startup projection: `Ready`, `Disabled`,
+or `Unavailable(ManagedRepositoryUnavailableReason)`. Absence is `Disabled`. Invalid
+repository-only configuration and path, Git, executor, or reconciliation failure are
+`Unavailable`. They disable repository operations only and cannot block endpoint binding,
+PostgreSQL verification, account recovery, or repository-free Quick Task work.
+
+Core runtime configuration contains transport and PostgreSQL runtime inputs. It does not
+require `server_host.repositories`. Repository identity, admission, and persisted path
+policy remain PostgreSQL authority. A host-only repository configuration is permitted
+only when a concrete accepted host policy consumes it. Its parser and validator are
+separate from core configuration, so absent or malformed repository data cannot block
+core parsing or service assembly.
+
+Immediately before a Quick Task process spawn, the runtime host adapter validates the
+selected working directory by no-follow descriptor traversal, exact descriptor identity,
+directory type, ownership by the daemon effective UID, and the applicable accepted path
+policy. A request path, ambient current directory, or repository discovery is not
+authority. One unrelated broken repository cannot disable all Quick Tasks.
+
+Protocol and doctor project ProductStore, Quick Task, and ManagedRepository readiness as
+three independent typed fields. Quick Task execute, start, and resume return
+`QuickTaskUnavailable(reason)` when the Quick Task projection is unavailable. Persisted
+Quick Task list and get retain `ProductStateUnavailable` when PostgreSQL is unavailable.
+No `.ok()` conversion, optional setter, omitted field, or generic integrity error may
+hide the assembly result. `AcceptanceUnknown` and recovery-required results retain their
+existing effect and recovery semantics.
+
 The verifier rejects any extra, missing, changed, unsafe, or unreachable schema,
 relation, column, enum, constraint, index, function, trigger, rule, policy, RLS setting,
 sequence, dependency, owner, or grant. It closes inherited and `SET ROLE` authority,
@@ -309,6 +366,12 @@ Within the trusted single-host first-release boundary:
   cancellation, and repository mutation detection. Deliberately hostile same-UID code is
   outside first-release confinement. Hostile-project or multi-tenant operation requires a separate
   UID or sandbox owner and an independently accepted feasibility and authority gate.
+
+ManagedRepository service assembly is optional. Its `Ready`, `Disabled`, or typed
+`Unavailable` projection does not change ProductStore or Quick Task readiness. A static
+host repository map cannot duplicate PostgreSQL repository identity, admission, or path
+policy. Any accepted host-only policy is parsed separately and affects only repository
+operations.
 
 Every external operation is assigned one complete canonical descriptor. The descriptor
 contains every value capable of changing execution or success evidence, including the
@@ -599,6 +662,10 @@ state, status, revision, ordinal, kind, second item, or cross-link rejects the t
 Before ProcessGeneration prepare/spawn, thread fence/start/bind, and ProviderAttempt
 prepare/authorize, the effect owner locks the selected Turn and requires it to remain
 active revision 1 under the same Conversation and first RuntimeSession.
+
+Immediately before spawn, the runtime also validates the selected working directory under
+the runtime-composition contract. This host check cannot select an account, change the
+route, authorize a repository, or replace the exact Turn and ProcessGeneration fences.
 
 ProcessGeneration and thread establishment through bind require the applicable
 `starting` RuntimeSession revision. ProviderAttempt preparation and authorization require
@@ -1199,6 +1266,14 @@ GPUI, then the bounded Project/Lead/ManagedRun flow and Project-Work-Run GPUI, t
 two-account self-hosting restart E2E and Mac package. The exact gates and the
 MacDogfoodReady-versus-final deferred table are in the
 [gate manifest](vnext-gates.md#delivery-slices).
+
+After the Quick Task source freezes, one integration owner must produce the next runtime
+candidate. The third runtime-bootstrap candidate is donor source only. The owner
+reconciles core configuration; runtime bootstrap, application, library, Quick Task, and
+managed-repository modules; protocol doctor, Quick Task, wire, and library surfaces; root
+Cargo/task-runner/lock files; deleted storage-spike references; and stale
+migration/configuration fixtures. This source cleanup is part of integration acceptance.
+Another runtime-lane-only patch is not an accepted candidate.
 
 Freeze/close PR #1092 and do not cherry-pick its implementation wholesale. Every task
 uses a focused worktree branch and PR directly into `main`; there is no long-lived vNext

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -21,6 +21,10 @@ Acceptance proves an empty-target bootstrap and exact current authority. It does
 prove a historical upgrade, populated migration, version prefix, schema-history checksum,
 or source/restore migration receipt.
 
+The third runtime-bootstrap candidate is donor source only. The next candidate must be
+one integrated composition that keeps ProductStore, Quick Task, and ManagedRepository
+readiness independent. It cannot be another runtime-lane-only patch.
+
 ## Delivery slices
 
 | Slice | Usable result | Entry condition |
@@ -40,21 +44,41 @@ XY-1304. They do not block Candidate-5 initial selection or the first Mac dogfoo
 
 After one source candidate is frozen, run gates in this order:
 
-1. reverse scan for all retired schema machinery and duplicate owners;
+1. integrated source-boundary and reverse scan for retired machinery, stale references,
+   and duplicate owners;
 2. fresh PostgreSQL 18 empty-target latest-schema bootstrap;
 3. refusal of a second bootstrap against the same nonempty target;
 4. runtime-only `decodexd` startup with zero DDL and no schema-owner credential;
-5. exact current catalog/configured-authority verification and adversarial negative cases;
-6. changed adapter SQL and domain behavior;
-7. Candidate-5 behavioral boundaries, including current-main account observation/cache
+5. independent ProductStore, Quick Task, and ManagedRepository startup projections;
+6. exact current catalog/configured-authority verification and adversarial negative cases;
+7. changed adapter SQL and domain behavior;
+8. Candidate-5 behavioral boundaries, including current-main account observation/cache
    preservation;
-8. direct local database replacement/rebind and exact credential-negative reset-tuple
+9. direct local database replacement/rebind and exact credential-negative reset-tuple
    readback; and
-9. the applicable Rust, transport, UI, packaging, and slice checks.
+10. the applicable Rust, transport, UI, packaging, and slice checks.
 
 The exact bootstrap, current-authority validation, and local reset command names are
 implementation-owned. No command spelling is authoritative until its implementation and
 task-runner contract land together.
+
+## Integrated source boundary
+
+Freeze Quick Task source before runtime integration. Then use one integration owner for
+core configuration; runtime bootstrap, application, library, Quick Task, and
+managed-repository modules; protocol doctor, Quick Task, wire, and library surfaces; and
+the PostgreSQL latest-schema handoff.
+
+The same owner removes shared acceptance drift from the root Cargo workspace,
+`Cargo.lock`, task-runner definitions, deleted storage-spike references, and stale
+migration/configuration fixtures. The frozen source candidate must load as one workspace
+and must not require a deleted crate, removed command, rejected configuration field,
+numbered schema, or migration-era fixture.
+
+The third runtime-bootstrap candidate can donate reviewed source. It cannot supply
+acceptance identity. Reject a fourth isolated runtime-bootstrap patch, a shared-file
+handoff that is not integrated, or an exact-tree review that excludes root manifests,
+task-runner files, lockfiles, and active fixtures.
 
 ## Latest-schema gate
 
@@ -129,6 +153,43 @@ Prove:
 - missing, extra, changed, unsafe, authentication-failed, or unreachable authority keeps
   product state typed unavailable; and
 - endpoint replacement requires daemon restart and never causes repinning or repair.
+
+### Runtime composition and readiness
+
+Start one daemon and keep the one accepted endpoint. Exercise independent assembly
+outcomes and prove:
+
+- verified PostgreSQL produces `ProductStore::Available` even when Quick Task or
+  ManagedRepository assembly fails;
+- unavailable PostgreSQL produces `ProductStore::Unavailable` and persisted Quick Task
+  reads return `ProductStateUnavailable`;
+- Quick Task construction performs no I/O and cannot fail after validated ready
+  dependencies are supplied;
+- each missing or failed Quick Task dependency produces one immutable closed redacted
+  `QuickTaskUnavailableReason`, and execute/start/resume return the typed unavailable
+  result without hiding it through `.ok()`, an optional setter, or an omitted field;
+- Quick Task unavailability does not remove diagnostics, account recovery, control-plane
+  commands, or available PostgreSQL-backed reads;
+- ManagedRepository absence is `Disabled`; repository-only configuration, path, Git,
+  executor, or reconciliation failure is typed `Unavailable` and affects repository
+  operations only;
+- ProductStore, Quick Task, and ManagedRepository readiness are separate doctor/protocol
+  fields and no result overwrites another;
+- every Quick Task command repeats current owner fences, so startup readiness is not
+  effect authority; and
+- `AcceptanceUnknown` and recovery-required results are unchanged.
+
+Configuration cases must prove that core transport/PostgreSQL parsing does not require a
+static repository map. Missing or malformed isolated repository configuration cannot
+block endpoint binding, PostgreSQL verification, or Quick Task. If a concrete host-only
+repository policy remains, prove that it does not duplicate PostgreSQL identity,
+admission, or persisted path policy.
+
+For Quick Task spawn, prove exact no-follow working-directory traversal, descriptor
+identity, directory type, ownership by the daemon effective UID, and accepted policy.
+Reject ambient current directory, repository discovery, replacement, symlink, wrong
+owner, wrong type, and unauthorized path. One unrelated broken repository must not
+disable another Quick Task with a valid selected path.
 
 ## Current-authority gate
 
@@ -278,6 +339,11 @@ commit-acknowledged affine receipt, no receipt reconstruction, operation-specifi
 restart reconciliation, exact Git/filesystem readback, and no schema/history role for
 repository effect records.
 
+Also prove independent service assembly: `Ready`, `Disabled`, and typed `Unavailable`
+cannot alter ProductStore or Quick Task readiness. Repository configuration parsing is
+isolated from core runtime configuration, and no static path map duplicates PostgreSQL
+repository authority.
+
 ### Same-UID transport
 
 Prove fixed owner-only endpoint publication, descriptor identity, peer UID checks, stale
@@ -355,11 +421,18 @@ Stop the owning gate on:
 - any accepted bootstrap on a nonempty target;
 - any current-authority check that depends on schema history or an upgrade prefix;
 - any secret byte in database/reset metadata, protocol data, logs, or process arguments;
+- daemon-fatal Quick Task or ManagedRepository startup when the control plane can start;
+- a mutable capability manager, silent optional Quick Task disappearance, or readiness
+  state that substitutes for current owner fences;
+- repository configuration that blocks core parsing or duplicates PostgreSQL path
+  authority;
 - a second account selector, provider-effect ledger, process owner, or coordinator state;
 - possible external-effect replay without positive reconciliation;
 - Candidate-5 partial lineage, partial admission, ambiguous terminalization, or account
   observation/cache regression;
 - a second mutation path around `decodexd`;
+- a source candidate that retains deleted workspace/task-runner references or active
+  migration/configuration fixtures;
 - unbounded UI history loading; or
 - remote binding before security acceptance.
 


### PR DESCRIPTION
## Summary
- separate verified PostgreSQL, Quick Task, and ManagedRepository readiness
- make Quick Task availability an immutable typed projection, not a mutable capability manager
- require one integrated implementation owner after the third rejected runtime candidate

## Evidence
- exact staged tree: 7416df58e727c38710399ea94fc0870c38c5ff89
- independent review: APPROVED/READY, no P0/P1/P2
- docs-only change; git diff check passed