### PR TITLE
Restore ManagedRun gate and repair fast-uri audit

### DIFF
--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -309,6 +309,10 @@ or persisted projection without joining or starting provider refresh work.
 
 ## Domain-owner gates
 
+ManagedRun may reach successful terminal completion only from explicit authoritative
+WorkItem acceptance and validation. Objective achievement or evidence and any external
+Codex Goal state cannot establish WorkItem acceptance or ManagedRun success.
+
 ### ProcessGeneration
 
 Prove opaque launch identity, exact selected-account credential-negative binding, fresh

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/site/package.json
+++ b/site/package.json
@@ -23,6 +23,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
+    "fast-uri": "3.1.5",
     "yaml": "2.9.0",
     "vite": "8.0.16"
   }


### PR DESCRIPTION
## Summary

- restore the normative ManagedRun/WorkItem acceptance paragraph removed from `openwiki/specs/vnext-gates.md` by merged PR #1255
- pin transitive `fast-uri` to the fixed 3.1.5 release through the existing site override so the repository audit gate is green

## Evidence

- Base: `367471dc33ed256dd65b8d3d572c2ed9a89b4daa`
- Signed commits: `5379a07cb3642dd5a0a4d1fbaa19c884e0b18b6e`, `8889fde595a67b8863bc47cc0ffc14694bfea78d`
- `fast-uri`: 3.1.4 -> 3.1.5; no other resolved package changed
- `python3 -m unittest tests/scripts/test_vnext_architecture.py`: 24 passed
- `cargo make check-automations`: passed; npm audit 0 vulnerabilities, lock/provenance/signature audits passed, site checks passed, 816 Rust tests passed with 59 skipped, architecture suite passed, PostgreSQL authority/restore stages passed
- Advisory fixed: GHSA-7p8r-x3mc-p8w7

Please review and land through the normal signed Reviewer path.

Decodex-Autonomy: upstream-dependency-repair
Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/1247
Decodex-Repair-Scope: repository-gate