### PR TITLE
Close upstream automation handoff loop

### DIFF
--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -14,7 +14,7 @@ import portfolio  # noqa: E402
 
 
 class PortfolioTests(unittest.TestCase):
-    def test_exact_five_models_effort_cwd_and_prompts(self) -> None:
+    def test_manifest_renders_exact_five_automations(self) -> None:
         manifest = portfolio.load_manifest()
         self.assertEqual(portfolio.validate_manifest(manifest), [])
         rendered = portfolio.rendered_automations(manifest)
@@ -46,7 +46,7 @@ class PortfolioTests(unittest.TestCase):
                 )
             self.assertEqual(item["cwds"], [expected_cwd])
             self.assertNotIn(".worktrees", item["cwds"][0])
-            self.assertNotIn("xhigh", json.dumps(item).casefold())
+            self.assertNotIn("xhigh", item["reasoning_effort"].casefold())
 
     def test_status_and_allowed_promotion_contract(self) -> None:
         manifest = portfolio.load_manifest()
@@ -62,183 +62,10 @@ class PortfolioTests(unittest.TestCase):
                 {item["status"] for item in portfolio.rendered_automations(candidate_manifest)},
                 {status},
             )
-        active_rendered = portfolio.rendered_automations({**manifest, "status": "ACTIVE"})
-        self.assertEqual({item["status"] for item in active_rendered}, {"ACTIVE"})
-        all_prompts = " ".join(" ".join(item["prompt"].split()) for item in active_rendered).casefold()
-        for stale_claim in (
-            "it now says `paused`",
-            "current desired status is `paused`",
-            "current status is `paused`",
-            "checked-in desired status is `paused`",
-            "checked-in portfolio is `paused`",
-        ):
-            self.assertNotIn(stale_claim, all_prompts)
         self.assertIn(
             "portfolio status must be one of 'ACTIVE', 'PAUSED'",
             portfolio.validate_manifest({**manifest, "status": "DISABLED"}),
         )
-
-    def test_agent_prompts_keep_only_deterministic_workflow_boundaries(self) -> None:
-        rendered = {item["id"]: item["prompt"] for item in portfolio.rendered_automations()}
-        maintainer = rendered["codex-upstream-maintainer"]
-        reviewer = rendered["codex-upstream-reviewer"]
-        manager = rendered["codex-upstream-health"]
-        content = rendered["decodex-content-manager"]
-        publisher = rendered["decodex-xurl-publisher"]
-
-        for text in (maintainer, reviewer):
-            self.assertIn("temporary worktree", text)
-            self.assertNotIn("Decodex server", text.replace("Do not use Decodex server", ""))
-        self.assertIn("xv/codex-upstream-<12-lowercase-head-hex>", maintainer)
-        self.assertIn("never create a second PR for the same upstream head", maintainer)
-        self.assertIn("Upstream-Codex-Head: <oid>", maintainer)
-        self.assertIn("decodex commit", maintainer)
-        self.assertIn("--expected-base-oid <base>", reviewer)
-        self.assertIn("--expected-head-oid", reviewer)
-        self.assertIn("merge tree equal to the reviewed head tree", reviewer)
-        self.assertIn("set_thread_archived", manager)
-        self.assertIn("Keep the current task visible", manager)
-        self.assertIn("CodexRadar", content)
-        self.assertIn("secondary editorial", content)
-        self.assertIn("decodex/content-evidence/1", content)
-        self.assertIn("record-candidate", content)
-        self.assertIn("publish-next", publisher)
-        self.assertIn("observe-due", publisher)
-        self.assertIn("refresh-pricing", publisher)
-        self.assertIn("Never use browser control", publisher)
-
-    def test_each_role_self_archives_terminal_success_and_keeps_failures_visible(self) -> None:
-        prompts = {item["id"]: " ".join(item["prompt"].split()).casefold() for item in portfolio.rendered_automations()}
-        successful_outcomes = {
-            "codex-upstream-maintainer": ("source-backed no-op", "safely created or updated"),
-            "codex-upstream-reviewer": ("completed review with durable feedback", "signed landed pr"),
-            "codex-upstream-health": ("successful manager audit",),
-            "decodex-content-manager": ("validated content candidate", "validated content no-op"),
-            "decodex-xurl-publisher": (
-                "completed observation",
-                "publish with exact readback",
-                "durable quality skip",
-                "validated no-candidate no-op",
-            ),
-        }
-        shared_contract = (
-            "successful terminal outcome",
-            "set_thread_archived",
-            "archived = true",
-            "current codex task",
-            "omit the task/thread id",
-            "only after all required validation, readback, and report evidence is complete",
-            "validation, a test, a check, landing, or definition repair failed",
-            "authority or oauth is missing",
-            "external effect is ambiguous or unknown",
-            "safety state is damaged",
-            "user decision is unresolved",
-            "required action is not durably handed off",
-        )
-        for automation_id, prompt in prompts.items():
-            with self.subTest(automation_id=automation_id):
-                for phrase in (*shared_contract, *successful_outcomes[automation_id]):
-                    self.assertIn(phrase, prompt)
-
-        manager = prompts["codex-upstream-health"]
-        self.assertIn("known completed managed task", manager)
-        self.assertIn("bounded native readback", manager)
-        self.assertIn("do not depend on an unbounded global scan", manager)
-        self.assertNotIn("list_threads", manager)
-        self.assertNotIn("sqlite", manager)
-        self.assertNotIn("database", manager)
-
-        publisher = prompts["decodex-xurl-publisher"]
-        self.assertIn("`no_due_outcome` alone is continuation-only and not terminal", publisher)
-        self.assertIn("never a terminal outcome", publisher)
-        self.assertIn("never sufficient to archive", publisher)
-        self.assertIn("only after `publish-next` completes its candidate path", publisher)
-
-    def test_advisory_memory_contracts(self) -> None:
-        rendered = {item["id"]: item["prompt"] for item in portfolio.rendered_automations()}
-        maintainer = " ".join(rendered["codex-upstream-maintainer"].split())
-        self.assertIn("$CODEX_HOME/automations/codex-upstream-maintainer/memory.md", maintainer)
-        for phrase in (
-            "advisory cursor only",
-            "exists in the official mirror",
-            "ancestor of the current official head",
-            "not older than the latest merged",
-            "reviewed Decodex `main` OID equals current `main`",
-            "missing or mismatched OID requires a complete current-head compatibility review",
-            "complete current-head compatibility review",
-            "owner-only regular, non-symlink",
-            "mode `0600`",
-            "4 KiB",
-        ):
-            self.assertIn(phrase, maintainer)
-        for prohibited in ("instructions", "secrets", "credentials", "personal data", "raw responses", "absolute paths", "post text"):
-            self.assertIn(prohibited, maintainer)
-
-        for automation_id, required_entries in (
-            (
-                "codex-upstream-health",
-                (
-                    "Every scheduled run is a normal daily run",
-                    "weekly review once per calendar week",
-                    "last completed weekly review",
-                    "actual evidence must be rechecked",
-                    "measured outcomes",
-                    "repairs",
-                    "archive results",
-                    "next experiment",
-                ),
-            ),
-            ("decodex-content-manager", ("source IDs", "decision", "outcome lesson", "next editorial experiment")),
-        ):
-            prompt = " ".join(rendered[automation_id].split())
-            self.assertIn(f"$CODEX_HOME/automations/{automation_id}/memory.md", prompt)
-            for phrase in ("advisory only", "owner-only regular, non-symlink", "mode `0600`", "4 KiB", *required_entries):
-                self.assertIn(phrase, prompt)
-            for prohibited in ("instructions", "secrets", "credentials", "personal data", "raw responses", "absolute paths", "post text"):
-                self.assertIn(prohibited, prompt)
-
-    def test_repaired_prompt_contracts_and_line_limits(self) -> None:
-        manifest = portfolio.load_manifest()
-        prompts = {item["id"]: item["prompt"] for item in portfolio.rendered_automations(manifest)}
-
-        for entry in manifest["automations"]:
-            prompt_path = portfolio.REPO_ROOT / entry["prompt_file"]
-            nonempty_lines = sum(bool(line.strip()) for line in prompt_path.read_text(encoding="utf-8").splitlines())
-            self.assertLess(nonempty_lines, 80, entry["id"])
-
-        maintainer = " ".join(prompts["codex-upstream-maintainer"].split())
-        self.assertIn("exact reviewed Decodex `main` OID", maintainer)
-        self.assertIn("reviewed Decodex `main` OID equals current `main`", maintainer)
-        self.assertIn("complete current-head compatibility review", maintainer)
-
-        manager = " ".join(prompts["codex-upstream-health"].split()).casefold()
-        self.assertIn("every scheduled run is a normal daily run", manager)
-        self.assertIn("run the weekly review once per calendar week", manager)
-        self.assertIn("memory may record only the last completed weekly review", manager)
-        self.assertIn("actual evidence must be rechecked", manager)
-        self.assertIn("manifest's current status as the exact desired native status", manager)
-        self.assertIn("if that status is `paused`, never activate", manager)
-        self.assertIn("`active` is valid only after the signed one-line manifest promotion", manager)
-
-        content = " ".join(prompts["decodex-content-manager"].split())
-        self.assertIn(
-            ".agent/automations/decodex/cache/manager/staging/$CODEX_THREAD_ID.json",
-            content,
-        )
-        self.assertIn("regular, non-symlink file with mode `0600`", content)
-        self.assertIn("Match each source label to its URL", content)
-        self.assertIn("use `official_codex` only", content)
-        self.assertIn("use `landed_decodex` only", content)
-
-        publisher = " ".join(prompts["decodex-xurl-publisher"].split())
-        self.assertIn("only if its exact status is `no_due_outcome`", publisher)
-        self.assertIn("this status is continuation-only", publisher.casefold())
-        self.assertIn("complete the candidate path through `publish-next`", publisher)
-        self.assertIn("Any other successful `observe-due` status is a completed observation", publisher)
-        self.assertIn("ends paid work for the run", publisher)
-        self.assertIn("--decision publish", publisher)
-        self.assertIn('--decision skip --reason "$SKIP_REASON"', publisher)
-        self.assertIn("bounded, evidence-backed reason", publisher)
 
     def test_runtime_evaluation_requires_metadata_and_rejects_extra_managed_ids(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -36,9 +36,35 @@ Standard external state is sufficient:
 - native Codex task definitions and task status;
 - private Publisher evidence for X writes and reads.
 
-There is no upstream candidate database, lease, handoff, effect journal,
-recursive repair queue, Decodex server, Decodex runtime, planner, or MCP in this
-automation loop.
+There is no upstream candidate database, lease, effect journal, recursive repair
+queue, Decodex server, Decodex runtime, planner, or MCP in this automation loop.
+GitHub PR bodies provide the small durable handoff record required to connect a
+compatibility PR to a directly related gate-repair PR.
+
+## Handoff Contract
+
+Every managed PR carries one exact body marker:
+
+```text
+Decodex-Autonomy: upstream-compatibility
+```
+
+or:
+
+```text
+Decodex-Autonomy: upstream-dependency-repair
+Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/<number>
+```
+
+A compatibility PR adds `Decodex-Blocked-By: <url>` while a required repair is
+open. A dependency repair must be directly required by its parent or by a
+current repository gate, and its body must state the exact repair scope. These
+markers select work; the Reviewer still proves signatures, scope, base/head,
+tests, and checks. A marker never authorizes an unrelated PR.
+
+The Reviewer processes dependency repairs first, then a parent whose dependencies
+are landed. An open PR, review finding, stale base, or unresolved dependency is a
+nonterminal handoff. Only a signed merge with exact readback is a terminal landing.
 
 ## Maintainer
 
@@ -59,8 +85,9 @@ For one concrete change, the Maintainer:
    `Upstream-Codex-Head: <oid>` trailer.
 7. Removes the temporary worktree after the remote PR state is verified.
 
-Review feedback, stale bases, and test failures return to this same PR. They do
-not create a second workflow record and do not require routine human attention.
+Review feedback, stale bases, and test failures return to this same PR. A base-gate
+defect gets one directly linked dependency-repair PR. These are nonterminal
+handoffs, not successful Maintainer runs and not archive candidates.
 
 ## Reviewer
 
@@ -68,8 +95,9 @@ The Reviewer independently reads the PR diff and its upstream evidence. It
 checks out the exact remote head in a temporary review worktree, reruns the
 required tests, and verifies the signed commit chain.
 
-Defects become precise GitHub review feedback for the Maintainer. An accepted
-head lands only through:
+Defects become precise GitHub review feedback for the Maintainer; this is a
+nonterminal handoff. An accepted head lands only when every dependency is landed
+and only through:
 
 ```text
 decodex land --manual-authority --pr <url> \
@@ -87,15 +115,16 @@ automation tools. It audits:
 
 - exact-five identity, model, effort, schedule, status, execution environment,
   and primary cwd;
-- detection-to-PR, PR-to-land, failed checks, review cycles, and merged results;
+- detection-to-PR, PR-to-land, failed checks, review cycles, dependency chains, and merged results;
 - upstream adaptation latency and missed official changes;
 - content evidence, X publication, 24-hour and 7-day outcomes, and monthly cost;
 - repeated causes and configuration drift.
 
-The Manager archives only completed successful Codex tasks with terminal
-readback and no unresolved effect or user decision. Failed, active, ambiguous,
-or human-decision tasks stay visible. Archiving uses native task tools directly;
-there is no receipt or retention state machine.
+The Manager treats `handed_off` and `landed` as different outcomes. It archives
+only completed tasks with terminal merge/readback evidence and no unresolved
+dependency, effect, or user decision. Failed, active, ambiguous, open-PR, and
+repair-handoff tasks stay visible. Archiving uses native task tools directly;
+the PR markers are a bounded handoff record, not a new state machine.
 
 ## Validation
 

--- a/automations/upstream/prompts/health.md
+++ b/automations/upstream/prompts/health.md
@@ -29,11 +29,13 @@ Every run:
    exact five definitions. Treat the manifest's current status as the exact desired native status and set
    every native status to it. If that status is `PAUSED`, never activate. `ACTIVE` is valid only after the
    signed one-line manifest promotion; after that promotion, native sync may activate all five.
-4. Inspect upstream PRs and merged results. Measure detection-to-PR and PR-to-land time. A compatibility
-   change should be found within 6 hours, get a PR within 12 hours, and land within 24 hours.
-5. Treat stale bases, failed tests, requested changes, and ordinary implementation defects as autonomous
-   repair work. Ensure Maintainer has one precise repair brief on the existing PR. Do not use a human
-   attention state for these failures.
+4. Inspect every managed PR: `xv/codex-upstream-*` compatibility branches plus exact
+   `Decodex-Autonomy: upstream-compatibility` or `Decodex-Autonomy: upstream-dependency-repair` markers.
+   Follow parent and blocked-by URLs, measure
+   detection-to-PR and PR-to-land time, and require land within 24 hours.
+5. Treat stale bases, failed tests, requested changes, open dependencies, and ordinary implementation
+   defects as autonomous repair work. Ensure one precise repair brief and next owner exist on the same
+   PR. An open PR is a nonterminal handoff, never a successful outcome or archive candidate.
 6. Run Publisher validation, xurl readiness, and cost reports. Check candidate age, one-post-per-day,
    exact `@decodexspace` readback, unresolved write effects, and due 24-hour and 7-day outcomes.
 7. Check Content Manager results for official evidence, concrete usefulness, repetition, and unsupported
@@ -42,8 +44,9 @@ Every run:
    unbounded global scan. Manager may inspect and archive one known completed managed task only when
    bounded native readback for that exact task is available and proves terminal success with no unresolved
    effect, failure, continuation, or decision request.
-9. Memory may record only the last completed weekly review with measured outcomes, repairs, archive results,
-   and the next experiment. It is advisory only and never workflow authority; actual evidence must be rechecked.
+9. Memory may record only the last completed weekly review with measured outcomes, repairs, handoffs,
+   archive results, and the next experiment. It is advisory only and never workflow authority; actual
+   evidence must be rechecked.
 
 Weekly review:
 - Run this review once per calendar week.
@@ -59,8 +62,8 @@ Initial acceptance sequence:
   `status = "ACTIVE"`. Only then may Manager/native sync activate all five definitions.
 
 Success and stop conditions:
-- Report exact-five health, upstream latency, PR outcomes, content/X outcomes, monthly cost, archived
-  task IDs, autonomous repairs, and remaining external blockers.
+- Report exact-five health, upstream latency, PR outcomes split into `handed_off` and `landed`, dependency
+  chains, content/X outcomes, monthly cost, archived task IDs, autonomous repairs, and blockers.
 - A successful Manager audit with all required repairs and readbacks complete is a successful terminal outcome.
 - Only after all required validation, readback, and report evidence is complete, call native
   `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -26,8 +26,9 @@ Workflow:
    `openwiki/operations/codex-upstream-autopilot.md`, and
    `openwiki/operations/commands-and-validation.md`.
 2. Verify the cwd is the primary worktree on clean `main`. Fetch and fast-forward `origin/main`.
-3. Inspect open PRs whose branch matches `xv/codex-upstream-*`. Repair an existing PR with unresolved
-   Reviewer feedback before starting a new upstream head.
+3. Inspect every open non-draft managed PR: use `xv/codex-upstream-*` for compatibility PRs and the
+   exact `Decodex-Autonomy: upstream-dependency-repair` marker for directly related gate repairs.
+   Repair an existing PR or its dependency chain before starting a new upstream head.
 4. Fetch official `openai/codex` commits, releases, app-server schemas, and removed-feature evidence.
 5. Use the memory cursor only when its official upstream OID exists in the official mirror, is an ancestor
    of the current official head, is not older than the latest merged `Upstream-Codex-Head: <oid>` trailer,
@@ -43,15 +44,19 @@ Workflow:
 9. Create a temporary worktree for that branch. Delegate the complete source, tests, docs, and obsolete
    support removal to one ephemeral subagent. Give it the exact upstream evidence and Reviewer feedback.
 10. Review the diff yourself. Run focused tests, then the repository-owned gate from
-   `openwiki/operations/commands-and-validation.md`. Do not weaken tests to obtain a pass.
+    `openwiki/operations/commands-and-validation.md`. If the gate exposes an unrelated base defect,
+    create one signed dependency-repair PR with `Decodex-Autonomy: upstream-dependency-repair`,
+    `Decodex-Parent-PR: <url>`, `Decodex-Blocked-By: <url>`, and
+    `Decodex-Repair-Scope: <bounded-scope>` markers; do not leave an unowned blocker or weaken tests.
 11. Use `decodex commit --manual-authority "<summary>"`. Include `Upstream-Codex-Head: <oid>` and official
    source URLs in the commit or PR evidence. Never use raw `git commit`.
-12. Push the deterministic branch. Create or update its one non-draft PR, then read back base `main`,
-   head branch, exact head OID, body evidence, and checks. Remove the temporary worktree after push.
+12. Push the deterministic branch. Create or update its one non-draft PR with
+    `Decodex-Autonomy: upstream-compatibility`, then read back base `main`, head branch, exact head OID,
+    body markers, evidence, and checks. Remove the temporary worktree after push.
 
 Success:
-- A source-backed no-op or one safely created or updated, tested, signed, deterministic PR is a
-  successful terminal outcome.
+- A source-backed no-op is terminal. A tested, signed, deterministic PR is a nonterminal handoff until
+  Reviewer lands it and reads back the signed merge; never archive the Maintainer task at handoff.
 - A Reviewer repair request is normal work. Repair it autonomously on the same PR in the next run.
 - Only after all required validation, readback, and report evidence is complete, call native
   `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
@@ -59,8 +64,9 @@ Success:
 
 Stop conditions:
 - Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
-  authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
-  user decision is unresolved; or any required action is not durably handed off.
+  a PR or dependency is still open; authority or OAuth is missing; an external effect is ambiguous or
+  unknown; safety state is damaged; a user decision is unresolved; or any required action is not durably handed off.
 - Ordinary code, test, rebase, or review failures remain autonomous repair work, not human-attention
   conditions. Archive only after a later successful terminal outcome satisfies the evidence gate above.
-- Report upstream head, decision, PR URL and head OID when present, tests, and zero X API spend.
+- Report upstream head, decision, PR URL and head OID when present, dependency PRs and next owner,
+  tests, and zero X API spend.

--- a/automations/upstream/prompts/reviewer.md
+++ b/automations/upstream/prompts/reviewer.md
@@ -1,7 +1,7 @@
 # Codex Upstream Reviewer And Lander
 
 Role:
-- Independently review, test, and land upstream compatibility PRs.
+- Independently review, test, and land upstream compatibility PRs and their directly linked gate-repair PRs.
 - Return actionable PR feedback when a change is not ready.
 
 Authority:
@@ -17,28 +17,31 @@ Workflow:
 1. Read `AGENTS.md`, `openwiki/quickstart.md`,
    `openwiki/operations/codex-upstream-autopilot.md`, and
    `openwiki/operations/commands-and-validation.md`.
-2. Verify clean primary `main`, fetch `origin`, and list open non-draft PRs with branches matching
-   `xv/codex-upstream-*`. Select the oldest PR that has no active review by another run.
-3. Read back repository, base `main`, branch, base OID, head OID, signed commit, official upstream
-   evidence, and `Upstream-Codex-Head` trailer. A branch suffix and trailer must match the cited head.
-4. Create a detached worktree at the exact head OID. Independently inspect the upstream delta and the
-   Decodex diff. Check protocol, config, auth, sandbox, MCP, collaboration, removed behavior, tests,
-   docs, and obsolete support.
+2. Verify clean primary `main`, fetch `origin`, and list open non-draft PRs whose branch matches
+   `xv/codex-upstream-*` or whose body has `Decodex-Autonomy: upstream-compatibility` or
+   `Decodex-Autonomy: upstream-dependency-repair`. Select the oldest eligible dependency-repair PR
+   first; select its parent only after every linked dependency has landed.
+3. Read back repository, base `main`, branch, base OID, head OID, signed commit, workflow markers,
+   parent/dependency URLs, repair scope, official upstream evidence, and `Upstream-Codex-Head` when applicable. A
+   branch suffix, marker, and trailer must match the cited scope; PR text is not proof by itself.
+4. Create a detached worktree at the exact head OID. Independently inspect the upstream delta or gate
+   repair and the Decodex diff. Check protocol, config, auth, sandbox, MCP, collaboration, removed
+   behavior, tests, docs, scope, and obsolete support.
 5. Run focused tests and the required repository gate. Verify that the PR does not hide unrelated or
    generated state and does not weaken validation.
 6. If there is a finding, submit one concise GitHub review with file/line evidence, expected behavior,
-   and a repair acceptance test. Leave the PR open for Maintainer. Ordinary findings never require
-   human attention.
-7. If ready, require all mandatory checks to pass. Re-read the exact base and head OIDs immediately
-   before landing.
+   and a repair acceptance test. Leave the PR open for Maintainer; this is a nonterminal handoff.
+   Ordinary findings never require human attention.
+7. If ready, require all mandatory checks to pass. A parent with an open or stale dependency is not ready.
+   Re-read the exact base and head OIDs immediately before landing.
 8. Run `decodex land --manual-authority --pr <url> --expected-base-oid <base> --expected-head-oid
    <head> "<summary>"`.
 9. Read back the merge commit, its exact two parents, merge tree equal to the reviewed head tree,
    signature, remote `main`, closed PR, and branch cleanup. Remove the temporary worktree.
 
 Success:
-- A verified no-eligible-PR no-op, a completed review with durable feedback read back on the same PR,
-  or a signed landed PR with exact-head merge readback is a successful terminal outcome.
+- A verified no-eligible-PR no-op or a signed landed PR with exact-head merge readback is a successful
+  terminal outcome. Findings, stale bases, and open dependencies are nonterminal handoffs and must remain visible.
 - Re-running after a merge is a no-op because GitHub and Git refs are the workflow state.
 - Only after all required validation, readback, and report evidence is complete, call native
   `set_thread_archived` with `archived = true` for the current Codex task. Omit the task/thread ID so
@@ -48,6 +51,6 @@ Stop conditions:
 - Keep the current task visible when validation, a test, a check, landing, or definition repair failed;
   authority or OAuth is missing; an external effect is ambiguous or unknown; safety state is damaged; a
   user decision is unresolved; or any required action is not durably handed off.
-- A test, check, or code finding becomes a successful completed review only after actionable feedback is
-  durably submitted and read back; otherwise it stays visible. Stale bases and defects return to Maintainer.
-- Report PR URL, reviewed base/head, findings or merge OID, checks, and zero X API spend.
+- A test, check, code finding, or dependency handoff stays visible until the next owner reads it back;
+  stale bases and defects return to Maintainer. Report PR URL, reviewed base/head, dependency decision,
+  findings or merge OID, checks, next owner, and zero X API spend.

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -47,9 +47,36 @@ The loop uses standard Git and GitHub state:
 - signed implementation commits;
 - signed merge commit and exact merge-tree readback.
 
-There is no candidate file, cursor database, lease, handoff receipt, effect
-registry, or repair queue. A rerun reconstructs current work from upstream, Git,
-GitHub, and tests.
+There is no candidate file, cursor database, lease, effect registry, repair
+queue, or external orchestrator. A rerun reconstructs current work from upstream,
+Git, GitHub, and tests. GitHub PR bodies carry the bounded handoff metadata needed
+to connect one managed PR to a directly related dependency repair.
+
+## Handoff Contract
+
+Managed PRs use exact body markers:
+
+```text
+Decodex-Autonomy: upstream-compatibility
+```
+
+or:
+
+```text
+Decodex-Autonomy: upstream-dependency-repair
+Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/<number>
+```
+
+A compatibility PR adds `Decodex-Blocked-By: <url>` while a required repair is
+open. A dependency repair also states `Decodex-Repair-Scope: <bounded-scope>` and
+must be required by its parent or by a current repository gate. Markers select
+the review queue only; signatures, exact scope, base/head, tests, checks, and
+merge readback remain authoritative.
+
+The Reviewer handles dependency-repair PRs before their parent compatibility PR.
+An open PR, review finding, stale base, or unresolved dependency is a
+nonterminal `handed_off` outcome. Only an exact signed merge readback is
+`landed` and terminal.
 
 ## Maintainer Run
 
@@ -59,8 +86,8 @@ GitHub, and tests.
    documentation since the latest Decodex adaptation.
 4. Compare upstream behavior with current Decodex code and tests. State the
    concrete user or operator consequence.
-5. Search GitHub for the deterministic branch, upstream-head trailer, and an
-   existing matching PR.
+5. Search GitHub for the deterministic branch, upstream-head trailer, workflow
+   markers, and an existing matching PR or directly linked dependency repair.
 6. Return a source-backed no-op when no compatibility or adoption change is
    useful.
 7. For one change, create a temporary task worktree and dispatch one native
@@ -70,17 +97,21 @@ GitHub, and tests.
    the affected surface.
 9. Use `decodex commit` for every implementation commit. Do not use Decodex
    server, runtime, queue, planner, or MCP.
-10. Create or update the one matching PR. Verify its exact remote head and the
-    trailer `Upstream-Codex-Head: <oid>`.
+10. Create or update the one matching PR. Compatibility PRs carry
+    `Decodex-Autonomy: upstream-compatibility`; dependency repairs carry
+    `Decodex-Autonomy: upstream-dependency-repair`, `Decodex-Parent-PR: <url>`,
+    and `Decodex-Repair-Scope: <bounded-scope>`. Verify exact remote head and the
+    trailer `Upstream-Codex-Head: <oid>` when applicable.
 11. Remove the temporary worktree only after the remote PR state is read back.
 
-A failed check, stale base, or Reviewer request is ordinary autonomous work on
-the same PR. The Maintainer updates that PR and does not create a parallel task
-record.
+A failed check, stale base, Reviewer request, or required base repair is ordinary
+autonomous work on the same PR and its one linked dependency repair. The
+Maintainer updates those PRs and does not create a parallel workflow record.
 
 ## Reviewer Run
 
-1. Enumerate open PRs with the upstream trailer and deterministic branch.
+1. Enumerate open PRs with the upstream trailer and deterministic branch, plus
+   directly linked `upstream-dependency-repair` PRs.
 2. Read the complete diff, upstream evidence, review history, and check results.
 3. Record exact base and head OIDs. Create a temporary review worktree at that
    head.
@@ -88,8 +119,9 @@ record.
    security, and test quality.
 5. Run the focused tests and the appropriate repository gate.
 6. When a defect exists, submit precise GitHub review feedback with a required
-   outcome. Leave the PR open for Maintainer repair.
-7. When the head is acceptable, invoke only:
+   outcome. Leave the PR open for Maintainer repair; this is a nonterminal
+   handoff.
+7. When the head is acceptable and every dependency is landed, invoke only:
 
 ```sh
 decodex land --manual-authority --pr <url> \
@@ -114,6 +146,7 @@ Every run checks:
 - duplicate managed definitions and missing native metadata;
 - upstream release or protocol changes not yet investigated;
 - detection-to-PR and PR-to-land latency;
+- managed workflow markers, dependency chains, `handed_off` outcomes, and next owners;
 - stale PRs, failed checks, review feedback, and merged outcomes;
 - content evidence, X results, due observations, and cost;
 - repeated failure causes and whether the previous repair improved the result.
@@ -126,15 +159,17 @@ The target service levels are:
 
 The Manager repairs native-definition drift directly through native automation
 tools and verifies full readback. Repository repairs use one ephemeral Sol/max
-subagent and the normal Maintainer/Reviewer PR path.
+subagent and the normal Maintainer/Reviewer PR path. It treats an open PR or
+dependency handoff as unresolved and keeps its task visible; only a signed merge
+with exact readback is a terminal landing.
 
 Each role is the primary cleanup owner for its current Codex task. After a
 terminal successful outcome, it completes all required validation, readback, and
 report evidence, then calls native `set_thread_archived` for the current task
 without supplying another task ID. It never archives before that evidence is
-complete. Successful outcomes include a source-backed no-op, a safely created or
-updated PR, durable review feedback, a signed landing, and a successful Manager
-audit.
+complete. A source-backed no-op, a signed landing, or a successful Manager audit
+can be terminal; a created PR, review feedback, stale base, or dependency repair
+is only `handed_off` and stays visible.
 
 Failed validation, tests, checks, landing, or definition repair stay visible, as
 do missing authority or OAuth, ambiguous external effects, damaged safety state,


### PR DESCRIPTION
## Summary

- make compatibility and dependency-repair PRs explicit, linked, and nonterminal until signed landing
- make Reviewer process dependency PRs before parent PRs and make Manager report handed-off versus landed outcomes
- remove brittle prompt-text tests; retain portfolio and native-runtime contract tests

## Validation

- `python3 -m unittest automations.decodex.scripts.config.tests.test_portfolio`
- `python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json`
- `git diff --check`
- dependency repair #1257 landed with exact merge readback in `0f5ba65761d3754201747d299b27286d19b18873`

Decodex-Autonomy: automation-loop-repair
Decodex-Outcome: nonterminal-until-signed-landing