### PR TITLE
Accept current Codex thread section fields

### DIFF
--- a/crates/decodex-codex/src/quick_task.rs
+++ b/crates/decodex-codex/src/quick_task.rs
@@ -949,7 +949,19 @@ struct QuickTaskThreadResponseWire {
 	agent_role: Option<String>,
 	git_info: Option<QuickTaskGitInfoWire>,
 	name: Option<String>,
+	#[serde(default)]
+	section: Option<QuickTaskThreadSectionWire>,
+	#[serde(default)]
+	section_entered_at: Option<i64>,
 	turns: Vec<QuickTaskForbiddenValueWire>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct QuickTaskThreadSectionWire {
+	id: String,
+	name: String,
 }
 
 #[allow(dead_code)]
@@ -1499,6 +1511,8 @@ const THREAD_RESPONSE_FIELDS: &[&str] = &[
 	"agentRole",
 	"gitInfo",
 	"name",
+	"section",
+	"sectionEnteredAt",
 	"turns",
 ];
 const THREAD_RESPONSE_REQUIRED_FIELDS: &[&str] = &[
@@ -1845,6 +1859,85 @@ mod tests {
 		assert_eq!(turn.status(), QuickTaskTurnStatus::InProgress);
 		assert!(decode_quick_task_turn_interrupt_response(b"{}").is_ok());
 		assert!(decode_quick_task_thread_archive_response(b"{}").is_ok());
+	}
+
+	#[test]
+	fn current_null_thread_section_fields_decode() {
+		let mut current = thread_response("thread-1", "gpt-5", "/workspace");
+		current["thread"]["section"] = Value::Null;
+		current["thread"]["sectionEnteredAt"] = Value::Null;
+		let bytes = serde_json::to_vec(&current).expect("fixture response must serialize");
+
+		assert!(decode_quick_task_thread_start_response(&start_request(), &bytes).is_ok());
+		assert!(decode_quick_task_thread_resume_response(&resume_request(), &bytes).is_ok());
+	}
+
+	#[test]
+	fn populated_thread_section_decodes() {
+		let mut current = thread_response("thread-1", "gpt-5", "/workspace");
+		current["thread"]["section"] = json!({"id": "section-1", "name": "Active"});
+		current["thread"]["sectionEnteredAt"] = json!(2);
+
+		assert!(
+			decode_quick_task_thread_start_response(
+				&start_request(),
+				&serde_json::to_vec(&current).expect("fixture response must serialize"),
+			)
+			.is_ok()
+		);
+	}
+
+	#[test]
+	fn legacy_omitted_thread_section_fields_decode() {
+		let legacy = thread_response("thread-1", "gpt-5", "/workspace");
+		let thread = legacy["thread"].as_object().expect("fixture thread must be an object");
+
+		assert!(!thread.contains_key("section"));
+		assert!(!thread.contains_key("sectionEnteredAt"));
+		assert!(
+			decode_quick_task_thread_start_response(
+				&start_request(),
+				&serde_json::to_vec(&legacy).expect("fixture response must serialize"),
+			)
+			.is_ok()
+		);
+	}
+
+	#[test]
+	fn malformed_or_unknown_thread_section_is_rejected() {
+		let canonical = thread_response("thread-1", "gpt-5", "/workspace");
+		let cases = [
+			(
+				"missing name",
+				json!({"id": "section-1"}),
+				QuickTaskContractError::MissingResponseField,
+			),
+			(
+				"invalid id type",
+				json!({"id": 1, "name": "Active"}),
+				QuickTaskContractError::MalformedResponse,
+			),
+			(
+				"unknown field",
+				json!({"id": "section-1", "name": "Active", "unexpected": true}),
+				QuickTaskContractError::UnknownResponseField,
+			),
+		];
+
+		for (case, section, expected) in cases {
+			let mut response = canonical.clone();
+			response["thread"]["section"] = section;
+
+			assert_eq!(
+				decode_quick_task_thread_start_response(
+					&start_request(),
+					&serde_json::to_vec(&response).expect("fixture response must serialize"),
+				)
+				.map(|_| ()),
+				Err(expected),
+				"{case}",
+			);
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
Decodex-Autonomy: upstream-compatibility
Upstream-Codex-Head: 17df7545a34ac533eedf5b628f49f2f1ad60e44e
Reviewed-Decodex-Main: b00716dd2e44ca887a7f267bfe9f8d67ee2e36be

## Decision

Current official Codex serializes the optional, default-null section and sectionEnteredAt fields on Thread responses. The closed Decodex Quick Task decoder rejected those names as protocol drift. This change accepts both fields, strictly decodes a populated ThreadSection with required string id and name fields, preserves legacy omission allowed by the upstream serde defaults, and keeps unknown nested fields rejected.

The complete current-head review found no other required change across protocol, config, auth, sandbox, MCP, collaboration, thread, turn, and transport surfaces. The two commits that landed after implementation began redact command display values and adjust TUI-only MCP startup status handling; neither changes the accepted Decodex wire shape.

## Official evidence

- Current official head: https://github.com/openai/codex/commit/17df7545a34ac533eedf5b628f49f2f1ad60e44e
- Current Thread and ThreadSection source: https://github.com/openai/codex/blob/17df7545a34ac533eedf5b628f49f2f1ad60e44e/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L170-L206
- Verified prerelease and generated-schema evidence: https://github.com/openai/codex/releases/tag/rust-v0.147.0-alpha.7
- Command-display redaction delta: https://github.com/openai/codex/commit/fcf636a41dbcd8372ad64301b7092621a155747b
- TUI-only MCP startup delta: https://github.com/openai/codex/commit/17df7545a34ac533eedf5b628f49f2f1ad60e44e

The rust-v0.147.0-alpha.7 macOS arm64 asset matched its official SHA-256. Its experimental app-server schema output was byte-identical to the source schema at the implementation review head. The current-head delta changes no schema shape.

## Validation

- cargo test -p decodex-codex --all-targets --all-features: 60 passed
- cargo make check with full Xcode and Metal: passed in 620.67 seconds
- Full nextest stage: 893 passed, 59 skipped
- PostgreSQL aggregate and restore authority stages: passed
- Signed commit verification: passed

No dependency-repair PR is required.