### PR TITLE
Fix route refresh coordination

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardRefreshCoordinator.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardRefreshCoordinator.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum ResetCardRefreshWork: Equatable {
+	case full
+	case skeleton
+}
+
+/// Coalesces refresh intent without losing a daemon observation that arrives
+/// while another account operation is active.
+struct ResetCardRefreshRequests: Equatable {
+	private(set) var manualRefreshRequested = false
+	private(set) var observationGeneration: UInt64 = 0
+	private var consumedObservationGeneration: UInt64 = 0
+	private(set) var skeletonGeneration: UInt64 = 0
+	private var consumedSkeletonGeneration: UInt64 = 0
+
+	var hasFullRefreshRequest: Bool {
+		manualRefreshRequested
+			|| observationGeneration != consumedObservationGeneration
+	}
+
+	var hasSkeletonRefreshRequest: Bool {
+		skeletonGeneration != consumedSkeletonGeneration
+	}
+
+	func didConsumeSkeletonRefresh(upTo generation: UInt64) -> Bool {
+		consumedSkeletonGeneration >= generation
+	}
+
+	var hasWork: Bool {
+		hasFullRefreshRequest || hasSkeletonRefreshRequest
+	}
+
+	mutating func requestManualRefresh() {
+		manualRefreshRequested = true
+	}
+
+	mutating func requestObservationRefresh() {
+		observationGeneration &+= 1
+	}
+
+	@discardableResult
+	mutating func requestSkeletonRefresh() -> UInt64 {
+		skeletonGeneration &+= 1
+		return skeletonGeneration
+	}
+
+	mutating func takeNext() -> ResetCardRefreshWork? {
+		if hasFullRefreshRequest {
+			manualRefreshRequested = false
+			consumedObservationGeneration = observationGeneration
+			return .full
+		}
+		if hasSkeletonRefreshRequest {
+			consumedSkeletonGeneration = skeletonGeneration
+			return .skeleton
+		}
+		return nil
+	}
+
+	mutating func reset() {
+		self = Self()
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -325,7 +325,8 @@ final class ResetCardStore {
 	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
 	@ObservationIgnored private var accountObservationTask: Task<Void, Never>?
-	@ObservationIgnored private var refreshCycleTask: Task<Void, Never>?
+	@ObservationIgnored private var refreshCoordinatorTask: Task<Void, Never>?
+	@ObservationIgnored private var refreshRequests = ResetCardRefreshRequests()
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var postUseReconciliationTasks = [
@@ -385,7 +386,7 @@ final class ResetCardStore {
 	deinit {
 		startupTask?.cancel()
 		accountObservationTask?.cancel()
-		refreshCycleTask?.cancel()
+		refreshCoordinatorTask?.cancel()
 		pendingRecoveryTask?.cancel()
 		accountReauthenticationTask?.cancel()
 		for task in postUseReconciliationTasks.values {
@@ -501,7 +502,7 @@ final class ResetCardStore {
 		isPreparingForTermination = true
 
 		let inFlightStartupTask = startupTask
-		let inFlightRefreshCycleTask = refreshCycleTask
+		let inFlightRefreshCoordinatorTask = refreshCoordinatorTask
 		let inFlightPendingRecoveryTask = pendingRecoveryTask
 		let inFlightAccountReauthenticationTask = accountReauthenticationTask
 		let inFlightPostUseReconciliationTasks = Array(
@@ -512,8 +513,9 @@ final class ResetCardStore {
 		startupTask = nil
 		accountObservationTask?.cancel()
 		accountObservationTask = nil
-		refreshCycleTask?.cancel()
-		refreshCycleTask = nil
+		refreshCoordinatorTask?.cancel()
+		refreshCoordinatorTask = nil
+		refreshRequests.reset()
 		pendingRecoveryTask?.cancel()
 		pendingRecoveryTask = nil
 		accountReauthenticationTask?.cancel()
@@ -527,7 +529,7 @@ final class ResetCardStore {
 		// The native wait is a bounded synchronous FFI request. Client destruction
 		// safely releases its in-flight Arc, so termination cancels this owner but
 		// does not wait for a daemon heartbeat before shutting down the shared client.
-		await inFlightRefreshCycleTask?.value
+		await inFlightRefreshCoordinatorTask?.value
 		await inFlightPendingRecoveryTask?.value
 		await inFlightAccountReauthenticationTask?.value
 		for task in inFlightPostUseReconciliationTasks {
@@ -554,7 +556,7 @@ final class ResetCardStore {
 					}
 					generation = signal.generation
 					failureCount = 0
-					self.requestRefresh()
+					self.requestObservationRefresh()
 				} catch {
 					guard Task.isCancelled == false, reconnectDelays.isEmpty == false else {
 						return
@@ -573,32 +575,99 @@ final class ResetCardStore {
 
 	func requestRefresh() {
 		guard isPreparingForTermination == false,
-			refreshCycleTask == nil
-		else {
-			return
-		}
-
-		refreshCycleTask = Task { [weak self] in
-			guard let self else {
-				return
-			}
-			await self.performRefreshCycle()
-			self.refreshCycleTask = nil
-		}
-	}
-
-	func refresh() async {
-		requestRefresh()
-		await refreshCycleTask?.value
-	}
-
-	private func performRefreshCycle() async {
-		guard isRefreshing == false,
+			refreshCoordinatorTask == nil,
+			isRefreshing == false,
 			isRefreshingAccountSkeleton == false,
 			isAccountControlInProgress == false
 		else {
 			return
 		}
+		refreshRequests.requestManualRefresh()
+		scheduleRefreshCoordinator()
+	}
+
+	private func requestObservationRefresh() {
+		guard isPreparingForTermination == false else {
+			return
+		}
+		refreshRequests.requestObservationRefresh()
+		scheduleRefreshCoordinator()
+	}
+
+	private func requestSkeletonRefresh() {
+		guard isPreparingForTermination == false else {
+			return
+		}
+		refreshRequests.requestSkeletonRefresh()
+		scheduleRefreshCoordinator()
+	}
+
+	private func waitForAccountSkeletonRefresh() async {
+		let requestedGeneration = refreshRequests.requestSkeletonRefresh()
+		scheduleRefreshCoordinator()
+
+		while Task.isCancelled == false,
+			isPreparingForTermination == false,
+			refreshRequests.didConsumeSkeletonRefresh(upTo: requestedGeneration) == false
+		{
+			if let task = refreshCoordinatorTask {
+				await task.value
+			} else {
+				scheduleRefreshCoordinator()
+				await Task.yield()
+			}
+		}
+	}
+
+	private var canStartCoordinatedRead: Bool {
+		isRefreshing == false
+			&& isRefreshingAccountSkeleton == false
+			&& isAccountControlInProgress == false
+	}
+
+	private func scheduleRefreshCoordinator() {
+		guard isPreparingForTermination == false,
+			refreshCoordinatorTask == nil,
+			refreshRequests.hasWork
+		else {
+			return
+		}
+
+		refreshCoordinatorTask = Task { [weak self] in
+			await self?.runRefreshCoordinator()
+		}
+	}
+
+	private func runRefreshCoordinator() async {
+		defer {
+			refreshCoordinatorTask = nil
+			if canStartCoordinatedRead {
+				scheduleRefreshCoordinator()
+			}
+		}
+
+		guard Task.isCancelled == false,
+			canStartCoordinatedRead,
+			let work = refreshRequests.takeNext()
+		else {
+			return
+		}
+
+		switch work {
+		case .full:
+			await performRefreshCycle()
+		case .skeleton:
+			await performAccountSkeletonRead()
+		}
+	}
+
+	func refresh() async {
+		let inFlightCoordinatorTask = refreshCoordinatorTask
+		requestRefresh()
+		await (refreshCoordinatorTask ?? inFlightCoordinatorTask)?.value
+	}
+
+	private func performRefreshCycle() async {
 		let inFlightStartupTask = startupTask
 		let inFlightPendingRecoveryTask = pendingRecoveryTask
 		startupTask?.cancel()
@@ -667,6 +736,7 @@ final class ResetCardStore {
 			isRefreshing = false
 			refreshSkeletonIsPublished = false
 			hasLoaded = true
+			scheduleRefreshCoordinator()
 		}
 
 		var shouldRetry = false
@@ -1057,6 +1127,7 @@ final class ResetCardStore {
 		isEnrollingAccount = true
 		defer {
 			isEnrollingAccount = false
+			scheduleRefreshCoordinator()
 		}
 		let accountID = Self.newCanonicalUUID()
 		let operationID = Self.newCanonicalUUID()
@@ -1785,7 +1856,7 @@ final class ResetCardStore {
 		case .current, .failed, .missing:
 			return true
 		case .awaitingSkeleton:
-			await refreshAccountSkeleton()
+			await waitForAccountSkeletonRefresh()
 			if canCompletePostUseReconciliation(accountID) {
 				completePostUseReconciliation(accountID)
 				return true
@@ -1793,7 +1864,7 @@ final class ResetCardStore {
 			return postUseReconciliationAccountIDs.contains(accountID) == false
 		case .retryNeeded:
 			if isAwaitingFreshAccountSkeleton(accountID) {
-				await refreshAccountSkeleton()
+				await waitForAccountSkeletonRefresh()
 			}
 			return postUseReconciliationAccountIDs.contains(accountID) == false
 		}
@@ -1971,11 +2042,8 @@ final class ResetCardStore {
 		}
 	}
 
-	private func refreshAccountSkeleton() async {
-		guard let accountControlClient,
-			isRefreshingAccountSkeleton == false,
-			isAccountControlInProgress == false
-		else {
+	private func performAccountSkeletonRead() async {
+		guard let accountControlClient else {
 			return
 		}
 		let refreshGeneration = accountSkeletonRefreshGeneration
@@ -1985,6 +2053,7 @@ final class ResetCardStore {
 			if refreshGeneration != accountSkeletonRefreshGeneration {
 				scheduleFreshAccountSkeletonRead()
 			}
+			scheduleRefreshCoordinator()
 		}
 		do {
 			let projectionGeneration = beginCodexProjectionRequest()
@@ -2231,12 +2300,7 @@ final class ResetCardStore {
 			return
 		}
 		accountSkeletonRefreshGeneration &+= 1
-		guard isAccountControlInProgress == false else {
-			return
-		}
-		Task { [weak self] in
-			await self?.refreshAccountSkeleton()
-		}
+		requestSkeletonRefresh()
 	}
 
 	private func reconcileAccountSkeletonRevisionTargets() {
@@ -2906,6 +2970,7 @@ final class ResetCardStore {
 			retryDelays: accountObservationRetryDelays
 		)
 		accountReauthenticationTask = nil
+		scheduleRefreshCoordinator()
 	}
 
 	private func refreshReauthenticatedAccountAuthority(
@@ -2931,9 +2996,9 @@ final class ResetCardStore {
 	}
 
 	private func refreshReauthenticatedAccountAuthorityOnce(_ accountID: String) async {
-		await refreshAccountSkeleton()
+		await waitForAccountSkeletonRefresh()
 		await refreshAccountDetails(accountID)
-		await refreshAccountSkeleton()
+		await waitForAccountSkeletonRefresh()
 	}
 
 	private func failAccountReauthentication(
@@ -2954,6 +3019,7 @@ final class ResetCardStore {
 		if failure == .outcomeUnknown {
 			await refreshReauthenticatedAccountAuthority(accountID)
 		}
+		scheduleRefreshCoordinator()
 	}
 
 	private func finishAccountReauthentication(
@@ -2967,6 +3033,7 @@ final class ResetCardStore {
 		accountReauthenticationTask = nil
 		accountControlActivities.removeValue(forKey: accountID)
 		accountReauthentication = nil
+		scheduleRefreshCoordinator()
 	}
 
 	nonisolated private static func accountControlMessage(_ error: Error) -> String {
@@ -3036,6 +3103,7 @@ final class ResetCardStore {
 				isRoutingAccountControl = false
 			}
 			scheduleFreshAccountSkeletonRead()
+			scheduleRefreshCoordinator()
 		}
 
 		do {
@@ -3170,9 +3238,7 @@ final class ResetCardStore {
 				)
 			}
 		case .skeleton:
-			Task { [weak self] in
-				await self?.refreshAccountSkeleton()
-			}
+			requestSkeletonRefresh()
 		}
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -170,6 +170,181 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(finalReads.snapshot, 1)
 	}
 
+	func testObservationRefreshIsQueuedWhileRoutingControlIsInProgress() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsFixedSelection: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+		func stopObservation() async {
+			await store.prepareForApplicationTermination()
+			await client.publishObservation(generation: 2)
+		}
+		store.start()
+
+		for _ in 0 ..< 200 {
+			if store.hasLoaded,
+				store.isRefreshing == false,
+				store.accounts.first?.inventoryIsCurrent == true
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		XCTAssertTrue(store.hasLoaded)
+		XCTAssertFalse(store.isRefreshing)
+		XCTAssertTrue(store.accounts.first?.inventoryIsCurrent == true)
+
+		let routingTask = Task {
+			await store.selectFixedAccount(accountID)
+		}
+		for _ in 0 ..< 200 {
+			if await client.fixedSelectionIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.fixedSelectionIsPending() else {
+			await client.releaseFixedSelection()
+			await routingTask.value
+			await stopObservation()
+			return XCTFail("Routing control did not enter the pending state.")
+		}
+
+		await client.replaceAccount(accountRecord(revision: 8))
+		await client.setInventoryRevision(8, accountID: accountID)
+		for _ in 0 ..< 200 {
+			if await client.observationIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.observationIsPending() else {
+			await client.releaseFixedSelection()
+			await routingTask.value
+			await stopObservation()
+			return XCTFail("Account observation signal did not enter the pending state.")
+		}
+		await client.publishObservation(generation: 1)
+		for _ in 0 ..< 200 {
+			if await client.deliveredObservationGeneration() == 1 {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		await client.releaseFixedSelection()
+		await routingTask.value
+
+		for _ in 0 ..< 200 {
+			if store.accounts.first?.account.accountRevision == 8,
+				store.accounts.first?.inventory?.accountRevision == 8,
+				store.accounts.first?.isRefreshing == false
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let finalState = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(finalState.account.accountRevision, 8)
+		XCTAssertEqual(finalState.inventory?.accountRevision, 8)
+		XCTAssertFalse(finalState.isRefreshing)
+		let readsAfterObservation = await client.readCounts()
+		XCTAssertGreaterThanOrEqual(readsAfterObservation.snapshot, 2)
+		XCTAssertGreaterThanOrEqual(readsAfterObservation.inventory, 2)
+		await stopObservation()
+	}
+
+	func testObservationRefreshIsQueuedUntilEnrollmentCompletes() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsEnrollment: true,
+			allowsEnrollment: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+		func stopObservation() async {
+			await store.prepareForApplicationTermination()
+			await client.publishObservation(generation: 2)
+		}
+		store.start()
+
+		for _ in 0 ..< 200 {
+			if store.hasLoaded,
+				store.isRefreshing == false,
+				store.accounts.first?.inventoryIsCurrent == true
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let enrollmentTask = Task {
+			await store.enrollFromSharedCodex()
+		}
+		for _ in 0 ..< 200 {
+			if await client.enrollmentIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.enrollmentIsPending() else {
+			await client.releaseEnrollment()
+			await enrollmentTask.value
+			await stopObservation()
+			return XCTFail("Enrollment did not enter the pending state.")
+		}
+
+		await client.replaceAccount(accountRecord(revision: 8))
+		await client.setInventoryRevision(8, accountID: accountID)
+		for _ in 0 ..< 200 {
+			if await client.observationIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.observationIsPending() else {
+			await client.releaseEnrollment()
+			await enrollmentTask.value
+			await stopObservation()
+			return XCTFail("Account observation signal did not enter the pending state.")
+		}
+		await client.publishObservation(generation: 1)
+		await client.releaseEnrollment()
+		await enrollmentTask.value
+
+		for _ in 0 ..< 200 {
+			if store.accounts.first?.account.accountRevision == 8,
+				store.accounts.first?.inventory?.accountRevision == 8,
+				store.accounts.first?.isRefreshing == false
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
+		XCTAssertEqual(store.accounts.first?.inventory?.accountRevision, 8)
+		XCTAssertFalse(store.accounts.first?.isRefreshing == true)
+		await stopObservation()
+	}
+
 	func testAdvancedInventoryWaitsForFreshSkeletonBeforeControls() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -1190,7 +1365,7 @@ private struct AccountControlStoreCounts: Equatable, Sendable {
 	let projection: Int
 }
 
-private actor AccountControlStoreClient: AccountControlClient {
+private actor AccountControlStoreClient: AccountControlClient, AccountObservationClient {
 	private var account: ResetCardAccountRecord
 	private var secondaryAccount: ResetCardAccountRecord?
 	private let authority: ResetCardAuthority
@@ -1198,6 +1373,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private let snapshotGate: AccountControlReadGate?
 	private let capturesSnapshotBeforeWait: Bool
 	private let fixedSelectionGate: AccountControlReadGate?
+	private let enrollmentGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
 	private let maxSuccessfulInventoryReads: Int?
 	private var inventoryRevisionsByAccountID = [String: UInt64]()
@@ -1219,6 +1395,12 @@ private actor AccountControlStoreClient: AccountControlClient {
 	private var projectionReads = 0
 	private var snapshotReadCount = 0
 	private var inventoryReadCount = 0
+	private var observationGenerations = [UInt64]()
+	private var observationContinuation: CheckedContinuation<
+		AccountObservationSignal,
+		Never
+	>?
+	private var deliveredObservationGenerationValue: UInt64?
 	private var enrollmentRequests = 0
 	private var reauthenticationStates: [AccountReauthenticationState]
 	private var lastReauthenticationStartRequest: AccountControlStoreReauthenticationRequest?
@@ -1237,6 +1419,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		suspendsSnapshotAfterFirstRead: Bool = false,
 		capturesSnapshotBeforeWait: Bool = false,
 		suspendsFixedSelection: Bool = false,
+		suspendsEnrollment: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
 		maxSuccessfulInventoryReads: Int? = nil,
 		allowsEnrollment: Bool = false,
@@ -1257,6 +1440,7 @@ private actor AccountControlStoreClient: AccountControlClient {
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
 		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
+		enrollmentGate = suspendsEnrollment ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
 		self.maxSuccessfulInventoryReads = maxSuccessfulInventoryReads
 		self.allowsEnrollment = allowsEnrollment
@@ -1423,6 +1607,40 @@ private actor AccountControlStoreClient: AccountControlClient {
 		(snapshotReadCount, inventoryReadCount)
 	}
 
+	func waitForAccountObservation(
+		afterGeneration _: UInt64
+	) async throws -> AccountObservationSignal {
+		if observationGenerations.isEmpty == false {
+			let signal = AccountObservationSignal(
+				generation: observationGenerations.removeFirst()
+			)
+			deliveredObservationGenerationValue = signal.generation
+			return signal
+		}
+		return await withCheckedContinuation { continuation in
+			observationContinuation = continuation
+		}
+	}
+
+	func observationIsPending() -> Bool {
+		observationContinuation != nil
+	}
+
+	func deliveredObservationGeneration() -> UInt64? {
+		deliveredObservationGenerationValue
+	}
+
+	func publishObservation(generation: UInt64) {
+		let signal = AccountObservationSignal(generation: generation)
+		if let observationContinuation {
+			self.observationContinuation = nil
+			deliveredObservationGenerationValue = generation
+			observationContinuation.resume(returning: signal)
+		} else {
+			observationGenerations.append(generation)
+		}
+	}
+
 	func inventoryIsPending() async -> Bool {
 		guard let inventoryGate else {
 			return false
@@ -1480,11 +1698,23 @@ private actor AccountControlStoreClient: AccountControlClient {
 			throw AccountControlError.applicationUnavailable
 		}
 		enrollmentRequests += 1
+		await enrollmentGate?.wait()
 		return .accountChanged(account)
 	}
 
 	func enrollmentRequestCount() -> Int {
 		enrollmentRequests
+	}
+
+	func enrollmentIsPending() async -> Bool {
+		guard let enrollmentGate else {
+			return false
+		}
+		return await enrollmentGate.isPending()
+	}
+
+	func releaseEnrollment() async {
+		await enrollmentGate?.release()
 	}
 
 	func codexAuthProjection(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -787,13 +787,14 @@ final class ResetCardArchitectureTests: XCTestCase {
 
 		XCTAssertFalse(store.contains("defaultAutomaticRefreshInterval"))
 		XCTAssertTrue(store.contains("private var accountObservationTask"))
-		XCTAssertTrue(store.contains("private var refreshCycleTask"))
+		XCTAssertTrue(store.contains("private var refreshCoordinatorTask"))
 		XCTAssertTrue(store.contains("startAccountObservationSignals()"))
 		XCTAssertTrue(store.contains("accountObservationTask?.cancel()"))
 		XCTAssertTrue(store.contains("waitForAccountObservation("))
 		XCTAssertFalse(store.contains("ContinuousClock()"))
-		XCTAssertTrue(store.contains("self.requestRefresh()"))
-		XCTAssertTrue(store.contains("await self.performRefreshCycle()"))
+		XCTAssertTrue(store.contains("self.requestObservationRefresh()"))
+		XCTAssertTrue(store.contains("await performRefreshCycle()"))
+		XCTAssertTrue(store.contains("await performAccountSkeletonRead()"))
 		XCTAssertFalse(store.contains("Timer.publish"))
 		XCTAssertTrue(panel.contains("store.requestRefresh()"))
 	}

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardRefreshCoordinatorTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardRefreshCoordinatorTests.swift
@@ -1,0 +1,37 @@
+@testable import DecodexApp
+import XCTest
+
+final class ResetCardRefreshCoordinatorTests: XCTestCase {
+	func testObservationGenerationsSurviveUntilAFullReadConsumesThem() {
+		var requests = ResetCardRefreshRequests()
+		requests.requestObservationRefresh()
+		requests.requestObservationRefresh()
+
+		XCTAssertTrue(requests.hasFullRefreshRequest)
+		XCTAssertEqual(requests.takeNext(), .full)
+		XCTAssertFalse(requests.hasFullRefreshRequest)
+		XCTAssertFalse(requests.hasWork)
+	}
+
+	func testSkeletonWorkWaitsBehindAFullRefresh() {
+		var requests = ResetCardRefreshRequests()
+		requests.requestSkeletonRefresh()
+		requests.requestObservationRefresh()
+
+		XCTAssertEqual(requests.takeNext(), .full)
+		XCTAssertEqual(requests.takeNext(), .skeleton)
+		XCTAssertNil(requests.takeNext())
+	}
+
+	func testResetDiscardsAllPendingWork() {
+		var requests = ResetCardRefreshRequests()
+		requests.requestManualRefresh()
+		requests.requestObservationRefresh()
+		requests.requestSkeletonRefresh()
+
+		requests.reset()
+
+		XCTAssertFalse(requests.hasWork)
+		XCTAssertNil(requests.takeNext())
+	}
+}


### PR DESCRIPTION
## Summary
- Replace losable refresh tasks with a generation-based refresh coordinator.
- Queue observation updates across route, enrollment, and reauthentication operations.
- Add regression coverage for queued observations and skeleton ordering.

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app (208 passed)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/decodex-app