### PR TITLE
Fix menu-bar panel toggle race

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -10,6 +10,7 @@ final class StatusPanelController: NSObject {
 	private let panel: TransparentStatusPanel
 	private let hostingView: TransparentHostingView<StatusPanelRootView>
 	private let store: ResetCardStore
+	private var panelPresentation = StatusPanelPresentationState()
 
 	init(store: ResetCardStore) {
 		self.store = store
@@ -35,12 +36,12 @@ final class StatusPanelController: NSObject {
 
 	@objc
 	private func togglePanel() {
-		if panel.isVisible {
-			hidePanel()
-			return
+		switch panelPresentation.toggle() {
+		case .present:
+			showPanel()
+		case .dismiss:
+			orderPanelOut()
 		}
-
-		showPanel()
 	}
 
 	private func showPanel() {
@@ -50,28 +51,28 @@ final class StatusPanelController: NSObject {
 			panel.setContentSize(fittingSize)
 		}
 		positionPanel()
-		NSApp.activate(ignoringOtherApps: true)
+		if NSApp.isActive == false {
+			NSApp.activate(ignoringOtherApps: true)
+		}
 		panel.makeKeyAndOrderFront(nil)
 		store.requestRefresh()
 	}
 
-	private func hidePanel() {
+	private func orderPanelOut() {
 		panel.orderOut(nil)
 	}
 
 	@objc
 	private func applicationDidResignActive(_: Notification) {
-		if let eventType = NSApp.currentEvent?.type,
-			let statusItemRect = statusItemScreenRect(),
-			StatusPanelInteraction.isStatusItemPress(
-				eventType: eventType,
-				mouseLocation: NSEvent.mouseLocation,
-				statusItemRect: statusItemRect
-			)
-		{
-			return
+		let generation = panelPresentation.scheduleDeactivateDismissal()
+		DispatchQueue.main.async { [weak self] in
+			guard let self,
+				self.panelPresentation.dismissIfCurrent(generation)
+			else {
+				return
+			}
+			self.orderPanelOut()
 		}
-		hidePanel()
 	}
 
 	private func configureStatusItem() {
@@ -177,6 +178,44 @@ final class StatusPanelController: NSObject {
 	}
 }
 
+struct StatusPanelPresentationState: Equatable {
+	enum Transition: Equatable {
+		case present
+		case dismiss
+	}
+
+	private(set) var isPresented = false
+	private var eventGeneration: UInt64 = 0
+
+	mutating func toggle() -> Transition {
+		invalidatePendingDismissal()
+		isPresented.toggle()
+		return isPresented ? .present : .dismiss
+	}
+
+	mutating func dismiss() {
+		invalidatePendingDismissal()
+		isPresented = false
+	}
+
+	mutating func scheduleDeactivateDismissal() -> UInt64 {
+		invalidatePendingDismissal()
+		return eventGeneration
+	}
+
+	mutating func dismissIfCurrent(_ generation: UInt64) -> Bool {
+		guard eventGeneration == generation, isPresented else {
+			return false
+		}
+		isPresented = false
+		return true
+	}
+
+	private mutating func invalidatePendingDismissal() {
+		eventGeneration &+= 1
+	}
+}
+
 @MainActor
 final class TransparentHostingView<Content: View>: NSHostingView<Content> {
 	override var isOpaque: Bool {
@@ -240,16 +279,6 @@ enum StatusPanelLayout {
 			return minimum
 		}
 		return min(max(value, minimum), maximum)
-	}
-}
-
-enum StatusPanelInteraction {
-	static func isStatusItemPress(
-		eventType: NSEvent.EventType,
-		mouseLocation: NSPoint,
-		statusItemRect: NSRect
-	) -> Bool {
-		eventType == .leftMouseDown && statusItemRect.contains(mouseLocation)
 	}
 }
 

--- a/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/PanelWindowSizingLayoutTests.swift
@@ -232,30 +232,44 @@ final class PanelWindowSizingLayoutTests: XCTestCase {
 		)
 	}
 
-	func testStatusItemPressDefersDeactivateHideForTheToggleAction() {
-		let statusItemRect = NSRect(x: 400, y: 900, width: 28, height: 24)
+	func testStatusPanelPresentationStateDismissalDoesNotReopenThePanel() {
+		var presentation = StatusPanelPresentationState()
 
-		XCTAssertTrue(
-			StatusPanelInteraction.isStatusItemPress(
-				eventType: .leftMouseDown,
-				mouseLocation: NSPoint(x: 414, y: 912),
-				statusItemRect: statusItemRect
-			)
-		)
-		XCTAssertFalse(
-			StatusPanelInteraction.isStatusItemPress(
-				eventType: .leftMouseDown,
-				mouseLocation: NSPoint(x: 300, y: 700),
-				statusItemRect: statusItemRect
-			)
-		)
-		XCTAssertFalse(
-			StatusPanelInteraction.isStatusItemPress(
-				eventType: .leftMouseUp,
-				mouseLocation: NSPoint(x: 414, y: 912),
-				statusItemRect: statusItemRect
-			)
-		)
+		XCTAssertEqual(presentation.toggle(), .present)
+		XCTAssertTrue(presentation.isPresented)
+		let deferredDismissal = presentation.scheduleDeactivateDismissal()
+
+		presentation.dismiss()
+		XCTAssertFalse(presentation.isPresented)
+		presentation.dismiss()
+		XCTAssertFalse(presentation.isPresented)
+		XCTAssertFalse(presentation.dismissIfCurrent(deferredDismissal))
+		XCTAssertEqual(presentation.toggle(), .present)
+		XCTAssertTrue(presentation.isPresented)
+		XCTAssertEqual(presentation.toggle(), .dismiss)
+		XCTAssertFalse(presentation.isPresented)
+	}
+
+	func testStatusPanelPresentationStateAppliesTheCurrentDeferredDismissalOnce() {
+		var presentation = StatusPanelPresentationState()
+
+		XCTAssertEqual(presentation.toggle(), .present)
+		let deferredDismissal = presentation.scheduleDeactivateDismissal()
+
+		XCTAssertTrue(presentation.dismissIfCurrent(deferredDismissal))
+		XCTAssertFalse(presentation.dismissIfCurrent(deferredDismissal))
+		XCTAssertFalse(presentation.isPresented)
+	}
+
+	func testStatusPanelPresentationStateCancelsAQueuedDismissalWhenTheToggleWins() {
+		var presentation = StatusPanelPresentationState()
+
+		XCTAssertEqual(presentation.toggle(), .present)
+		let deferredDismissal = presentation.scheduleDeactivateDismissal()
+
+		XCTAssertEqual(presentation.toggle(), .dismiss)
+		XCTAssertFalse(presentation.dismissIfCurrent(deferredDismissal))
+		XCTAssertFalse(presentation.isPresented)
 	}
 
 	func testRoundedContentSizeCeilsFractionalDimensions() {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -545,6 +545,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(
 			statusPanel.contains("#selector(applicationDidResignActive(_:))")
 		)
+		XCTAssertTrue(statusPanel.contains("private var panelPresentation"))
+		XCTAssertTrue(statusPanel.contains("DispatchQueue.main.async"))
+		XCTAssertFalse(statusPanel.contains("NSApp.currentEvent"))
+		XCTAssertFalse(statusPanel.contains("StatusPanelInteraction.isStatusItemPress"))
 		XCTAssertTrue(statusPanel.contains("NSWindow.didResizeNotification"))
 		XCTAssertTrue(statusPanel.contains("#selector(panelDidResize(_:))"))
 		XCTAssertEqual(


### PR DESCRIPTION
## Summary
- Make menu-bar panel presentation an explicit state machine.
- Cancel stale deactivate hides so a toggle cannot reopen the panel or steal focus.
- Keep existing refresh, positioning, and external-deactivation behavior.

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app (210 passed)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer DECODEX_APP_STAGE_DIR=$PWD/target/decodex-app apps/decodex-app/script/build_and_run.sh --verify
- codesign --verify --deep --strict target/decodex-app/Decodex.app