### PR TITLE
Define Quick Task Account Registry routing authority

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -180,6 +180,12 @@ Every Quick Task command repeats the current Account Service, routing,
 ProcessGeneration, ProviderAttempt, app-server, and path fences before it can cause an
 effect.
 
+RoleProfile remains a separate global PostgreSQL authority. One initial bootstrap seam accepts
+user-supplied typed server configuration for all four advisor/lead/task/reviewer groups and creates
+them atomically. PostgreSQL owns all later revisions and updates. Quick Task requires the current
+`task` profile; if it is missing, initialization returns typed `QuickTaskUnavailable` and does not
+synthesize model, reasoning, or service-tier defaults.
+
 This structure has no capability-manager module. The startup projections own no durable
 state, receipt, task, channel, retry, or lifecycle. They only make the result of service
 assembly explicit. A deletion test must continue to hold: removing the Quick Task owner
@@ -207,7 +213,8 @@ they are not startup readiness.
 
 | State or surface | Authority |
 | --- | --- |
-| Projects, Agents, policies, Programs, Objectives, WorkItems, ManagedRuns, Automations, profiles, context, messages, mappings, and UI-visible activity | PostgreSQL domain relations with optimistic revisions, leases, append-only activity, and transactional outbox |
+| Projects, Agents, policies, Programs, Objectives, WorkItems, ManagedRuns, Automations, context, messages, mappings, and UI-visible activity | PostgreSQL domain relations with optimistic revisions, leases, append-only activity, and transactional outbox |
+| Global advisor/lead/task/reviewer RoleProfiles | PostgreSQL RoleProfile Authority with immutable revisions and one current pointer per role |
 | Conversations, Turns, RuntimeSessions, history, Context Packs, and routing | PostgreSQL current domain authority |
 | Account product state | PostgreSQL Account Registry |
 | Credentials | one versioned HostCredentialStore |
@@ -246,15 +253,19 @@ schema upgrade, or schema-history records.
 
 Candidate 5 is the accepted target for one ordinary multi-turn Quick Task. It is not a
 ManagedRun and has no WorkItem, reviewer, PR, harness, or Goal. Current source must be
-aligned to this target while preserving current-main account observation behavior.
+aligned to this target while preserving current-main account observation behavior. Its initial
+selection is independent of Project routing: no current or accepted Project policy,
+`routing_compatibility_evidence`, or `quota_windows` row is required. Selection occurs only while
+establishing the first RuntimeSession.
 
 ### Owner order
 
-The exact initial order is:
+The exact first-session order is:
 
 ```text
 Conversation create
 -> prospective Turn UUID intent
+-> Quick Task routing adapter locks Account Registry authority
 -> Routing Snapshot
 -> Routing Decision
 -> first account/profile snapshots + starting RuntimeSession + inert initial plan
@@ -265,17 +276,43 @@ Conversation create
 -> ProviderAttempt
 ```
 
-Routing Snapshot locks the complete policy member universe, canonical order, account
-revisions, two separate quota facts per member, required capability facts, and blockers.
-Routing Decision is the sole account selector. Account Service owns lifecycle facts and
-rechecks only the selected account's current readiness, credential version/fingerprint,
-provider binding, and HostCredentialStore binding immediately before spawn. It cannot
-preselect, replace, fall back to, or wake another account.
+The Quick Task routing adapter owns one transaction that locks complete non-tombstoned Account
+Registry membership, canonical routing mode/fixed target/order and routing revision, exact account
+revisions, enabled/lifecycle/health/credential-binding blockers, the current Task RoleProfile
+revision, and exactly one 300-minute and one 10080-minute `account_quota_facts` slot per member. It
+materializes the only selecting Quick Task Routing Snapshot and immutable Decision directly from
+those facts. Project-policy/evidence/build fields are null.
+
+Each quota slot exactly copies one source state: missing has all observation fields null; current
+has `used_percent`, `observed_at`, and `resets_at` with no error; observation error has typed
+`error_code` and `observed_at` with no usage or reset. Routing invents no quota revision, remaining
+value, confidence, provenance, or legacy `quota_windows` value.
+
+Routing Decision remains the sole account selector. Fixed mode accepts only its exact fixed
+eligible member. Balanced mode follows canonical Account Registry order and classifies exhausted,
+unknown, and error state for each quota window independently; it never forms a merged quota pool.
+Account Service rechecks only the selected account's current readiness, credential
+version/fingerprint, provider binding, and HostCredentialStore binding immediately before spawn.
+It cannot preselect, replace, fall back to, or wake another account.
+
+Account Registry owns current account, quota, blocker, and routing facts. The Quick Task routing
+adapter owns only first-session materialization. Every later Turn receives an immutable
+non-selecting continuation decision bound to the current RuntimeSession, original initial
+decision, selected account snapshot, and copied Task RoleProfile snapshot. Same-thread and Context
+Pack planning retain that account and profile; they do not call current Project routing, resolve
+another Account Registry snapshot, or select. Specifically, they never call
+`read_current_task_routing_authority_exact()` or `resolve_routing_snapshot_exact`. Drift,
+exhaustion, or readiness failure returns
+typed manual recovery without fallback, wake, or re-selection. `QuickTaskRuntime` and
+`ServiceApplication` only sequence and consume typed results. Project routing retains accepted
+policy/evidence authority for ManagedRun. There is no general selector, capability manager,
+compatibility bridge, or duplicate Quick Task policy path.
 
 Continuation Plan consumes the selected initial decision. In one transaction it creates
 the selected account snapshot, copied RoleProfile snapshot, first revision-1 unfenced
 `starting` RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and
-outbox. Failure rolls back the complete cluster.
+outbox. It uses the current `task` RoleProfile from the separate PostgreSQL authority; routing and
+runtime do not choose or derive it. Failure rolls back the complete cluster.
 
 Conversation authority then admits exactly one Turn with the prospective UUID, sequence
 1, role `user`, `possible_side_effects=unknown`, status `active`, and revision 1 under the
@@ -291,19 +328,36 @@ The latest schema defines two routing lineage shapes:
   fields are null; and
 - `L6`: all six are present and the three revisions are positive.
 
-Conversation routing permits `L0` or `L6`. ManagedRun routing permits only `L6`. All
-existing foreign keys remain. One exact all-null/all-present constraint rejects partial
-lineage.
+Source lineage and routing authority are closed independently. Selecting snapshots have two
+`authority_shape` values. `conversation_account_registry` permits only initial Conversation `L0`
+with the Account Registry fields above and null Project policy/evidence/build fields.
+`managed_run_project_policy` permits only ManagedRun `L6` and retains its existing complete
+Project policy/evidence/capability/quota representation. Reverse constraints reject mixed fields,
+children, or consumers.
 
-`L0` requires one open exact-revision Conversation, no existing RuntimeSession or Turn,
-zero sticky members, and exact equality with the complete locked routing universe.
-Source fields, sticky members, closed or stale Conversation state, a source-less
-ManagedRun, or missing, extra, duplicate, cross-linked, or reordered evidence fails
-closed. `L6` retains the existing exact one-sticky-member rule.
+A later Quick Task Turn uses `L6` only in a non-selecting `conversation_continuation` decision. It
+directly references the source RuntimeSession and original initial selected decision, repeats only
+their exact account/profile snapshot identities, and has no candidate, policy, quota, exclusion,
+waiting, or selection fields. Same-thread and Context Pack planning consume this binding.
 
-There is one initial route decision. Same-key replay is read-only. A competing cross-key
-initial decision loses under the Conversation lock. Initial planning is first-session
-creation and cannot enter same-thread reuse, explicit successor, or Context Pack fallback.
+There is one initial selecting decision. Same-key replay is read-only. A competing cross-key
+initial command loses under the Conversation lock and creates no routing rows. Initial planning is
+first-session creation. Later selected-account drift fails closed before spawn as typed manual
+recovery without fallback, wake, or re-selection.
+
+### Initial selection transaction
+
+Initial selection is one top-level `READ COMMITTED` exact command. A fresh command locks the
+Conversation intent first, then the `account_routing_control` singleton, all complete
+non-tombstoned account rows in canonical UUID order, and the current Task RoleProfile row. It then
+copies `account_routing_order` and both quota slots while retaining every lock through commit.
+
+Membership/routing writers lock routing control before affected or all account rows in the same
+UUID order. A quota writer locks its account row before quota insert/update and never takes routing
+control afterward. Selection's account lock therefore serializes even an absent quota insertion
+without a lock cycle. Before commit, selection compares every locked revision and exact source fact
+with the immutable copy. Mismatch rolls back all effects. Same-key contenders replay the stored
+exact response; cross-key contenders serialize at the Conversation and only one is fresh.
 
 ### Thread and effect fences
 
@@ -332,23 +386,22 @@ status `failed`, and revision 2. It has no product or runtime mutation surface.
 
 ### Final trigger definitions
 
-The latest schema creates the final bodies and unchanged bindings for these seven affected
+The latest schema creates the final bodies and unchanged bindings for these eight affected
 trigger functions:
 
 | Function | Final Candidate-5 responsibility |
 | --- | --- |
-| `decodex.enforce_routing_completeness()` | Preserve complete existing `L6` policy/evidence rules and add only the exact zero-sticky `L0` branch. |
+| `decodex.enforce_routing_completeness()` | Enforce both selecting snapshot authority shapes, exact Account Registry quota tri-states, reverse nullability, and retained ManagedRun `L6`. |
+| `decodex.enforce_routing_decision_completeness()` | Enforce selecting classification/exclusions or the exact non-selecting Conversation continuation binding, never both. |
 | `decodex.enforce_runtime_session_state()` | Permit only request fencing, exact start-response/thread binding, and last-Turn acknowledgement as the narrow nonterminal edges; reject generic `starting` to `active`. |
 | `decodex.enforce_turn_state()` | Under `starting`, permit only exact first-Turn admission and positive definite pre-effect failure; preserve all existing active-session behavior. |
 | `decodex.enforce_history_item_state()` | Under `starting`, permit only the admission transaction's exact ordinal-0 completed Message; preserve existing active-session behavior. |
 | `decodex.enforce_provider_attempt_transition()` | Keep the accepted state algebra and add the immutable RuntimeSession thread-binding receipt identities. |
-| `decodex.enforce_provider_attempt_binding()` | Require the exact initial route/plan/account/session/process/thread receipts and active revision-1 Turn for `initial_thread`; preserve other continuation branches. |
-| `decodex.enforce_continuation_plan_completeness()` | Require the selected `L0` decision and complete first account/profile/session lineage for `initial_thread`; preserve same-thread and Context Pack branches. |
+| `decodex.enforce_provider_attempt_binding()` | Require exact initial selected lineage or exact later non-selecting account/profile lineage, plus the accepted session/process/thread fences. |
+| `decodex.enforce_continuation_plan_completeness()` | Require selected `L0` for `initial_thread`; require the non-selecting continued decision and unchanged original account/profile snapshots for same-thread and Context Pack. |
 
-The latest schema does not roll an old body forward. It creates each final body once.
-`decodex.enforce_routing_decision_completeness()` remains a separate unchanged semantic
-boundary. No trigger is dropped, rebound, disabled, renamed, or used as a broad
-starting-session bypass.
+The latest schema does not roll an old body forward. It creates each final body once. No trigger
+is dropped, rebound, disabled, renamed, or used as a broad starting-session bypass.
 
 <a id="account-lifecycle-and-credential-authority"></a>
 

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -188,6 +188,10 @@ multi-turn Conversation with no WorkItem, ManagedRun, reviewer, PR, harness, or 
 Candidate-4 tree `f82b866e21f12742648023a2b468cc057afa52a1` remains materially
 rejected provenance.
 
+Scoped supersession: the earlier Candidate-5 requirement for Project policy order and
+capability facts does not apply to ordinary Quick Task. Account Registry authority selects once
+when the first RuntimeSession is established. ManagedRun Project-policy authority is unchanged.
+
 Candidate 4 failed because it did not close five authority boundaries:
 
 1. effect and successor fences did not lock the exact selected Turn and revision;
@@ -202,8 +206,9 @@ Candidate 5 uses existing owners in this exact order:
 1. Conversation authority creates the Conversation.
 2. Routing receives one prospective Turn UUID as intent. No Turn row or Turn foreign
    key exists at this point.
-3. Routing Snapshot authority locks the complete account universe, policy order,
-   account revisions, separate quota facts, capability facts, and blockers.
+3. The Quick Task routing adapter locks complete Account Registry membership, canonical routing
+   control, exact account facts and blockers, the current Task RoleProfile revision, and two exact
+   Account Registry quota slots per member.
 4. Routing Decision authority runs once and is the sole Quick Task account selector.
 5. Continuation Plan authority consumes that selected decision and atomically creates
    the selected account snapshot, copied RoleProfile snapshot, first revision-1
@@ -223,19 +228,26 @@ Candidate 5 uses existing owners in this exact order:
 Runtime is a stateless sequencer across these owners. It does not become an account,
 route, session, Turn, process, thread, or provider-effect authority.
 
-The routing lineage has two closed shapes. `L0` has all six RuntimeSession, account
-snapshot, and profile snapshot identity/revision fields absent. `L6` has all six fields
-present and all three revisions positive. Conversation routing permits `L0` or `L6`.
-ManagedRun routing permits only `L6`. `L0` requires an open exact-revision Conversation,
-no existing RuntimeSession or Turn, zero sticky members, and an exact complete locked
-account universe. Half-present lineage, sticky `L0`, source fields in `L0`, a source-less
-ManagedRun, stale Conversation state, or incomplete, duplicate, extra, cross-linked, or
-reordered evidence fails closed.
+Selecting snapshots have two closed authority shapes. `conversation_account_registry` is the
+initial Quick Task `L0` shape and has null Project policy/evidence/build fields.
+`managed_run_project_policy` is the existing ManagedRun `L6` shape and keeps its complete Project
+policy/evidence/quota contract. Reverse-shape constraints reject mixed fields.
 
-There is no second route decision, fallback, wake, alternate account, or account
-re-selection in the initial operation. Initial planning is first-session creation. It
-is not same-thread reuse, explicit successor, or Context Pack fallback. Those existing
-continuation modes keep their own contracts. Automatic cross-account fallback and
+The Account Registry shape binds exact routing revision/mode/fixed target/order, current Task
+RoleProfile revision, every non-tombstoned member and blocker, and duration-keyed 300-minute and
+10080-minute quota slots. Each slot exactly preserves `account_quota_facts` as missing, current
+(`used_percent`, `observed_at`, `resets_at`), or observation error (`error_code`, `observed_at`).
+It fabricates no revision, remaining value, confidence, or provenance.
+
+There is exactly one selecting route decision for an ordinary Quick Task. Each later Turn creates
+an immutable non-selecting `conversation_continuation` decision binding to the current
+RuntimeSession, its original
+initial decision, selected account snapshot, and copied Task RoleProfile snapshot. It does not
+call `read_current_task_routing_authority_exact()`, resolve another Account Registry snapshot, or
+run selection.
+Same-thread continuation and Context Pack fallback retain that exact account and profile.
+Selected-account drift, exhaustion, or readiness failure returns typed manual recovery without
+fallback, wake, alternate account, or re-selection. Automatic cross-account fallback and
 all-depleted wake remain disabled under XY-1304.
 
 Every process, thread, and provider-effect fence locks and rechecks the exact selected
@@ -256,10 +268,11 @@ locks the Turn named by the selected decision and requires that Turn to be in th
 Conversation and source RuntimeSession, `failed`, and revision 2. It has no protocol
 field, product command, runtime grant, facade, fallback, or wake path.
 
-The latest schema defines the final forms of the seven affected trigger functions
+The latest schema defines the final forms of the eight affected trigger functions
 directly:
 
 - `decodex.enforce_routing_completeness()`;
+- `decodex.enforce_routing_decision_completeness()`;
 - `decodex.enforce_runtime_session_state()`;
 - `decodex.enforce_turn_state()`;
 - `decodex.enforce_history_item_state()`;
@@ -317,9 +330,9 @@ work for an explicit decision.
   operations.
 - One app-server process remains bound to one Account UUID and provider identity for its
   lifetime. Credentials do not switch accounts in a live process.
-- PostgreSQL remains the complete routing-fact and decision authority. Runtime and
-  clients cannot supply the account universe, eligibility, policy order, selection, or
-  exclusions.
+- PostgreSQL remains the complete routing-fact and decision authority. Runtime and clients cannot
+  supply the account universe, eligibility, Account Registry order, Project-policy order,
+  selection, continuation binding, or exclusions.
 - ProcessSupervisor and ProviderAttemptService retain separate replacement-safety and
   external-effect-safety authority.
 - ExecutionCoordinator remains stateless and cannot authorize dispatch by itself.

--- a/openwiki/specs/execution-coordinator-authority.md
+++ b/openwiki/specs/execution-coordinator-authority.md
@@ -17,9 +17,9 @@ decision, RuntimeSession decision, process state, or ProviderAttempt state.
 | --- | --- |
 | Conversation authority | Ordinary Conversation and Turn lifecycle, including Candidate-5 atomic first Turn/history admission and legal Turn finalization. |
 | ManagedRun authority | ManagedRun lifecycle, execution assignment, wait state, review, acceptance, and completion. |
-| Routing Snapshot | Complete account universe, policy order, account/evidence revisions, capability/quota facts, and blocker completeness. |
-| Routing Decision | Sole account selection, exact cause projection, and immutable route result. |
-| Continuation Plan | First-session planning, exact same-thread reuse, atomic Context Pack plus fallback RuntimeSession, and PostgreSQL-only explicit-successor evidence. |
+| Routing Snapshot | Closed consumer-specific authority: initial `conversation_account_registry` `L0` facts or `managed_run_project_policy` `L6` policy/evidence facts; never a merged shape. |
+| Routing Decision | Sole selector for selecting snapshots, exact shape-specific cause projection, and immutable non-selecting `conversation_continuation` binding. |
+| Continuation Plan | First-session planning plus same-thread or Context Pack continuation that retains the original Quick Task account/profile binding; PostgreSQL-only explicit-successor evidence. |
 | RuntimeSession Thread Establishment | Exact thread request fence, start binding, activation, and acknowledgement. |
 | ProcessSupervisor | ProcessGeneration intent, live fence, positive-only death evidence, and account-local quarantine. |
 | ProviderAttemptService | Atomic attempt binding, dispatch authorization, provider-effect state, positive evidence, restore projection, and reconciliation. |
@@ -51,7 +51,7 @@ second ledger or synthesize acceptance.
 ## Final latest-schema cut
 
 The latest schema includes the final closed route and wait vocabulary and the final
-consumer-generic routing, continuation, and ProviderAttempt definitions directly. It does
+consumer-specific routing, continuation, and ProviderAttempt definitions directly. It does
 not contain the retired ManagedRun-local submitted-turn receipts, safety inputs, effects,
 or barriers. It contains no compatibility or fallback writer for those shapes.
 
@@ -62,7 +62,8 @@ action. Product runtime never interprets an old shape.
 
 The latest schema retains sole writers:
 
-- Routing Decision for account choice and route causes;
+- Routing Decision for initial Quick Task or ManagedRun account choice, route causes, and
+  non-selecting Quick Task continuation binding;
 - Continuation Plan for RuntimeSession continuation/creation;
 - ProcessSupervisor for ProcessGeneration;
 - ProviderAttemptService for provider effects; and
@@ -70,40 +71,56 @@ The latest schema retains sole writers:
 
 ## Route projection
 
-Routing Decision loads and locks the complete Routing Snapshot. The caller supplies no
-account list, policy order, eligibility, exclusion, or account choice.
+Routing Snapshot and Routing Decision expose closed consumer-specific authority shapes. For a
+selecting shape, Routing Decision locks the complete matching snapshot. The caller supplies no
+account list, order, eligibility, exclusion, evidence, or account choice.
 
-Selection and pure-wait classification use only independently eligible included members.
-Policy-excluded members never become eligible and do not participate in quota or
-reconciliation wait classification. A `no_route` projection uses the complete persisted
-policy-member universe. Every excluded member keeps `excluded_by_policy` plus every other
-blocker. Every included member keeps its exact blockers. An all-excluded universe is a
-cause-complete `no_route`; cause-free `no_route` is invalid.
+### ManagedRun Project-policy `L6`
 
-The 300-minute and 10,080-minute quota facts remain independent. Each retains duration,
-source identity, observation revision, exact raw timestamp, exact microsecond value,
-confidence, and reset instant. Routing classifies both again at its database-authored
-decision instant. A fact that ages after snapshot creation keeps the exact stale or
-reset-elapsed cause.
+Only `managed_run_project_policy` uses the complete policy-member universe, policy-excluded
+members, sticky affinity, capability facts, Project evidence, and Project-era quota provenance.
+Selection and pure-wait classification use independently eligible included members. A `no_route`
+projection retains `excluded_by_policy` and every other exact blocker for each excluded member and
+all exact blockers for included members. An all-excluded universe is cause-complete; cause-free
+`no_route` is invalid.
 
-Sticky affinity applies only after independent account, capability, quota, process, and
-attempt eligibility. Route results are:
+For this shape only, each independent 300-minute and 10080-minute quota window retains source
+identity, observation revision, raw provider timestamp, exact microsecond value, confidence, reset
+instant, and other accepted Project-era provenance. Routing reclassifies both at its
+database-authored decision instant and retains exact stale or reset-elapsed causes.
 
-- `selected`: one independently eligible account;
-- `waiting_usage`: every otherwise eligible account is blocked only by current positive
-  quota depletion; includes complete depletion causes and earliest ready instant;
-- `waiting_reconciliation`: every otherwise eligible path is blocked only by unresolved
-  ProcessGeneration or ProviderAttempt state; and
-- `no_route`: complete mixed or non-wake causes; it grants no wake and does not fail the
-  task by itself.
+Sticky affinity applies only after independent account, capability, quota, process, and attempt
+eligibility. ManagedRun route results are `selected`, `waiting_usage`,
+`waiting_reconciliation`, or `no_route`. `waiting_usage` requires pure positive depletion and an
+earliest-ready instant. `waiting_reconciliation` requires exact unresolved ProcessGeneration or
+ProviderAttempt state. Mixed causes are `no_route`. Missing quota provenance is `usage_unproven`;
+reconciliation without an exact unresolved process or attempt is `reconciliation_unproven`.
 
-Authentication, plugin, disabled account, unknown capability, dependency, approval,
-user, external, and Reviewer causes do not become quota or reconciliation causes. Missing
-quota provenance becomes `usage_unproven`. Reconciliation without an exact unresolved
-process or attempt becomes `reconciliation_unproven`.
+### Initial Quick Task Account Registry `L0`
 
-An unresolved process plus positive depletion is mixed `no_route`, not a quota wake.
-Separate account quotas are never pooled, merged, summed, averaged, or caller-ranked.
+`conversation_account_registry` binds complete non-tombstoned Account Registry membership,
+canonical mode/fixed target/order and routing revision, exact account revisions and blockers, and
+the current Task RoleProfile revision. Every member has exactly two duration-keyed quota slots:
+
+- `missing`: `used_percent`, `resets_at`, `error_code`, and `observed_at` are null;
+- `current`: `used_percent`, `resets_at`, and `observed_at` are present and `error_code` is null;
+  or
+- `observation_error`: typed `error_code` and `observed_at` are present while `used_percent` and
+  `resets_at` are null.
+
+The slot durations are exactly `300` and `10080`. This shape has no policy member/exclusion,
+sticky, capability, Project evidence, quota source identity, observation revision, remaining,
+confidence, or provenance fields. Fixed mode accepts only its exact eligible target. Balanced mode
+uses canonical Account Registry order. The independent slots and separate accounts are never
+pooled. The immutable result persists only `selected`, `waiting`, or `no_route` plus exact replay
+exclusions. `waiting` is manual-retry state and grants no wake.
+
+### Later Quick Task continuation `L6`
+
+`conversation_continuation` is an immutable non-selecting decision bound to the current
+RuntimeSession and its original initial decision, selected account snapshot, and copied Task
+RoleProfile snapshot. It has no candidate projection and never invokes Routing Snapshot resolution
+or the selector. Same-thread and Context Pack planning retain that exact account and profile.
 
 ## Candidate-5 initial operation
 
@@ -112,9 +129,9 @@ Candidate 5 adds no coordinator state or new owner. The exact order is:
 1. Conversation authority creates the Conversation.
 2. The routing request supplies one prospective Turn UUID as intent only. No Turn row or
    Turn foreign key exists yet.
-3. Routing Snapshot proves the exact initial zero-source lineage and complete locked
-   account universe.
-4. Routing Decision selects one account exactly once.
+3. Routing Snapshot proves exact `conversation_account_registry` zero-source lineage and the
+   complete locked Account Registry facts defined above.
+4. Routing Decision selects one account exactly once for the Quick Task lifetime.
 5. Continuation Plan atomically creates selected account/profile snapshots, the first
    revision-1 unfenced `starting` RuntimeSession, inert `initial_thread` plan, exact
    receipt, activity, and outbox.
@@ -126,27 +143,30 @@ Candidate 5 adds no coordinator state or new owner. The exact order is:
    thread.
 10. ProviderAttemptService prepares and authorizes the exact attempt.
 
-There is no second route decision, alternate account, initial fallback, wake, or account
-re-selection. Initial planning has no source RuntimeSession and no sticky member. It is
-first-session creation, not same-thread reuse, explicit successor, or Context Pack
-fallback.
+There is no second selection, alternate account, fallback, wake, or account re-selection. Initial
+planning has no source RuntimeSession and no sticky member. Later Turns use only
+`conversation_continuation`; selected-account drift, exhaustion, or readiness failure returns typed
+manual recovery without invoking the selector.
 
 ### Initial lineage
 
-`L0` has all six RuntimeSession, account-snapshot, and profile-snapshot
-identity/revision fields absent. `L6` has all six present with positive revisions.
-Conversation work permits `L0` or `L6`; ManagedRun work permits only `L6`.
+`L0` has all six RuntimeSession, account-snapshot, and profile-snapshot identity/revision fields
+absent. `L6` has all six present with positive revisions. Initial Quick Task selection is
+`conversation_account_registry` `L0`; later Quick Task binding is non-selecting
+`conversation_continuation` `L6`; ManagedRun selection is `managed_run_project_policy` `L6`.
 
-The final schema keeps all foreign keys and one exact all-null/all-present check. `L0`
-requires an open exact-revision Conversation, no RuntimeSession or Turn, zero sticky
-members, and exact complete locked membership/order/account/two-window quota/eight
-capability/blocker facts. Partial lineage, source fields, sticky `L0`, existing session or
-Turn, closed/stale Conversation, source-less ManagedRun, and missing, extra, duplicate,
-cross-linked, or reordered evidence reject.
+The final schema keeps all foreign keys and the exact all-null/all-present check. Initial `L0`
+requires an open exact-revision Conversation, no RuntimeSession or Turn, zero sticky members, and
+complete Account Registry membership/order/routing/account/blocker/Task RoleProfile facts with
+exactly the two tri-state quota slots above. Its policy/capability/Project evidence and Project-era
+quota fields are null. ManagedRun `L6` retains the complete Project-policy representation. Reverse
+constraints reject partial lineage, mixed shapes, wrong consumers, missing or duplicate members or
+slots, cross-links, and reordered facts.
 
-One Conversation lock permits one cross-key initial decision to be fresh. Exact-key replay
-is read-only. Continuation planning accepts only the selected `L0` result and rolls back
-the complete first-session authority cluster on any failure.
+One Conversation lock permits one cross-key initial decision to be fresh. Exact-key replay is
+read-only. Initial planning accepts only selected `conversation_account_registry` `L0` and rolls
+back the complete first-session authority cluster on failure. Later planning accepts only the
+non-selecting binding and preserves the original account/profile identities.
 
 ### Initial admission
 
@@ -218,9 +238,11 @@ dependencies, and routes remain independently eligible.
 ## Transport and production isolation
 
 The exact-current protocol may expose one read-only immutable execution-decision query.
-It returns the closed consumer, route kind, complete exact causes, and independent quota
-exclusions. It cannot create a route, RuntimeSession, process, ProviderAttempt, wake,
-retry, receipt, or dispatch fence.
+It returns the closed consumer and authority shape. A ManagedRun result includes complete
+Project-policy causes and quota exclusions; an initial Quick Task result includes only its exact
+Account Registry tri-state causes; a later Quick Task result includes only the non-selecting source
+binding. The query cannot create a route, RuntimeSession, process, ProviderAttempt, wake, retry,
+receipt, or dispatch fence.
 
 The service uses the owner-only same-UID Unix transport. It has no TCP or loopback
 fallback. Remote and cross-UID authority remains separately gated.
@@ -238,13 +260,16 @@ After source freeze, validation must cover:
   daemon startup with zero DDL and no schema-owner credential;
 - exact current catalog/authority for all routing, continuation, Conversation,
   ProcessGeneration, ProviderAttempt, and read-only projection objects;
-- both consumer shapes and rejection of every partial or cross-linked identity;
-- complete route universe, all-excluded and mixed policies, cause-free rejection,
-  independent quota facts, aging, sticky eligibility, and exact pure-wait rules;
-- Candidate-5 `L0`/`L6`, sole account selection, atomic first-session cluster, atomic
-  first Turn/history admission, exact effect fences, fresh/replay/reject/unknown behavior,
-  and definite pre-effect refusal;
-- existing-session same-thread and atomic Context Pack paths;
+- `conversation_account_registry` `L0`, `managed_run_project_policy` `L6`, and non-selecting
+  `conversation_continuation` `L6`, including reverse-shape and cross-link rejection;
+- exact Account Registry missing/current/observation-error slots, fixed/balanced selection, and no
+  Project-era fields in initial Quick Task;
+- ManagedRun policy-member/exclusion, capability, sticky, provenance/confidence, aging, mixed-cause,
+  and pure-wait behavior without leaking those fields into Conversation routing;
+- sole first-session Quick Task selection, atomic first-session cluster and Turn/history admission,
+  exact effect fences, fresh/replay/reject/unknown behavior, and definite pre-effect refusal;
+- existing-session same-thread and atomic Context Pack paths bound to the original account/profile
+  without selector invocation;
 - positive-only process/attempt reconciliation, late evidence, smallest-scope isolation,
   and no replay after lost supervision;
 - ManagedRun and Reviewer authority isolation;

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -505,12 +505,16 @@ code and may supply only independently re-derived invariants and hostile-test id
 
 RoleProfile Authority persists exactly the `advisor`, `lead`, `task`, and `reviewer` identities in
 `role_profiles`, keeps every configuration in immutable `role_profile_revisions`, and advances one
-current-revision pointer per role. `bootstrap_role_profiles_exact` accepts four fixed
-advisor/lead/task/reviewer scalar groups and creates all four revision-one profiles atomically.
-`update_role_profile_exact` accepts one typed role plus an expected revision, appends exactly one
-immutable revision, and advances only that role's pointer. Both functions return and retain
-PostgreSQL-built response bytes whose effects are assembled from the returned profile rows and the
-actual canonical activity/outbox identities.
+current-revision pointer per role. One initial bootstrap seam accepts user-supplied typed server
+configuration containing all four role-implied advisor/lead/task/reviewer scalar groups and invokes
+`bootstrap_role_profiles_exact` to create all four revision-one profiles atomically. PostgreSQL then
+owns every revision and current pointer. Later changes use only `update_role_profile_exact`, which
+accepts one typed role plus an expected revision, appends exactly one immutable revision, and
+advances only that role's pointer. Both functions return and retain PostgreSQL-built response bytes
+whose effects are assembled from the returned profile rows and the actual canonical
+activity/outbox identities. Routing and runtime never derive, select, or override model, reasoning,
+or service tier. Quick Task requires the current `task` RoleProfile; absence is a typed
+`QuickTaskUnavailable` initialization refusal and never authorizes synthesized defaults.
 
 ## Conversation, context, and communication
 
@@ -555,16 +559,23 @@ side effects until tool/repository readback reconciles them.
 Status: Candidate 5 is approved target architecture. Implementation and integrated
 acceptance remain pending. Candidate-4 tree
 `f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance.
+This authority amendment changes no schema or product code, creates no migration, records no
+validation evidence, and does not claim live Quick Task success.
 
 Quick Task remains an ordinary multi-turn Conversation. Candidate 5 uses existing owners
-in this exact order:
+in this exact order. Its ordinary initial account selection is independent of Project and
+accepted Project routing policy. It requires no current Project routing-policy row, accepted
+Project policy, per-account `routing_compatibility_evidence`, or `quota_windows` projection. This
+selection occurs only while establishing the first RuntimeSession:
 
 1. Conversation authority creates the Conversation.
 2. Routing receives a prospective Turn UUID as intent. It creates no Turn, and no routing
    column has a foreign key to `turns` for that intent.
-3. Routing Snapshot loads and locks the complete account universe without a source
-   RuntimeSession or sticky member.
-4. Routing Decision selects the account exactly once.
+3. The Quick Task routing adapter starts one transaction, locks the Account Registry's complete
+   current authority, and materializes Routing Snapshot without a source RuntimeSession or sticky
+   member.
+4. The existing Routing Decision selects the account exactly once in that transaction and persists
+   the immutable decision.
 5. Continuation Plan consumes that selected decision and atomically creates the selected
    account snapshot, copied RoleProfile snapshot, one revision-1 unfenced `starting`
    RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and outbox.
@@ -579,30 +590,37 @@ in this exact order:
 11. ProviderAttemptService owns preparation, authorization, ambiguity, positive evidence,
     and reconciliation.
 
-There is no second route decision, fallback, wake, alternate account, or account
-re-selection in the initial operation. Initial planning creates the first session. It is
-not explicit successor, same-thread reuse, or Context Pack fallback. Automatic
-cross-account fallback and wake remain disabled under XY-1304.
+There is exactly one selecting Routing Decision for an ordinary Quick Task. Initial planning
+creates the first session; it is not explicit successor, same-thread reuse, or Context Pack
+fallback. Every later Turn uses a non-selecting immutable continuation route binding to the
+current RuntimeSession and its original initial decision, selected account snapshot, and copied
+Task RoleProfile snapshot. Same-thread and Context Pack planning retain that exact account and
+profile. Later routing never calls `read_current_task_routing_authority_exact()`, resolves another
+Account Registry snapshot, or runs selection. Selected-account drift, exhaustion, or readiness
+failure returns typed manual recovery without fallback, wake, alternate account, or re-selection.
 
 | Owner | Candidate-5 authority |
 | --- | --- |
-| Account Registry and Routing Snapshot | Complete lifecycle, control, capability, quota, blocker, and routing facts; no selection. |
+| Account Registry | Complete non-tombstoned membership, canonical routing control and revision, account revisions, eligibility blockers, and current independent account-quota facts; no selection. |
+| Quick Task routing adapter | One transaction that materializes the only selecting Quick Task Routing Snapshot and Decision from locked Account Registry facts; later Turns receive non-selecting continuation bindings. |
+| Project routing | Accepted Project policy and compatibility evidence for ManagedRun and other policy-bound `L6` work; no ordinary initial Quick Task authority. |
 | Account Service | Account operations and exact selected-account readiness/credential/provider/HostCredentialStore pre-spawn fence; no selection. |
-| Routing Decision | Sole Quick Task account selector and immutable route-decision writer. |
-| Continuation Plan | Initial snapshots, first starting RuntimeSession, inert initial plan, existing same-thread/Context Pack planning, and PostgreSQL-only explicit-successor evidence. |
+| Routing Decision | Sole Quick Task account selector for first-session establishment and immutable route/continuation-binding writer. |
+| Continuation Plan | Initial snapshots, first starting RuntimeSession, inert initial plan, and same-thread/Context Pack planning that retains the original account/profile binding. |
 | Conversation authority | Conversation creation, atomic initial Turn/history admission, legal Turn finalization, and exact Turn lock/read proof. |
 | RuntimeSession Thread Establishment | RuntimeSession state/thread fields, exact thread fence and bind, and acknowledgement. |
 | ProcessSupervisor | ProcessGeneration intent, fresh spawn authority, exact readback, positive death evidence, and account-local quarantine. |
 | ProviderAttemptService | Attempt preparation, dispatch authorization, ambiguity, positive evidence, and reconciliation. |
 | ExecutionCoordinator | Crate-private stateless sequencing only. |
+| QuickTaskRuntime and ServiceApplication | Sequence and consume typed owner results only; no account, policy, profile, or capability selection. |
 
 Account Service can report and fence facts for the selected account. It cannot preselect,
-substitute, fall back to, or wake another account. If account A passes an Account Service
-subset but fails a complete routing capability while B is fully eligible, Routing
-Decision selects B. Continuation Plan creates only B's snapshots and RuntimeSession.
-Later B drift fails closed before spawn without a second decision or account A.
+substitute, fall back to, or wake another account. Fixed mode accepts only its exact fixed
+eligible member. Balanced mode selects the first eligible member in canonical Account Registry
+order. Continuation Plan creates only the selected member's snapshots and RuntimeSession. Later
+selected-account drift fails closed before spawn without a second decision or another account.
 
-#### Closed initial lineage
+#### Closed routing lineage
 
 For `routing_snapshots`:
 
@@ -612,34 +630,90 @@ For `routing_snapshots`:
   `profile_snapshot_source_revision`.
 - `L6` means all six fields are present and the three revisions are positive.
 
-The latest schema keeps the existing foreign keys and defines one closed
-all-null/all-present shape check. The only valid combinations are
-`conversation_turn AND (L0 OR L6)` and `managed_run_execution AND L6`. Half-null
-lineage and a source-less ManagedRun reject.
+Source lineage retains its closed all-null/all-present rule. Conversation initial selection uses
+`L0`; a later Conversation continuation binding uses `L6`; ManagedRun uses `L6`. Half-null lineage
+and a source-less ManagedRun reject.
 
-`decodex.enforce_routing_completeness()` has one narrow `L0` branch. It accepts only the
-exact prospective Conversation Turn intent when the locked Conversation is open at the
-expected revision, has no RuntimeSession or Turn, and every candidate member has
-`sticky=false`. Candidate membership, policy positions, account revisions, both quota
-observations, all eight capability observations, and blocker rows must exactly equal the
-locked Routing Snapshot universe. Missing, extra, duplicate, cross-linked, or reordered
-evidence rejects. The existing `L6` branch keeps exactly one sticky member.
+Selecting snapshots in the existing routing relations have exactly two `authority_shape` values:
+
+- `conversation_account_registry` is permitted only for initial Conversation `L0`. It binds the
+  exact Account Registry routing revision/mode/fixed target/order, current Task RoleProfile
+  revision, complete non-tombstoned membership, exact account revisions,
+  enabled/lifecycle/health/credential-binding blockers, and exactly two quota slots per member.
+  Project policy/evidence/build fields are null and no Project capability or compatibility rows
+  are consumed.
+- `managed_run_project_policy` is permitted only for ManagedRun `L6`. It retains the existing
+  accepted Project policy, compatibility evidence, capability, and Project-era quota shape.
+  Account-Registry-specific routing/profile/quota-slot fields are null.
+
+Reverse-shape constraints reject mixed fields, consumers, candidate children, or evidence. Each
+Account Registry quota slot has `duration_minutes` equal to `300` or `10080` and preserves one exact
+`account_quota_facts` source state:
+
+- `missing`: `used_percent`, `observed_at`, `resets_at`, and `error_code` are all null;
+- `current`: `used_percent`, `observed_at`, and `resets_at` are present and `error_code` is null; or
+- `observation_error`: typed `error_code` and `observed_at` are present while `used_percent` and
+  `resets_at` are null.
+
+The snapshot fabricates no quota revision, remaining value, confidence, evidence provenance, or
+legacy `quota_windows` value. The initial decision references that immutable snapshot and persists
+only `selected`, `waiting`, or `no_route`, plus exact exclusion reasons needed for replay. Fixed
+selection accepts only the exact fixed eligible member. Balanced selection follows canonical
+Account Registry order and classifies the two slots independently without a merged quota pool.
+
+The existing decision relation also has a closed `conversation_continuation` decision shape. It is
+non-selecting, has `L6` source lineage, directly references the current RuntimeSession and original
+initial selected decision, and repeats only that decision's account snapshot and copied Task
+RoleProfile snapshot identities. Candidate, policy, quota, exclusion, waiting, and selection fields
+are null. Reverse constraints require exact identity/revision equality with the source lineage.
 
 The supporting current owners obey these predicates:
 
-- `resolve_routing_snapshot_exact` accepts source RuntimeSession identity/revision only
-  when both are present or both absent. The absent branch proves initial predicates and
-  zero sticky members, then writes exact `L0`.
-- `route_account_exact` applies the same pair rule, selects in policy order, and replays
-  only its stored decision. The Conversation lock permits one competing initial key to be
-  fresh; exact-key replay is read-only.
+- The Quick Task routing adapter locks the canonical Account Registry routing row, complete
+  non-tombstoned membership, account revisions, blockers, current Task RoleProfile, and both quota
+  slots, then invokes snapshot resolution and route decision in one transaction. It does not call
+  `read_current_task_routing_authority_exact()` or create a Project-policy compatibility bridge.
+- `resolve_routing_snapshot_exact` accepts source RuntimeSession identity/revision only when both
+  are absent for Quick Task. It is used only for initial selection, consumes the locked Account
+  Registry facts, proves zero sticky members, and writes `conversation_account_registry` `L0`.
+- `route_account_exact` uses canonical Account Registry fixed or balanced control only for initial
+  selection and replays only its stored decision.
+- `bind_quick_task_continuation_exact` creates the immutable non-selecting continued decision from
+  the locked Conversation/source RuntimeSession and original initial decision. It never reads
+  current Project routing, resolves a snapshot, invokes the decision kernel, or changes
+  account/profile identity. Same-key replay returns the stored binding; a competing key for the
+  same prospective Turn creates no second binding.
 - `plan_initial_thread_continuation_exact` consumes only selected `L0` and creates the
   complete first-session authority cluster in one transaction.
-- Routing codecs/readbacks represent the source pair as jointly optional and permit zero
-  sticky members only for `L0`.
-- Continuation-plan completeness proves selected `L0` and the new account/profile/session
-  lineage.
-- Routing-decision completeness remains unchanged.
+- Same-thread and Context Pack planning consume only `conversation_continuation`, retain the exact
+  original account and Task RoleProfile snapshots, and return typed manual recovery for selected
+  account drift, exhaustion, or readiness failure.
+- Routing codecs/readbacks preserve the closed snapshot and decision discriminators. Decision
+  completeness enforces selecting classification/exclusions or continued lineage, never both.
+
+#### Initial selection concurrency
+
+Initial selection is one top-level `READ COMMITTED` exact command. A completed same-key replay
+returns its stored response without domain work. A fresh execution takes authority locks in this
+order: the Conversation intent first; the
+`account_routing_control` singleton; every complete non-tombstoned account row in canonical UUID
+order; and the current Task RoleProfile row. It then reads and copies `account_routing_order` and
+both duration slots from `account_quota_facts` while retaining those locks through commit.
+
+Every enrollment, tombstone, order, fixed-target, or mode operation that can change membership or
+routing locks `account_routing_control` before the affected or complete account set in the same
+UUID order. Every account-local quota observation locks its account row before it inserts or
+updates the quota row and never takes `account_routing_control` afterward. Therefore selection's
+account locks also serialize an insert for an absent quota slot, and no routing/quota lock cycle is
+possible.
+
+Before commit, the command compares the locked routing revision/control/order, Task RoleProfile
+revision, account membership/revisions/blockers, and both exact quota tri-states with the copied
+snapshot. Any stale expected revision or mismatch rolls back the snapshot, decision, receipt,
+activity, and outbox and returns the typed conflict/refusal. Same-key concurrency waits for and
+replays the completed exact response without another snapshot or selection. Cross-key initial
+commands serialize on the Conversation lock: one may be fresh; every loser returns the persisted
+initial decision conflict/readback and creates no routing rows.
 
 #### Atomic initial admission
 
@@ -691,17 +765,18 @@ RuntimeSession, status `failed`, and revision 2.
 
 #### Final trigger functions
 
-The latest schema creates these seven final trigger-function bodies and bindings directly:
+The latest schema creates these eight final trigger-function bodies and bindings directly:
 
 | Trigger function | Exact Candidate-5 predicate |
 | --- | --- |
-| `decodex.enforce_routing_completeness()` | Preserve complete existing policy/evidence/`L6` behavior and add only the exact zero-sticky `L0` branch above. |
+| `decodex.enforce_routing_completeness()` | Enforce the two selecting snapshot authority shapes, exact Account Registry quota tri-states, reverse nullability, and retained ManagedRun Project-policy `L6` behavior. |
+| `decodex.enforce_routing_decision_completeness()` | Require either one initial/ManagedRun selection classification with exact replay exclusions or one non-selecting Conversation continuation binding to the source RuntimeSession and original initial decision; reject mixed fields. |
 | `decodex.enforce_runtime_session_state()` | Preserve revision-one insert, identity, timestamps, terminal immutability, legal terminal edges, and ended-session active-Turn rules. Permit only: unfenced `starting` to request-fenced `starting` by setting the complete request ID/digest pair; that exact row to `active` by preserving the request, matching response ID, and setting exact response digest/thread ID; and `active` to `active` only for exact last-Turn acknowledgement. Reject generic `starting` to `active`, partial receipts, combined edges, or unrelated drift. |
 | `decodex.enforce_turn_state()` | Preserve active-session behavior. Under `starting`, permit only exact first-Turn insertion and active-revision-1 to failed-revision-2 after positive definite pre-effect refusal. Reject every other starting-session write. |
 | `decodex.enforce_history_item_state()` | Preserve active-session behavior. Under `starting`, permit only the admission transaction's ordinal-0 completed Message for the exact first Turn; reject update, second item, other ordinal/kind/status, wrong Turn, or cross-link. |
 | `decodex.enforce_provider_attempt_transition()` | Keep the accepted state algebra, unknown reasons, positive terminal-evidence rule, and immutable tuple; include immutable RuntimeSession thread-binding protocol/key identities. |
-| `decodex.enforce_provider_attempt_binding()` | For `initial_thread`, require exact selected route/plan/account snapshot, ready ProcessGeneration/live epoch, completed thread fence/bind receipts, active post-bind RuntimeSession revision, and active revision-1 selected Turn. Preserve all non-initial branches. |
-| `decodex.enforce_continuation_plan_completeness()` | For `initial_thread`, require selected `L0`, prospective Turn intent, selected account/profile snapshots, one revision-1 unfenced starting RuntimeSession, and inert plan. Preserve same-thread and Context Pack branches; explicit-successor completeness also requires the exact failed revision-2 Turn. |
+| `decodex.enforce_provider_attempt_binding()` | For `initial_thread`, require the exact selected route lineage; for later Quick Task Turns, require the exact non-selecting continuation account/profile binding. Preserve ManagedRun and other accepted branches. |
+| `decodex.enforce_continuation_plan_completeness()` | For `initial_thread`, require selected `L0` and complete first-session lineage. For same-thread and Context Pack, require the continued decision and unchanged original account/Task RoleProfile snapshots. Explicit-successor completeness still requires the exact failed revision-2 Turn. |
 
 The dispatch-authorization command performs its own exact Turn lock. A deferred trigger
 does not replace this pre-write fence. The continuation-rejection helper derives only the
@@ -712,11 +787,11 @@ unrelated write keeps existing active-only semantics. The narrow first-session p
 are not a generic starting-session bypass.
 
 Candidate 5 adds no module, fixed hierarchy, schema phase, ledger, generic transaction or
-recovery framework, transport/idempotency mechanism, wrapper, runner, scheduler, or
-explicit-successor product surface. It must preserve current-main independent account
-observations, Reset Card-before-profile ordering within an account, concurrent progress
-across accounts, revision-fenced cache publication, and query paths that do not join or
-start refresh work.
+recovery framework, transport/idempotency mechanism, wrapper, runner, scheduler, general selector,
+capability manager, compatibility bridge, duplicate Quick Task policy path, or explicit-successor
+product surface. It must preserve current-main independent account observations, Reset
+Card-before-profile ordering within an account, concurrent progress across accounts,
+revision-fenced cache publication, and query paths that do not join or start refresh work.
 
 Long-term context consists of immutable Project, Advisor, and Program revisions. Project
 context records decisions, constraints, repository facts, active Programs/Objectives,
@@ -745,9 +820,11 @@ for the same account, but the account and provider identity never switch under a
 runner. Account
 observed state is `unavailable`, `available`, `depleted`, `unknown`, `auth_failed`, or
 `plugin_unready`. Administrative `enabled` is a separate versioned boolean; no observed
-state sets or clears it. Each quota window stores its class/duration, remaining amount,
-reset time, observation time, and confidence; 5-hour and 7-day windows are never inferred
-from positional primary/secondary ordering.
+state sets or clears it. Only `managed_run_project_policy` `L6` uses the Project-era quota
+representation with class/duration, remaining amount, reset time, observation time, and
+confidence. `conversation_account_registry` does not consume that representation; its exact
+duration-keyed 300-minute and 10080-minute slots preserve only the missing, current, or
+observation-error `account_quota_facts` fields defined above.
 
 `plugin_unready` is inert reserved state; no first-release passive probe sets it.
 Codex 0.144.2 and 0.144.4 expose no stable passive complete account-owned plugin,
@@ -874,70 +951,114 @@ ProviderAttempt storage, remote authentication, UI, packaging, release, or live 
 A future live-dispatch protocol gateway must be a separate typed authority that source-rejects
 alternate-control RPCs before enablement. XY-1400 does not add that gateway.
 
-### Durable routing-policy and candidate-set authority
+### Durable routing and candidate-set authority
 
-PostgreSQL owns a revisioned complete routing-authority snapshot and is the only authority that
-may construct the candidate universe. A routing-resolution request supplies identity and
-idempotency inputs only. Runtime, protocol clients, adapters, and tests cannot supply or override
-authoritative policy order, candidate membership, sticky identity, eligibility facts, exclusions,
-or a preclassified candidate array.
+PostgreSQL owns revisioned complete Routing Snapshots and immutable Routing Decisions. A selecting
+Routing Decision remains the sole account selector; a continued decision binds lineage and cannot
+select. A routing request supplies identity and idempotency inputs only. Runtime, protocol clients,
+tests, `QuickTaskRuntime`, and
+`ServiceApplication` cannot supply or override candidate membership, routing control, sticky
+identity, eligibility facts, exclusions, or a preclassified candidate array.
+
+Ordinary initial Quick Task routing uses Account Registry authority directly. The Quick Task
+routing adapter is the only transaction owner that may materialize its `L0` Routing Snapshot and
+selecting Routing Decision from locked current facts. No later Quick Task Turn enters that path.
+The adapter does not require or consult Project routing policy, accepted Project policy,
+`routing_compatibility_evidence`, or `quota_windows`. It creates no compatibility bridge or
+duplicate policy synchronization authority.
+
+An initial `L0` snapshot binds, under one Account Registry revision boundary:
+
+- every non-tombstoned member exactly once and its exact account revision;
+- the canonical routing mode, optional fixed Account UUID, complete account order, and routing
+  revision;
+- the current Task RoleProfile revision;
+- current enabled, lifecycle, health, and credential-binding blockers for every member; and
+- exactly one 300-minute and one 10080-minute `account_quota_facts` slot for every member, each
+  copied as the exact missing/current/observation-error shape defined above.
+
+Those candidate facts remain in the existing Routing Snapshot/Decision lineage for exact replay
+and continuation. They do not acquire legacy revision, remaining, confidence, provenance, or
+`quota_windows` values. Project-policy/evidence/build fields are inapplicable and null.
 
 The current `decodex-core::PolicySnapshot` remains a bounded inert value inside one accepted
 Project Policy revision. It neither enumerates the account inventory nor establishes routing
-completeness, eligibility, evidence provenance, or persistence freshness. Routing Snapshot is the
-distinct database-owned complete value; a Rust wrapper cannot become authorization authority.
+completeness, eligibility, evidence provenance, or persistence freshness. For ManagedRun and other
+Project-policy `L6` work, Routing Snapshot remains the distinct database-owned complete value. A
+Rust wrapper cannot become authorization authority.
 
-One snapshot binds, under the database locks that establish its revision boundary:
+A Project-policy `L6` snapshot continues to bind:
 
 - the exact accepted routing Policy revision, versioned `fixed` or `balanced` mode,
   optional fixed Account UUID, and canonical user-owned account order;
 - every current account-inventory member exactly once, with an explicit included or excluded
   disposition and an exact account revision;
-- sticky affinity, when present, plus the exact source RuntimeSession identity and revision;
+- sticky affinity plus the exact source RuntimeSession identity and revision;
 - required account, RoleProfile, and Codex-build compatibility facts and their exact revisions;
 - each exact quota, authentication, capability, and administrative evidence revision used;
 - the accepted required-capability set and capability applicability for every member; and
 - explicit blocker facts for every unknown or otherwise unusable member.
 
-Completeness is fail-closed. A duplicate, omitted, foreign, newly added, concurrently removed, or
-revision-changed inventory member; an unbound sticky source; or an unknown required fact blocks the
-snapshot or decision. Silence never means excluded, eligible, or non-applicable.
+The two selecting snapshot shapes use a closed discriminator and reverse nullability:
+`conversation_account_registry` accepts only the `L0` fields above, while
+`managed_run_project_policy` accepts only the retained Project-policy `L6` representation.
+Completeness is fail-closed within each shape. A duplicate, omitted, foreign, newly added,
+concurrently removed, or revision-changed inventory member, or an unknown required fact, blocks
+the snapshot or decision. `managed_run_project_policy` `L6` also rejects an unbound sticky source
+or incomplete Project policy/evidence. Silence never means excluded, eligible, or non-applicable.
 
-Selection and pure quota or reconciliation waits classify only included members after independent
-eligibility. Excluded members remain ineligible and do not alter those wait classifications.
-`no_route` instead projects the complete policy-member universe: every excluded member retains
-`excluded_by_policy` and its other persisted blockers, and every included member retains its exact
-blockers. An all-excluded universe is an explicit cause-complete `no_route`; a cause-free
-`no_route` is invalid.
+For Project-policy `L6`, selection and pure quota or reconciliation waits classify only included
+members after independent eligibility. Excluded members remain ineligible and do not alter those
+wait classifications. `no_route` projects the complete policy-member universe: every excluded
+member retains `excluded_by_policy` and its other persisted blockers, and every included member
+retains its exact blockers. An all-excluded universe is an explicit cause-complete `no_route`; a
+cause-free `no_route` is invalid.
 
-`decodex-core` is a pure deterministic decision kernel over this database-produced snapshot. It
-does not establish provenance or completeness. PostgreSQL atomically persists the resulting Routing
-decision, its complete normalized exclusions, and every evidence reference. Runtime consumes one
-exact persisted decision and sequences effects only; it cannot substitute a decision. Codex is a
+`decodex-core` is a pure deterministic selection kernel over a database-produced selecting
+snapshot. It does not establish provenance or completeness and is never invoked for a continued
+decision. PostgreSQL atomically persists only the resulting classification and exact normalized
+exclusions required for replay. Runtime consumes one exact persisted decision and sequences effects
+only; it cannot substitute a decision. Codex is a
 positive-evidence capability adapter and cannot determine membership, policy, or eligibility.
 One app-server process remains bound to one account, credentials never switch in a live process,
 and the separate 300-minute and 10080-minute quota facts for separate accounts are never merged.
 
-Sticky affinity wins only when the bound member is independently eligible under the same complete
-snapshot. Eligibility requires the independent versioned `enabled=true` fact; observed health does
-not imply enablement. Every known depleted window excludes its account until reset. Unknown, stale,
-incompatible, disabled, authentication-failed, missing-duration, low-confidence, or precision-
-incompatible evidence blocks eligibility. When every otherwise eligible account is excluded only
-by usage, Routing Decision persists `waiting_usage` and the exact earliest-ready time. XY-1362 owns one
-restart-safe scheduler wake and always re-enters fresh authoritative resolution; routing owns no
-wake lifecycle.
+Sticky affinity applies only to selecting `managed_run_project_policy` `L6` and wins only when the
+bound member is independently eligible under the same complete snapshot. Eligibility requires the
+independent versioned `enabled=true` fact; observed health does not imply enablement. Every known
+depleted window excludes its account until reset. Unknown, stale, incompatible, disabled,
+authentication-failed, missing-duration, low-confidence, or precision-incompatible Project-policy
+facts block eligibility.
 
-Account-owned readiness is evaluated only for capabilities explicitly required by the accepted
-routing Policy revision. Unknown never satisfies a required capability. If the accepted required-
-capability set is empty, unknown account-owned plugin inventory is non-applicable; it is not
-positive readiness evidence and does not change an account to ready. XY-1336 remains future
-passive-receipt tracking. Host-owned before/after receipts prove causal no-mutation integrity only
-and cannot establish account-owned readiness.
+For initial Quick Task `L0`, fixed mode accepts only the exact fixed eligible member. Balanced mode
+uses canonical Account Registry order. Each 300-minute and 10080-minute quota fact is classified
+independently from its exact missing, current, or observation-error source shape; neither windows
+nor accounts form a merged pool. The persisted result is `selected`, `waiting`, or `no_route`.
+`waiting` is manual-retry state in this slice and registers no wake. There is no fallback,
+scheduler wake, or re-selection. Policy-bound routing may use only its separately accepted wait
+authority; routing itself owns no wake lifecycle.
+
+Account-owned readiness is evaluated only for Project-policy `L6` capabilities explicitly required
+by the accepted routing Policy revision. Unknown never satisfies a required capability. If the
+accepted required-capability set is empty, unknown account-owned plugin inventory is
+non-applicable; it is not positive readiness evidence and does not change an account to ready.
+XY-1336 remains future passive-receipt tracking. Host-owned before/after receipts prove causal
+no-mutation integrity only and cannot establish account-owned readiness. These capability rules do
+not add `routing_compatibility_evidence` to initial Quick Task eligibility.
+
+For a later Quick Task Turn, Routing Authority locks the current RuntimeSession and traces its
+immutable lineage to the original `conversation_account_registry` selected decision. It writes
+only a `conversation_continuation` decision binding for the prospective Turn. Same-thread and
+Context Pack planning consume that binding and retain the exact account and copied Task RoleProfile
+snapshots. A selected-account quota, lifecycle, health, credential, or readiness failure returns
+typed manual recovery. It cannot call current Project routing, resolve a candidate snapshot, invoke
+the selection kernel, fall back, wake, or re-select.
 
 Experiment Authority owns the original causal experiment record. Retained-title Authority owns its
-two-effect title bridge. After an exact Routing Decision with an existing source RuntimeSession,
-Continuation Plan owns same-thread continuation when exact positive account/profile/build evidence
-permits it. Otherwise, it owns one atomic Context Pack plus fallback RuntimeSession. These owners
+two-effect title bridge. After an exact non-selecting continuation binding with an existing source
+RuntimeSession, Continuation Plan owns same-thread continuation when exact positive selected-account
+and retained-profile evidence permits it. Otherwise, it owns one atomic Context Pack plus fallback
+RuntimeSession on that same account and profile. These owners
 serve ordinary Conversation Turns and ManagedRun executions. The stateless ExecutionCoordinator
 sequences one Routing Decision, one Continuation Plan, one live ProcessGeneration fence, and
 ProviderAttempt preparation. Current production
@@ -948,12 +1069,9 @@ Repository/worktree/Git and artifact effects retain their own accepted authoriti
 owns or weakens those boundaries.
 
 Those paragraphs define retained final routing authority, not current implementation.
-Slice 1 enables only initial selection after the Slice-1 subset of MacDogfoodReady
-passes: `fixed` considers its exact target, and `balanced` selects the first fully eligible
-account in canonical order.
-Selection evaluates both quota windows and returns a typed no-route or all-depleted
-result. Recovery is an explicit versioned enable/disable, mode, or order command followed
-by a new task. It does not rebind or replay a thread.
+Slice 1 enables only initial Quick Task selection after the Slice-1 subset of
+MacDogfoodReady passes. Recovery is an explicit versioned enable/disable, mode, or order
+command followed by a new task. It does not rebind or replay a thread.
 
 [XY-1304](https://linear.app/hack-ink/issue/XY-1304) is the later acceptance owner for
 automatic cross-account same-thread fallback and all-depleted scheduler wake. Until its
@@ -962,20 +1080,23 @@ remain hard disabled. It does not block Quick Task, Project/Lead, ManagedRun, GP
 first Mac dogfood. Replay after an ambiguous outcome remains prohibited independent of
 XY-1304 and is reconciled by ProviderAttempt.
 
-Unknown, missing-duration, stale, low-confidence, auth-failed, capability-unready, or
-disabled facts never imply eligibility. An all-depleted Slice-1 result exposes reset
-evidence and waits for explicit retry; it does not schedule a wake.
+Missing or observation-error quota slots and unknown, stale, auth-failed, or disabled Account
+Registry blockers never imply initial Quick Task eligibility. Capability-unready, incompatible,
+missing-duration, low-confidence, and precision-incompatible facts apply only to
+`managed_run_project_policy` `L6`. An all-depleted Slice-1 result exposes reset evidence and waits
+for explicit retry; it does not schedule a wake.
 
-Readiness outside the accepted capability-applicability rule cannot authorize account eligibility,
-assignment, reassignment, fallback, scheduling, wakeup, continuation, or production routing. A
-future operator-triggered active diagnostic requires a separate authority decision and remains
-non-routing evidence.
+For Project-policy routing, readiness outside the accepted capability-applicability rule cannot
+authorize eligibility, assignment, reassignment, fallback, scheduling, wakeup, continuation, or
+production routing. A future operator-triggered active diagnostic requires a separate authority
+decision and remains non-routing evidence.
 
-Users exclusively select the four global RoleProfiles. Runtime cannot alter model,
-reasoning, or service tier. Each RuntimeSession snapshots its profile. Decodex keeps a
-user-owned desired inventory only as intent. Until a stable passive account-owned receipt
-exists, the first release reports plugin readiness as `unknown`; that unknown is blocking only when the exact
-accepted routing policy requires the corresponding capability, and is non-applicable when the
+Users exclusively select the four global RoleProfiles through their separate PostgreSQL
+authority. Runtime and routing cannot alter or derive model, reasoning, or service tier. Each
+RuntimeSession snapshots the current profile for its role; Quick Task requires `task`. Decodex keeps
+a user-owned desired inventory only as intent. Until a stable passive account-owned receipt exists,
+the first release reports plugin readiness as `unknown`; that unknown is blocking only when a
+Project-policy `L6` route requires the corresponding capability, and is non-applicable when the
 required-capability set is empty. Host facts never become positive account-readiness evidence or
 guide mutation from such a conclusion.
 

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -171,6 +171,8 @@ outcomes and prove:
 - each missing or failed Quick Task dependency produces one immutable closed redacted
   `QuickTaskUnavailableReason`, and execute/start/resume return the typed unavailable
   result without hiding it through `.ok()`, an optional setter, or an omitted field;
+- the initial user-supplied typed RoleProfile configuration bootstraps all four roles atomically,
+  and a missing current `task` profile is a typed Quick Task initialization refusal;
 - Quick Task unavailability does not remove diagnostics, account recovery, control-plane
   commands, or available PostgreSQL-backed reads;
 - ManagedRepository absence is `Disabled`; repository-only configuration, path, Git,
@@ -247,34 +249,46 @@ old/new adapter compatibility matrix.
 Candidate 5 remains target architecture. Candidate-4 tree
 `f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance and cannot supply
 implementation evidence.
+This documentation amendment is not schema, code, migration, validation, or live-success evidence.
 
 The integrated gate covers seven bounded behavior groups. They are test responsibilities,
 not schema phases or separate authority frameworks.
 
-1. **Initial routing lineage.** Prove exact `L0` all-null source lineage, open
-   exact-revision Conversation, no RuntimeSession or Turn, zero sticky members, and exact
-   complete locked member/order/account/two-window quota/eight-capability/blocker facts.
-   Preserve exact `L6` all-present positive lineage and one sticky member. Reject every
-   partial, source-bearing/sticky `L0`, source-less ManagedRun, stale Conversation, or
-   missing/extra/duplicate/reordered/cross-linked fact. Under cross-key concurrency, one
-   initial Routing Decision is fresh; same-key replay is read-only.
-2. **First-session and admission atomicity.** Prove Continuation Plan creates only the
-   selected account/profile snapshots, first revision-1 unfenced starting RuntimeSession,
-   inert initial plan, receipt/activity/outbox in one transaction. Then prove Conversation
-   authority creates the exact active revision-1 sequence-1 user Turn and only ordinal-0
-   completed Message in one transaction. Every failure or competing key leaves no partial
-   domain effect.
-3. **Sole selection and exact fences.** Make one account pass a subset of Account Service
-   checks but fail complete routing capability while another is eligible. Routing Decision
-   must select only the eligible account, and Continuation Plan must create only that
-   account's lineage. Account Service later fences that selected account only. Prove exact
-   Turn locks at ProcessGeneration, thread, and ProviderAttempt boundaries and refusal on
-   drift without re-selection, fallback, or wake.
-4. **Replay, ambiguity, and terminalization.** At every process/thread/attempt lost-result
-   and restart cut, only a fresh ProcessGeneration can spawn. Replayed, rejected, and
-   unknown state cannot spawn, replace, adopt, create a successor, duplicate an attempt,
-   or fail the Turn. Only positive definite pre-effect refusal can move the exact Turn to
-   failed revision 2. Explicit successor locks only that failed revision-2 Turn and stays
+1. **First and later Turn authority.** On a fresh latest-schema local database, establish six ready
+   non-tombstoned accounts, canonical Account Registry routing, and the separately bootstrapped
+   RoleProfiles. Prove the first RuntimeSession is selected and created with no Project, accepted
+   Project policy, `routing_compatibility_evidence`, or `quota_windows` seed. On later Turns, prove
+   `read_current_task_routing_authority_exact()` and `resolve_routing_snapshot_exact` are never
+   called. The immutable
+   non-selecting continuation decision must reference the current RuntimeSession, original initial
+   decision, selected account, and copied Task RoleProfile. Same-thread and Context Pack retain
+   those identities. Drift, exhaustion, or readiness failure returns typed manual recovery with no
+   fallback, wake, or re-selection. ManagedRun still requires its complete Project-policy `L6`.
+2. **Closed persistence and quota replay.** Prove `conversation_account_registry` initial `L0` and
+   `managed_run_project_policy` `L6` are the only selecting snapshot shapes, and reverse constraints
+   reject mixed consumers, fields, children, or evidence. For every Account Registry member, prove
+   exactly one 300-minute and one 10080-minute slot and exact replay of: missing with all
+   observation fields null; current with `used_percent`/`observed_at`/`resets_at` and no error; and
+   observation error with typed `error_code`/`observed_at` and no usage/reset. Reject fabricated
+   revision, remaining, confidence, provenance, or legacy quota values. Exercise fixed exact-target
+   and balanced canonical-order selection with independent missing/current/error and 5-hour/7-day
+   exhaustion. Replay only `selected`/`waiting`/`no_route` and exact exclusion reasons.
+3. **Selection concurrency.** Prove one top-level `READ COMMITTED` exact command locks Conversation
+   intent, routing control, canonical-UUID account rows, and current Task RoleProfile before it
+   copies order and quota facts. Race it against enrollment, tombstone, order, fixed/mode, account
+   observation, and quota writes. Prove routing writers take control before account rows, quota
+   writers take account before quota and never control afterward, and an absent quota insertion
+   waits on the account fence. Verify stale pre-commit facts roll back every effect. Same-key
+   contenders replay one exact result; cross-key contenders produce one fresh selection and no
+   duplicate snapshot/decision. For a later Turn, same-key contenders replay one continued binding
+   and cross-key contenders create neither a second binding nor any selection work.
+4. **Role, admission, and effect fences.** Prove typed configuration bootstraps all four
+   RoleProfiles atomically, later updates remain in RoleProfile Authority, and missing current
+   `task` returns `QuickTaskUnavailable` without synthesized defaults. Prove initial
+   account/profile/session/plan and first Turn/Message atomicity. At every selected-account,
+   ProcessGeneration, thread, and ProviderAttempt fence, prove drift or lost-result/restart state
+   cannot re-select, spawn from non-fresh authority, duplicate an attempt, or fail the Turn. Only
+   positive definite pre-effect refusal may create failed revision 2; explicit successor remains
    PostgreSQL-only non-dispatch evidence.
 5. **Conversation and stream order.** Preserve result-before-stream order, one actor owner,
    bounded deferred publication, one command/registration slot, explicit publication
@@ -288,10 +302,11 @@ not schema phases or separate authority frameworks.
    reconciliation, exact session admission bounds including handshakes, zero surviving
    work, and cleanup only after closed accounting.
 
-The latest schema must create the final accepted bodies and bindings for exactly these
+The latest schema must create the final accepted bodies and bindings for exactly these eight
 affected trigger functions:
 
 - `decodex.enforce_routing_completeness()`;
+- `decodex.enforce_routing_decision_completeness()`;
 - `decodex.enforce_runtime_session_state()`;
 - `decodex.enforce_turn_state()`;
 - `decodex.enforce_history_item_state()`;
@@ -403,11 +418,14 @@ MacDogfoodReady requires:
 - a fresh latest-schema PostgreSQL 18 database or the accepted local reset result;
 - the signed daemon wrapper, exact Keychain identity/access group, and same-UID transport;
 - Account Registry/HostCredentialStore exact bindings and routing controls;
+- all four global RoleProfiles from the atomic typed configuration bootstrap, including a current
+  `task` profile;
 - exact-build account login/refresh callback proof;
 - independent 300-minute and 10,080-minute quota facts;
 - current-main account observations, Reset Card/profile readback, and terminal Reset Card
   replay;
-- Candidate-5 initial routing/process/thread/attempt fences;
+- Candidate-5 Account Registry initial routing without a Project/policy/evidence seed, plus
+  process/thread/attempt fences;
 - minimal Accounts/Conversation/Health GPUI; and
 - packaged startup with zero DDL, no schema-owner credential, no old watcher,
   environment credential projection, helper, `:8192`, or old database input.
@@ -443,6 +461,9 @@ Stop the owning gate on:
   state that substitutes for current owner fences;
 - repository configuration that blocks core parsing or duplicates PostgreSQL path
   authority;
+- a Quick Task dependency on Project policy, `routing_compatibility_evidence`, or `quota_windows`;
+  a later-Turn snapshot/selection call; or a compatibility bridge that keeps duplicate routing
+  paths;
 - a second account selector, provider-effect ledger, process owner, or coordinator state;
 - possible external-effect replay without positive reconciliation;
 - Candidate-5 partial lineage, partial admission, ambiguous terminalization, or account


### PR DESCRIPTION
## Summary

- define one Account Registry selection only when the first Quick Task RuntimeSession is established
- keep later turns on an immutable non-selecting continuation binding
- separate ordinary Quick Task quota authority from ManagedRun Project-policy routing
- define deadlock-safe account/routing/quota lock order and exact acceptance gates

## Scope

Documentation authority only. No code, SQL, migration, runtime, or validation claim.

## Evidence

- base: `1c0e9265c8a2f9ea8b08e70e76913c2d8e6ee2f6`
- reviewed diff: `cddbc97b8c6825426791a875833a138a287c4742183fb4c89ec0c246405ffffb`
- `git diff --check`: passed
- fresh independent review: `APPROVED/READY`, no P0/P1/P2 findings
