### PR TITLE
Fix menu-bar panel presentation for accessory app

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -50,6 +50,10 @@ final class StatusPanelController: NSObject {
 		}
 		positionPanel()
 		if NSApp.isActive == false {
+			// This is an explicit status-item click. Accessory apps do not
+			// reliably become active from cooperative activation before the panel
+			// is ordered front, so force activation for this explicit user-initiated
+			// presentation only. The close path never activates the app.
 			NSApp.activate(ignoringOtherApps: true)
 		}
 		panel.makeKeyAndOrderFront(nil)

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -539,6 +539,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(statusPanel.contains("AccountPanelView(store: store)"))
 		XCTAssertTrue(statusPanel.contains("panel.hidesOnDeactivate = true"))
 		XCTAssertTrue(statusPanel.contains("button.sendAction(on: [.leftMouseUp])"))
+		XCTAssertTrue(statusPanel.contains("NSApp.activate(ignoringOtherApps: true)"))
 		XCTAssertFalse(
 			statusPanel.contains("NSApplication.didResignActiveNotification")
 		)


### PR DESCRIPTION
## Summary
- keep direct activation only on explicit panel presentation for the LSUIElement accessory app
- keep closing activation-free and preserve AppKit-owned panel lifecycle
- add an architecture regression assertion for the activation contract

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app
- release bundle build/sign/launch via apps/decodex-app/script/build_and_run.sh --verify
- 10 external-focus open/close cycles via the menu-bar accessibility action: opened=1, closed=0
