### PR TITLE
Repair current-main Rust format gate for upstream compatibility

### DIFF
--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -2037,9 +2037,8 @@ max_entry_bytes = 0
 		let mut listener = authority.bind().await.expect("test operation must succeed");
 		let account_id = EntityId::new("40000000-0000-4000-8000-000000000001")
 			.expect("test operation must succeed");
-		let descriptor =
-			ResetCardDescriptorDto::new(1_700_000_000, 1_700_003_600)
-				.expect("test operation must succeed");
+		let descriptor = ResetCardDescriptorDto::new(1_700_000_000, 1_700_003_600)
+			.expect("test operation must succeed");
 		let expected_account_id = account_id.clone();
 		let task = tokio::spawn(async move {
 			let _temp = temp;
@@ -2107,8 +2106,7 @@ max_entry_bytes = 0
 					account_id.clone(),
 					descriptor,
 					EntityRevision(7),
-					IdempotencyKey::new("delayed-close-key")
-						.expect("test operation must succeed"),
+					IdempotencyKey::new("delayed-close-key").expect("test operation must succeed"),
 				)
 				.await
 				.expect("completed response must remain authoritative"),


### PR DESCRIPTION
## Summary

Repair the two canonical nightly rustfmt line wraps that currently block the repository automation gate needed by the upstream compatibility adaptation.

## Scope

Only `crates/decodex-protocol/src/client.rs` is changed. This is a formatting-only base repair with no behavior change.

## Evidence

- Current base `main`: `4475f22da3e771337dbbe31d9774fc15aae2afda`
- Signed commit: `2c0a28a0731100abdd624fb0a145c90b11a82aeb`
- Parent compatibility handoff: https://github.com/hack-ink/decodex/pull/1270

## Validation

- `CARGO_NET_OFFLINE=true cargo test -p decodex-protocol --all-targets --all-features`: 73 passed
- `rustup run nightly-2026-07-16 cargo fmt --all -- --check`: passed
- `git verify-commit`: passed

Decodex-Autonomy: upstream-dependency-repair
Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/1270
Decodex-Repair-Scope: repository-format-gate

## Handoff

Next owner: Reviewer. Land this dependency repair first, read back the signed merge, then re-run the complete repository gate and review #1270 at its exact base and head.