### PR TITLE
Accept current Codex thread response semantics

### DIFF
--- a/crates/decodex-codex/src/quick_task.rs
+++ b/crates/decodex-codex/src/quick_task.rs
@@ -128,7 +128,7 @@ pub enum QuickTaskContractError {
 	EphemeralThreadRejected,
 	/// An app-server response did not identify the exact requested thread.
 	ThreadIdMismatch,
-	/// App-server response cwd facts disagreed with each other or with the request.
+	/// A required app-server response cwd agreement failed.
 	CwdMismatch,
 	/// The app-server reported a model other than the explicit requested model.
 	ModelMismatch,
@@ -426,7 +426,7 @@ impl QuickTaskThreadStartResponse {
 	) -> Result<Self, QuickTaskContractError> {
 		wire.validate_private_facts()?;
 		let facts = validate_thread_response_facts(
-			None,
+			ThreadResponseContext::Start,
 			request.cwd(),
 			request.model(),
 			wire.thread,
@@ -562,7 +562,7 @@ impl QuickTaskThreadResumeResponse {
 	) -> Result<Self, QuickTaskContractError> {
 		wire.validate_private_facts()?;
 		let facts = validate_thread_response_facts(
-			Some(request.thread_id()),
+			ThreadResponseContext::Resume(request.thread_id()),
 			request.cwd(),
 			request.model(),
 			wire.thread,
@@ -584,7 +584,7 @@ impl QuickTaskThreadResumeResponse {
 		&self.thread_id
 	}
 
-	/// Bounded working directory returned by the app server.
+	/// Bounded live working directory returned at the top level by the resumed session.
 	pub fn cwd(&self) -> &ThreadCwd {
 		&self.cwd
 	}
@@ -949,7 +949,19 @@ struct QuickTaskThreadResponseWire {
 	agent_role: Option<String>,
 	git_info: Option<QuickTaskGitInfoWire>,
 	name: Option<String>,
+	#[serde(default)]
+	section: Option<QuickTaskThreadSectionWire>,
+	#[serde(default)]
+	section_entered_at: Option<i64>,
 	turns: Vec<QuickTaskForbiddenValueWire>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct QuickTaskThreadSectionWire {
+	id: String,
+	name: String,
 }
 
 #[allow(dead_code)]
@@ -1397,8 +1409,14 @@ struct ValidatedThreadResponseFacts {
 	reasoning_effort: Option<QuickTaskReasoningEffort>,
 }
 
+#[derive(Clone, Copy)]
+enum ThreadResponseContext<'a> {
+	Start,
+	Resume(&'a ExactThreadId),
+}
+
 fn validate_thread_response_facts(
-	expected_thread_id: Option<&ExactThreadId>,
+	context: ThreadResponseContext<'_>,
 	expected_cwd: &ThreadCwd,
 	expected_model: &QuickTaskModel,
 	thread: QuickTaskThreadResponseWire,
@@ -1415,7 +1433,7 @@ fn validate_thread_response_facts(
 
 	let thread_id =
 		ExactThreadId::new(thread.id).map_err(|_| QuickTaskContractError::InvalidThreadId)?;
-	if expected_thread_id.is_some_and(|expected| expected != &thread_id) {
+	if matches!(context, ThreadResponseContext::Resume(expected) if expected != &thread_id) {
 		return Err(QuickTaskContractError::ThreadIdMismatch);
 	}
 
@@ -1423,7 +1441,10 @@ fn validate_thread_response_facts(
 		.map_err(|_| QuickTaskContractError::InvalidCwd)?;
 	let cwd =
 		ThreadCwd::from_protocol(response_cwd).map_err(|_| QuickTaskContractError::InvalidCwd)?;
-	if thread_cwd != cwd || expected_cwd != &cwd {
+	if expected_cwd != &cwd {
+		return Err(QuickTaskContractError::CwdMismatch);
+	}
+	if matches!(context, ThreadResponseContext::Start) && thread_cwd != cwd {
 		return Err(QuickTaskContractError::CwdMismatch);
 	}
 
@@ -1499,6 +1520,8 @@ const THREAD_RESPONSE_FIELDS: &[&str] = &[
 	"agentRole",
 	"gitInfo",
 	"name",
+	"section",
+	"sectionEnteredAt",
 	"turns",
 ];
 const THREAD_RESPONSE_REQUIRED_FIELDS: &[&str] = &[
@@ -1845,6 +1868,148 @@ mod tests {
 		assert_eq!(turn.status(), QuickTaskTurnStatus::InProgress);
 		assert!(decode_quick_task_turn_interrupt_response(b"{}").is_ok());
 		assert!(decode_quick_task_thread_archive_response(b"{}").is_ok());
+	}
+
+	#[test]
+	fn current_thread_section_fields_decode_when_omitted_null_or_populated() {
+		let canonical = thread_response("thread-1", "gpt-5", "/workspace");
+		let omitted = canonical.clone();
+
+		let mut null = canonical.clone();
+		null["thread"]["section"] = Value::Null;
+		null["thread"]["sectionEnteredAt"] = Value::Null;
+
+		let mut populated = canonical;
+		populated["thread"]["section"] = json!({"id": "section-1", "name": "Active"});
+		populated["thread"]["sectionEnteredAt"] = json!(2);
+
+		for (case, response) in [("omitted", omitted), ("null", null), ("populated", populated)] {
+			let bytes = serde_json::to_vec(&response).expect("fixture response must serialize");
+
+			assert!(
+				decode_quick_task_thread_start_response(&start_request(), &bytes).is_ok(),
+				"thread/start must accept {case} section fields",
+			);
+			assert!(
+				decode_quick_task_thread_resume_response(&resume_request(), &bytes).is_ok(),
+				"thread/resume must accept {case} section fields",
+			);
+		}
+	}
+
+	#[test]
+	fn malformed_or_unknown_thread_section_fields_are_rejected() {
+		let canonical = thread_response("thread-1", "gpt-5", "/workspace");
+		let cases = [
+			("missing id", json!({"name": "Active"}), QuickTaskContractError::MissingResponseField),
+			(
+				"missing name",
+				json!({"id": "section-1"}),
+				QuickTaskContractError::MissingResponseField,
+			),
+			(
+				"non-string id",
+				json!({"id": 1, "name": "Active"}),
+				QuickTaskContractError::MalformedResponse,
+			),
+			(
+				"non-string name",
+				json!({"id": "section-1", "name": 1}),
+				QuickTaskContractError::MalformedResponse,
+			),
+			("non-object section", json!("section-1"), QuickTaskContractError::MalformedResponse),
+			(
+				"unknown nested field",
+				json!({"id": "section-1", "name": "Active", "unexpected": true}),
+				QuickTaskContractError::UnknownResponseField,
+			),
+		];
+
+		for (case, section, expected) in cases {
+			let mut response = canonical.clone();
+			response["thread"]["section"] = section;
+
+			assert_eq!(
+				decode_quick_task_thread_start_response(
+					&start_request(),
+					&serde_json::to_vec(&response).expect("fixture response must serialize"),
+				)
+				.map(|_| ()),
+				Err(expected),
+				"{case}",
+			);
+		}
+
+		let mut malformed_entered_at = canonical;
+		malformed_entered_at["thread"]["sectionEnteredAt"] = json!("2");
+
+		assert_eq!(
+			decode_quick_task_thread_start_response(
+				&start_request(),
+				&serde_json::to_vec(&malformed_entered_at)
+					.expect("fixture response must serialize"),
+			)
+			.map(|_| ()),
+			Err(QuickTaskContractError::MalformedResponse),
+			"non-integer section-entered timestamp",
+		);
+	}
+
+	#[test]
+	fn resume_uses_live_response_cwd_when_persisted_thread_cwd_differs() {
+		let mut response = thread_response("thread-1", "gpt-5", "/workspace");
+		response["thread"]["cwd"] = json!("/persisted");
+		let bytes = serde_json::to_vec(&response).expect("fixture response must serialize");
+
+		let resume = decode_quick_task_thread_resume_response(&resume_request(), &bytes)
+			.expect("resume must allow distinct persisted thread metadata cwd");
+
+		assert_eq!(resume.cwd().as_str(), "/workspace");
+	}
+
+	#[test]
+	fn resume_rejects_live_response_cwd_that_differs_from_request() {
+		let mut response = thread_response("thread-1", "gpt-5", "/other");
+		response["thread"]["cwd"] = json!("/persisted");
+
+		assert_eq!(
+			decode_quick_task_thread_resume_response(
+				&resume_request(),
+				&serde_json::to_vec(&response).expect("fixture response must serialize"),
+			)
+			.map(|_| ()),
+			Err(QuickTaskContractError::CwdMismatch),
+		);
+	}
+
+	#[test]
+	fn start_rejects_nested_thread_cwd_that_differs_from_live_response() {
+		let mut response = thread_response("thread-1", "gpt-5", "/workspace");
+		response["thread"]["cwd"] = json!("/persisted");
+
+		assert_eq!(
+			decode_quick_task_thread_start_response(
+				&start_request(),
+				&serde_json::to_vec(&response).expect("fixture response must serialize"),
+			)
+			.map(|_| ()),
+			Err(QuickTaskContractError::CwdMismatch),
+		);
+	}
+
+	#[test]
+	fn resume_rejects_relative_persisted_thread_cwd() {
+		let mut response = thread_response("thread-1", "gpt-5", "/workspace");
+		response["thread"]["cwd"] = json!("persisted");
+
+		assert_eq!(
+			decode_quick_task_thread_resume_response(
+				&resume_request(),
+				&serde_json::to_vec(&response).expect("fixture response must serialize"),
+			)
+			.map(|_| ()),
+			Err(QuickTaskContractError::MalformedResponse),
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Decodex-Autonomy: upstream-compatibility
Upstream-Codex-Head: 57f42a81131ccf5933e7ec5dc659c381eeb5d72b
Current-Official-Codex-Head: 57f42a81131ccf5933e7ec5dc659c381eeb5d72b
Reviewed-Decodex-Main: 24c79ca5037e6ffae85527d3f930b0fb4b96bfd6
Decodex-Blocked-By: https://github.com/hack-ink/decodex/pull/1276

## Decision

The existing Decodex Quick Task adaptation accepts current Codex Thread responses with optional default-null section and sectionEnteredAt fields. It strictly validates populated section id/name fields and rejects malformed or unknown nested fields.

For thread/resume, persisted metadata may report a nested thread.cwd that differs from the requested live cwd. Decodex accepts that distinction only for resume, validates both paths as bounded absolute paths, requires the top-level live cwd to equal the request, and returns the live top-level cwd. thread/start still requires nested metadata, top-level response, and request cwd to agree.

The seven official commits from 7a0e974e08c798d1e8d59d407aeb6e24db1313af through 57f42a81131ccf5933e7ec5dc659c381eeb5d72b create no additional Decodex compatibility change across protocol, config, auth, sandbox, MCP, collaboration, thread, turn, transport, or skills/tool surfaces. ThreadSection, stable/experimental app-server schemas, config schema, and legacy feature registry retain identical blob identities at the reviewed endpoints.

## Repair brief

Refresh this same deterministic compatibility handoff to signed head f27d932f0549b93278ce0cf48b1997a4e087e109, directly parented by current main 24c79ca5037e6ffae85527d3f930b0fb4b96bfd6. The one-file Quick Task change retains the merged #1275 gate repairs; the nine repair files are unchanged relative to current main, and the two later-evolved files match the 8c9248a67c7cd157f6f46a5189783f3aa481f0cc to current-main evolution.

## Evidence

- Official current head: https://github.com/openai/codex/commit/57f42a81131ccf5933e7ec5dc659c381eeb5d72b
- Reviewed range: https://github.com/openai/codex/compare/7a0e974e08c798d1e8d59d407aeb6e24db1313af...57f42a81131ccf5933e7ec5dc659c381eeb5d72b
- Thread source: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
- Current stable schema: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server-protocol/schema/precomputed/app-server-exports-stable.json.zst
- Current experimental schema: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/app-server-protocol/schema/precomputed/app-server-exports-experimental.json.zst
- Current config schema: https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/core/config.schema.json

## Validation

- Signed compatibility head: f27d932f0549b93278ce0cf48b1997a4e087e109; direct parent current main; git verify-commit passed
- CARGO_NET_OFFLINE=true cargo test -p decodex-codex --all-targets --all-features: 57 passed
- Pinned nightly package/workspace formatting: passed
- Focused Clippy with -D warnings: passed
- Full check-automations is currently blocked by the linked js-yaml security repair #1276 and offline Sigstore TUF metadata
- X API spend: $0

Next owner: Reviewer. Land #1276 first with exact signed merge readback, rerun the full repository gate, then review and land this exact head. Keep this PR open until both dependency evidence and signed landing are complete.
