### PR TITLE
Fix menubar refresh freshness and route flicker

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -38,11 +38,16 @@ to 50%, and destructive red at 20% or below. The numeric percentage and
 accessibility value remain the primary status.
 
 The app keeps one bounded wait open for the daemon's account-observation
-generation. Each progressive daemon publication wakes that wait and causes one
-coalesced reload of daemon-owned values. A 30-second daemon heartbeat bounds a
-missed notification or daemon restart, and transport failures reconnect with a
-250-millisecond to 8-second bounded backoff. The UI has no 15-second refresh
-clock. Opening the panel and `Refresh all` can still request one cache reload.
+generation. A daemon observation always updates its per-account freshness
+metadata, but the opaque generation advances only when the public cached value
+or its typed result changes. Only a newly observed generation wakes the wait and
+causes one coalesced background synchronization of daemon-owned values. A
+same-generation 30-second daemon heartbeat only retries a previously failed
+synchronization; it does not start a normal reload. Transport failures reconnect
+with a 250-millisecond to 8-second bounded backoff. The UI has no 15-second
+refresh clock or background loading gate. Opening the panel renders the latest
+published values immediately, then asks the daemon for one coalesced priority
+observation; `Refresh all` remains the explicit full-read action.
 Independently, the daemon starts one observation round immediately, repeats it
 every 15 seconds, and wakes it after account and Reset Card changes. It starts
 every independent account concurrently, keeps at most one active observation

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -18,6 +18,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 	var expectedAccountRevision: UInt64? = nil
 	var expectedRoutingRevision: UInt64? = nil
 	var afterGeneration: UInt64? = nil
+	var requestRefresh: Bool? = nil
 	var order: [String]? = nil
 	var idempotencyKey: String? = nil
 	var operationID: String? = nil
@@ -36,6 +37,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 		case expectedAccountRevision = "expected_account_revision"
 		case expectedRoutingRevision = "expected_routing_revision"
 		case afterGeneration = "after_generation"
+		case requestRefresh = "request_refresh"
 		case order
 		case idempotencyKey = "idempotency_key"
 		case operationID = "operation_id"

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -418,6 +418,17 @@ protocol AccountObservationClient: Sendable {
 	func waitForAccountObservation(
 		afterGeneration: UInt64
 	) async throws -> AccountObservationSignal
+	func requestAccountObservationRefresh(
+		afterGeneration: UInt64
+	) async throws -> AccountObservationSignal
+}
+
+extension AccountObservationClient {
+	func requestAccountObservationRefresh(
+		afterGeneration: UInt64
+	) async throws -> AccountObservationSignal {
+		try await waitForAccountObservation(afterGeneration: afterGeneration)
+	}
 }
 
 extension ResetCardClient {
@@ -552,13 +563,33 @@ extension DecodexNativeClient: AccountObservationClient {
 	func waitForAccountObservation(
 		afterGeneration: UInt64
 	) async throws -> AccountObservationSignal {
+		try await waitForAccountObservation(
+			afterGeneration: afterGeneration,
+			requestRefresh: false
+		)
+	}
+
+	func requestAccountObservationRefresh(
+		afterGeneration: UInt64
+	) async throws -> AccountObservationSignal {
+		try await waitForAccountObservation(
+			afterGeneration: afterGeneration,
+			requestRefresh: true
+		)
+	}
+
+	private func waitForAccountObservation(
+		afterGeneration: UInt64,
+		requestRefresh: Bool
+	) async throws -> AccountObservationSignal {
 		let response: (
 			authority: ResetCardAuthority,
 			data: AccountObservationSignal
 		) = try await perform(
 			DecodexNativeRequest(
 				operation: "wait_for_account_observation",
-				afterGeneration: afterGeneration
+				afterGeneration: afterGeneration,
+				requestRefresh: requestRefresh ? true : nil
 			),
 			authority: nil
 		)

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardRefreshCoordinator.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardRefreshCoordinator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum ResetCardRefreshWork: Equatable {
 	case full
+	case observation
 	case skeleton
 }
 
@@ -9,6 +10,8 @@ enum ResetCardRefreshWork: Equatable {
 /// while another account operation is active.
 struct ResetCardRefreshRequests: Equatable {
 	private(set) var manualRefreshRequested = false
+	private(set) var manualRefreshGeneration: UInt64 = 0
+	private(set) var completedManualRefreshGeneration: UInt64 = 0
 	private(set) var observationGeneration: UInt64 = 0
 	private var consumedObservationGeneration: UInt64 = 0
 	private(set) var skeletonGeneration: UInt64 = 0
@@ -16,7 +19,10 @@ struct ResetCardRefreshRequests: Equatable {
 
 	var hasFullRefreshRequest: Bool {
 		manualRefreshRequested
-			|| observationGeneration != consumedObservationGeneration
+	}
+
+	var hasObservationRefreshRequest: Bool {
+		observationGeneration != consumedObservationGeneration
 	}
 
 	var hasSkeletonRefreshRequest: Bool {
@@ -27,12 +33,25 @@ struct ResetCardRefreshRequests: Equatable {
 		consumedSkeletonGeneration >= generation
 	}
 
-	var hasWork: Bool {
-		hasFullRefreshRequest || hasSkeletonRefreshRequest
+	func didCompleteManualRefresh(upTo generation: UInt64) -> Bool {
+		completedManualRefreshGeneration >= generation
 	}
 
-	mutating func requestManualRefresh() {
+	var hasWork: Bool {
+		hasFullRefreshRequest
+			|| hasObservationRefreshRequest
+			|| hasSkeletonRefreshRequest
+	}
+
+	@discardableResult
+	mutating func requestManualRefresh() -> UInt64 {
+		manualRefreshGeneration &+= 1
 		manualRefreshRequested = true
+		return manualRefreshGeneration
+	}
+
+	mutating func completeManualRefresh() {
+		completedManualRefreshGeneration = manualRefreshGeneration
 	}
 
 	mutating func requestObservationRefresh() {
@@ -50,6 +69,10 @@ struct ResetCardRefreshRequests: Equatable {
 			manualRefreshRequested = false
 			consumedObservationGeneration = observationGeneration
 			return .full
+		}
+		if hasObservationRefreshRequest {
+			consumedObservationGeneration = observationGeneration
+			return .observation
 		}
 		if hasSkeletonRefreshRequest {
 			consumedSkeletonGeneration = skeletonGeneration

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -325,8 +325,12 @@ final class ResetCardStore {
 	@ObservationIgnored private let resolveCodexExecutable: @MainActor @Sendable () throws -> String
 	@ObservationIgnored private var startupTask: Task<Void, Never>?
 	@ObservationIgnored private var accountObservationTask: Task<Void, Never>?
+	@ObservationIgnored private var priorityObservationTask: Task<Void, Never>?
 	@ObservationIgnored private var refreshCoordinatorTask: Task<Void, Never>?
 	@ObservationIgnored private var refreshRequests = ResetCardRefreshRequests()
+	@ObservationIgnored private var observationSyncNeedsRetry = false
+	@ObservationIgnored private var accountObservationGeneration: UInt64 = 0
+	@ObservationIgnored private var lastPriorityObservationRequestAt: Date?
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var postUseReconciliationTasks = [
@@ -339,6 +343,7 @@ final class ResetCardStore {
 	@ObservationIgnored private var requestedProfileEmailVisibility = false
 	@ObservationIgnored private var profilePrivacyEpoch: UInt64 = 0
 	@ObservationIgnored private var codexProjectionRequestGeneration: UInt64 = 0
+	@ObservationIgnored private var accountSnapshotRequestGeneration: UInt64 = 0
 	@ObservationIgnored private var accountSkeletonRefreshGeneration: UInt64 = 0
 	@ObservationIgnored private var advancedInventoriesAwaitingSkeleton = [
 		String: ResetCardInventory
@@ -386,6 +391,7 @@ final class ResetCardStore {
 	deinit {
 		startupTask?.cancel()
 		accountObservationTask?.cancel()
+		priorityObservationTask?.cancel()
 		refreshCoordinatorTask?.cancel()
 		pendingRecoveryTask?.cancel()
 		accountReauthenticationTask?.cancel()
@@ -503,6 +509,7 @@ final class ResetCardStore {
 
 		let inFlightStartupTask = startupTask
 		let inFlightRefreshCoordinatorTask = refreshCoordinatorTask
+		let inFlightPriorityObservationTask = priorityObservationTask
 		let inFlightPendingRecoveryTask = pendingRecoveryTask
 		let inFlightAccountReauthenticationTask = accountReauthenticationTask
 		let inFlightPostUseReconciliationTasks = Array(
@@ -513,6 +520,8 @@ final class ResetCardStore {
 		startupTask = nil
 		accountObservationTask?.cancel()
 		accountObservationTask = nil
+		priorityObservationTask?.cancel()
+		priorityObservationTask = nil
 		refreshCoordinatorTask?.cancel()
 		refreshCoordinatorTask = nil
 		refreshRequests.reset()
@@ -526,6 +535,7 @@ final class ResetCardStore {
 		postUseReconciliationTasks.removeAll()
 
 		await inFlightStartupTask?.value
+		await inFlightPriorityObservationTask?.value
 		// The native wait is a bounded synchronous FFI request. Client destruction
 		// safely releases its in-flight Arc, so termination cancels this owner but
 		// does not wait for a daemon heartbeat before shutting down the shared client.
@@ -554,9 +564,13 @@ final class ResetCardStore {
 					guard Task.isCancelled == false, let self else {
 						return
 					}
+					let advanced = signal.generation != generation
 					generation = signal.generation
+					self.accountObservationGeneration = signal.generation
 					failureCount = 0
-					self.requestObservationRefresh()
+					if self.hasLoaded && (advanced || self.observationSyncNeedsRetry) {
+						self.requestObservationRefresh()
+					}
 				} catch {
 					guard Task.isCancelled == false, reconnectDelays.isEmpty == false else {
 						return
@@ -573,11 +587,55 @@ final class ResetCardStore {
 		}
 	}
 
+	/// Keep the panel immediate while asking the daemon for the freshest available cache.
+	/// The request is coalesced by the daemon and never enters the visible full-refresh lane.
+	func ensureFresh() {
+		guard hasLoaded,
+			isPreparingForTermination == false,
+			let accountObservationClient
+		else {
+			return
+		}
+		let now = Date()
+		if let lastPriorityObservationRequestAt,
+			now.timeIntervalSince(lastPriorityObservationRequestAt) < 5
+		{
+			return
+		}
+		guard priorityObservationTask == nil else {
+			return
+		}
+		lastPriorityObservationRequestAt = now
+		let generation = accountObservationGeneration
+		requestObservationRefresh()
+		priorityObservationTask = Task { [weak self, accountObservationClient] in
+			do {
+				let signal = try await accountObservationClient.requestAccountObservationRefresh(
+					afterGeneration: generation
+				)
+				guard Task.isCancelled == false, let self else {
+					self?.priorityObservationTask = nil
+					return
+				}
+				defer {
+					self.priorityObservationTask = nil
+				}
+				if signal.generation != self.accountObservationGeneration {
+					self.accountObservationGeneration = signal.generation
+					self.requestObservationRefresh()
+				} else if self.observationSyncNeedsRetry {
+					self.requestObservationRefresh()
+				}
+			} catch {
+				self?.priorityObservationTask = nil
+				// The standing observation wait will reconnect. Panel presentation must
+				// remain usable when a priority request cannot reach the daemon.
+			}
+		}
+	}
+
 	func requestRefresh() {
 		guard isPreparingForTermination == false,
-			refreshCoordinatorTask == nil,
-			isRefreshing == false,
-			isRefreshingAccountSkeleton == false,
 			isAccountControlInProgress == false
 		else {
 			return
@@ -656,15 +714,34 @@ final class ResetCardStore {
 		switch work {
 		case .full:
 			await performRefreshCycle()
+			if Task.isCancelled == false {
+				refreshRequests.completeManualRefresh()
+			}
+		case .observation:
+			await performObservationRefresh()
 		case .skeleton:
 			await performAccountSkeletonRead()
 		}
 	}
 
 	func refresh() async {
-		let inFlightCoordinatorTask = refreshCoordinatorTask
+		let previousManualRefreshGeneration = refreshRequests.manualRefreshGeneration
 		requestRefresh()
-		await (refreshCoordinatorTask ?? inFlightCoordinatorTask)?.value
+		guard refreshRequests.manualRefreshGeneration != previousManualRefreshGeneration else {
+			return
+		}
+		let requestedManualRefreshGeneration = refreshRequests.manualRefreshGeneration
+		while Task.isCancelled == false,
+			isPreparingForTermination == false,
+			refreshRequests.didCompleteManualRefresh(upTo: requestedManualRefreshGeneration) == false
+		{
+			if let task = refreshCoordinatorTask {
+				await task.value
+			} else {
+				scheduleRefreshCoordinator()
+				await Task.yield()
+			}
+		}
 	}
 
 	private func performRefreshCycle() async {
@@ -681,11 +758,20 @@ final class ResetCardStore {
 			return
 		}
 		clearStaleControlError()
-		_ = await refreshReadState()
+		let result = await refreshReadState()
+		observationSyncNeedsRetry = result == .retryNeeded
 		guard Task.isCancelled == false else {
 			return
 		}
 		_ = await recoverPendingAttempts()
+	}
+
+	private func performObservationRefresh() async {
+		guard Task.isCancelled == false else {
+			return
+		}
+		let result = await refreshReadState(backgroundObservation: true)
+		observationSyncNeedsRetry = result == .retryNeeded
 	}
 
 	func setProfileEmailVisibility(_ isVisible: Bool) async {
@@ -725,16 +811,22 @@ final class ResetCardStore {
 		_ = publishProfileEmailsIfReady(expectedEpoch: visibilityEpoch)
 	}
 
-	private func refreshReadState() async -> ResetCardRefreshResult {
-		guard isRefreshing == false else {
+	private func refreshReadState(
+		backgroundObservation: Bool = false
+	) async -> ResetCardRefreshResult {
+		guard backgroundObservation || isRefreshing == false else {
 			return .skipped
 		}
 
-		isRefreshing = true
-		refreshSkeletonIsPublished = false
-		defer {
-			isRefreshing = false
+		if backgroundObservation == false {
+			isRefreshing = true
 			refreshSkeletonIsPublished = false
+		}
+		defer {
+			if backgroundObservation == false {
+				isRefreshing = false
+				refreshSkeletonIsPublished = false
+			}
 			hasLoaded = true
 			scheduleRefreshCoordinator()
 		}
@@ -751,9 +843,10 @@ final class ResetCardStore {
 			let discovered: [ResetCardAccountRecord]
 			var projectionReadback: (
 				generation: UInt64,
-				projection: CodexAuthProjection
+				projection: CodexAuthProjection?
 			)?
 			if let accountControlClient {
+				let snapshotGeneration = beginAccountSnapshotRequest()
 				let projectionGeneration = beginCodexProjectionRequest()
 				async let snapshotRead = accountControlClient.accountSnapshot(
 					authority: retainedAuthority
@@ -762,9 +855,16 @@ final class ResetCardStore {
 					authority: retainedAuthority
 				)
 				let snapshot = try await snapshotRead
-				let projection = await projectionRead ?? .unavailable
+				let projection = await projectionRead
+				// A local account-control result may have superseded this snapshot while
+				// either read was suspended. Never publish that older routing/account view.
+				guard snapshotGeneration == accountSnapshotRequestGeneration else {
+					return .complete
+				}
 				projectionReadback = (projectionGeneration, projection)
-				routing = snapshot.routing
+				if routing != snapshot.routing {
+					routing = snapshot.routing
+				}
 				discovered = snapshot.accounts
 			} else {
 				discovered = try await client.accounts(authority: retainedAuthority)
@@ -772,7 +872,7 @@ final class ResetCardStore {
 			let previousByID = Dictionary(
 				uniqueKeysWithValues: accounts.map { ($0.account.accountID, $0) }
 			)
-			accounts = discovered.map { account in
+			let nextAccounts = discovered.map { account in
 				let previous = previousByID[account.accountID]
 				let authority = retainedAuthority
 					?? account.authority
@@ -833,20 +933,29 @@ final class ResetCardStore {
 					&& retainedProfileError == nil
 				)
 			}
+			if accounts != nextAccounts {
+				accounts = nextAccounts
+			}
 			prunePostUseReconciliationsForCurrentAccounts()
 			pruneProfileEmailCache()
 			reconcileAccountSkeletonRevisionTargets()
 			if let projectionReadback,
+				let projection = projectionReadback.projection,
 				applyCodexAuthProjection(
-					projectionReadback.projection,
+					projection,
 					generation: projectionReadback.generation
 				) {
 				scheduleCodexProjectionRefresh()
 			}
-			if message?.tone == .error, isPendingRecoveryBlocked == false {
+			if backgroundObservation == false,
+				message?.tone == .error,
+				isPendingRecoveryBlocked == false
+			{
 				message = nil
 			}
-			refreshSkeletonIsPublished = true
+			if backgroundObservation == false {
+				refreshSkeletonIsPublished = true
+			}
 
 			let inventoryReads = self.inventoryReads
 			let accountProfileClient = self.accountProfileClient
@@ -964,22 +1073,24 @@ final class ResetCardStore {
 		} catch {
 			let clientError = Self.clientError(error)
 			shouldRetry = clientError.isRetryableReadFailure
-			accounts = accounts.map {
-				ResetCardAccountState(
-					account: $0.account,
-					inventory: $0.inventory,
-					error: $0.error,
-					isRefreshing: false,
-					profile: $0.profile,
-					profileUnavailable: $0.profileUnavailable,
-					profileError: $0.profileError,
-					isProfileRefreshing: false
+			if backgroundObservation == false {
+				accounts = accounts.map {
+					ResetCardAccountState(
+						account: $0.account,
+						inventory: $0.inventory,
+						error: $0.error,
+						isRefreshing: false,
+						profile: $0.profile,
+						profileUnavailable: $0.profileUnavailable,
+						profileError: $0.profileError,
+						isProfileRefreshing: false
+					)
+				}
+				message = ResetCardStoreMessage(
+					tone: .error,
+					text: clientError.localizedDescription
 				)
 			}
-			message = ResetCardStoreMessage(
-				tone: .error,
-				text: clientError.localizedDescription
-			)
 		}
 
 		if isPendingRecoveryBlocked {
@@ -2056,6 +2167,7 @@ final class ResetCardStore {
 			scheduleRefreshCoordinator()
 		}
 		do {
+			let snapshotGeneration = beginAccountSnapshotRequest()
 			let projectionGeneration = beginCodexProjectionRequest()
 			async let snapshotRead = accountControlClient.accountSnapshot(
 				authority: establishedAuthority
@@ -2064,6 +2176,9 @@ final class ResetCardStore {
 				authority: establishedAuthority
 			)
 			let snapshot = try await snapshotRead
+			guard snapshotGeneration == accountSnapshotRequestGeneration else {
+				return
+			}
 			let previousByID = Dictionary(
 				uniqueKeysWithValues: accounts.map {
 					($0.account.accountID, $0)
@@ -2151,10 +2266,11 @@ final class ResetCardStore {
 					)
 				)
 			}
-			if applyCodexAuthProjection(
-				await projectionRead ?? .unavailable,
-				generation: projectionGeneration
-			) {
+			if let projection = await projectionRead,
+				applyCodexAuthProjection(
+					projection,
+					generation: projectionGeneration
+				) {
 				scheduleCodexProjectionRefresh()
 			}
 		} catch {
@@ -2234,7 +2350,7 @@ final class ResetCardStore {
 		let retainsProfileState = accounts[index].account.accountRevision
 			== inventory.accountRevision
 		let revisionChanged = retainsProfileState == false
-		accounts[index] = ResetCardAccountState(
+		let updatedState = ResetCardAccountState(
 			account: account,
 			inventory: inventory,
 			error: nil,
@@ -2247,6 +2363,9 @@ final class ResetCardStore {
 			profileError: retainsProfileState ? accounts[index].profileError : nil,
 			isProfileRefreshing: accounts[index].isProfileRefreshing
 		)
+		if accounts[index] != updatedState {
+			accounts[index] = updatedState
+		}
 		if completesPostUseReconciliation
 			|| postUseReconciliationTasks[accountID] == nil
 		{
@@ -3087,6 +3206,7 @@ final class ResetCardStore {
 				return
 			}
 		}
+		invalidateAccountSnapshotRequest()
 
 		if let accountID, let activity {
 			accountControlActivities[accountID] = activity
@@ -3261,6 +3381,16 @@ final class ResetCardStore {
 		return codexProjectionRequestGeneration
 	}
 
+	private func beginAccountSnapshotRequest() -> UInt64 {
+		accountSnapshotRequestGeneration &+= 1
+		return accountSnapshotRequestGeneration
+	}
+
+	private func invalidateAccountSnapshotRequest() {
+		// Fence every snapshot already in flight before a local account mutation.
+		accountSnapshotRequestGeneration &+= 1
+	}
+
 	@discardableResult
 	private func applyCodexAuthProjection(
 		_ projection: CodexAuthProjection,
@@ -3277,6 +3407,9 @@ final class ResetCardStore {
 				codexAuthProjection = nil
 				return true
 			}
+		}
+		guard codexAuthProjection != projection else {
+			return false
 		}
 		codexAuthProjection = projection
 		return false
@@ -3307,9 +3440,11 @@ final class ResetCardStore {
 			return
 		}
 		let generation = beginCodexProjectionRequest()
-		let projection = (try? await accountControlClient.codexAuthProjection(
+		guard let projection = try? await accountControlClient.codexAuthProjection(
 			authority: establishedAuthority
-		)) ?? .unavailable
+		) else {
+			return
+		}
 		_ = applyCodexAuthProjection(projection, generation: generation)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
+++ b/apps/decodex-app/Sources/DecodexApp/StatusPanelController.swift
@@ -57,7 +57,9 @@ final class StatusPanelController: NSObject {
 			NSApp.activate(ignoringOtherApps: true)
 		}
 		panel.makeKeyAndOrderFront(nil)
-		store.requestRefresh()
+		// Presentation remains immediate. The store asks the daemon for one
+		// coalesced priority observation without entering the visible full-refresh lane.
+		store.ensureFresh()
 	}
 
 	private func orderPanelOut() {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -264,6 +264,86 @@ final class AccountControlStoreTests: XCTestCase {
 		await stopObservation()
 	}
 
+	func testBackgroundObservationCannotOverwriteRoutingChangedDuringRead() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsSnapshotAfterFirstRead: true,
+			capturesSnapshotBeforeWait: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+		func stopObservation() async {
+			await store.prepareForApplicationTermination()
+			await client.publishObservation(generation: 2)
+		}
+		store.start()
+
+		for _ in 0 ..< 200 {
+			if store.hasLoaded,
+				store.isRefreshing == false,
+				store.accounts.first?.inventoryIsCurrent == true
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		XCTAssertTrue(store.hasLoaded)
+		XCTAssertTrue(store.accounts.first?.inventoryIsCurrent == true)
+
+		for _ in 0 ..< 200 {
+			if await client.observationIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.observationIsPending() else {
+			await stopObservation()
+			return XCTFail("Account observation signal did not enter the pending state.")
+		}
+		await client.publishObservation(generation: 1)
+
+		for _ in 0 ..< 200 {
+			if await client.snapshotIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.snapshotIsPending() else {
+			await client.releaseSnapshot()
+			await stopObservation()
+			return XCTFail("Background account snapshot did not enter the pending state.")
+		}
+
+		await store.selectFixedAccount(accountID)
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		store.message = ResetCardStoreMessage(tone: .error, text: "Keep this message")
+
+		await client.releaseSnapshot()
+		for _ in 0 ..< 200 {
+			if store.isRefreshing == false,
+				(await client.readCounts()).snapshot >= 2
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTAssertEqual(
+			store.routing?.mode,
+			.fixed(accountID: accountID),
+			"A stale background snapshot must not flash the route back to balanced."
+		)
+		XCTAssertEqual(store.message?.text, "Keep this message")
+		await stopObservation()
+	}
+
 	func testObservationRefreshIsQueuedUntilEnrollmentCompletes() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -1068,6 +1148,42 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 	}
 
+	func testTransientProjectionReadFailureRetainsCurrentRouteState() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			routing: AccountRoutingControl(
+				revision: 9,
+				mode: .fixed(accountID: accountID),
+				order: [accountID]
+			),
+			projection: .current(
+				accountID: accountID,
+				accountRevision: 7,
+				projectionDigest: String(repeating: "a", count: 64)
+			)
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		XCTAssertTrue(store.isCodexProjection(accountID))
+
+		await client.setProjectionError(.applicationUnavailable)
+		await store.refresh()
+
+		XCTAssertTrue(
+			store.isCodexProjection(accountID),
+			"A transient read failure must not flash the current route back to Route."
+		)
+	}
+
 	func testRouteAccountSerializesSharedProjectionAcrossAccounts() async throws {
 		let secondAccountID = "22222222-2222-4222-8222-222222222222"
 		let account = accountRecord()
@@ -1392,6 +1508,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private var fixedRequestCount = 0
 	private var projectionRequestCount = 0
 	private var projection: CodexAuthProjection
+	private var projectionError: AccountControlError?
 	private var projectionReads = 0
 	private var snapshotReadCount = 0
 	private var inventoryReadCount = 0
@@ -1721,7 +1838,14 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		authority: ResetCardAuthority?
 	) async throws -> CodexAuthProjection {
 		projectionReads += 1
+		if let projectionError {
+			throw projectionError
+		}
 		return projection
+	}
+
+	func setProjectionError(_ error: AccountControlError?) {
+		projectionError = error
 	}
 
 	func projectionReadCount() -> Int {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -793,11 +793,18 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(store.contains("startAccountObservationSignals()"))
 		XCTAssertTrue(store.contains("accountObservationTask?.cancel()"))
 		XCTAssertTrue(store.contains("waitForAccountObservation("))
+		XCTAssertTrue(store.contains("func ensureFresh()"))
+		XCTAssertTrue(store.contains("requestAccountObservationRefresh("))
 		XCTAssertFalse(store.contains("ContinuousClock()"))
 		XCTAssertTrue(store.contains("self.requestObservationRefresh()"))
 		XCTAssertTrue(store.contains("await performRefreshCycle()"))
+		XCTAssertTrue(store.contains("await performObservationRefresh()"))
 		XCTAssertTrue(store.contains("await performAccountSkeletonRead()"))
 		XCTAssertFalse(store.contains("Timer.publish"))
-		XCTAssertTrue(panel.contains("store.requestRefresh()"))
+		XCTAssertFalse(
+			panel.contains("store.requestRefresh()"),
+			"Opening the panel must not start a full refresh; Refresh all is explicit."
+		)
+		XCTAssertTrue(panel.contains("store.ensureFresh()"))
 	}
 }

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardCLIClientTests.swift
@@ -89,6 +89,34 @@ final class ResetCardNativeClientTests: XCTestCase {
 		)
 	}
 
+	func testNativePriorityObservationWaitRequestsOneCoalescedRefresh() async throws {
+		let authority = authority
+		let recorder = NativeRequestRecorder()
+		let client = DecodexNativeClient { request, requestedAuthority in
+			recorder.append(request, authority: requestedAuthority)
+			return nativeSuccess(
+				operation: "wait_for_account_observation",
+				authority: authority,
+				data: #"{"generation":43}"#
+			)
+		}
+
+		let signal = try await client.requestAccountObservationRefresh(afterGeneration: 17)
+
+		XCTAssertEqual(signal, AccountObservationSignal(generation: 43))
+		let request = try XCTUnwrap(recorder.requests.first)
+		XCTAssertNil(request.authority)
+		XCTAssertEqual(
+			try nativeJSONObject(request.data),
+			[
+				"schema": decodexNativeClientSchema,
+				"operation": "wait_for_account_observation",
+				"after_generation": 17,
+				"request_refresh": true,
+			]
+		)
+	}
+
 	func testNativeInventoryAndStatusUsePinnedAuthority() async throws {
 		let accountID = accountID
 		let idempotencyKey = idempotencyKey

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardRefreshCoordinatorTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardRefreshCoordinatorTests.swift
@@ -7,20 +7,43 @@ final class ResetCardRefreshCoordinatorTests: XCTestCase {
 		requests.requestObservationRefresh()
 		requests.requestObservationRefresh()
 
-		XCTAssertTrue(requests.hasFullRefreshRequest)
-		XCTAssertEqual(requests.takeNext(), .full)
-		XCTAssertFalse(requests.hasFullRefreshRequest)
+		XCTAssertTrue(requests.hasObservationRefreshRequest)
+		XCTAssertEqual(requests.takeNext(), .observation)
+		XCTAssertFalse(requests.hasObservationRefreshRequest)
 		XCTAssertFalse(requests.hasWork)
 	}
 
-	func testSkeletonWorkWaitsBehindAFullRefresh() {
+	func testSkeletonWorkWaitsBehindAnObservationRefresh() {
 		var requests = ResetCardRefreshRequests()
 		requests.requestSkeletonRefresh()
 		requests.requestObservationRefresh()
 
-		XCTAssertEqual(requests.takeNext(), .full)
+		XCTAssertEqual(requests.takeNext(), .observation)
 		XCTAssertEqual(requests.takeNext(), .skeleton)
 		XCTAssertNil(requests.takeNext())
+	}
+
+	func testManualRefreshSubsumesPendingObservation() {
+		var requests = ResetCardRefreshRequests()
+		requests.requestObservationRefresh()
+		requests.requestManualRefresh()
+
+		XCTAssertEqual(requests.takeNext(), .full)
+		XCTAssertFalse(requests.hasWork)
+	}
+
+	func testManualRefreshCompletionDoesNotWaitForFollowUpWork() {
+		var requests = ResetCardRefreshRequests()
+		let firstGeneration = requests.requestManualRefresh()
+		let secondGeneration = requests.requestManualRefresh()
+
+		XCTAssertFalse(requests.didCompleteManualRefresh(upTo: firstGeneration))
+		XCTAssertEqual(requests.takeNext(), .full)
+		requests.completeManualRefresh()
+
+		XCTAssertTrue(requests.didCompleteManualRefresh(upTo: firstGeneration))
+		XCTAssertTrue(requests.didCompleteManualRefresh(upTo: secondGeneration))
+		XCTAssertFalse(requests.hasWork)
 	}
 
 	func testResetDiscardsAllPendingWork() {

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardStoreStartupRetryTests.swift
@@ -269,6 +269,127 @@ final class ResetCardStoreStartupRetryTests: XCTestCase {
 		XCTAssertEqual(finalCounts, stoppedCounts)
 	}
 
+	func testDaemonHeartbeatDoesNotRequestAnotherRefreshForTheSameGeneration() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ObservationDrivenResetCardClient(
+			account: Self.account,
+			inventory: try Self.inventory
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 1
+				&& counts.inventory == 1
+				&& store.isRefreshing == false
+		}
+
+		await client.publish(generation: 1)
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 2
+				&& counts.inventory == 2
+				&& store.isRefreshing == false
+		}
+		try await waitUntil { await client.observationIsPending() }
+		let synchronizedCounts = await client.callCounts()
+
+		// The daemon uses a same-generation heartbeat to bound a missed wake. It
+		// must not turn an unchanged heartbeat into another full UI refresh.
+		await client.publish(generation: 1)
+		try await waitUntil { await client.observationIsPending() }
+		try await Task.sleep(for: .milliseconds(50))
+
+		let finalCounts = await client.callCounts()
+		XCTAssertEqual(finalCounts, synchronizedCounts)
+	}
+
+	func testBackgroundObservationKeepsThePublishedStateUsableWhileReading() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ObservationDrivenResetCardClient(
+			account: Self.account,
+			inventory: try Self.inventory
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 1
+				&& counts.inventory == 1
+				&& store.isRefreshing == false
+		}
+		await client.blockInventoryReads()
+		await client.publish(generation: 1)
+		try await waitUntil { await client.isInventoryReadBlocked() }
+
+		XCTAssertFalse(store.isRefreshing)
+		XCTAssertTrue(store.canPerformDirectAccountControl)
+		XCTAssertFalse(store.accounts.first?.isRefreshing ?? true)
+
+		await client.releaseInventoryRead()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return store.isRefreshing == false && counts.inventory == 2
+		}
+	}
+
+	func testPanelPriorityObservationKeepsThePublishedStateUsableWhileReading() async throws {
+		let fixture = try makePendingFixture()
+		defer { fixture.remove() }
+		let client = ObservationDrivenResetCardClient(
+			account: Self.account,
+			inventory: try Self.inventory
+		)
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		store.start()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return counts.accounts == 1
+				&& counts.inventory == 1
+				&& store.isRefreshing == false
+		}
+
+		await client.blockInventoryReads()
+		store.ensureFresh()
+		try await waitUntil {
+			let priorityRefreshRequestCount = await client.priorityRefreshRequestCount()
+			let inventoryReadBlocked = await client.isInventoryReadBlocked()
+			return priorityRefreshRequestCount == 1 && inventoryReadBlocked
+		}
+
+		XCTAssertFalse(store.isRefreshing)
+		XCTAssertTrue(store.canPerformDirectAccountControl)
+		XCTAssertFalse(store.accounts.first?.isRefreshing ?? true)
+
+		store.ensureFresh()
+		try await Task.sleep(for: .milliseconds(50))
+		let priorityRefreshRequestCount = await client.priorityRefreshRequestCount()
+		XCTAssertEqual(priorityRefreshRequestCount, 1)
+
+		await client.releaseInventoryRead()
+		try await waitUntil {
+			let counts = await client.callCounts()
+			return store.isRefreshing == false && counts.inventory == 2
+		}
+	}
+
 	func testTerminationRejectsRefreshWhileDrainingTheActiveCycle() async throws {
 		let fixture = try makePendingFixture()
 		defer { fixture.remove() }
@@ -925,8 +1046,11 @@ private actor ObservationDrivenResetCardClient: ResetCardClient, AccountObservat
 	private let inventoryValue: ResetCardInventory
 	private var accountCalls = 0
 	private var inventoryCalls = 0
+	private var inventoryReadsBlocked = false
+	private var inventoryReadContinuation: CheckedContinuation<Void, Never>?
 	private var generations = [UInt64]()
 	private var signalContinuation: CheckedContinuation<AccountObservationSignal, Never>?
+	private var priorityRefreshRequests = 0
 
 	init(account: ResetCardAccountRecord, inventory: ResetCardInventory) {
 		self.account = account
@@ -940,7 +1064,27 @@ private actor ObservationDrivenResetCardClient: ResetCardClient, AccountObservat
 
 	func inventory(for _: ResetCardAccountRecord) async throws -> ResetCardInventory {
 		inventoryCalls += 1
+		if inventoryReadsBlocked {
+			await withCheckedContinuation { continuation in
+				inventoryReadContinuation = continuation
+			}
+		}
 		return inventoryValue
+	}
+
+	func blockInventoryReads() {
+		inventoryReadsBlocked = true
+	}
+
+	func isInventoryReadBlocked() -> Bool {
+		inventoryReadContinuation != nil
+	}
+
+	func releaseInventoryRead() {
+		inventoryReadsBlocked = false
+		let continuation = inventoryReadContinuation
+		inventoryReadContinuation = nil
+		continuation?.resume()
 	}
 
 	func waitForAccountObservation(
@@ -954,6 +1098,17 @@ private actor ObservationDrivenResetCardClient: ResetCardClient, AccountObservat
 		}
 	}
 
+	func requestAccountObservationRefresh(
+		afterGeneration _: UInt64
+	) async throws -> AccountObservationSignal {
+		priorityRefreshRequests += 1
+		return AccountObservationSignal(generation: 0)
+	}
+
+	func priorityRefreshRequestCount() -> Int {
+		priorityRefreshRequests
+	}
+
 	func publish(generation: UInt64) {
 		if let signalContinuation {
 			self.signalContinuation = nil
@@ -965,6 +1120,10 @@ private actor ObservationDrivenResetCardClient: ResetCardClient, AccountObservat
 
 	func callCounts() -> ClientCallCounts {
 		ClientCallCounts(accounts: accountCalls, inventory: inventoryCalls, status: 0, use: 0)
+	}
+
+	func observationIsPending() -> Bool {
+		signalContinuation != nil
 	}
 
 	func use(_: ResetCardUseAttempt) async throws -> ResetCardOperationState {

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -73,6 +73,8 @@ enum Request {
 	WaitForAccountObservation {
 		schema: String,
 		after_generation: u64,
+		#[serde(default)]
+		request_refresh: bool,
 	},
 	ResetCardStatus {
 		schema: String,
@@ -641,8 +643,8 @@ async fn execute_request(
 		Request::GetAccountProfile { account_id, include_email, .. } =>
 			get_account_profile(profile, account_id, include_email).await,
 		Request::GetCodexAuthProjection { .. } => get_codex_auth_projection(profile).await,
-		Request::WaitForAccountObservation { after_generation, .. } =>
-			wait_for_account_observation(profile, after_generation).await,
+		Request::WaitForAccountObservation { after_generation, request_refresh, .. } =>
+			wait_for_account_observation(profile, after_generation, request_refresh).await,
 		Request::ResetCardStatus { idempotency_key, .. } =>
 			get_reset_card_status(profile, idempotency_key).await,
 		Request::UseResetCard {
@@ -758,13 +760,16 @@ async fn get_codex_auth_projection(profile: ClientProfile) -> Result<Value, Requ
 async fn wait_for_account_observation(
 	profile: ClientProfile,
 	after_generation: u64,
+	request_refresh: bool,
 ) -> Result<Value, RequestFailure> {
-	to_value(
-		AccountClient::new(profile)
-			.wait_for_observation(after_generation)
-			.await
-			.map_err(RequestFailure::Client)?,
-	)
+	let client = AccountClient::new(profile);
+	let signal = if request_refresh {
+		client.request_observation_refresh(after_generation).await
+	} else {
+		client.wait_for_observation(after_generation).await
+	}
+	.map_err(RequestFailure::Client)?;
+	to_value(signal)
 }
 
 async fn get_reset_card_status(
@@ -1136,12 +1141,24 @@ mod tests {
 	}
 
 	#[test]
-	fn observation_wait_is_exact_and_direct_refresh_is_not_an_app_operation() {
+	fn observation_wait_is_exact_and_priority_refresh_is_not_a_separate_app_operation() {
 		let request = serde_json::from_str::<Request>(&format!(
 			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"wait_for_account_observation","after_generation":17}}"#
 		))
 		.expect("observation wait must decode");
 		assert_eq!(request.operation(), "wait_for_account_observation");
+		assert!(matches!(
+			request,
+			Request::WaitForAccountObservation { request_refresh: false, .. }
+		));
+		let priority_request = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"wait_for_account_observation","after_generation":17,"request_refresh":true}}"#
+		))
+		.expect("priority observation wait must decode");
+		assert!(matches!(
+			priority_request,
+			Request::WaitForAccountObservation { request_refresh: true, .. }
+		));
 		assert!(
 			serde_json::from_str::<Request>(&format!(
 				r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"wait_for_account_observation"}}"#

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -1063,12 +1063,31 @@ impl AccountClient {
 		&self,
 		after_generation: u64,
 	) -> Result<AccountObservationSignal, ClientFailure> {
+		self.wait_for_observation_inner(after_generation, false).await
+	}
+
+	/// Ask the daemon to coalesce one observation round, then wait for its semantic generation.
+	pub async fn request_observation_refresh(
+		&self,
+		after_generation: u64,
+	) -> Result<AccountObservationSignal, ClientFailure> {
+		self.wait_for_observation_inner(after_generation, true).await
+	}
+
+	async fn wait_for_observation_inner(
+		&self,
+		after_generation: u64,
+		request_refresh: bool,
+	) -> Result<AccountObservationSignal, ClientFailure> {
 		self.transport.require_local_profile()?;
 		let completed = time::timeout(
 			self.transport.timeout,
 			self.transport.query_inner(
 				"decodex-account-observation-wait",
-				QueryPayload::WaitForAccountObservation { after_generation },
+				QueryPayload::WaitForAccountObservation {
+					after_generation,
+					request_refresh: request_refresh.then_some(true),
+				},
 			),
 		)
 		.await

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -2331,6 +2331,9 @@ pub enum QueryPayload {
 	WaitForAccountObservation {
 		/// Last daemon-lifetime generation applied by the caller.
 		after_generation: u64,
+		/// Optionally ask the daemon to schedule one coalesced observation before waiting.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		request_refresh: Option<bool>,
 	},
 }
 impl QueryPayload {
@@ -4401,7 +4404,8 @@ mod tests {
 
 	#[test]
 	fn account_observation_wait_is_one_strict_opaque_generation() {
-		let query = QueryPayload::WaitForAccountObservation { after_generation: 17 };
+		let query =
+			QueryPayload::WaitForAccountObservation { after_generation: 17, request_refresh: None };
 		let result = QueryResultPayload::AccountObservation(AccountObservationSignal::new(42));
 
 		assert_eq!(
@@ -4409,6 +4413,17 @@ mod tests {
 			serde_json::json!({
 				"name": "wait_for_account_observation",
 				"arguments": {"after_generation": 17}
+			}),
+		);
+		assert_eq!(
+			serde_json::to_value(QueryPayload::WaitForAccountObservation {
+				after_generation: 17,
+				request_refresh: Some(true),
+			})
+			.unwrap(),
+			serde_json::json!({
+				"name": "wait_for_account_observation",
+				"arguments": {"after_generation": 17, "request_refresh": true}
 			}),
 		);
 		assert_eq!(

--- a/crates/decodex-runtime/src/account_launch.rs
+++ b/crates/decodex-runtime/src/account_launch.rs
@@ -6,6 +6,7 @@ mod protocol;
 mod reset_card;
 
 pub(crate) use process::{AttestedAppServerLaunch, AttestedAppServerProfile, AttestedProcessChild};
+#[cfg(test)] pub(crate) use reset_card::ResetCardInventoryView;
 pub(crate) use reset_card::{
 	ResetCardInventoryObservation, ResetCardRuntime, ResetCardServiceError, ResetCardVaultStatus,
 };

--- a/crates/decodex-runtime/src/account_observation.rs
+++ b/crates/decodex-runtime/src/account_observation.rs
@@ -7,7 +7,9 @@ use std::{
 	time::Duration,
 };
 
-use decodex_core::{AccountId, AccountLifecycleReadiness};
+use decodex_core::{
+	AccountId, AccountLifecycleReadiness, AccountQuotaDisposition, AccountQuotaWindowObservation,
+};
 use decodex_protocol::AccountObservationSignal;
 use tokio::{
 	sync::{Notify, RwLock, watch},
@@ -95,7 +97,17 @@ impl AccountObservationState {
 		if !self.generation_matches(&observation.account_id, &observation.cache_generation) {
 			return false;
 		}
-		let has_value = observation.reset_cards.is_some() || observation.profile.is_some();
+		let account_id = observation.account_id.clone();
+		let reset_cards_changed = observation.reset_cards.as_ref().is_some_and(|next| {
+			self.reset_cards.get(&account_id).is_none_or(|current| {
+				reset_card_observation_semantically_equal(&current.result, next) == false
+			})
+		});
+		let profile_changed = observation.profile.as_ref().is_some_and(|next| {
+			self.profiles
+				.get(&account_id)
+				.is_none_or(|current| profile_status_semantically_equal(current, next) == false)
+		});
 		if let Some(reset_cards) = observation.reset_cards {
 			let inventory_revision = reset_cards
 				.as_ref()
@@ -103,7 +115,7 @@ impl AccountObservationState {
 				.map(inventory_revision)
 				.unwrap_or(observation.requested_revision);
 			self.reset_cards.insert(
-				observation.account_id.clone(),
+				account_id.clone(),
 				CachedResetCardInventory {
 					account_revision: inventory_revision,
 					result: reset_cards,
@@ -111,10 +123,85 @@ impl AccountObservationState {
 			);
 		}
 		if let Some(profile) = observation.profile {
-			self.profiles.insert(observation.account_id, profile);
+			self.profiles.insert(account_id, profile);
 		}
-		has_value
+		reset_cards_changed || profile_changed
 	}
+}
+
+fn reset_card_observation_semantically_equal(
+	left: &Result<ResetCardInventoryObservation, ResetCardServiceError>,
+	right: &Result<ResetCardInventoryObservation, ResetCardServiceError>,
+) -> bool {
+	match (left, right) {
+		(
+			Ok(ResetCardInventoryObservation::Available(left)),
+			Ok(ResetCardInventoryObservation::Available(right)),
+		) =>
+			left.account_id == right.account_id
+				&& left.account_revision == right.account_revision
+				&& left.reported_available_count == right.reported_available_count
+				&& left.details_complete == right.details_complete
+				&& left.cards == right.cards
+				&& quota_observation_semantically_equal(
+					&left.five_hour_quota,
+					&right.five_hour_quota,
+				) && quota_observation_semantically_equal(&left.seven_day_quota, &right.seven_day_quota),
+		(
+			Ok(ResetCardInventoryObservation::ObservationFailed(left)),
+			Ok(ResetCardInventoryObservation::ObservationFailed(right)),
+		) =>
+			left.account_id == right.account_id
+				&& left.account_revision == right.account_revision
+				&& quota_observation_semantically_equal(
+					&left.five_hour_quota,
+					&right.five_hour_quota,
+				) && quota_observation_semantically_equal(&left.seven_day_quota, &right.seven_day_quota)
+				&& left.error == right.error,
+		(Err(left), Err(right)) => left == right,
+		_ => false,
+	}
+}
+
+fn quota_observation_semantically_equal(
+	left: &AccountQuotaWindowObservation,
+	right: &AccountQuotaWindowObservation,
+) -> bool {
+	left.duration_minutes == right.duration_minutes
+		&& match (left.disposition, right.disposition) {
+			(AccountQuotaDisposition::Unknown, AccountQuotaDisposition::Unknown) => true,
+			(AccountQuotaDisposition::Current(left), AccountQuotaDisposition::Current(right)) =>
+				left == right,
+			(AccountQuotaDisposition::Stale(left), AccountQuotaDisposition::Stale(right)) =>
+				left == right,
+			(AccountQuotaDisposition::Error(left), AccountQuotaDisposition::Error(right)) =>
+				left == right,
+			_ => false,
+		}
+}
+
+fn profile_status_semantically_equal(
+	left: &AccountProfileRefreshStatus,
+	right: &AccountProfileRefreshStatus,
+) -> bool {
+	left.account_revision == right.account_revision
+		&& left.refresh_error == right.refresh_error
+		&& match (&left.snapshot, &right.snapshot) {
+			(None, None) => true,
+			(Some(left), Some(right)) =>
+				left.account_id == right.account_id
+					&& left.account_revision == right.account_revision
+					&& left.provider == right.provider
+					&& left.display_name == right.display_name
+					&& left.username == right.username
+					&& left.lifetime_tokens == right.lifetime_tokens
+					&& left.peak_daily_tokens == right.peak_daily_tokens
+					&& left.longest_task_seconds == right.longest_task_seconds
+					&& left.current_streak_days == right.current_streak_days
+					&& left.longest_streak_days == right.longest_streak_days
+					&& left.daily_usage == right.daily_usage,
+			_ => false,
+		}
 }
 
 /// One daemon-lifecycle observer that refreshes independent accounts concurrently.
@@ -190,7 +277,7 @@ impl AccountObservationService {
 		include_email: bool,
 	) -> Option<AccountProfileRuntimeResult> {
 		let profiles = self.profiles.as_ref()?;
-		let status = self.state.read().await.profiles.get(account_id).copied();
+		let status = self.state.read().await.profiles.get(account_id).cloned();
 		Some(profiles.read_cached(account_id, include_email, status).await)
 	}
 
@@ -470,15 +557,22 @@ const fn inventory_revision(observation: &ResetCardInventoryObservation) -> i64 
 mod tests {
 	use std::{
 		collections::{HashMap, HashSet},
+		sync::Arc,
 		time::Duration,
 	};
 
-	use decodex_core::AccountId;
+	use decodex_core::{
+		AccountId, AccountProvider, AccountQuotaWindowObservation, ProviderIdentity,
+	};
+	use decodex_postgres::AccountProfileSnapshot;
 	use tokio::{sync::watch, time};
+
+	use crate::account_launch::ResetCardInventoryView;
 
 	use super::{
 		AccountObservationOutcome, AccountObservationState, AccountProfileRefreshStatus,
-		ResetCardServiceError, plan_observation_round, wait_for_generation,
+		ResetCardInventoryObservation, ResetCardServiceError, plan_observation_round,
+		wait_for_generation,
 	};
 
 	#[tokio::test]
@@ -535,7 +629,11 @@ mod tests {
 			requested_revision: 7,
 			cache_generation,
 			reset_cards: Some(Err(ResetCardServiceError::InventoryIncomplete)),
-			profile: Some(AccountProfileRefreshStatus { account_revision: 7, refresh_error: None }),
+			profile: Some(AccountProfileRefreshStatus {
+				account_revision: 7,
+				refresh_error: None,
+				snapshot: None,
+			}),
 		});
 
 		state.retain_current(&HashMap::from([(account_id.clone(), 8)]));
@@ -560,7 +658,11 @@ mod tests {
 			requested_revision: 9,
 			cache_generation: stale_generation,
 			reset_cards: Some(Err(ResetCardServiceError::InventoryIncomplete)),
-			profile: Some(AccountProfileRefreshStatus { account_revision: 9, refresh_error: None }),
+			profile: Some(AccountProfileRefreshStatus {
+				account_revision: 9,
+				refresh_error: None,
+				snapshot: None,
+			}),
 		});
 
 		assert!(state.reset_cards.is_empty());
@@ -576,7 +678,11 @@ mod tests {
 			requested_revision: 9,
 			cache_generation,
 			reset_cards: Some(Err(ResetCardServiceError::InventoryIncomplete)),
-			profile: Some(AccountProfileRefreshStatus { account_revision: 9, refresh_error: None }),
+			profile: Some(AccountProfileRefreshStatus {
+				account_revision: 9,
+				refresh_error: None,
+				snapshot: None,
+			}),
 		});
 
 		assert!(state.reset_cards.contains_key(&account_id));
@@ -597,14 +703,143 @@ mod tests {
 			requested_revision: 9,
 			cache_generation,
 			reset_cards: None,
-			profile: Some(AccountProfileRefreshStatus { account_revision: 9, refresh_error: None }),
+			profile: Some(AccountProfileRefreshStatus {
+				account_revision: 9,
+				refresh_error: None,
+				snapshot: None,
+			}),
 		});
 
 		assert!(state.reset_cards.is_empty());
 		assert_eq!(
 			state.profiles.get(&account_id),
-			Some(&AccountProfileRefreshStatus { account_revision: 9, refresh_error: None })
+			Some(&AccountProfileRefreshStatus {
+				account_revision: 9,
+				refresh_error: None,
+				snapshot: None,
+			})
 		);
+	}
+
+	#[test]
+	fn unchanged_observation_updates_freshness_without_advancing_generation() {
+		let account_id = account(3);
+		let mut state = AccountObservationState::default();
+		let cache_generation = state.cache_generation(&account_id);
+
+		assert!(state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 11,
+			cache_generation: Arc::clone(&cache_generation),
+			reset_cards: Some(Ok(available_inventory(&account_id, 100))),
+			profile: None,
+		}));
+
+		assert!(!state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 11,
+			cache_generation,
+			reset_cards: Some(Ok(available_inventory(&account_id, 200))),
+			profile: None,
+		}));
+
+		let cached = state.reset_cards.get(&account_id).expect("cached observation");
+		let Ok(ResetCardInventoryObservation::Available(inventory)) = &cached.result else {
+			panic!("expected available inventory");
+		};
+		assert_eq!(inventory.five_hour_quota.observed_at_unix_micros, Some(200));
+		assert_eq!(inventory.seven_day_quota.observed_at_unix_micros, Some(200));
+	}
+
+	#[test]
+	fn unchanged_profile_updates_observation_time_without_advancing_generation() {
+		let account_id = account(4);
+		let mut state = AccountObservationState::default();
+		let cache_generation = state.cache_generation(&account_id);
+
+		assert!(state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 12,
+			cache_generation: Arc::clone(&cache_generation),
+			reset_cards: None,
+			profile: Some(profile_status(&account_id, 100)),
+		}));
+
+		assert!(!state.insert(AccountObservationOutcome {
+			account_id: account_id.clone(),
+			requested_revision: 12,
+			cache_generation,
+			reset_cards: None,
+			profile: Some(profile_status(&account_id, 200)),
+		}));
+
+		assert_eq!(
+			state
+				.profiles
+				.get(&account_id)
+				.and_then(|status| status.snapshot.as_ref())
+				.map(|snapshot| snapshot.observed_at_unix_micros),
+			Some(200)
+		);
+	}
+
+	fn available_inventory(
+		account_id: &AccountId,
+		observed_at_unix_micros: i64,
+	) -> ResetCardInventoryObservation {
+		ResetCardInventoryObservation::Available(ResetCardInventoryView {
+			account_id: account_id.clone(),
+			account_revision: 11,
+			reported_available_count: Some(0),
+			details_complete: true,
+			cards: Vec::new(),
+			five_hour_quota: quota(300, observed_at_unix_micros, 20, 2_000_000),
+			seven_day_quota: quota(10_080, observed_at_unix_micros, 30, 3_000_000),
+		})
+	}
+
+	fn profile_status(
+		account_id: &AccountId,
+		observed_at_unix_micros: i64,
+	) -> AccountProfileRefreshStatus {
+		AccountProfileRefreshStatus {
+			account_revision: 12,
+			refresh_error: None,
+			snapshot: Some(AccountProfileSnapshot {
+				account_id: account_id.clone(),
+				account_revision: 12,
+				provider: ProviderIdentity::new(AccountProvider::Chatgpt, "provider-account")
+					.expect("fixture provider identity"),
+				observed_at_unix_micros,
+				display_name: None,
+				username: None,
+				lifetime_tokens: None,
+				peak_daily_tokens: None,
+				longest_task_seconds: None,
+				current_streak_days: None,
+				longest_streak_days: None,
+				daily_usage: Vec::new(),
+			}),
+		}
+	}
+
+	fn quota(
+		duration_minutes: u32,
+		observed_at_unix_micros: i64,
+		used_percent: u8,
+		resets_at_unix_micros: i64,
+	) -> AccountQuotaWindowObservation {
+		AccountQuotaWindowObservation {
+			duration_minutes,
+			observed_at_unix_micros: Some(observed_at_unix_micros),
+			disposition: decodex_core::AccountQuotaDisposition::Current(
+				decodex_core::AccountQuotaWindow {
+					duration_minutes,
+					used_percent,
+					resets_at_unix_micros,
+				},
+			),
+		}
 	}
 
 	fn account(index: u16) -> AccountId {

--- a/crates/decodex-runtime/src/account_profile.rs
+++ b/crates/decodex-runtime/src/account_profile.rs
@@ -29,29 +29,30 @@ pub(crate) enum AccountProfileRuntimeResult {
 }
 
 /// Daemon-owned refresh state for one exact account revision.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct AccountProfileRefreshStatus {
 	pub(crate) account_revision: i64,
 	pub(crate) refresh_error: Option<AccountProfileRuntimeError>,
+	pub(crate) snapshot: Option<AccountProfileSnapshot>,
 }
 
 impl AccountProfileRuntimeResult {
-	pub(crate) const fn refresh_status(
-		&self,
-		requested_revision: i64,
-	) -> AccountProfileRefreshStatus {
+	pub(crate) fn refresh_status(&self, requested_revision: i64) -> AccountProfileRefreshStatus {
 		match self {
 			Self::Current(profile) => AccountProfileRefreshStatus {
 				account_revision: profile.snapshot.account_revision,
 				refresh_error: None,
+				snapshot: Some(profile.snapshot.clone()),
 			},
 			Self::Cached { profile, refresh_error } => AccountProfileRefreshStatus {
 				account_revision: profile.snapshot.account_revision,
 				refresh_error: Some(*refresh_error),
+				snapshot: Some(profile.snapshot.clone()),
 			},
 			Self::Unavailable { error, .. } => AccountProfileRefreshStatus {
 				account_revision: requested_revision,
 				refresh_error: Some(*error),
+				snapshot: None,
 			},
 		}
 	}

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -1506,11 +1506,15 @@ impl Application for ServiceApplication {
 				QueryResultPayload::InitialAccountSelection(self.initial_account_selection().await),
 			QueryPayload::GetCodexAuthProjection =>
 				QueryResultPayload::CodexAuthProjection(self.codex_auth_projection().await),
-			QueryPayload::WaitForAccountObservation { after_generation } =>
+			QueryPayload::WaitForAccountObservation { after_generation, request_refresh } => {
+				if request_refresh == &Some(true) {
+					self.request_account_observation_refresh();
+				}
 				QueryResultPayload::AccountObservation(match self.account_observations.as_ref() {
 					Some(observations) => observations.wait_for_change(*after_generation).await,
 					None => AccountObservationService::heartbeat(*after_generation).await,
-				}),
+				})
+			},
 		}
 	}
 

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -434,7 +434,10 @@ delay another.
 
 Results publish progressively only against the current Account revision and cache
 generation. A changed account invalidates its old Reset Card/profile state before a stale
-in-flight result can publish.
+in-flight result can publish. Each accepted account observation updates the daemon's
+per-account freshness metadata and cache value. The opaque public cache generation
+advances only when the semantic public value or its typed result changes; a timestamp-only
+refresh does not create a UI invalidation.
 
 `GetResetCards` and `GetAccountProfile` are isolated reads. They do not contact the
 provider, start an app-server, join a refresh future, wait for an observation round, or
@@ -444,10 +447,16 @@ cache. Restart discards that cache and reports typed retryable unavailability un
 new observation warms it.
 
 The UI starts independent daemon value reads concurrently and keeps one bounded
-`WaitForAccountObservation` query open instead of owning a second refresh clock. Each
-daemon publication advances an opaque generation and wakes one coalesced cached-value
-reload. Panel-open and manual triggers reload cached values only; they do not start
-provider or app-server work.
+`WaitForAccountObservation` query open instead of owning a second refresh clock. A
+daemon publication with a newly observed opaque generation wakes one coalesced
+background synchronization. A same-generation heartbeat is ignored unless the
+previous synchronization needs retry. Background synchronization retains the last
+published snapshot and does not enter the global loading or action gate. Opening
+the panel presents that snapshot immediately and may issue one single-flight
+priority observation request; the daemon coalesces it with its current round and
+the panel never waits for provider work. The manual `Refresh all` trigger remains
+the explicit full-read action. Normal value reads do not start provider or app-server
+work; only the explicit priority observation request schedules daemon-owned work.
 
 The macOS UI uses its existing in-process Rust protocol client. `Refresh login` is its
 only credential-replacement surface, and the native app ABI has no separate direct

--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -171,7 +171,11 @@ decodex-publisher validate-social
   `Refresh all`, that material selector, and Quit. A manual reload remains available
   during a background read and coalesces into the active reload cycle; it reads
   daemon-owned values and does not start provider work. Account mutations and Reset
-  Card submissions still disable it.
+  Card submissions still disable it. Observation synchronization keeps the last
+  published values usable while a new cache read is in flight. Opening the panel
+  presents the latest published values immediately and may ask the daemon for one
+  coalesced priority observation; only the explicit `Refresh all` action enters the
+  full-read lane.
 - Reveals a compact trailing-edge reorder grip over an account card's padding while
   the pointer is over that card, so the grip does not reserve a layout column. A
   drag uses the stable list coordinate space and keeps the full-size card on a

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -337,11 +337,16 @@ not queue a hot-loop successor for an already slow account.
 One slow account does not delay completion or later scheduling for another account.
 Observation results publish progressively and only against the current Account revision.
 An account change prunes old Reset Card and profile refresh state before a later result
-can become current. Every accepted publication advances one opaque daemon-lifetime
-observation generation. `WaitForAccountObservation` returns when that generation differs
-from the caller's last applied value, or after one 30-second heartbeat. The macOS app keeps
-one such wait open and reloads daemon values after the response. It has no independent
-15-second refresh clock; a disconnected wait reconnects with bounded backoff.
+can become current. Every accepted observation updates its per-account freshness metadata
+and daemon-owned cache. The opaque daemon-lifetime observation generation advances only
+when the semantic public cache value or its typed result changes; timestamp-only refreshes
+do not invalidate the UI. `WaitForAccountObservation` returns when that generation differs
+from the caller's last applied value, or after one 30-second heartbeat. Its optional
+`request_refresh` flag asks the daemon to schedule one coalesced observation before waiting;
+it does not make the query perform or await provider work directly. The macOS app keeps
+one standing wait plus at most one bounded priority wait, and synchronizes the cache in
+the background without entering the global loading gate. It has no independent 15-second
+refresh clock; a disconnected wait reconnects with bounded backoff.
 
 Normal `GetResetCards` and `GetAccountProfile` queries do not contact OpenAI or start an
 app-server. They read daemon-owned values. PostgreSQL remains the persistence authority for
@@ -354,10 +359,12 @@ account value and advances its cache generation before requesting observation. A
 older in-flight generation cannot republish after that invalidation. No credential or
 provider-private Reset Card ID enters this cache.
 
-Query handling is isolated from refresh work. A query does not join, await, register with,
-or inject work into an observation owner. It cannot convert a read into provider access or
-make a slow refresh hold the request path. Candidate-5 Quick Task work must preserve this
-current-main cache-read and observation behavior unchanged.
+Normal value-query handling is isolated from refresh work. `GetResetCards` and
+`GetAccountProfile` do not join, await, register with, or inject work into an observation
+owner. The explicit priority form of `WaitForAccountObservation` is the only client
+revalidation hook; it only signals the daemon scheduler and waits on the semantic
+generation. Candidate-5 Quick Task work must preserve this cache-read and observation
+boundary.
 
 ```mermaid
 sequenceDiagram
@@ -366,10 +373,11 @@ sequenceDiagram
     participant Accounts as Account service
     participant Provider as Provider adapters
     participant Store as PostgreSQL
-    participant Cache as Daemon Reset Card cache
+	participant Cache as Daemon Reset Card cache
 	participant Client as UI or protocol client
 
 	Client->>Observer: Wait after last observation generation
+	Client->>Observer: Optional priority wait requests one coalesced round
 	Timer->>Observer: Request coalesced observation round
     Observer->>Accounts: List lifecycle-ready account revisions
     par Each independent account


### PR DESCRIPTION
## Summary
- Separate observation freshness from semantic data revision so background observation does not force a full UI refresh.
- Make panel-open revalidation single-flight and priority-aware while retaining the last published snapshot.
- Fence route/account snapshot publication so stale reads cannot overwrite a newer mutation.

## Validation
- Rust tests: decodex-runtime, decodex-protocol, decodex-app-client-ffi
- Swift tests: apps/decodex-app
- Rust and Xcode release builds
- Formatting and diff checks

## Local install
- Updated the signed local daemon LaunchAgent and CLI.
- Installed /Applications/Decodex.app from this commit; previous bundle is retained for rollback.