### PR TITLE
Reset Quick Task routing recovery authority

### DIFF
--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -249,6 +249,11 @@ relation privilege or private-helper authority.
 These records protect command idempotency and atomicity. They are not schema bootstrap,
 schema upgrade, or schema-history records.
 
+`crates/decodex-postgres/src/exact_commands.rs` remains the owner of shared receipt and
+error primitives only. The domain-specific Quick Task routing transaction belongs to
+PostgreSQL `quick_task_routing`; `exact_commands.rs` is not a generic transaction or
+workflow framework.
+
 ## Candidate-5 Quick Task
 
 Candidate 5 is the accepted target for one ordinary multi-turn Quick Task. It is not a
@@ -260,14 +265,13 @@ establishing the first RuntimeSession.
 
 ### Owner order
 
-The exact first-session order is:
+One ordinary Conversation has exactly one immutable initial Account Registry snapshot and
+one immutable initial Routing Decision. The exact first-session order is:
 
 ```text
-Conversation create
--> prospective Turn UUID intent
--> Quick Task routing adapter locks Account Registry authority
--> Routing Snapshot
--> Routing Decision
+Conversation create: routing_pending
+-> one PostgreSQL quick_task_routing transaction: snapshot + decision
+-> selected decision: establishment_pending
 -> first account/profile snapshots + starting RuntimeSession + inert initial plan
 -> Conversation-owned atomic Turn/history admission
 -> Account Service selected-account pre-spawn fence
@@ -276,12 +280,22 @@ Conversation create
 -> ProviderAttempt
 ```
 
-The Quick Task routing adapter owns one transaction that locks complete non-tombstoned Account
-Registry membership, canonical routing mode/fixed target/order and routing revision, exact account
-revisions, enabled/lifecycle/health/credential-binding blockers, the current Task RoleProfile
-revision, and exactly one 300-minute and one 10080-minute `account_quota_facts` slot per member. It
-materializes the only selecting Quick Task Routing Snapshot and immutable Decision directly from
-those facts. Project-policy/evidence/build fields are null.
+The substantive PostgreSQL `quick_task_routing` owner exposes one command-complete,
+top-level `READ COMMITTED` exact operation. It locks the Conversation first, then Account
+Routing Control, complete non-tombstoned accounts in UUID order, current Task RoleProfile,
+complete routing order, and exact quota facts. It retains all locks while it materializes
+the complete `conversation_account_registry` `L0` snapshot, runs the bounded I/O-free
+`decodex-core` routing kernel, persists and validates the snapshot, one decision, every
+reference, exact receipt, activity, and outbox, and commits them together. Snapshot and
+decision persistence are private transaction steps, not independently committable
+commands.
+
+Authority drift and every kernel, insert, reference, and completeness failure roll back
+the complete transaction. PostgreSQL allocates all generated route and prospective-Turn
+identities as effects. A committed exact receipt replays its stored identities and response
+bytes. After rollback no generated identity remains authoritative, and a resumed operation
+may allocate replacement identities without requiring runtime to reproduce an uncommitted
+random value. Different command keys serialize on the Conversation and have one winner.
 
 Each quota slot exactly copies one source state: missing has all observation fields null; current
 has `used_percent`, `observed_at`, and `resets_at` with no error; observation error has typed
@@ -295,18 +309,19 @@ Account Service rechecks only the selected account's current readiness, credenti
 version/fingerprint, provider binding, and HostCredentialStore binding immediately before spawn.
 It cannot preselect, replace, fall back to, or wake another account.
 
-Account Registry owns current account, quota, blocker, and routing facts. The Quick Task routing
-adapter owns only first-session materialization. Every later Turn receives an immutable
-non-selecting continuation decision bound to the current RuntimeSession, original initial
-decision, selected account snapshot, and copied Task RoleProfile snapshot. Same-thread and Context
-Pack planning retain that account and profile; they do not call current Project routing, resolve
-another Account Registry snapshot, or select. Specifically, they never call
+Account Registry owns current account, quota, blocker, and routing facts. PostgreSQL
+`quick_task_routing` owns only initial route persistence plus each later immutable
+non-selecting `conversation_continuation` binding. That binding retains the source
+RuntimeSession, original initial decision, selected account snapshot, and copied Task
+RoleProfile snapshot. Ordinary Quick Task same-thread and Context Pack planning preserve
+that lineage; they do not call current Project routing, resolve another Account Registry
+snapshot, or select. Specifically, they never call
 `read_current_task_routing_authority_exact()` or `resolve_routing_snapshot_exact`. Drift,
 exhaustion, or readiness failure returns
-typed manual recovery without fallback, wake, or re-selection. `QuickTaskRuntime` and
-`ServiceApplication` only sequence and consume typed results. Project routing retains accepted
-policy/evidence authority for ManagedRun. There is no general selector, capability manager,
-compatibility bridge, or duplicate Quick Task policy path.
+typed manual recovery without a wake, account switch, or re-selection. XY-1304 disables
+automatic cross-account same-thread substitution and all-depleted wake; it does not remove
+ordinary same-account Quick Task Context Pack planning. Project routing retains accepted
+policy/evidence authority for ManagedRun.
 
 Continuation Plan consumes the selected initial decision. In one transaction it creates
 the selected account snapshot, copied RoleProfile snapshot, first revision-1 unfenced
@@ -314,11 +329,12 @@ the selected account snapshot, copied RoleProfile snapshot, first revision-1 unf
 outbox. It uses the current `task` RoleProfile from the separate PostgreSQL authority; routing and
 runtime do not choose or derive it. Failure rolls back the complete cluster.
 
-Conversation authority then admits exactly one Turn with the prospective UUID, sequence
-1, role `user`, `possible_side_effects=unknown`, status `active`, and revision 1 under the
-same Conversation and new RuntimeSession. The same transaction creates exactly one
-ordinal-0 completed Message plus receipt/activity/outbox. A competing key creates no
-partial domain effect. No Turn row exists before this transaction.
+Conversation authority then admits exactly one Turn with the database-generated
+prospective UUID returned by the committed selected route, sequence 1, role `user`,
+`possible_side_effects=unknown`, status `active`, and revision 1 under the same
+Conversation and new RuntimeSession. The same transaction creates exactly one ordinal-0
+completed Message plus receipt/activity/outbox. A competing key creates no partial domain
+effect. No Turn row exists before this transaction.
 
 ### Closed lineage
 
@@ -335,15 +351,17 @@ with the Account Registry fields above and null Project policy/evidence/build fi
 Project policy/evidence/capability/quota representation. Reverse constraints reject mixed fields,
 children, or consumers.
 
-A later Quick Task Turn uses `L6` only in a non-selecting `conversation_continuation` decision. It
-directly references the source RuntimeSession and original initial selected decision, repeats only
-their exact account/profile snapshot identities, and has no candidate, policy, quota, exclusion,
-waiting, or selection fields. Same-thread and Context Pack planning consume this binding.
+A later Quick Task Turn uses `L6` only in a non-selecting
+`conversation_continuation` binding. It directly references the source RuntimeSession and
+original initial selected decision, repeats only their exact account/profile snapshot
+identities, and has no candidate, policy, quota, exclusion, waiting, or selection fields.
+It does not occupy the one initial decision slot. Same-thread and Context Pack planning
+consume this binding.
 
 There is one initial selecting decision. Same-key replay is read-only. A competing cross-key
 initial command loses under the Conversation lock and creates no routing rows. Initial planning is
 first-session creation. Later selected-account drift fails closed before spawn as typed manual
-recovery without fallback, wake, or re-selection.
+recovery without wake, account switch, or re-selection.
 
 ### Initial selection transaction
 
@@ -359,6 +377,51 @@ without a lock cycle. Before commit, selection compares every locked revision an
 with the immutable copy. Mismatch rolls back all effects. Same-key contenders replay the stored
 exact response; cross-key contenders serialize at the Conversation and only one is fresh.
 
+### Recovery states and readback
+
+`routing_pending` is the typed readback for an open ordinary Conversation with no
+committed initial decision or downstream authority. `resume_routing` invokes that
+Conversation's same initial route operation from its durable request coordinates. It does
+not create a route attempt, second snapshot, second decision, or routing Conversation
+successor.
+
+A committed `waiting` or `no_route` decision remains durable. Explicit retry invokes a
+separate PostgreSQL Conversation-owner exact command. It locks the expected source
+revision, requires no selected result or RuntimeSession, Turn, Message, plan, process,
+thread, or provider effect, creates exactly one fresh revision-1 **routing Conversation
+successor**, records exact one-to-one lineage, archives the source, writes its receipt,
+activity, and outbox, and commits. Same-key replay returns the stored response. A competing
+key returns the existing successor or a typed stale result and cannot create another.
+
+The routing Conversation successor command and initial routing are separate. A crash after
+successor commit leaves an open `routing_pending` successor whose initial route may resume
+after restart.
+Get-by-Conversation-ID on the archived source returns a typed `routing_successor` redirect
+with the direct successor identity and revision. Ordinary lists filter archived sources
+before ordering, cursoring, and limiting, and include each open successor exactly once.
+
+A committed `selected` decision without a RuntimeSession or initial plan projects
+`establishment_pending`. `resume_establishment` consumes only that decision and may replay
+or complete initial planning; it cannot invoke selection. After `selected`, or once any
+RuntimeSession, Turn, Message, plan, process, thread, or provider effect exists, routing
+Conversation successor creation, route retry, wake, account re-selection, account switch,
+and any other automatic cross-account fallback are rejected.
+
+### Routing modules
+
+PostgreSQL `quick_task_routing` owns the atomic initial route, exact response
+codecs/readback, and immutable continuation binding. PostgreSQL Conversation authority
+owns routing Conversation successor creation/archive/readback. Runtime
+`routing_orchestration.rs` owns
+only stateless owner-order sequencing. Runtime `quick_task.rs` owns lifecycle plus process,
+thread, and provider execution. `decodex-core` owns only the bounded I/O-free kernel, and
+`exact_commands.rs` owns only receipt/error primitives.
+
+The deletion test is required. Removing `quick_task_routing` must spread its transaction,
+codecs/readback, and continuation invariants into callers. Removing
+`routing_orchestration.rs` must spread recovery sequencing into `quick_task.rs` or other
+callers. A file removable with forwarding changes alone is not an accepted owner.
+
 ### Thread and effect fences
 
 Before ProcessGeneration preparation or spawn, each thread fence/start/bind, and each
@@ -372,7 +435,8 @@ bind receipts. A terminalization race loses before an effect.
 
 Only `Fresh` ProcessGeneration outcome returns the non-clone spawn authority. `Replayed`,
 `Rejected`, and `Unknown` return readback or refusal without spawn authority. They cannot
-spawn, replace, adopt, create a successor, duplicate an attempt, or terminalize the Turn.
+spawn, replace, adopt, create a routing Conversation successor, duplicate an attempt, or
+terminalize the Turn.
 
 Conversation authority may move the active revision-1 Turn to `failed` revision 2 under
 the starting session only when positive readback proves definite pre-effect refusal. The
@@ -384,6 +448,9 @@ Explicit successor is PostgreSQL-only non-dispatch evidence. It locks the exact 
 by the route decision before any write and requires the same Conversation/source session,
 status `failed`, and revision 2. It has no product or runtime mutation surface.
 
+This failed-Turn Explicit successor is distinct from the pre-establishment routing
+Conversation successor.
+
 ### Final trigger definitions
 
 The latest schema creates the final bodies and unchanged bindings for these eight affected
@@ -391,8 +458,8 @@ trigger functions:
 
 | Function | Final Candidate-5 responsibility |
 | --- | --- |
-| `decodex.enforce_routing_completeness()` | Enforce both selecting snapshot authority shapes, exact Account Registry quota tri-states, reverse nullability, and retained ManagedRun `L6`. |
-| `decodex.enforce_routing_decision_completeness()` | Enforce selecting classification/exclusions or the exact non-selecting Conversation continuation binding, never both. |
+| `decodex.enforce_routing_completeness()` | Enforce both selecting snapshot authority shapes, one initial Account Registry snapshot per Conversation, exact quota tri-states, reverse nullability, and retained ManagedRun `L6`. |
+| `decodex.enforce_routing_decision_completeness()` | Enforce one immutable initial Conversation classification, retain ManagedRun selection, and keep the non-selecting Conversation continuation binding outside the initial decision slot. |
 | `decodex.enforce_runtime_session_state()` | Permit only request fencing, exact start-response/thread binding, and last-Turn acknowledgement as the narrow nonterminal edges; reject generic `starting` to `active`. |
 | `decodex.enforce_turn_state()` | Under `starting`, permit only exact first-Turn admission and positive definite pre-effect failure; preserve all existing active-session behavior. |
 | `decodex.enforce_history_item_state()` | Under `starting`, permit only the admission transaction's exact ordinal-0 completed Message; preserve existing active-session behavior. |
@@ -517,15 +584,18 @@ without starving later attempts.
 
 ## Stateless execution coordination
 
-ExecutionCoordinator is a zero-sized crate-private sequencer. It retains no relation,
-receipt, retry state, task, channel, lifecycle, account choice, RuntimeSession choice,
-process state, or ProviderAttempt state. It consumes typed outputs from the sole owners
-and returns an inert projection until a separately accepted product dispatch root exists.
+Runtime `routing_orchestration.rs` is the crate-private stateless routing/planning
+sequencer. Runtime `quick_task.rs` consumes its typed results and owns lifecycle plus
+process/thread/provider execution. Neither retains a routing relation, receipt, retry
+state, task, channel, lifecycle decision, account choice, RuntimeSession choice, process
+state, or ProviderAttempt state. They return an inert projection until a separately
+accepted product dispatch root exists.
 
-Conversation remains the ordinary Turn owner. ManagedRun remains its own lifecycle and
-acceptance owner. Routing Snapshot/Decision own eligibility and selection. Continuation
-Plan owns first-session, same-thread, and Context Pack planning. ProcessSupervisor owns
-process fences. ProviderAttemptService owns provider effects.
+PostgreSQL Conversation authority remains the ordinary Conversation/Turn and routing
+Conversation successor owner. ManagedRun remains its own lifecycle and acceptance owner.
+PostgreSQL `quick_task_routing` owns initial Quick Task routing and later continuation bindings.
+Continuation Plan owns first-session, same-thread, and Context Pack planning.
+ProcessSupervisor owns process fences. ProviderAttemptService owns provider effects.
 
 The protocol may expose read-only immutable execution-decision projection. It exposes no
 route, session, process, attempt, wake, retry, receipt, or dispatch mutation.
@@ -620,8 +690,10 @@ path, compatibility mechanism, or executable schema owner.
 - Runtime composition changes must preserve independent ProductStore, Quick Task, and
   ManagedRepository projections. Do not add a mutable capability manager or silent
   optional startup path.
-- Candidate-5 changes must preserve sole account selection, atomic first Turn/history
-  admission, exact effect fencing, and current-main account cache-read isolation.
+- Candidate-5 changes must preserve one atomic initial route, sole account selection,
+  routing Conversation successor/readback rules, ordinary same-thread and Context Pack authority,
+  atomic first Turn/history admission, exact effect fencing, and current-main account
+  cache-read isolation.
 - ProcessGeneration changes must preserve positive-only death and account-local
   quarantine.
 - ProviderAttempt changes must preserve positive-only outcome evidence and no replay.

--- a/openwiki/decisions/vnext-authority.md
+++ b/openwiki/decisions/vnext-authority.md
@@ -189,8 +189,9 @@ Candidate-4 tree `f82b866e21f12742648023a2b468cc057afa52a1` remains materially
 rejected provenance.
 
 Scoped supersession: the earlier Candidate-5 requirement for Project policy order and
-capability facts does not apply to ordinary Quick Task. Account Registry authority selects once
-when the first RuntimeSession is established. ManagedRun Project-policy authority is unchanged.
+capability facts does not apply to ordinary Quick Task. ManagedRun Project-policy
+authority is unchanged. This reset supersedes every same-Conversation `RetryRouting` or
+`RetryQuickTaskRouting` contract and every split initial snapshot/decision command.
 
 Candidate 4 failed because it did not close five authority boundaries:
 
@@ -201,32 +202,41 @@ Candidate 4 failed because it did not close five authority boundaries:
 4. the required narrow trigger behavior contradicted an active-only trigger rule; and
 5. Account Service and routing could select different accounts.
 
-Candidate 5 uses existing owners in this exact order:
+One ordinary Conversation has exactly one immutable initial Account Registry snapshot and
+one immutable initial Routing Decision. Candidate 5 uses these owners in this exact order:
 
-1. Conversation authority creates the Conversation.
-2. Routing receives one prospective Turn UUID as intent. No Turn row or Turn foreign
-   key exists at this point.
-3. The Quick Task routing adapter locks complete Account Registry membership, canonical routing
-   control, exact account facts and blockers, the current Task RoleProfile revision, and two exact
-   Account Registry quota slots per member.
-4. Routing Decision authority runs once and is the sole Quick Task account selector.
-5. Continuation Plan authority consumes that selected decision and atomically creates
-   the selected account snapshot, copied RoleProfile snapshot, first revision-1
-   unfenced `starting` RuntimeSession, inert `initial_thread` plan, exact receipt,
-   activity, and outbox.
-6. Conversation authority atomically admits the exact prospective UUID as the active
-   revision-1 sequence-1 user Turn and creates exactly one ordinal-0 completed Message.
-7. Account Service rechecks only the selected account's readiness, credential version
-   and fingerprint, provider binding, and HostCredentialStore binding immediately
-   before spawn. It cannot select or substitute an account.
-8. ProcessSupervisor may spawn only from a fresh ProcessGeneration fence.
-9. RuntimeSession Thread Establishment owns the exact thread-start fence, start binding,
-   activation, and acknowledgement.
-10. ProviderAttemptService owns attempt preparation, dispatch authorization, ambiguity,
-    positive evidence, and reconciliation.
+1. PostgreSQL Conversation authority creates a revision-1 Conversation and retains its
+   durable initial request coordinates. Before a decision commits, readback is
+   `routing_pending`.
+2. Runtime `routing_orchestration.rs` invokes one command-complete PostgreSQL
+   `quick_task_routing` operation with typed inputs and a protocol-scoped idempotency key,
+   but no generated identity.
+3. The operation locks the Conversation, complete Account Registry routing/account/quota
+   authority, and current Task RoleProfile; materializes the complete snapshot; runs the
+   bounded I/O-free `decodex-core` kernel while locks remain held; and commits the snapshot,
+   one decision, references, exact receipt, activity, and outbox together.
+4. Continuation Plan consumes a committed selected decision and atomically creates the
+   selected account snapshot, copied RoleProfile snapshot, first revision-1 unfenced
+   `starting` RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and
+   outbox.
+5. Conversation authority atomically admits the database-generated prospective Turn as
+   the active revision-1 sequence-1 user Turn and creates exactly one ordinal-0 completed
+   Message.
+6. Account Service fences only the selected account immediately before spawn.
+   ProcessSupervisor may spawn only from a fresh ProcessGeneration fence. RuntimeSession
+   Thread Establishment and ProviderAttemptService retain their exact thread and effect
+   authorities.
 
-Runtime is a stateless sequencer across these owners. It does not become an account,
-route, session, Turn, process, thread, or provider-effect authority.
+PostgreSQL `quick_task_routing` exposes no independently committable snapshot or decision
+half-command. Authority drift and every kernel, insert, reference, or completeness failure
+roll back the entire initial route. PostgreSQL owns generated identity authority. A
+committed exact receipt replays its stored identities and response bytes; after rollback
+no generated identity survives, and runtime never has to reproduce an uncommitted random
+value. Different keys serialize on the Conversation and have one winner.
+
+Runtime `routing_orchestration.rs` remains a stateless owner-order sequencer. Runtime
+`quick_task.rs` owns Quick Task lifecycle plus process, thread, and provider execution and
+does not persist routing.
 
 Selecting snapshots have two closed authority shapes. `conversation_account_registry` is the
 initial Quick Task `L0` shape and has null Project policy/evidence/build fields.
@@ -239,16 +249,38 @@ RoleProfile revision, every non-tombstoned member and blocker, and duration-keye
 (`used_percent`, `observed_at`, `resets_at`), or observation error (`error_code`, `observed_at`).
 It fabricates no revision, remaining value, confidence, or provenance.
 
-There is exactly one selecting route decision for an ordinary Quick Task. Each later Turn creates
-an immutable non-selecting `conversation_continuation` decision binding to the current
-RuntimeSession, its original
-initial decision, selected account snapshot, and copied Task RoleProfile snapshot. It does not
-call `read_current_task_routing_authority_exact()`, resolve another Account Registry snapshot, or
-run selection.
-Same-thread continuation and Context Pack fallback retain that exact account and profile.
-Selected-account drift, exhaustion, or readiness failure returns typed manual recovery without
-fallback, wake, alternate account, or re-selection. Automatic cross-account fallback and
-all-depleted wake remain disabled under XY-1304.
+There is exactly one selecting route decision for an ordinary Quick Task. PostgreSQL
+`quick_task_routing` creates each later immutable non-selecting
+`conversation_continuation` binding from the current RuntimeSession, its original initial
+decision, selected account snapshot, and copied Task RoleProfile snapshot. It does not
+occupy the initial decision slot, call `read_current_task_routing_authority_exact()`,
+resolve another Account Registry snapshot, or run selection. Ordinary same-thread and
+Context Pack planning preserve the original RuntimeSession/account/profile lineage.
+Selected-account drift, exhaustion, or readiness failure returns typed manual recovery
+without wake, alternate account, or re-selection. XY-1304 disables automatic
+cross-account same-thread substitution and all-depleted wake; it does not disable ordinary
+same-account Quick Task Context Pack planning.
+
+A Conversation with no committed initial decision projects `routing_pending`.
+`resume_routing` invokes its same one-slot route from durable request coordinates and does
+not create a second snapshot or decision. A committed `waiting` or `no_route` result is
+immutable; explicit retry invokes a separate PostgreSQL Conversation-owner command that
+creates exactly one fresh **routing Conversation successor**, records one-to-one lineage,
+archives the source, and commits its receipt, activity, and outbox atomically. Same-key
+replay returns the stored response, while different keys have one winner.
+
+Routing Conversation successor creation and initial routing are separate commands. A crash
+between them leaves the open successor `routing_pending`. Get-by-Conversation-ID on an
+archived source returns a typed `routing_successor` redirect containing the direct
+successor identity and revision. Ordinary lists omit archived sources and include each
+open successor exactly once.
+
+A committed selected decision without a RuntimeSession or initial plan projects
+`establishment_pending`. `resume_establishment` consumes only that decision and cannot
+invoke selection. After `selected`, or once any RuntimeSession, Turn, Message, plan,
+process, thread, or provider effect exists, routing Conversation successor creation, route
+retry, wake, account re-selection, account switch, and any other automatic cross-account
+fallback are rejected.
 
 Every process, thread, and provider-effect fence locks and rechecks the exact selected
 Turn as active revision 1 under the same Conversation and first RuntimeSession.
@@ -257,9 +289,9 @@ ProcessGeneration and thread establishment through bind require the applicable
 require the exact post-bind `active` revision and exact thread fence/bind receipts.
 
 Only a fresh ProcessGeneration result can spawn. Replayed, rejected, or uncertain state
-returns durable readback or `Unknown`; it cannot spawn, replace, adopt, create a
-successor, prepare a duplicate attempt, or terminalize the Turn. Conversation authority
-may move the exact Turn to `failed` revision 2 under a starting session only after
+returns durable readback or `Unknown`; it cannot spawn, replace, adopt, create a routing
+Conversation successor, prepare a duplicate attempt, or terminalize the Turn.
+Conversation authority may move the exact Turn to `failed` revision 2 under a starting session only after
 positive proof of a definite pre-effect refusal. Any ambiguous or started effect keeps
 the Turn active for manual recovery.
 
@@ -267,6 +299,17 @@ Explicit successor remains PostgreSQL-only, non-dispatch evidence. Before any wr
 locks the Turn named by the selected decision and requires that Turn to be in the same
 Conversation and source RuntimeSession, `failed`, and revision 2. It has no protocol
 field, product command, runtime grant, facade, fallback, or wake path.
+
+This failed-Turn Explicit successor is distinct from the pre-establishment routing
+Conversation successor.
+
+The module deletion test is normative. PostgreSQL `quick_task_routing` must be
+substantive: deleting it must spread the atomic initial transaction, codecs/readback, and
+continuation invariants into callers. Deleting runtime `routing_orchestration.rs` must
+spread its owner-order recovery sequencing into `quick_task.rs` or other callers. Runtime
+`quick_task.rs` retains lifecycle/process/thread/provider execution only;
+`decodex-core` retains the bounded I/O-free routing kernel; and `exact_commands.rs`
+retains shared receipt/error primitives only.
 
 The latest schema defines the final forms of the eight affected trigger functions
 directly:
@@ -335,7 +378,8 @@ work for an explicit decision.
   selection, continuation binding, or exclusions.
 - ProcessSupervisor and ProviderAttemptService retain separate replacement-safety and
   external-effect-safety authority.
-- ExecutionCoordinator remains stateless and cannot authorize dispatch by itself.
+- Runtime `routing_orchestration.rs` remains stateless and cannot authorize dispatch by
+  itself.
 - Git/filesystem own repository bytes and worktrees. GitHub owns PR/check/merge
   readback. PostgreSQL owns the admitted repository-effect state and evidence.
 - Quick Task construction is I/O-free and infallible after validated dependencies exist.
@@ -373,8 +417,14 @@ Stop and return to the authority owner if evidence shows that:
 - normal daemon startup requires DDL or a schema-owner credential;
 - the local credential-negative rebind cannot preserve exact host-vault bindings without
   exposing token bytes outside the `HostCredentialStore` owner or changing them;
-- Candidate-5 owners cannot compose without a second account selector, coordinator
-  state, pre-admission Turn row, or ambiguous-effect replay;
+- Candidate-5 initial snapshot and decision cannot share one PostgreSQL transaction and
+  exact receipt;
+- selected-without-session recovery must invoke selection, or committed waiting/no-route
+  retry cannot use a separate one-winner routing Conversation successor;
+- ordinary Quick Task Context Pack planning cannot preserve the immutable original
+  RuntimeSession/account/profile lineage;
+- Candidate-5 owners cannot compose without a second account selector, routing sequencer
+  state, pre-admission Turn row, wrapper-only routing module, or ambiguous-effect replay;
 - ordinary Conversation execution requires a ManagedRun;
 - ProviderAttempt must create or rewrite RuntimeSession state;
 - ProcessGeneration uncertainty must be treated as provider non-submission; or

--- a/openwiki/specs/execution-coordinator-authority.md
+++ b/openwiki/specs/execution-coordinator-authority.md
@@ -9,26 +9,39 @@ ManagedRun-local submitted-turn/effect-barrier machinery.
 
 ## Owner composition
 
-`ExecutionCoordinator` is a zero-sized, stateless sequencer. It does not persist state or
-own a lifecycle, retry machine, receipt, effect barrier, ambiguity ledger, account
-decision, RuntimeSession decision, process state, or ProviderAttempt state.
+Execution coordination is stateless. Runtime `routing_orchestration.rs` owns only the
+owner-order sequences from routing Conversation successor to initial route, route to
+initial plan, `resume_establishment`, and continuation binding to plan. Runtime
+`quick_task.rs` owns the remaining Quick Task lifecycle and process, thread, and provider
+execution. Neither module persists routing authority or owns a receipt, retry machine,
+effect barrier, ambiguity ledger, account decision, RuntimeSession decision, process
+state, or ProviderAttempt state.
 
 | Owner | Sole authority |
 | --- | --- |
-| Conversation authority | Ordinary Conversation and Turn lifecycle, including Candidate-5 atomic first Turn/history admission and legal Turn finalization. |
+| PostgreSQL Conversation authority | Ordinary Conversation and Turn lifecycle, one-winner routing Conversation successor creation/archive/readback, Candidate-5 atomic first Turn/history admission, legal Turn finalization, and Conversation/Turn/history readback. |
 | ManagedRun authority | ManagedRun lifecycle, execution assignment, wait state, review, acceptance, and completion. |
-| Routing Snapshot | Closed consumer-specific authority: initial `conversation_account_registry` `L0` facts or `managed_run_project_policy` `L6` policy/evidence facts; never a merged shape. |
-| Routing Decision | Sole selector for selecting snapshots, exact shape-specific cause projection, and immutable non-selecting `conversation_continuation` binding. |
-| Continuation Plan | First-session planning plus same-thread or Context Pack continuation that retains the original Quick Task account/profile binding; PostgreSQL-only explicit-successor evidence. |
+| PostgreSQL `quick_task_routing` | One atomic initial Quick Task snapshot/decision operation with exact receipt, codecs/readback, and one immutable non-selecting continuation binding; no independently committable half-command. |
+| ManagedRun routing | Closed `managed_run_project_policy` `L6` facts and the sole ManagedRun selector; unchanged by the Quick Task reset. |
+| `decodex-core` routing | Bounded I/O-free pure selection kernel only; no lock, persistence, provenance, receipt, completeness, retry, or lifecycle authority. |
+| Continuation Plan | First-session planning from an already selected decision plus ordinary Quick Task same-thread or Context Pack planning from an already persisted continuation binding; PostgreSQL-only Explicit successor evidence. |
 | RuntimeSession Thread Establishment | Exact thread request fence, start binding, activation, and acknowledgement. |
 | ProcessSupervisor | ProcessGeneration intent, live fence, positive-only death evidence, and account-local quarantine. |
 | ProviderAttemptService | Atomic attempt binding, dispatch authorization, provider-effect state, positive evidence, restore projection, and reconciliation. |
 | Reviewer | Execution-scoped read-only review; missing or ambiguous output grants no approval or completion. |
-| ExecutionCoordinator | One in-memory sequence across accepted owners; no independent authority. |
+| Runtime `routing_orchestration.rs` | Owner-order routing and planning sequences; no independent authority. |
+| Runtime `quick_task.rs` | Quick Task lifecycle plus process/thread/provider execution; no routing persistence. |
+| PostgreSQL `exact_commands.rs` | Exact receipt and error primitives only; no generic transaction or workflow framework. |
 
-The coordinator consumes typed results in owner order and returns an inert projection
+The runtime modules consume typed results in owner order and return an inert projection
 unless a separately accepted production dispatch root consumes the complete fence chain.
-It cannot reconstruct a fresh fence from durable readback.
+They cannot reconstruct a fresh fence from durable readback.
+
+The deletion test is normative. Deleting PostgreSQL `quick_task_routing` must spread its
+atomic route transaction, codecs/readback, and continuation-binding invariants into
+callers. Deleting runtime `routing_orchestration.rs` must spread its owner-order recovery
+sequencing into `quick_task.rs` or other callers. A file whose deletion requires only
+forwarding changes is wrapper plumbing, not an accepted owner.
 
 ## Closed execution consumer
 
@@ -60,19 +73,25 @@ old local state cannot satisfy the latest schema, the operator replaces the loca
 database or directly transforms that one development database under the reviewed local
 action. Product runtime never interprets an old shape.
 
-The latest schema retains sole writers:
+The target retains sole writers:
 
-- Routing Decision for initial Quick Task or ManagedRun account choice, route causes, and
-  non-selecting Quick Task continuation binding;
-- Continuation Plan for RuntimeSession continuation/creation;
+- PostgreSQL `quick_task_routing` for the indivisible initial Quick Task snapshot and
+  decision, exact route readback, and non-selecting Quick Task continuation binding;
+- ManagedRun routing for its retained Project-policy selection;
+- PostgreSQL Conversation authority for the routing Conversation successor, archive, and
+  redirect/list readback;
+- Continuation Plan for RuntimeSession continuation/creation from committed routing
+  authority;
 - ProcessSupervisor for ProcessGeneration;
 - ProviderAttemptService for provider effects; and
 - Conversation or ManagedRun for their own lifecycle.
 
 ## Route projection
 
-Routing Snapshot and Routing Decision expose closed consumer-specific authority shapes. For a
-selecting shape, Routing Decision locks the complete matching snapshot. The caller supplies no
+Routing Snapshot and Routing Decision expose closed consumer-specific authority shapes.
+For ordinary Quick Task, PostgreSQL `quick_task_routing` locks current authority,
+materializes the complete snapshot, runs selection, and persists the snapshot and decision
+in one transaction. ManagedRun keeps its separate selection owner. The caller supplies no
 account list, order, eligibility, exclusion, evidence, or account choice.
 
 ### ManagedRun Project-policy `L6`
@@ -113,40 +132,60 @@ sticky, capability, Project evidence, quota source identity, observation revisio
 confidence, or provenance fields. Fixed mode accepts only its exact eligible target. Balanced mode
 uses canonical Account Registry order. The independent slots and separate accounts are never
 pooled. The immutable result persists only `selected`, `waiting`, or `no_route` plus exact replay
-exclusions. `waiting` is manual-retry state and grants no wake.
+exclusions. `waiting` and `no_route` grant no wake or same-Conversation re-selection.
+Explicit retry uses the separate Conversation-owner routing Conversation successor
+command.
 
 ### Later Quick Task continuation `L6`
 
-`conversation_continuation` is an immutable non-selecting decision bound to the current
-RuntimeSession and its original initial decision, selected account snapshot, and copied Task
-RoleProfile snapshot. It has no candidate projection and never invokes Routing Snapshot resolution
-or the selector. Same-thread and Context Pack planning retain that exact account and profile.
+`conversation_continuation` is an immutable non-selecting routing binding bound to the
+current RuntimeSession and its original initial decision, selected account snapshot, and
+copied Task RoleProfile snapshot. It has no candidate projection and never invokes Routing
+Snapshot resolution or the selector. Ordinary Quick Task same-thread and Context Pack
+planning retain that exact RuntimeSession, account, and profile lineage.
 
 ## Candidate-5 initial operation
 
-Candidate 5 adds no coordinator state or new owner. The exact order is:
+Candidate 5 adds no coordinator state. The exact order is:
 
-1. Conversation authority creates the Conversation.
-2. The routing request supplies one prospective Turn UUID as intent only. No Turn row or
-   Turn foreign key exists yet.
-3. Routing Snapshot proves exact `conversation_account_registry` zero-source lineage and the
-   complete locked Account Registry facts defined above.
-4. Routing Decision selects one account exactly once for the Quick Task lifetime.
-5. Continuation Plan atomically creates selected account/profile snapshots, the first
-   revision-1 unfenced `starting` RuntimeSession, inert `initial_thread` plan, exact
-   receipt, activity, and outbox.
-6. Conversation authority atomically admits the exact active revision-1 sequence-1 user
-   Turn and exactly one ordinal-0 completed Message.
+1. PostgreSQL Conversation authority creates the revision-1 Conversation and retains its
+   durable initial request coordinates. Before a decision commits, readback is
+   `routing_pending`.
+2. Runtime `routing_orchestration.rs` invokes the one command-complete
+   `quick_task_routing` operation. Runtime supplies typed inputs and a protocol-scoped
+   idempotency key, but no generated identity.
+3. The operation locks the Conversation, Account Routing Control, all complete
+   non-tombstoned accounts in UUID order, current Task RoleProfile, complete routing order,
+   and exact quota facts in one top-level `READ COMMITTED` transaction.
+4. With those locks retained, it materializes the complete
+   `conversation_account_registry` `L0` snapshot, runs the bounded I/O-free core kernel,
+   persists and validates the snapshot, one initial decision, references, exact receipt,
+   activity, and outbox, and commits them together.
+5. If the result is `selected`, Continuation Plan atomically creates selected
+   account/profile snapshots, the first revision-1 unfenced `starting` RuntimeSession,
+   inert `initial_thread` plan, exact receipt, activity, and outbox.
+6. Conversation authority atomically admits the database-generated prospective Turn as
+   the exact active revision-1 sequence-1 user Turn and creates exactly one ordinal-0
+   completed Message.
 7. Account Service fences only the selected account immediately before spawn.
-8. ProcessSupervisor can spawn only from a fresh ProcessGeneration outcome.
-9. RuntimeSession Thread Establishment fences, starts, binds, and activates the exact
-   thread.
-10. ProviderAttemptService prepares and authorizes the exact attempt.
+   ProcessSupervisor can spawn only from a fresh ProcessGeneration outcome. RuntimeSession
+   Thread Establishment and ProviderAttemptService retain their exact thread and effect
+   authority.
 
-There is no second selection, alternate account, fallback, wake, or account re-selection. Initial
-planning has no source RuntimeSession and no sticky member. Later Turns use only
-`conversation_continuation`; selected-account drift, exhaustion, or readiness failure returns typed
-manual recovery without invoking the selector.
+Any authority drift, kernel error, insert error, reference error, or completeness failure
+rolls back the complete initial route transaction. No snapshot, decision, reference,
+receipt, activity, or outbox subset can commit. PostgreSQL allocates generated route and
+prospective-Turn identities as transaction effects. Exact identity equality is required
+only when a committed exact receipt replays its stored response. If the transaction rolled
+back, no generated identity remains authoritative and a resumed operation may allocate
+replacement identities; runtime never has to reproduce an uncommitted random value.
+Different keys serialize on the Conversation and have one winner.
+
+There is no second initial selection on the same Conversation, alternate account, wake,
+or account re-selection. Initial planning has no source RuntimeSession and no sticky
+member. Later Turns use only `conversation_continuation`; selected-account drift,
+exhaustion, or readiness failure returns typed manual recovery without invoking the
+selector or switching accounts.
 
 ### Initial lineage
 
@@ -163,15 +202,53 @@ quota fields are null. ManagedRun `L6` retains the complete Project-policy repre
 constraints reject partial lineage, mixed shapes, wrong consumers, missing or duplicate members or
 slots, cross-links, and reordered facts.
 
-One Conversation lock permits one cross-key initial decision to be fresh. Exact-key replay is
-read-only. Initial planning accepts only selected `conversation_account_registry` `L0` and rolls
-back the complete first-session authority cluster on failure. Later planning accepts only the
-non-selecting binding and preserves the original account/profile identities.
+One Conversation lock permits one cross-key initial operation to be fresh. A committed
+exact-key replay is read-only and returns its stored identities and response bytes. Initial
+planning accepts only selected `conversation_account_registry` `L0` and rolls back the
+complete first-session authority cluster on failure. Later planning accepts only the
+non-selecting binding and preserves the original RuntimeSession, account, and profile
+lineage.
+
+### Routing recovery and readback
+
+`routing_pending` means no initial decision or downstream RuntimeSession, Turn, Message,
+plan, process, thread, or provider effect exists. `resume_routing` invokes the same
+Conversation's one initial route operation from its durable request coordinates. It does
+not create an attempt ordinal, attempt head, second snapshot, second decision, or routing
+Conversation successor.
+
+A committed `waiting` or `no_route` decision remains immutable. Explicit retry invokes a
+separate PostgreSQL Conversation-owner exact command with the expected source revision.
+Under one lock, that command requires no selected result or downstream authority, creates
+exactly one fresh revision-1 Conversation, records the exact one-to-one relation, archives
+the source, writes one receipt/activity/outbox result, and commits. This new Conversation
+is the **routing Conversation successor**. Same-key replay returns the committed stored
+response. A competing key returns the existing successor or a typed stale result and
+cannot create another.
+
+Routing Conversation successor creation and initial routing are separate owner commands.
+A crash between them leaves the successor open and `routing_pending`; restart may resume
+its one initial route.
+Routing never creates or archives a Conversation.
+
+Exact ordinary readback follows the one-to-one relation. Get-by-Conversation-ID for an
+archived source returns a typed `routing_successor` redirect containing its direct
+successor Conversation identity and revision, not an archived-source summary. Ordinary
+lists apply the archived-source filter before ordering, cursoring, and limiting: archived
+sources are absent, and each open routing Conversation successor appears exactly once.
+
+`establishment_pending` means one `selected` decision committed without a RuntimeSession
+or initial plan. `resume_establishment` consumes only that selected decision and may replay
+or complete initial planning; it cannot invoke selection. After `selected`, or once any
+RuntimeSession, Turn, Message, plan, process, thread, or provider effect exists, routing
+Conversation successor creation, route retry, wake, account re-selection, account switch,
+and any other automatic cross-account fallback are rejected.
 
 ### Initial admission
 
 Conversation authority creates the first Turn and history item in one one-winner
-transaction. Required Turn values are the prospective UUID, sequence 1, `user`,
+transaction. Required Turn values are the database-generated prospective UUID returned by
+the committed selected route, sequence 1, `user`,
 `possible_side_effects=unknown`, `active`, revision 1, and the exact Conversation/new
 RuntimeSession cross-link. The only first history item is ordinal 0, Message, `completed`,
 revision 1.
@@ -191,8 +268,8 @@ receipts.
 
 Only a fresh ProcessGeneration outcome can spawn. Replay, rejection, and uncertainty use
 durable ProcessGeneration, RuntimeSession, ProviderAttempt, and Conversation readback.
-They cannot spawn, replace, adopt, create a successor, duplicate an attempt, or
-terminalize the Turn.
+They cannot spawn, replace, adopt, create a routing Conversation successor, duplicate an
+attempt, or terminalize the Turn.
 
 Conversation authority can move the Turn to failed revision 2 under a starting session
 only after positive proof of definite pre-effect refusal. The proof excludes every process
@@ -204,6 +281,9 @@ locks the Turn named by the selected route and requires the same Conversation/so
 RuntimeSession, `failed`, revision 2. It has no protocol field, command, runtime grant,
 facade, fallback, or wake path.
 
+This failed-Turn Explicit successor is distinct from the routing Conversation successor
+used only after a committed initial `waiting` or `no_route` decision.
+
 ## RuntimeSession continuity
 
 For an existing ordinary Conversation session, same-thread reuse requires positive exact
@@ -214,9 +294,13 @@ For ManagedRun, same-thread reuse requires the accepted causal experiment and po
 exact-thread attestation bound to the source RuntimeSession.
 
 When accepted existing-session same-thread evidence is absent, stale, negative,
-incomplete, ambiguous, or cross-linked, Continuation Plan uses its atomic Context Pack
-path. It creates the Context Pack, account snapshot, starting fallback RuntimeSession,
-plan, activity, outbox, and exact receipt as one authority cluster.
+incomplete, ambiguous, or cross-linked, ordinary Quick Task Continuation Plan uses its
+atomic Context Pack path. It creates the Context Pack, account snapshot, new starting
+RuntimeSession, plan, activity, outbox, and exact receipt as one authority cluster while
+preserving the immutable source RuntimeSession and original account/profile lineage.
+
+XY-1304 disables automatic cross-account same-thread substitution and all-depleted wake.
+It does not disable this ordinary same-account Quick Task Context Pack path.
 
 Candidate-5 initial planning cannot enter either existing-session branch. Continuation
 Plan never writes ProviderAttempt state, and ProviderAttempt never writes RuntimeSession
@@ -247,10 +331,11 @@ receipt, or dispatch fence.
 The service uses the owner-only same-UID Unix transport. It has no TCP or loopback
 fallback. Remote and cross-UID authority remains separately gated.
 
-The coordinator method remains crate-private and accepts only crate-private owner
-capabilities. No protocol, CLI, scheduler, UI, credential owner, Codex adapter, or client
-can construct the sequence or mint dispatch authority. Product dispatch remains disabled
-until the Candidate-5 gate accepts the complete composition.
+The `routing_orchestration.rs` methods remain crate-private and accept only typed owner
+results. `quick_task.rs` consumes them without persisting routing. No protocol, CLI,
+scheduler, UI, credential owner, Codex adapter, or client can construct the sequence or
+mint dispatch authority. Product dispatch remains disabled until the Candidate-5 gate
+accepts the complete composition.
 
 ## Acceptance
 
@@ -260,23 +345,39 @@ After source freeze, validation must cover:
   daemon startup with zero DDL and no schema-owner credential;
 - exact current catalog/authority for all routing, continuation, Conversation,
   ProcessGeneration, ProviderAttempt, and read-only projection objects;
-- `conversation_account_registry` `L0`, `managed_run_project_policy` `L6`, and non-selecting
-  `conversation_continuation` `L6`, including reverse-shape and cross-link rejection;
+- exactly one `conversation_account_registry` `L0` snapshot and initial decision per
+  ordinary Conversation, retained `managed_run_project_policy` `L6`, and a distinct
+  non-selecting `conversation_continuation` `L6` binding, including reverse-shape and
+  cross-link rejection;
 - exact Account Registry missing/current/observation-error slots, fixed/balanced selection, and no
   Project-era fields in initial Quick Task;
 - ManagedRun policy-member/exclusion, capability, sticky, provenance/confidence, aging, mixed-cause,
   and pure-wait behavior without leaking those fields into Conversation routing;
-- sole first-session Quick Task selection, atomic first-session cluster and Turn/history admission,
-  exact effect fences, fresh/replay/reject/unknown behavior, and definite pre-effect refusal;
-- existing-session same-thread and atomic Context Pack paths bound to the original account/profile
-  without selector invocation;
+- one atomic Quick Task route transaction with rollback on authority, kernel, insert,
+  reference, or completeness failure; no orphan snapshot/decision; committed-receipt
+  identity replay without runtime replay of rolled-back generated IDs; and one-winner
+  different-key concurrency;
+- no-decision `routing_pending` restart and `resume_routing`; committed waiting/no-route
+  routing Conversation successor concurrency, typed archived-source redirect, list
+  filtering, and crash-before-route recovery; and selected-without-session
+  `establishment_pending`/`resume_establishment` without selection;
+- atomic first-session cluster and Turn/history admission, exact effect fences,
+  fresh/replay/reject/unknown behavior, and definite pre-effect refusal while preserving
+  the distinct failed-Turn Explicit successor evidence;
+- existing-session ordinary Quick Task same-thread and atomic Context Pack paths bound to
+  the original RuntimeSession/account/profile lineage without selector invocation;
 - positive-only process/attempt reconciliation, late evidence, smallest-scope isolation,
   and no replay after lost supervision;
 - ManagedRun and Reviewer authority isolation;
-- stateless coordinator layout and restart behavior;
+- module reverse scans and the deletion test: one substantive PostgreSQL
+  `quick_task_routing` owner, runtime `routing_orchestration.rs` sequencing, runtime
+  `quick_task.rs` lifecycle/effects, pure-core kernel only, and primitive-only
+  `exact_commands.rs`;
+- stateless runtime sequencing and restart behavior;
 - same-UID transport and complete read-only protocol projection; and
-- reverse scans proving no old barrier writer, second ledger, alternate selector,
-  unauthorized dispatch root, or schema upgrade machinery remains.
+- reverse scans proving no same-Conversation `RetryRouting`/`RetryQuickTaskRouting`, split
+  snapshot/decision command, route-attempt ledger, old barrier writer, second ledger,
+  alternate selector, or unauthorized dispatch root remains.
 
 No historical upgrade, populated cutover, schema-ledger, migration, or restore-digest
 proof is part of acceptance.
@@ -288,9 +389,15 @@ Stop and return to the authority owner if:
 - ordinary Conversation execution requires a ManagedRun;
 - ProviderAttempt must create or rewrite RuntimeSession state;
 - Continuation Plan must write ProviderAttempt state;
-- ExecutionCoordinator must persist authority;
+- runtime routing sequencing must persist authority;
+- the initial Quick Task snapshot and decision cannot share one transaction and receipt;
+- a committed initial decision requires same-Conversation re-selection;
+- selected-without-session recovery must invoke the selector;
+- ordinary Quick Task Context Pack planning cannot preserve the original
+  RuntimeSession/account/profile lineage;
 - the retired ManagedRun effect path requires a second live or compatibility writer;
 - mixed route causes must collapse into a pure wait;
 - lost supervision must authorize replay without positive evidence; or
-- Candidate-5 requires a second account selector, pre-admission Turn row, generic
-  recovery framework, or alternate dispatch owner.
+- Candidate-5 requires a route-attempt ledger, second account selector, pre-admission Turn
+  row, generic recovery or transaction framework, wrapper-only routing module, or
+  alternate dispatch owner.

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -559,60 +559,65 @@ side effects until tool/repository readback reconciles them.
 Status: Candidate 5 is approved target architecture. Implementation and integrated
 acceptance remain pending. Candidate-4 tree
 `f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance.
-This authority amendment changes no schema or product code, creates no migration, records no
-validation evidence, and does not claim live Quick Task success.
+This section is target authority. Integrated acceptance remains pending.
 
-Quick Task remains an ordinary multi-turn Conversation. Candidate 5 uses existing owners
-in this exact order. Its ordinary initial account selection is independent of Project and
-accepted Project routing policy. It requires no current Project routing-policy row, accepted
-Project policy, per-account `routing_compatibility_evidence`, or `quota_windows` projection. This
-selection occurs only while establishing the first RuntimeSession:
+Quick Task remains an ordinary multi-turn Conversation. Its ordinary initial account
+selection is independent of Project and accepted Project routing policy. It requires no
+current Project routing-policy row, accepted Project policy, per-account
+`routing_compatibility_evidence`, or `quota_windows` projection. One ordinary Conversation
+has exactly one immutable initial Account Registry snapshot and one immutable initial
+Routing Decision. Candidate 5 uses these owners in this exact order:
 
-1. Conversation authority creates the Conversation.
-2. Routing receives a prospective Turn UUID as intent. It creates no Turn, and no routing
-   column has a foreign key to `turns` for that intent.
-3. The Quick Task routing adapter starts one transaction, locks the Account Registry's complete
-   current authority, and materializes Routing Snapshot without a source RuntimeSession or sticky
-   member.
-4. The existing Routing Decision selects the account exactly once in that transaction and persists
-   the immutable decision.
-5. Continuation Plan consumes that selected decision and atomically creates the selected
-   account snapshot, copied RoleProfile snapshot, one revision-1 unfenced `starting`
-   RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and outbox.
-6. Conversation authority admits the exact prospective Turn and first history item in one
-   transaction.
-7. Every establishment fence locks and rechecks that Turn as active revision 1 under the
-   same Conversation and new RuntimeSession.
-8. Account Service fences only the selected account immediately before spawn.
-9. Only a fresh ProcessGeneration fence may spawn.
-10. RuntimeSession Thread Establishment owns thread request fencing, exact start binding,
-    activation, and acknowledgement.
-11. ProviderAttemptService owns preparation, authorization, ambiguity, positive evidence,
-    and reconciliation.
+1. PostgreSQL Conversation authority creates a revision-1 Conversation and retains its
+   durable initial request coordinates. With no committed decision, readback is
+   `routing_pending`.
+2. Runtime `routing_orchestration.rs` invokes the command-complete PostgreSQL
+   `quick_task_routing` owner with typed inputs and a protocol-scoped idempotency key, but
+   no generated identity.
+3. The routing owner locks the Conversation and complete Account Registry/profile
+   authority, materializes the complete `L0` snapshot, runs the bounded I/O-free
+   `decodex-core` kernel while those locks remain held, and atomically commits the snapshot,
+   one decision, references, exact receipt, activity, and outbox.
+4. Continuation Plan consumes a committed selected decision and atomically creates the
+   selected account snapshot, copied RoleProfile snapshot, one revision-1 unfenced
+   `starting` RuntimeSession, inert `initial_thread` plan, exact receipt, activity, and
+   outbox.
+5. Conversation authority admits the database-generated prospective Turn and first
+   history item in one transaction.
+6. Every establishment fence locks and rechecks that Turn as active revision 1 under the
+   same Conversation and new RuntimeSession. Account Service fences only the selected
+   account immediately before spawn. Only a fresh ProcessGeneration fence may spawn.
+   RuntimeSession Thread Establishment and ProviderAttemptService retain their exact thread
+   and effect authorities.
 
-There is exactly one selecting Routing Decision for an ordinary Quick Task. Initial planning
-creates the first session; it is not explicit successor, same-thread reuse, or Context Pack
-fallback. Every later Turn uses a non-selecting immutable continuation route binding to the
-current RuntimeSession and its original initial decision, selected account snapshot, and copied
-Task RoleProfile snapshot. Same-thread and Context Pack planning retain that exact account and
-profile. Later routing never calls `read_current_task_routing_authority_exact()`, resolves another
-Account Registry snapshot, or runs selection. Selected-account drift, exhaustion, or readiness
-failure returns typed manual recovery without fallback, wake, alternate account, or re-selection.
+There is exactly one initial selecting Routing Decision for an ordinary Conversation.
+Initial planning creates the first session; it is not the failed-Turn Explicit successor,
+same-thread reuse, or Context Pack planning. Every later Turn uses an immutable
+non-selecting `conversation_continuation` binding to the source RuntimeSession, original
+initial decision, selected account snapshot, and copied Task RoleProfile snapshot. It does
+not occupy the initial decision slot. Ordinary same-thread and Context Pack planning
+retain that exact RuntimeSession/account/profile lineage. Later routing never calls
+`read_current_task_routing_authority_exact()`, resolves another Account Registry snapshot,
+or runs selection. Selected-account drift, exhaustion, or readiness failure returns typed
+manual recovery without wake, alternate account, or re-selection. XY-1304 disables
+automatic cross-account same-thread substitution and all-depleted wake; it does not
+disable ordinary same-account Quick Task Context Pack planning.
 
 | Owner | Candidate-5 authority |
 | --- | --- |
+| PostgreSQL Conversation authority | Conversation creation; one-winner routing Conversation successor creation/archive/readback; atomic initial Turn/history admission; legal Turn finalization; and Conversation, Turn, history, redirect, and list readback. |
 | Account Registry | Complete non-tombstoned membership, canonical routing control and revision, account revisions, eligibility blockers, and current independent account-quota facts; no selection. |
-| Quick Task routing adapter | One transaction that materializes the only selecting Quick Task Routing Snapshot and Decision from locked Account Registry facts; later Turns receive non-selecting continuation bindings. |
+| `decodex-core` routing | Bounded I/O-free pure selection kernel over one database-produced complete snapshot; no persistence, provenance, completeness, locking, receipt, retry, or lifecycle authority. |
+| PostgreSQL `quick_task_routing` | One command-complete atomic initial route, exact response codecs/readback, and immutable non-selecting continuation binding; no independently committable snapshot or decision half-command. |
 | Project routing | Accepted Project policy and compatibility evidence for ManagedRun and other policy-bound `L6` work; no ordinary initial Quick Task authority. |
 | Account Service | Account operations and exact selected-account readiness/credential/provider/HostCredentialStore pre-spawn fence; no selection. |
-| Routing Decision | Sole Quick Task account selector for first-session establishment and immutable route/continuation-binding writer. |
-| Continuation Plan | Initial snapshots, first starting RuntimeSession, inert initial plan, and same-thread/Context Pack planning that retains the original account/profile binding. |
-| Conversation authority | Conversation creation, atomic initial Turn/history admission, legal Turn finalization, and exact Turn lock/read proof. |
+| Continuation Plan | Initial snapshots, first starting RuntimeSession, inert initial plan, and ordinary same-thread/Context Pack planning from committed routing authority; no routing persistence or selection. |
 | RuntimeSession Thread Establishment | RuntimeSession state/thread fields, exact thread fence and bind, and acknowledgement. |
 | ProcessSupervisor | ProcessGeneration intent, fresh spawn authority, exact readback, positive death evidence, and account-local quarantine. |
 | ProviderAttemptService | Attempt preparation, dispatch authorization, ambiguity, positive evidence, and reconciliation. |
-| ExecutionCoordinator | Crate-private stateless sequencing only. |
-| QuickTaskRuntime and ServiceApplication | Sequence and consume typed owner results only; no account, policy, profile, or capability selection. |
+| Runtime `routing_orchestration.rs` | Stateless routing Conversation successor-to-route, route-to-plan, `resume_establishment`, and continuation-bind-to-plan sequencing. |
+| Runtime `quick_task.rs` | Quick Task lifecycle plus process/thread/provider execution; no routing persistence. |
+| PostgreSQL `exact_commands.rs` | Shared exact receipt and error primitives only; no generic transaction or workflow framework. |
 
 Account Service can report and fence facts for the selected account. It cannot preselect,
 substitute, fall back to, or wake another account. Fixed mode accepts only its exact fixed
@@ -661,44 +666,42 @@ only `selected`, `waiting`, or `no_route`, plus exact exclusion reasons needed f
 selection accepts only the exact fixed eligible member. Balanced selection follows canonical
 Account Registry order and classifies the two slots independently without a merged quota pool.
 
-The existing decision relation also has a closed `conversation_continuation` decision shape. It is
-non-selecting, has `L6` source lineage, directly references the current RuntimeSession and original
-initial selected decision, and repeats only that decision's account snapshot and copied Task
-RoleProfile snapshot identities. Candidate, policy, quota, exclusion, waiting, and selection fields
-are null. Reverse constraints require exact identity/revision equality with the source lineage.
+The closed `conversation_continuation` binding shape is non-selecting, has `L6` source
+lineage, directly references the current RuntimeSession and original initial selected
+decision, and repeats only that decision's account snapshot and copied Task RoleProfile
+snapshot identities. Candidate, policy, quota, exclusion, waiting, and selection fields
+are null. Reverse constraints require exact identity/revision equality with the source
+lineage. The binding does not occupy or supersede the one initial decision slot.
 
-The supporting current owners obey these predicates:
+The target owners must obey these predicates:
 
-- The Quick Task routing adapter locks the canonical Account Registry routing row, complete
-  non-tombstoned membership, account revisions, blockers, current Task RoleProfile, and both quota
-  slots, then invokes snapshot resolution and route decision in one transaction. It does not call
-  `read_current_task_routing_authority_exact()` or create a Project-policy compatibility bridge.
-- `resolve_routing_snapshot_exact` accepts source RuntimeSession identity/revision only when both
-  are absent for Quick Task. It is used only for initial selection, consumes the locked Account
-  Registry facts, proves zero sticky members, and writes `conversation_account_registry` `L0`.
-- `route_account_exact` uses canonical Account Registry fixed or balanced control only for initial
-  selection and replays only its stored decision.
-- `bind_quick_task_continuation_exact` creates the immutable non-selecting continued decision from
-  the locked Conversation/source RuntimeSession and original initial decision. It never reads
-  current Project routing, resolves a snapshot, invokes the decision kernel, or changes
-  account/profile identity. Same-key replay returns the stored binding; a competing key for the
-  same prospective Turn creates no second binding.
+- The substantive PostgreSQL `quick_task_routing` owner exposes one command-complete
+  initial route. Snapshot materialization and decision persistence are private steps inside
+  its one transaction and cannot be called or committed separately.
+- The same owner creates each immutable non-selecting continuation binding from the locked
+  Conversation, source RuntimeSession, original initial decision, and selected
+  account/profile snapshots. It never reads current Account Registry or Project routing
+  authority, materializes a selecting snapshot, invokes the kernel, or changes lineage.
+  Same-key replay returns the stored binding; a competing key for one prospective Turn
+  creates no second binding.
 - `plan_initial_thread_continuation_exact` consumes only selected `L0` and creates the
   complete first-session authority cluster in one transaction.
-- Same-thread and Context Pack planning consume only `conversation_continuation`, retain the exact
-  original account and Task RoleProfile snapshots, and return typed manual recovery for selected
-  account drift, exhaustion, or readiness failure.
+- Ordinary same-thread and Context Pack planning consume only
+  `conversation_continuation`, retain the exact original RuntimeSession, account, and Task
+  RoleProfile lineage, and return typed manual recovery for selected-account drift,
+  exhaustion, or readiness failure.
 - Routing codecs/readbacks preserve the closed snapshot and decision discriminators. Decision
   completeness enforces selecting classification/exclusions or continued lineage, never both.
 
 #### Initial selection concurrency
 
-Initial selection is one top-level `READ COMMITTED` exact command. A completed same-key replay
-returns its stored response without domain work. A fresh execution takes authority locks in this
-order: the Conversation intent first; the
-`account_routing_control` singleton; every complete non-tombstoned account row in canonical UUID
-order; and the current Task RoleProfile row. It then reads and copies `account_routing_order` and
-both duration slots from `account_quota_facts` while retaining those locks through commit.
+Initial selection is one top-level `READ COMMITTED` exact command with one exact receipt.
+A completed same-key replay returns its stored response without domain work. A fresh
+execution takes authority locks in this order: the Conversation first;
+`account_routing_control`; every complete non-tombstoned account row in canonical UUID
+order; the current Task RoleProfile row; complete `account_routing_order`; and applicable
+`account_quota_facts` rows in canonical account/duration order. It retains all locks
+through commit.
 
 Every enrollment, tombstone, order, fixed-target, or mode operation that can change membership or
 routing locks `account_routing_control` before the affected or complete account set in the same
@@ -707,19 +710,65 @@ updates the quota row and never takes `account_routing_control` afterward. There
 account locks also serialize an insert for an absent quota slot, and no routing/quota lock cycle is
 possible.
 
-Before commit, the command compares the locked routing revision/control/order, Task RoleProfile
-revision, account membership/revisions/blockers, and both exact quota tri-states with the copied
-snapshot. Any stale expected revision or mismatch rolls back the snapshot, decision, receipt,
-activity, and outbox and returns the typed conflict/refusal. Same-key concurrency waits for and
-replays the completed exact response without another snapshot or selection. Cross-key initial
-commands serialize on the Conversation lock: one may be fresh; every loser returns the persisted
-initial decision conflict/readback and creates no routing rows.
+While the locks remain held, the owner materializes the complete snapshot and runs the
+bounded I/O-free pure Rust kernel. It then persists and validates the snapshot, one initial
+decision, every reference, activity, and outbox and completes the receipt. Any stale
+authority, kernel error, insert error, reference error, or completeness error rolls back
+every effect. A snapshot or decision can never commit alone. Same-key concurrency waits
+for and replays a committed exact response without another snapshot or selection.
+Cross-key initial commands serialize on the Conversation lock: one may be fresh; every
+loser returns the existing decision or typed conflict and creates no routing rows.
+
+PostgreSQL allocates generated snapshot, decision, reference, and prospective-Turn
+identities as command effects. Exact identity equality is a committed-receipt replay
+property. If the transaction rolled back, no generated identity remains authoritative and
+a resumed operation may allocate replacements. Runtime supplies no generated identity and
+never has to replay a vanished random value. After ambiguous commit acknowledgement, the
+same command key either replays the committed stored response or finds no receipt and runs
+the same one-slot operation.
+
+#### Typed routing recovery and readback
+
+`routing_pending` is the typed readback for an open ordinary Conversation with no
+committed initial decision and no RuntimeSession, Turn, Message, plan, process, thread, or
+provider effect. `resume_routing` invokes that Conversation's same initial route operation
+from its durable request coordinates. It allocates no attempt ordinal/head and cannot
+create a second snapshot, second decision, or routing Conversation successor.
+
+A committed `waiting` or `no_route` result is immutable. Explicit retry invokes one
+narrow PostgreSQL Conversation-owner exact command. The command locks the expected source
+revision and requires no selected result, RuntimeSession, Turn, Message, plan, process,
+thread, or provider effect. In one transaction it creates exactly one fresh revision-1
+Conversation, records an exact one-to-one source/successor relation, archives the source,
+and completes one exact receipt, activity, and outbox result. This fresh Conversation is
+the **routing Conversation successor**.
+Same-key replay returns the committed stored response. A competing key returns the
+existing successor or a typed stale result and cannot create another.
+
+Routing Conversation successor creation and initial routing are separate owner commands.
+Runtime `routing_orchestration.rs` may stop between them; the successor remains open and
+`routing_pending`, and its one initial route may resume after restart. Routing owns
+neither Conversation creation nor archive.
+
+Ordinary readback is exact. Get-by-Conversation-ID for an archived source returns a typed
+`routing_successor` redirect containing the direct successor Conversation identity and
+revision, not an archived-source summary. Ordinary list queries exclude archived sources
+before ordering, keyset cursoring, and limiting, and include every open routing
+Conversation successor exactly once.
+
+`establishment_pending` is the typed readback for a committed `selected` decision with no
+RuntimeSession and no initial plan. `resume_establishment` consumes only that selected
+decision and may complete or replay the atomic initial-plan command. It cannot read current
+routing authority, materialize a snapshot, or invoke selection. After `selected`, or once
+any RuntimeSession, Turn, Message, plan, process, thread, or provider effect exists,
+routing Conversation successor creation, route retry, wake, account re-selection, account
+switch, and any other automatic cross-account fallback are rejected.
 
 #### Atomic initial admission
 
 Conversation authority admits exactly one Turn with:
 
-- the prospective UUID bound by the selected route;
+- the database-generated prospective UUID returned by the committed selected route;
 - sequence 1 and role `user`;
 - `possible_side_effects=unknown`;
 - status `active` and revision 1; and
@@ -748,9 +797,9 @@ terminalization race loses before effect execution.
 
 ProcessGeneration has four typed outcomes: `Fresh`, `Replayed`, `Rejected`, and
 `Unknown`. Only `Fresh` returns non-clone spawn authority. All other outcomes use durable
-readback or refusal and cannot spawn, replace, adopt, create a successor, duplicate an
-attempt, or terminalize the Turn. The same rule applies after result loss at every thread
-and ProviderAttempt fence.
+readback or refusal and cannot spawn, replace, adopt, create a routing Conversation
+successor, duplicate an attempt, or terminalize the Turn. The same rule applies after
+result loss at every thread and ProviderAttempt fence.
 
 Conversation authority may transition the exact Turn to `failed` revision 2 under the
 starting RuntimeSession only when positive readback proves definite pre-effect refusal.
@@ -763,14 +812,17 @@ field, product command, runtime execution grant, facade, fallback, or wake path.
 any write, it locks the Turn named by the route and requires the same Conversation/source
 RuntimeSession, status `failed`, and revision 2.
 
+This failed-Turn Explicit successor is distinct from the pre-establishment routing
+Conversation successor.
+
 #### Final trigger functions
 
 The latest schema creates these eight final trigger-function bodies and bindings directly:
 
 | Trigger function | Exact Candidate-5 predicate |
 | --- | --- |
-| `decodex.enforce_routing_completeness()` | Enforce the two selecting snapshot authority shapes, exact Account Registry quota tri-states, reverse nullability, and retained ManagedRun Project-policy `L6` behavior. |
-| `decodex.enforce_routing_decision_completeness()` | Require either one initial/ManagedRun selection classification with exact replay exclusions or one non-selecting Conversation continuation binding to the source RuntimeSession and original initial decision; reject mixed fields. |
+| `decodex.enforce_routing_completeness()` | Enforce the two selecting snapshot authority shapes, one initial Account Registry snapshot per Conversation, exact quota tri-states, reverse nullability, and retained ManagedRun Project-policy `L6` behavior. |
+| `decodex.enforce_routing_decision_completeness()` | Require exactly one immutable initial Conversation classification with exact replay exclusions, preserve ManagedRun selection, and keep the non-selecting Conversation continuation binding outside the initial decision slot; reject mixed fields. |
 | `decodex.enforce_runtime_session_state()` | Preserve revision-one insert, identity, timestamps, terminal immutability, legal terminal edges, and ended-session active-Turn rules. Permit only: unfenced `starting` to request-fenced `starting` by setting the complete request ID/digest pair; that exact row to `active` by preserving the request, matching response ID, and setting exact response digest/thread ID; and `active` to `active` only for exact last-Turn acknowledgement. Reject generic `starting` to `active`, partial receipts, combined edges, or unrelated drift. |
 | `decodex.enforce_turn_state()` | Preserve active-session behavior. Under `starting`, permit only exact first-Turn insertion and active-revision-1 to failed-revision-2 after positive definite pre-effect refusal. Reject every other starting-session write. |
 | `decodex.enforce_history_item_state()` | Preserve active-session behavior. Under `starting`, permit only the admission transaction's ordinal-0 completed Message for the exact first Turn; reject update, second item, other ordinal/kind/status, wrong Turn, or cross-link. |
@@ -786,10 +838,24 @@ No other trigger function changes. Trigger bindings and ACLs remain closed. Ever
 unrelated write keeps existing active-only semantics. The narrow first-session permissions
 are not a generic starting-session bypass.
 
-Candidate 5 adds no module, fixed hierarchy, schema phase, ledger, generic transaction or
-recovery framework, transport/idempotency mechanism, wrapper, runner, scheduler, general selector,
-capability manager, compatibility bridge, duplicate Quick Task policy path, or explicit-successor
-product surface. It must preserve current-main independent account observations, Reset
+Candidate 5 requires substantive owner modules. Deleting PostgreSQL
+`quick_task_routing` must spread its atomic transaction, response codecs/readback, and
+continuation-binding invariants into callers. Deleting runtime
+`routing_orchestration.rs` must spread its recovery owner-order sequencing into
+`quick_task.rs` or other callers. A file whose deletion requires only forwarding changes
+is prohibited. Runtime `quick_task.rs` retains Quick Task lifecycle plus
+process/thread/provider execution and owns no routing persistence. `decodex-core` retains
+only the bounded I/O-free routing kernel. `exact_commands.rs` retains receipt/error
+primitives and cannot become a generic transaction or workflow framework.
+
+`RetryRouting` and `RetryQuickTaskRouting` are not accepted same-Conversation APIs. The
+typed operations are `resume_routing` only when no initial decision exists,
+`resume_establishment` only after selection and before RuntimeSession/plan creation, and
+the Conversation-owned routing Conversation successor command only for committed
+`waiting` or `no_route`. These rules do not change the failed-Turn Explicit successor
+evidence.
+
+Candidate 5 must preserve current-main independent account observations, Reset
 Card-before-profile ordering within an account, concurrent progress across accounts,
 revision-fenced cache publication, and query paths that do not join or start refresh work.
 
@@ -955,17 +1021,20 @@ alternate-control RPCs before enablement. XY-1400 does not add that gateway.
 
 PostgreSQL owns revisioned complete Routing Snapshots and immutable Routing Decisions. A selecting
 Routing Decision remains the sole account selector; a continued decision binds lineage and cannot
-select. A routing request supplies identity and idempotency inputs only. Runtime, protocol clients,
+select. An initial Quick Task routing request supplies the durable Conversation coordinates,
+typed operation inputs, and idempotency key only; PostgreSQL supplies every generated identity.
+Runtime, protocol clients,
 tests, `QuickTaskRuntime`, and
 `ServiceApplication` cannot supply or override candidate membership, routing control, sticky
 identity, eligibility facts, exclusions, or a preclassified candidate array.
 
-Ordinary initial Quick Task routing uses Account Registry authority directly. The Quick Task
-routing adapter is the only transaction owner that may materialize its `L0` Routing Snapshot and
-selecting Routing Decision from locked current facts. No later Quick Task Turn enters that path.
-The adapter does not require or consult Project routing policy, accepted Project policy,
-`routing_compatibility_evidence`, or `quota_windows`. It creates no compatibility bridge or
-duplicate policy synchronization authority.
+Ordinary initial Quick Task routing uses Account Registry authority directly. PostgreSQL
+`quick_task_routing` is the only transaction owner that may materialize its `L0` Routing
+Snapshot and selecting Routing Decision from locked current facts. It must commit the
+snapshot, decision, references, exact receipt, activity, and outbox together after running
+the bounded I/O-free core kernel while all authority locks remain held. No later Quick
+Task Turn enters that path. The owner does not require or consult Project routing policy,
+accepted Project policy, `routing_compatibility_evidence`, or `quota_windows`.
 
 An initial `L0` snapshot binds, under one Account Registry revision boundary:
 
@@ -1014,11 +1083,11 @@ member retains `excluded_by_policy` and its other persisted blockers, and every 
 retains its exact blockers. An all-excluded universe is an explicit cause-complete `no_route`; a
 cause-free `no_route` is invalid.
 
-`decodex-core` is a pure deterministic selection kernel over a database-produced selecting
-snapshot. It does not establish provenance or completeness and is never invoked for a continued
-decision. PostgreSQL atomically persists only the resulting classification and exact normalized
-exclusions required for replay. Runtime consumes one exact persisted decision and sequences effects
-only; it cannot substitute a decision. Codex is a
+`decodex-core` is a bounded I/O-free pure selection kernel over a database-produced
+selecting snapshot. It does not establish provenance or completeness and is never invoked
+for a continued decision. PostgreSQL atomically persists the snapshot and resulting
+classification with exact normalized exclusions required for replay. Runtime consumes one
+exact persisted decision and sequences effects only; it cannot substitute a decision. Codex is a
 positive-evidence capability adapter and cannot determine membership, policy, or eligibility.
 One app-server process remains bound to one account, credentials never switch in a live process,
 and the separate 300-minute and 10080-minute quota facts for separate accounts are never merged.
@@ -1033,10 +1102,12 @@ facts block eligibility.
 For initial Quick Task `L0`, fixed mode accepts only the exact fixed eligible member. Balanced mode
 uses canonical Account Registry order. Each 300-minute and 10080-minute quota fact is classified
 independently from its exact missing, current, or observation-error source shape; neither windows
-nor accounts form a merged pool. The persisted result is `selected`, `waiting`, or `no_route`.
-`waiting` is manual-retry state in this slice and registers no wake. There is no fallback,
-scheduler wake, or re-selection. Policy-bound routing may use only its separately accepted wait
-authority; routing itself owns no wake lifecycle.
+nor accounts form a merged pool. The persisted result is `selected`, `waiting`, or
+`no_route`. `waiting` and `no_route` register no wake or same-Conversation re-selection.
+Explicit retry uses the separate Conversation-owned routing Conversation successor
+command.
+Policy-bound routing may use only its separately accepted wait authority; routing itself
+owns no wake lifecycle.
 
 Account-owned readiness is evaluated only for Project-policy `L6` capabilities explicitly required
 by the accepted routing Policy revision. Unknown never satisfies a required capability. If the
@@ -1046,22 +1117,25 @@ XY-1336 remains future passive-receipt tracking. Host-owned before/after receipt
 no-mutation integrity only and cannot establish account-owned readiness. These capability rules do
 not add `routing_compatibility_evidence` to initial Quick Task eligibility.
 
-For a later Quick Task Turn, Routing Authority locks the current RuntimeSession and traces its
-immutable lineage to the original `conversation_account_registry` selected decision. It writes
-only a `conversation_continuation` decision binding for the prospective Turn. Same-thread and
-Context Pack planning consume that binding and retain the exact account and copied Task RoleProfile
-snapshots. A selected-account quota, lifecycle, health, credential, or readiness failure returns
-typed manual recovery. It cannot call current Project routing, resolve a candidate snapshot, invoke
-the selection kernel, fall back, wake, or re-select.
+For a later Quick Task Turn, PostgreSQL `quick_task_routing` locks the current
+RuntimeSession and traces its immutable lineage to the original
+`conversation_account_registry` selected decision. It writes only a
+`conversation_continuation` binding for the prospective Turn. Ordinary same-thread and
+Context Pack planning consume that binding and retain the exact original RuntimeSession,
+account, and copied Task RoleProfile lineage. A selected-account quota, lifecycle, health,
+credential, or readiness failure returns typed manual recovery. It cannot call current
+Project routing, resolve a candidate snapshot, invoke the selection kernel, wake, switch
+accounts, or re-select.
 
 Experiment Authority owns the original causal experiment record. Retained-title Authority owns its
 two-effect title bridge. After an exact non-selecting continuation binding with an existing source
-RuntimeSession, Continuation Plan owns same-thread continuation when exact positive selected-account
-and retained-profile evidence permits it. Otherwise, it owns one atomic Context Pack plus fallback
-RuntimeSession on that same account and profile. These owners
-serve ordinary Conversation Turns and ManagedRun executions. The stateless ExecutionCoordinator
-sequences one Routing Decision, one Continuation Plan, one live ProcessGeneration fence, and
-ProviderAttempt preparation. Current production
+RuntimeSession, Continuation Plan owns same-thread continuation when exact positive
+selected-account and retained-profile evidence permits it. Otherwise, ordinary Quick Task
+Continuation Plan owns one atomic Context Pack plus a new RuntimeSession on that same
+account and profile while preserving source lineage. These owners serve ordinary
+Conversation Turns and ManagedRun executions. Stateless runtime
+`routing_orchestration.rs` sequences routing and planning owners; runtime `quick_task.rs`
+owns subsequent lifecycle/process/thread/provider execution. Current production
 dispatch stays structurally disabled until its applicable slice gate passes. Ambiguous-turn
 replay remains blocked by ProviderAttempt. ManagedRun
 consumes the attempt result and keeps only domain lifecycle authority.
@@ -1070,15 +1144,16 @@ owns or weakens those boundaries.
 
 Those paragraphs define retained final routing authority, not current implementation.
 Slice 1 enables only initial Quick Task selection after the Slice-1 subset of
-MacDogfoodReady passes. Recovery is an explicit versioned enable/disable, mode, or order
-command followed by a new task. It does not rebind or replay a thread.
+MacDogfoodReady passes. Account recovery may use the accepted enable/disable, mode, or
+order commands. A committed initial `waiting` or `no_route` retry creates a routing
+Conversation successor; it does not rebind or replay a thread.
 
 [XY-1304](https://linear.app/hack-ink/issue/XY-1304) is the later acceptance owner for
-automatic cross-account same-thread fallback and all-depleted scheduler wake. Until its
-separate reviewed enablement amendment, those paths and automatic Context-Pack fallback
-remain hard disabled. It does not block Quick Task, Project/Lead, ManagedRun, GPUI, or
-first Mac dogfood. Replay after an ambiguous outcome remains prohibited independent of
-XY-1304 and is reconciled by ProviderAttempt.
+automatic cross-account same-thread fallback and all-depleted scheduler wake. Those two
+paths remain disabled. XY-1304 does not remove ordinary same-account Quick Task Context
+Pack planning through the immutable non-selecting continuation binding. It does not block
+Quick Task, Project/Lead, ManagedRun, GPUI, or first Mac dogfood. Replay after an ambiguous
+outcome remains prohibited independent of XY-1304 and is reconciled by ProviderAttempt.
 
 Missing or observation-error quota slots and unknown, stale, auth-failed, or disabled Account
 Registry blockers never imply initial Quick Task eligibility. Capability-unready, incompatible,

--- a/openwiki/specs/vnext-gates.md
+++ b/openwiki/specs/vnext-gates.md
@@ -249,55 +249,87 @@ old/new adapter compatibility matrix.
 Candidate 5 remains target architecture. Candidate-4 tree
 `f82b866e21f12742648023a2b468cc057afa52a1` is rejected provenance and cannot supply
 implementation evidence.
-This documentation amendment is not schema, code, migration, validation, or live-success evidence.
+This documentation amendment is target authority only; it is not validation or live-success
+evidence.
 
-The integrated gate covers seven bounded behavior groups. They are test responsibilities,
-not schema phases or separate authority frameworks.
+These focused falsifiers belong inside the existing sole canonical product-native gate,
+`cargo make test-vnext-latest-schema`. No second aggregate is permitted. The integrated
+gate covers eleven bounded behavior groups; failure in any group rejects Candidate-5
+acceptance.
 
-1. **First and later Turn authority.** On a fresh latest-schema local database, establish six ready
-   non-tombstoned accounts, canonical Account Registry routing, and the separately bootstrapped
-   RoleProfiles. Prove the first RuntimeSession is selected and created with no Project, accepted
-   Project policy, `routing_compatibility_evidence`, or `quota_windows` seed. On later Turns, prove
-   `read_current_task_routing_authority_exact()` and `resolve_routing_snapshot_exact` are never
-   called. The immutable
-   non-selecting continuation decision must reference the current RuntimeSession, original initial
-   decision, selected account, and copied Task RoleProfile. Same-thread and Context Pack retain
-   those identities. Drift, exhaustion, or readiness failure returns typed manual recovery with no
-   fallback, wake, or re-selection. ManagedRun still requires its complete Project-policy `L6`.
-2. **Closed persistence and quota replay.** Prove `conversation_account_registry` initial `L0` and
-   `managed_run_project_policy` `L6` are the only selecting snapshot shapes, and reverse constraints
-   reject mixed consumers, fields, children, or evidence. For every Account Registry member, prove
-   exactly one 300-minute and one 10080-minute slot and exact replay of: missing with all
-   observation fields null; current with `used_percent`/`observed_at`/`resets_at` and no error; and
-   observation error with typed `error_code`/`observed_at` and no usage/reset. Reject fabricated
-   revision, remaining, confidence, provenance, or legacy quota values. Exercise fixed exact-target
-   and balanced canonical-order selection with independent missing/current/error and 5-hour/7-day
-   exhaustion. Replay only `selected`/`waiting`/`no_route` and exact exclusion reasons.
-3. **Selection concurrency.** Prove one top-level `READ COMMITTED` exact command locks Conversation
-   intent, routing control, canonical-UUID account rows, and current Task RoleProfile before it
-   copies order and quota facts. Race it against enrollment, tombstone, order, fixed/mode, account
-   observation, and quota writes. Prove routing writers take control before account rows, quota
-   writers take account before quota and never control afterward, and an absent quota insertion
-   waits on the account fence. Verify stale pre-commit facts roll back every effect. Same-key
-   contenders replay one exact result; cross-key contenders produce one fresh selection and no
-   duplicate snapshot/decision. For a later Turn, same-key contenders replay one continued binding
-   and cross-key contenders create neither a second binding nor any selection work.
-4. **Role, admission, and effect fences.** Prove typed configuration bootstraps all four
-   RoleProfiles atomically, later updates remain in RoleProfile Authority, and missing current
-   `task` returns `QuickTaskUnavailable` without synthesized defaults. Prove initial
-   account/profile/session/plan and first Turn/Message atomicity. At every selected-account,
-   ProcessGeneration, thread, and ProviderAttempt fence, prove drift or lost-result/restart state
-   cannot re-select, spawn from non-fresh authority, duplicate an attempt, or fail the Turn. Only
-   positive definite pre-effect refusal may create failed revision 2; explicit successor remains
-   PostgreSQL-only non-dispatch evidence.
-5. **Conversation and stream order.** Preserve result-before-stream order, one actor owner,
+1. **Atomic initial routing.** On a fresh latest-schema database, establish six ready
+   non-tombstoned accounts, canonical Account Registry routing, and separately bootstrapped
+   RoleProfiles. Prove one top-level `READ COMMITTED` PostgreSQL `quick_task_routing`
+   command and one exact receipt lock the Conversation, Account Routing Control, complete
+   accounts in UUID order, current Task RoleProfile, complete routing order, and exact
+   quota facts. While all locks remain held, the command must materialize the complete
+   snapshot, run the bounded I/O-free pure Rust kernel, persist and validate one snapshot,
+   one decision, references, activity, and outbox, complete the receipt, and commit.
+2. **Rollback and closed persistence.** Inject authority drift, kernel failure, each
+   snapshot/decision/reference/activity/outbox write failure, and receipt or deferred
+   completeness failure. Every case must roll back all route effects. Prove exactly one
+   `conversation_account_registry` initial `L0` snapshot and decision per ordinary
+   Conversation, retained `managed_run_project_policy` `L6`, and rejection of mixed
+   consumers, fields, children, or evidence. Preserve exact missing/current/
+   observation-error 300-minute and 10080-minute slots without fabricated facts.
+3. **Identity replay and concurrency.** Prove runtime supplies no generated identity.
+   PostgreSQL-generated identities become exact only through a committed receipt replay;
+   rollback leaves no identity that runtime must reproduce, and a resumed operation may
+   allocate replacements. An ambiguous commit with the same key must either replay the
+   committed stored identities/bytes or run the one-slot operation after rollback. Race
+   enrollment, tombstone, order, fixed/mode, account-observation, and quota writers against
+   routing; prove the lock order, absent-quota insertion fence, same-key exact replay, and
+   one-winner different-key behavior with no partial or duplicate route authority.
+4. **No-decision recovery.** Crash before route commit. Readback must project
+   `routing_pending`; `resume_routing` must use the same Conversation and durable request
+   coordinates and may commit only its one initial snapshot and decision. Reject an attempt
+   ordinal/head, second decision, routing Conversation successor, or independently
+   committable route half.
+5. **Waiting/no-route routing Conversation successor and reads.** For committed `waiting` and
+   `no_route`, prove the separate PostgreSQL Conversation command locks the expected source
+   revision, requires no selected result or downstream RuntimeSession/Turn/Message/plan/
+   process/thread/provider effect, creates exactly one fresh routing Conversation
+   successor and one-to-one relation, archives the source, and commits one
+   receipt/activity/outbox result. Prove same-key stored replay and one-winner different-key
+   behavior. Crash before the separate routing command must leave the open successor
+   `routing_pending`. Get by archived source must return the typed `routing_successor`
+   redirect to the direct successor; ordinary lists must omit archived sources and include
+   every open successor exactly once.
+6. **Selected establishment and continuation.** A selected decision without a
+   RuntimeSession or initial plan must project `establishment_pending`.
+   `resume_establishment` may complete or replay only initial planning and must not invoke
+   selection. Later-Turn `conversation_continuation` binding must be owned by PostgreSQL
+   `quick_task_routing` and preserve the original decision, RuntimeSession, selected
+   account, and copied Task RoleProfile. Prove ordinary same-thread and Context Pack
+   planning both consume that binding without selection or account switch. XY-1304 must
+   disable only automatic cross-account same-thread substitution and all-depleted wake.
+7. **Role, admission, effect, and successor fences.** Prove RoleProfile ownership,
+   atomic initial account/profile/session/plan creation, and atomic first Turn/Message
+   admission. After `selected`, or after any RuntimeSession, Turn, Message, plan, process,
+   thread, or provider effect exists, reject routing Conversation successor creation,
+   `RetryRouting`, `RetryQuickTaskRouting`, route re-selection, wake, account switch, and
+   every other automatic cross-account fallback.
+   At every Account Service, ProcessGeneration, thread, and ProviderAttempt fence, prove
+   drift or lost-result/restart state cannot reselect, spawn from non-fresh authority,
+   duplicate an attempt, or fail the Turn. Preserve the distinct PostgreSQL-only failed-Turn
+   Explicit successor as non-dispatch evidence.
+8. **Module ownership.** Reverse-scan production source and apply the deletion test for one
+   bounded I/O-free `decodex-core` kernel, one substantive PostgreSQL
+   `quick_task_routing` owner, PostgreSQL Conversation owner for routing Conversation
+   successor/archive/readback,
+   stateless runtime `routing_orchestration.rs`, lifecycle/effect-only runtime
+   `quick_task.rs`, and primitive-only `exact_commands.rs`. Reject wrapper-only routing
+   files, split snapshot/decision commands, continuation persistence in Conversation or
+   runtime Quick Task owners, generic transaction/workflow machinery, duplicate selectors,
+   and active `RetryRouting`/`RetryQuickTaskRouting` APIs.
+9. **Conversation and stream order.** Preserve result-before-stream order, one actor owner,
    bounded deferred publication, one command/registration slot, explicit publication
    source, non-reserving per-session acceptance, and no cross-session starvation.
-6. **Transport completion.** Preserve duplicate/conflict command order, disconnect and
+10. **Transport completion.** Preserve duplicate/conflict command order, disconnect and
    reconnect, snapshot/cursor order, receiver-close outcomes, terminal result retention,
    one-shot peer-close finalization, task wake, and leak-free accounting. A local write or
    close does not prove peer receipt.
-7. **Service shutdown.** Preserve `Accepting -> DrainingApplication -> DrainingEgress ->
+11. **Service shutdown.** Preserve `Accepting -> DrainingApplication -> DrainingEgress ->
    Closed`, one absolute deadline, admitted command completion, complete ordinal/transport
    reconciliation, exact session admission bounds including handshakes, zero surviving
    work, and cleanup only after closed accounting.
@@ -323,7 +355,10 @@ Candidate-5 acceptance must preserve current-main account behavior: deterministi
 one-word aliases, negative Reset Card counts as empty inventory, independent concurrent
 per-account observations, Reset Card-before-profile ordering within an account,
 coalesced successor rounds, revision-fenced publication, and query paths that read cache
-or persisted projection without joining or starting provider refresh work.
+or persisted projection without joining or starting provider refresh work. It must also
+prove semantic-only public cache-generation advancement, same-generation heartbeat retry
+handling, panel-open single-flight priority observation coalescing without waiting for
+provider work, and the manual `Refresh all` full-read action.
 
 ## Domain-owner gates
 


### PR DESCRIPTION
## Scope

Defines the materially different Quick Task routing recovery boundary required after the third rejected implementation candidate.

- one immutable initial Account Registry snapshot and decision per Conversation
- one atomic PostgreSQL `quick_task_routing` owner
- separate waiting/no-route routing Conversation successor and failed-Turn Explicit successor
- exact `routing_pending` and `establishment_pending` recovery
- preserved ordinary Quick Task Context Pack lineage and current-main account-observation behavior
- explicit module deletion tests and one existing product-native gate

## Exact checkpoint

- base: `fa8579bcf6c19e31100026b080510f1344b82ebc`
- signed head: `36991ac22b6f285fd78ae0020a71abe44be90bd8`
- tree: `9d10333aff071efdea60f4ff117cb1202b918a9c`
- reviewed pre-commit object: `87c98b6dc1177920bee3f09631f87f4172c1b89f`
- binary diff SHA-256: `61bee1aee75a78844a3d5ba6de3ad568f516f9ac0a20256b6ed56c8f354d6240`

Fresh independent exact-tree review: `APPROVED/READY`, no P0/P1/P2. `git diff --check` passed. Documentation only; product tests were intentionally not run.

Linear: XY-1276.