### PR TITLE
Repair current repository gate for upstream compatibility

### DIFF
--- a/crates/decodex-codex/src/account_api.rs
+++ b/crates/decodex-codex/src/account_api.rs
@@ -425,7 +425,7 @@ fn decode_snake_case_quota_windows(
 ) -> Result<[AccountApiQuotaWindow; 2], AccountApiProtocolError> {
 	let mut windows = optional_quota_windows();
 	for key in ["primary_window", "secondary_window"] {
-		let Some(value) = object.get(key).filter(|value| value.is_null() == false) else {
+		let Some(value) = object.get(key).filter(|value| !value.is_null()) else {
 			continue;
 		};
 		let duration_minutes = reported_duration_minutes(value, "limit_window_seconds", 60)?;
@@ -442,7 +442,7 @@ fn decode_camel_case_quota_windows(
 ) -> Result<[AccountApiQuotaWindow; 2], AccountApiProtocolError> {
 	let mut windows = optional_quota_windows();
 	for key in ["primary", "secondary"] {
-		let Some(value) = object.get(key).filter(|value| value.is_null() == false) else {
+		let Some(value) = object.get(key).filter(|value| !value.is_null()) else {
 			continue;
 		};
 		let duration_minutes = reported_duration_minutes(value, "windowDurationMins", 1)?;
@@ -484,17 +484,14 @@ fn optional_quota_windows() -> [AccountApiQuotaWindow; 2] {
 }
 
 fn optional_quota_window(expected_duration: u32) -> AccountApiQuotaWindow {
-	AccountApiQuotaWindow {
-		duration_minutes: expected_duration,
-		result: Ok(None),
-	}
+	AccountApiQuotaWindow { duration_minutes: expected_duration, result: Ok(None) }
 }
 
 fn decode_snake_case_quota_window(
 	value: Option<&Value>,
 	expected_duration: u32,
 ) -> AccountApiQuotaWindow {
-	let Some(value) = value.filter(|value| value.is_null() == false) else {
+	let Some(value) = value.filter(|value| !value.is_null()) else {
 		return optional_quota_window(expected_duration);
 	};
 	if value.as_object().is_some_and(|object| {
@@ -532,7 +529,7 @@ fn decode_camel_case_quota_window(
 	value: Option<&Value>,
 	expected_duration: u32,
 ) -> AccountApiQuotaWindow {
-	let Some(value) = value.filter(|value| value.is_null() == false) else {
+	let Some(value) = value.filter(|value| !value.is_null()) else {
 		return optional_quota_window(expected_duration);
 	};
 	let result = (|| {
@@ -880,10 +877,7 @@ mod tests {
 		.to_string();
 		let usage = decode_account_api_usage(body.as_bytes()).expect("usage should decode");
 		assert_eq!(usage.quota_windows[0].result, Ok(None));
-		assert_eq!(
-			usage.quota_windows[1].result.unwrap().unwrap().used_percent,
-			42
-		);
+		assert_eq!(usage.quota_windows[1].result.unwrap().unwrap().used_percent, 42);
 	}
 
 	#[test]
@@ -902,10 +896,7 @@ mod tests {
 		.to_string();
 		let usage = decode_account_api_usage(body.as_bytes()).expect("usage should decode");
 		assert_eq!(usage.quota_windows[0].result, Ok(None));
-		assert_eq!(
-			usage.quota_windows[1].result.unwrap().unwrap().duration_minutes,
-			10_080
-		);
+		assert_eq!(usage.quota_windows[1].result.unwrap().unwrap().duration_minutes, 10_080);
 	}
 
 	#[test]

--- a/crates/decodex-postgres/src/account_lifecycle.rs
+++ b/crates/decodex-postgres/src/account_lifecycle.rs
@@ -1851,8 +1851,9 @@ fn parse_quota(
 			AccountQuotaDisposition::Error(parse_quota_error(error)?),
 		_ => return Err(incompatible("quota observation shape")),
 	};
-	let observed_at_unix_micros =
-		(!matches!(disposition, AccountQuotaDisposition::Unknown)).then_some(observed_micros).flatten();
+	let observed_at_unix_micros = (!matches!(disposition, AccountQuotaDisposition::Unknown))
+		.then_some(observed_micros)
+		.flatten();
 	Ok(AccountQuotaWindowObservation {
 		duration_minutes: duration,
 		observed_at_unix_micros,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -2043,7 +2043,8 @@ pub enum AccountsResult {
 	Available {
 		/// Bounded visible account projections.
 		accounts: Vec<AccountDto>,
-		/// Routing controls with an exact account permutation, when that capability read succeeded.
+		/// Routing controls with an exact account permutation, when that capability read
+		/// succeeded.
 		routing: Option<AccountRoutingControlDto>,
 	},
 	/// The account authority could not return a safe snapshot.
@@ -2146,10 +2147,7 @@ impl Serialize for AccountsResult {
 		#[derive(Serialize)]
 		#[serde(tag = "outcome", content = "data", rename_all = "snake_case")]
 		enum Raw<'a> {
-			Available {
-				accounts: &'a [AccountDto],
-				routing: Option<&'a AccountRoutingControlDto>,
-			},
+			Available { accounts: &'a [AccountDto], routing: Option<&'a AccountRoutingControlDto> },
 			Unavailable,
 		}
 		let raw = match self {
@@ -2170,10 +2168,7 @@ impl<'de> Deserialize<'de> for AccountsResult {
 		#[derive(Deserialize)]
 		#[serde(tag = "outcome", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 		enum Raw {
-			Available {
-				accounts: Vec<AccountDto>,
-				routing: Option<AccountRoutingControlDto>,
-			},
+			Available { accounts: Vec<AccountDto>, routing: Option<AccountRoutingControlDto> },
 			Unavailable,
 		}
 		match Raw::deserialize(deserializer)? {
@@ -4081,20 +4076,19 @@ fn validate_public_quota_window(quota: AccountQuotaWindowDto) -> Result<(), &'st
 #[cfg(test)]
 mod tests {
 	use crate::{
-		AccountCommandRejectionDto, AccountDto, AccountInitialSelectionResult, AccountsResult,
+		AccountCommandRejectionDto, AccountDto, AccountInitialSelectionResult,
 		AccountLifecycleReadinessDto, AccountObservationSignal, AccountObservedStateDto,
 		AccountProfileDailyUsageDto, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto, AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto,
-		CURRENT_VERSION,
-		CausationId, ClientCommandId, CodexAuthProjectionResult, CommandError, CorrelationId,
-		EntityId, EventPayload, HistoryCursorToken, HistoryText, IdempotencyKey,
-		MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
-		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
-		MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES, MAX_WORK_ITEM_BOARD_PAGE_SIZE, QueryId,
-		QueryResultPayload, ResetCardDescriptorDto, ResetCardOutcome, ResultPayload, ServerId,
-		ServerInstanceId, Sha256Digest, WireText, WorkItemBoardContractError, WorkItemBoardPage,
-		WorkItemBoardPageSize, WorkItemBoardProjectId, WorkItemBoardResult,
-		WorkItemBoardWorkItemId, WorkItemState,
+		AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId, CodexAuthProjectionResult,
+		CommandError, CorrelationId, EntityId, EventPayload, HistoryCursorToken, HistoryText,
+		IdempotencyKey, MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
+		MAX_HISTORY_METADATA_KEY_BYTES, MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE,
+		MAX_IDEMPOTENCY_KEY_BYTES, MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES,
+		MAX_WORK_ITEM_BOARD_PAGE_SIZE, QueryId, QueryResultPayload, ResetCardDescriptorDto,
+		ResetCardOutcome, ResultPayload, ServerId, ServerInstanceId, Sha256Digest, WireText,
+		WorkItemBoardContractError, WorkItemBoardPage, WorkItemBoardPageSize,
+		WorkItemBoardProjectId, WorkItemBoardResult, WorkItemBoardWorkItemId, WorkItemState,
 		wire::{
 			ClientHello, ClientMessage, CommandEnvelope, CommandPayload, Cursor, EntityRevision,
 			QueryEnvelope, QueryPayload, ResetCardInventoryResult, ResetCardOperationResult,

--- a/crates/decodex-runtime/src/account_api.rs
+++ b/crates/decodex-runtime/src/account_api.rs
@@ -208,12 +208,12 @@ impl AccountApiRuntime {
 			Ok(usage) => self.enrich_inventory(&credential, usage).await,
 			Err(error) => Err(error),
 		};
-		PendingAccountApiObservation::Pending(AccountApiObservation {
+		PendingAccountApiObservation::Pending(Box::new(AccountApiObservation {
 			account_revision: credential.account_revision,
 			provider: Some(credential.binding.provider.clone()),
 			inventory,
 			profile,
-		})
+		}))
 	}
 
 	async fn enrich_inventory(
@@ -239,16 +239,14 @@ impl AccountApiRuntime {
 				credits: Vec::new(),
 			});
 		}
-		let details = match self
-			.request_json(Method::GET, RESET_CREDITS_PATH, credential, None)
-			.await
-		{
-			Ok(body) => match decode_account_api_reset_credits(&body) {
-				Ok(details) => Ok(details),
-				Err(error) => Err(map_protocol_error(error)),
-			},
-			Err(error) => Err(map_request_error(error)),
-		};
+		let details =
+			match self.request_json(Method::GET, RESET_CREDITS_PATH, credential, None).await {
+				Ok(body) => match decode_account_api_reset_credits(&body) {
+					Ok(details) => Ok(details),
+					Err(error) => Err(map_protocol_error(error)),
+				},
+				Err(error) => Err(map_request_error(error)),
+			};
 		match details {
 			Ok(details) => Ok(AccountApiInventory {
 				account_revision: credential.account_revision,
@@ -313,10 +311,8 @@ impl AccountApiRuntime {
 		if let Some(json) = json {
 			request = request.json(json);
 		}
-		let response = request
-			.send()
-			.await
-			.map_err(|_| AccountApiRequestError::ProviderUnavailable)?;
+		let response =
+			request.send().await.map_err(|_| AccountApiRequestError::ProviderUnavailable)?;
 		let status = response.status();
 		if status == StatusCode::UNAUTHORIZED {
 			return Err(AccountApiRequestError::Unauthorized);
@@ -340,7 +336,7 @@ impl AccountApiRuntime {
 }
 
 enum PendingAccountApiObservation {
-	Pending(AccountApiObservation),
+	Pending(Box<AccountApiObservation>),
 	CredentialError { error: AccountApiRuntimeError },
 }
 impl PendingAccountApiObservation {
@@ -349,12 +345,12 @@ impl PendingAccountApiObservation {
 	}
 
 	fn failed(account_revision: i64, error: AccountApiRuntimeError) -> Self {
-		Self::Pending(AccountApiObservation {
+		Self::Pending(Box::new(AccountApiObservation {
 			account_revision,
 			provider: None,
 			inventory: Err(error),
 			profile: Err(error),
-		})
+		}))
 	}
 
 	fn account_revision(&self) -> i64 {
@@ -365,21 +361,17 @@ impl PendingAccountApiObservation {
 	}
 
 	fn requires_auth_retry(&self) -> bool {
-		matches!(
-			self,
-			Self::Pending(AccountApiObservation {
-				inventory: Err(AccountApiRuntimeError::Unauthorized),
-				..
-			}) | Self::Pending(AccountApiObservation {
-				profile: Err(AccountApiRuntimeError::Unauthorized),
-				..
-			})
-		)
+		match self {
+			Self::Pending(observation) =>
+				matches!(observation.inventory, Err(AccountApiRuntimeError::Unauthorized))
+					|| matches!(observation.profile, Err(AccountApiRuntimeError::Unauthorized)),
+			Self::CredentialError { .. } => false,
+		}
 	}
 
 	fn into_observation(self) -> AccountApiObservation {
 		match self {
-			Self::Pending(observation) => observation,
+			Self::Pending(observation) => *observation,
 			Self::CredentialError { error } => AccountApiObservation {
 				account_revision: 0,
 				provider: None,

--- a/crates/decodex-runtime/src/account_launch/api_reset_card.rs
+++ b/crates/decodex-runtime/src/account_launch/api_reset_card.rs
@@ -308,10 +308,7 @@ async fn read_inventory_for_claim(
 	inner: &Arc<ApiResetCardRuntimeInner>,
 	claim: &ResetCardClaim,
 ) -> Option<AccountApiInventory> {
-	match inner.api.observe_account(&claim.account_id).await.inventory {
-		Ok(inventory) => Some(inventory),
-		Err(_) => None,
-	}
+	inner.api.observe_account(&claim.account_id).await.inventory.ok()
 }
 
 async fn run_with_claim_heartbeat<T, MakeWork, Work>(

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -68,8 +68,8 @@ use decodex_codex::{
 	ExactThreadListResult, ExactThreadReadResult, LiveMethodOutcome, LossyThreadHistory,
 	MAX_EXACT_THREAD_LIST_RESULTS, MethodObservation, NormalizedEvent, QuickTaskMessageDelta,
 	QuickTaskThreadResumeRequest, QuickTaskThreadStartRequest, QuickTaskTurnInterruptRequest,
-	QuickTaskTurnInterruptResponse, QuickTaskTurnStartRequest,
-	ThreadSummary, TurnStatus, UnavailableReason, decode_quick_task_thread_resume_response,
+	QuickTaskTurnInterruptResponse, QuickTaskTurnStartRequest, ThreadSummary, TurnStatus,
+	UnavailableReason, decode_quick_task_thread_resume_response,
 	decode_quick_task_thread_start_response, decode_quick_task_turn_interrupt_response,
 	decode_quick_task_turn_start_response, normalize_event, project_quick_task_message_delta,
 	schema::{GeneratedSchemaEvidence, MAX_SCHEMA_FILE_BYTES},
@@ -985,7 +985,6 @@ impl AttestedProcessChild {
 	fn require_ordinary_turns_initialized(&self) -> Result<(), QuickTaskProcessError> {
 		self.initialized.then_some(()).ok_or(QuickTaskProcessError::Unavailable)
 	}
-
 }
 
 /// Exact request facts reserved before a RuntimeSession thread-start fence.
@@ -1166,7 +1165,6 @@ impl CredentialProjection<'_> {
 			.map(|_| ())
 			.map_err(|_| CredentialVaultError::ProjectionRejected)
 	}
-
 }
 
 impl Debug for CredentialProjection<'_> {
@@ -4634,9 +4632,8 @@ mod tests {
 	use crate::account_launch::{
 		RunnerCapacity, RunnerPermit,
 		process::{
-			self, AccountBinding, AccountIdentity, AppServerCommand,
-			AttestedAppServerLaunch, AttestedAppServerProfile,
-			CredentialProjection, CredentialProjectionResponse,
+			self, AccountBinding, AccountIdentity, AppServerCommand, AttestedAppServerLaunch,
+			AttestedAppServerProfile, CredentialProjection, CredentialProjectionResponse,
 			CredentialVault, CredentialVaultError, ExactThreadReconciler,
 			ExactThreadReconciliation, ExactThreadReconciliationResult, PROTOCOL_QUEUE_CAPACITY,
 			ProbeError, ProcessQuarantine, ReadOnlyMethod, ReadOnlyProbe, ShutdownOutcome,
@@ -4649,8 +4646,8 @@ mod tests {
 	};
 	use decodex_codex::{
 		ArchiveReconciliationOutcome, ArchiveUnverifiedReason, Capability, CapabilityCache,
-		CapabilityState, DecodexThreadSearchTerm, ExactThreadId, ExactThreadListFilter, SchemaMarker,
-		ThreadArchivedFilter, UnavailableReason, UnsupportedReason,
+		CapabilityState, DecodexThreadSearchTerm, ExactThreadId, ExactThreadListFilter,
+		SchemaMarker, ThreadArchivedFilter, UnavailableReason, UnsupportedReason,
 	};
 	use decodex_core::{
 		AccountId, AccountOperationId, AccountProvider, CredentialBinding, CredentialFingerprint,

--- a/crates/decodex-runtime/src/account_observation.rs
+++ b/crates/decodex-runtime/src/account_observation.rs
@@ -92,10 +92,7 @@ async fn persist_direct_quotas(
 		let observed_at_unix_micros =
 			current_unix_micros().ok_or(ResetCardServiceError::ProductStateUnavailable)?;
 		let cached_window = cached.as_ref().and_then(|windows| {
-			windows
-				.iter()
-				.find(|window| window.duration_minutes == quota.duration_minutes)
-				.copied()
+			windows.iter().find(|window| window.duration_minutes == quota.duration_minutes).copied()
 		});
 		let (observed_at_unix_micros, disposition) = match quota.result {
 			Ok(Some(fact)) => {
@@ -142,9 +139,8 @@ fn retained_last_good_quota(
 ) -> Option<(Option<i64>, AccountQuotaDisposition)> {
 	let window = cached.filter(|window| window.duration_minutes == duration_minutes)?;
 	match window.disposition {
-		AccountQuotaDisposition::Current(_) | AccountQuotaDisposition::Stale(_) => {
-			Some((window.observed_at_unix_micros, window.disposition))
-		},
+		AccountQuotaDisposition::Current(_) | AccountQuotaDisposition::Stale(_) =>
+			Some((window.observed_at_unix_micros, window.disposition)),
 		AccountQuotaDisposition::Unknown | AccountQuotaDisposition::Error(_) => None,
 	}
 }
@@ -910,8 +906,8 @@ mod tests {
 
 	use super::{
 		AccountObservationOutcome, AccountObservationState, AccountProfileRefreshStatus,
-		resolve_direct_quota, ResetCardInventoryObservation, ResetCardServiceError,
-		plan_observation_round, wait_for_generation,
+		ResetCardInventoryObservation, ResetCardServiceError, plan_observation_round,
+		resolve_direct_quota, wait_for_generation,
 	};
 
 	#[tokio::test]

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -385,11 +385,8 @@ impl ServiceApplication {
 			.into_iter()
 			.map(|inspection| account_dto(inspection.account))
 			.collect::<Result<Vec<_>, _>>();
-		let routing = service
-			.routing_control()
-			.await
-			.ok()
-			.and_then(|routing| routing_dto(routing).ok());
+		let routing =
+			service.routing_control().await.ok().and_then(|routing| routing_dto(routing).ok());
 		match accounts {
 			Ok(accounts) => AccountsResult::Available { accounts, routing },
 			Err(_) => AccountsResult::Unavailable,

--- a/crates/decodex-runtime/src/process_supervisor.rs
+++ b/crates/decodex-runtime/src/process_supervisor.rs
@@ -615,13 +615,7 @@ impl ProcessGenerationControl {
 		launch: AttestedAppServerLaunch,
 	) -> Result<FencedProcess, ProcessSupervisorError> {
 		let generation_id = admission.generation_id().clone();
-		self.spawn_fenced_inner(
-			generation_id,
-			execution_authorization,
-			launch,
-			admission,
-		)
-		.await
+		self.spawn_fenced_inner(generation_id, execution_authorization, launch, admission).await
 	}
 
 	async fn spawn_fenced_inner(
@@ -643,7 +637,7 @@ impl ProcessGenerationControl {
 			.store
 			.prepare_quick_task_bound_process_generation(&intent, &account_binding, admission)
 			.await
-		.map_err(|_| ProcessSupervisorError::ProductState)?;
+			.map_err(|_| ProcessSupervisorError::ProductState)?;
 		let fence = match preparation {
 			PrepareProcessGenerationOutcome::Fresh(fence) => fence,
 			PrepareProcessGenerationOutcome::Replayed(_)


### PR DESCRIPTION
Decodex-Autonomy: upstream-dependency-repair
Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/1270
Decodex-Repair-Scope: current-main-format-and-clippy-gate

## Summary

Repair the current-main repository gate required by the upstream compatibility handoff.

## Scope

This PR applies the repository-pinned Rust formatter to the account API and runtime changes that landed after dependency repair #1274. It also applies the current Clippy-prescribed equivalents for four null checks, one large enum variant, and one manual Result-to-Option conversion. It does not change workflows or supported behavior.

Changed files:

- crates/decodex-codex/src/account_api.rs
- crates/decodex-postgres/src/account_lifecycle.rs
- crates/decodex-protocol/src/wire.rs
- crates/decodex-runtime/src/account_api.rs
- crates/decodex-runtime/src/account_launch/api_reset_card.rs
- crates/decodex-runtime/src/account_launch/process.rs
- crates/decodex-runtime/src/account_observation.rs
- crates/decodex-runtime/src/application.rs
- crates/decodex-runtime/src/process_supervisor.rs

## Validation

- Base: ea84d8a3450cddb620a5ef705830081a0779e2aa
- Signed head: bbaecf1889b42596798ad491bcca42aea5821bba, direct child of base
- git verify-commit: passed
- cargo make check-automations: passed on the signed head; 780 Rust tests passed, 47 skipped; 49 Python tests and 2 CLI diagnostics tests passed
- X API spend: $0

## Handoff

Next owner: Reviewer. Land this dependency repair first, read back the signed merge, then rerun the complete repository gate and review PR #1270 at its refreshed exact base and head.
