### PR TITLE
Repair js-yaml security audit gate for upstream compatibility

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3631,9 +3631,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "fast-uri": "3.1.5",
+    "js-yaml": "4.3.1",
     "yaml": "2.9.0",
     "vite": "8.0.16"
   }


### PR DESCRIPTION
Pin the site transitive js-yaml dependency to patched version 4.3.1 with an exact override and generated lock update. Offline graph, advisory, lock-policy, clean-install, and current Astro checks pass.

Baseline: js-yaml 4.3.0 resolved through Astro with one high GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 finding. Final graph resolves js-yaml 4.3.1 only; the 399-package graph is otherwise unchanged.

Evidence:
- Advisory: https://github.com/advisories/GHSA-5p4m-2wfm-xmqj
- Package source: https://github.com/nodeca/js-yaml
- Patched package integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==

Validation:
- npm ls js-yaml: 4.3.1, overridden through Astro
- offline npm audit: 0 vulnerabilities
- offline npm ci --ignore-scripts: passed
- scripts/audit_node_lock.py --lock-only: passed
- Astro check: 22 files, 0 diagnostics
- npm audit signatures remains unavailable offline because Sigstore TUF metadata requires network access

Risk coverage is incomplete; risk delta is improved; decision is defer until Reviewer reruns the signature audit with trusted network access and accounts for the bounded site-check discrepancy.

Decodex-Autonomy: upstream-dependency-repair
Decodex-Parent-PR: https://github.com/hack-ink/decodex/pull/1270
Decodex-Repair-Scope: site-js-yaml-security-advisory

Next owner: Reviewer. Review signed head f03930e069e48e99bc541f59d2bc13160ceeb2a6, rerun the signature gate, then land this repair before PR #1270.
