### PR TITLE
Fix account panel loading and Reset Card cache latency

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardSectionView.swift
@@ -514,10 +514,7 @@ struct ResetCardAccountRow: View {
 					"Choose Refresh login in the menu bar app to sign in with the official Codex device login."
 				)
 		case .checking:
-			inventoryProgress(
-				"Checking Reset Cards…",
-				help: "Waiting for the current Reset Card inventory."
-			)
+			ResetCardInventoryPendingView()
 		case .connecting(let detail):
 			inventoryProgress("Connecting to Decodex…", help: detail)
 		case .unavailable(let detail):
@@ -801,6 +798,19 @@ struct ResetCardAccountRow: View {
 			timeZone.abbreviation(for: date)
 			?? timeZone.identifier
 		return "Reset Card, expires \(spokenExpiry) \(zone)"
+	}
+}
+
+private struct ResetCardInventoryPendingView: View {
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		ProgressView()
+			.controlSize(.mini)
+			.frame(width: 16, height: 16)
+			.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+			.help("Reset Card inventory is updating in the background.")
+			.accessibilityLabel("Reset Card inventory is updating")
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -860,27 +860,27 @@ final class ResetCardStore {
 			}
 			let retainedAuthority = retainedAuthorities.first
 			let discovered: [ResetCardAccountRecord]
-			var projectionReadback: (
-				generation: UInt64,
-				projection: CodexAuthProjection?
-			)?
+			var projectionReadTask: Task<CodexAuthProjection?, Never>?
+			var projectionReadGeneration: UInt64?
+			defer {
+				projectionReadTask?.cancel()
+			}
 			if let accountControlClient {
 				let snapshotGeneration = beginAccountSnapshotRequest()
-				let projectionGeneration = beginCodexProjectionRequest()
-				async let snapshotRead = accountControlClient.accountSnapshot(
+				projectionReadGeneration = beginCodexProjectionRequest()
+				projectionReadTask = Task { [accountControlClient] in
+					try? await accountControlClient.codexAuthProjection(
+						authority: retainedAuthority
+					)
+				}
+				let snapshot = try await accountControlClient.accountSnapshot(
 					authority: retainedAuthority
 				)
-				async let projectionRead = try? accountControlClient.codexAuthProjection(
-					authority: retainedAuthority
-				)
-				let snapshot = try await snapshotRead
-				let projection = await projectionRead
 				// A local account-control result may have superseded this snapshot while
-				// either read was suspended. Never publish that older routing/account view.
+				// the read was suspended. Never publish that older routing/account view.
 				guard snapshotGeneration == accountSnapshotRequestGeneration else {
 					return .complete
 				}
-				projectionReadback = (projectionGeneration, projection)
 				if let snapshotRouting = snapshot.routing,
 					routing != snapshotRouting
 				{
@@ -957,17 +957,13 @@ final class ResetCardStore {
 			if accounts != nextAccounts {
 				accounts = nextAccounts
 			}
+			// The account skeleton is the first usable panel state. Detail reads below
+			// are independent daemon-cache reads and must not keep the panel in its
+			// initial-loading state while one account is slow.
+			hasLoaded = true
 			prunePostUseReconciliationsForCurrentAccounts()
 			pruneProfileEmailCache()
 			reconcileAccountSkeletonRevisionTargets()
-			if let projectionReadback,
-				let projection = projectionReadback.projection,
-				applyCodexAuthProjection(
-					projection,
-					generation: projectionReadback.generation
-				) {
-				scheduleCodexProjectionRefresh()
-			}
 			if backgroundObservation == false,
 				message?.tone == .error,
 				isPendingRecoveryBlocked == false
@@ -1084,6 +1080,15 @@ final class ResetCardStore {
 				finishProfileRequest(request)
 			}
 			_ = publishProfileEmailsIfReady(expectedEpoch: visibilityEpoch)
+			if let projectionReadTask,
+				let projection = await projectionReadTask.value,
+				let projectionReadGeneration,
+				applyCodexAuthProjection(
+					projection,
+					generation: projectionReadGeneration
+				) {
+				scheduleCodexProjectionRefresh()
+			}
 			shouldRetry = accounts.contains { state in
 				state.error?.isRetryableReadFailure == true
 					|| state.inventory?.observationError?.isRetryableReadFailure == true

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -744,6 +744,8 @@ final class AccountControlStoreTests: XCTestCase {
 
 		XCTAssertTrue(store.isRefreshing)
 		XCTAssertTrue(store.refreshSkeletonIsPublished)
+		XCTAssertTrue(store.hasLoaded)
+		XCTAssertFalse(store.isInitialLoading)
 		XCTAssertTrue(store.canBeginEnrollment)
 
 		await store.enrollFromSharedCodex()
@@ -754,6 +756,38 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.message?.tone, .success)
 
 		await client.releaseInventory()
+		await refreshTask.value
+		XCTAssertFalse(store.isRefreshing)
+	}
+
+	func testSkeletonPublishesWhileProjectionReadIsPending() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsProjection: true
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		let refreshTask = Task { await store.refresh() }
+		for _ in 0 ..< 200 {
+			if await client.projectionIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		XCTAssertTrue(store.hasLoaded)
+		XCTAssertFalse(store.isInitialLoading)
+		XCTAssertEqual(store.accounts.map(\.account.accountID), [accountID])
+
+		await client.releaseProjection()
 		await refreshTask.value
 		XCTAssertFalse(store.isRefreshing)
 	}
@@ -1486,6 +1520,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private let authority: ResetCardAuthority
 	private let inventoryGate: AccountControlReadGate?
 	private let snapshotGate: AccountControlReadGate?
+	private let projectionGate: AccountControlReadGate?
 	private let capturesSnapshotBeforeWait: Bool
 	private let fixedSelectionGate: AccountControlReadGate?
 	private let enrollmentGate: AccountControlReadGate?
@@ -1533,6 +1568,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		authority: ResetCardAuthority,
 		suspendsInventory: Bool = false,
 		suspendsSnapshotAfterFirstRead: Bool = false,
+		suspendsProjection: Bool = false,
 		capturesSnapshotBeforeWait: Bool = false,
 		suspendsFixedSelection: Bool = false,
 		suspendsEnrollment: Bool = false,
@@ -1554,6 +1590,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		self.projection = projection
 		inventoryGate = suspendsInventory ? AccountControlReadGate() : nil
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
+		projectionGate = suspendsProjection ? AccountControlReadGate() : nil
 		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
 		enrollmentGate = suspendsEnrollment ? AccountControlReadGate() : nil
@@ -1837,6 +1874,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		authority: ResetCardAuthority?
 	) async throws -> CodexAuthProjection {
 		projectionReads += 1
+		await projectionGate?.wait()
 		if let projectionError {
 			throw projectionError
 		}
@@ -1849,6 +1887,17 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 
 	func projectionReadCount() -> Int {
 		projectionReads
+	}
+
+	func projectionIsPending() async -> Bool {
+		guard let projectionGate else {
+			return false
+		}
+		return await projectionGate.isPending()
+	}
+
+	func releaseProjection() async {
+		await projectionGate?.release()
 	}
 
 	func useAccountInCodex(

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -26,6 +26,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 		XCTAssertTrue(store.contains("Checking reset result…"))
 		XCTAssertTrue(store.contains("Check delayed; retrying…"))
+		XCTAssertFalse(rows.contains("Checking Reset Cards…"))
+		XCTAssertTrue(rows.contains("ResetCardInventoryPendingView()"))
 		XCTAssertFalse(rows.contains("Button(\"Resume\")"))
 		XCTAssertFalse(store.contains("Resume the pending request"))
 	}

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -445,7 +445,9 @@ impl ResetCardClient {
 		self.require_local_profile()?;
 		let expected_account_id = account_id.clone();
 		let completed = time::timeout(
-			self.timeout,
+			// This query reads the daemon-owned observation cache. It must not inherit
+			// the longer budget used by reset-card effects and recovery.
+			CLIENT_TIMEOUT,
 			self.query_inner("decodex-reset-card-list", QueryPayload::GetResetCards { account_id }),
 		)
 		.await
@@ -940,7 +942,7 @@ impl AccountClient {
 	pub async fn list(&self) -> Result<AccountsResult, ClientFailure> {
 		self.transport.require_local_profile()?;
 		let completed = time::timeout(
-			self.transport.timeout,
+			CLIENT_TIMEOUT,
 			self.transport.query_inner("decodex-accounts-list", QueryPayload::ListAccounts),
 		)
 		.await
@@ -961,7 +963,7 @@ impl AccountClient {
 		self.transport.require_local_profile()?;
 		let expected = account_id.clone();
 		let completed = time::timeout(
-			self.transport.timeout,
+			CLIENT_TIMEOUT,
 			self.transport.query_inner(
 				"decodex-account-inspect",
 				QueryPayload::InspectAccount { account_id },
@@ -993,7 +995,7 @@ impl AccountClient {
 		self.transport.require_local_profile()?;
 		let expected = account_id.clone();
 		let completed = time::timeout(
-			self.transport.timeout,
+			CLIENT_TIMEOUT,
 			self.transport.query_inner(
 				"decodex-account-profile",
 				QueryPayload::GetAccountProfile { account_id, include_email },
@@ -1044,7 +1046,7 @@ impl AccountClient {
 	pub async fn codex_auth_projection(&self) -> Result<CodexAuthProjectionResult, ClientFailure> {
 		self.transport.require_local_profile()?;
 		let completed = time::timeout(
-			self.transport.timeout,
+			CLIENT_TIMEOUT,
 			self.transport
 				.query_inner("decodex-codex-auth-projection", QueryPayload::GetCodexAuthProjection),
 		)


### PR DESCRIPTION
## Summary

- Publish the account skeleton as usable panel state without waiting for slow detail or projection reads.
- Use the short client timeout for daemon-cache reads while preserving longer effect and recovery budgets.
- Replace the visible Reset Card checking label with a compact background progress indicator.

## Validation

- Swift tests: 214 passed
- `cargo test -p decodex-protocol`: 75 passed
- Swift release build passed
- Signed staged app built and launched successfully.