### PR TITLE
Add durable detection timestamps to upstream PRs

### DIFF
--- a/automations/decodex/scripts/config/tests/test_portfolio.py
+++ b/automations/decodex/scripts/config/tests/test_portfolio.py
@@ -67,6 +67,21 @@ class PortfolioTests(unittest.TestCase):
             portfolio.validate_manifest({**manifest, "status": "DISABLED"}),
         )
 
+    def test_upstream_prompts_share_the_detection_marker_contract(self) -> None:
+        rendered = {item["id"]: item["prompt"] for item in portfolio.rendered_automations()}
+        marker = "Decodex-Detected-At: <RFC3339 UTC>"
+
+        for automation_id in (
+            "codex-upstream-maintainer",
+            "codex-upstream-reviewer",
+            "codex-upstream-health",
+        ):
+            self.assertIn(marker, rendered[automation_id])
+
+        self.assertIn("first detection instant", rendered["codex-upstream-maintainer"])
+        self.assertIn("marker finding blocks landing", rendered["codex-upstream-reviewer"])
+        self.assertIn("as `unknown`", rendered["codex-upstream-health"])
+
     def test_runtime_evaluation_requires_metadata_and_rejects_extra_managed_ids(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             codex_home = Path(directory)

--- a/automations/upstream/README.md
+++ b/automations/upstream/README.md
@@ -43,18 +43,39 @@ compatibility PR to a directly related gate-repair PR.
 
 ## Handoff Contract
 
-Every managed PR carries one exact body marker:
+Every managed PR carries one exact autonomy marker:
 
 ```text
 Decodex-Autonomy: upstream-compatibility
+Decodex-Detected-At: <RFC3339 UTC>
 ```
 
 or:
 
 ```text
 Decodex-Autonomy: upstream-dependency-repair
+Decodex-Detected-At: <RFC3339 UTC>
 Decodex-Parent-PR: https://github.com/acg-box/decodex/pull/<number>
+Decodex-Repair-Scope: <bounded-scope>
 ```
+
+A managed PR has exactly one durable detection marker. Its timestamp is the
+first instant when evidence established the actionable official compatibility
+change or the gate defect that requires that dependency repair. The value must
+be valid RFC3339 with the UTC `Z` designator. A dependency repair records its own
+gate-defect detection time; adding its blocked-by link does not change the
+parent's detection time.
+
+On first PR creation, the Maintainer writes `Decodex-Detected-At` and reads the
+exact body back. On every refresh, it first reads and then preserves the exact
+valid timestamp; refresh time is never a replacement. The Reviewer reads back
+exactly one marker, validates it, and reports detection-to-PR latency as the PR
+creation time minus the marker timestamp. A missing, duplicate, malformed,
+non-UTC, or post-creation marker blocks landing and returns one precise repair
+brief to the Maintainer on the same PR. The Manager reports that latency as
+`unknown` while the marker is absent or malformed and treats the marker defect
+as autonomous repair work. Marker repair never creates a replacement PR and
+never weakens the 24-hour landing requirement.
 
 A compatibility PR adds `Decodex-Blocked-By: <url>` while a required repair is
 open. A dependency repair must be directly required by its parent or by a

--- a/automations/upstream/prompts/health.md
+++ b/automations/upstream/prompts/health.md
@@ -31,20 +31,25 @@ Every run:
    signed one-line manifest promotion; after that promotion, native sync may activate all five.
 4. Inspect every managed PR: `xv/codex-upstream-*` compatibility branches plus exact
    `Decodex-Autonomy: upstream-compatibility` or `Decodex-Autonomy: upstream-dependency-repair` markers.
-   Follow parent and blocked-by URLs, measure
-   detection-to-PR and PR-to-land time, and require land within 24 hours.
-5. Treat stale bases, failed tests, requested changes, open dependencies, and ordinary implementation
-   defects as autonomous repair work. Ensure one precise repair brief and next owner exist on the same
-   PR. An open PR is a nonterminal handoff, never a successful outcome or archive candidate.
-6. Run Publisher validation, xurl readiness, and cost reports. Check candidate age, one-post-per-day,
+   Follow parent and blocked-by URLs and read back exactly one
+   `Decodex-Detected-At: <RFC3339 UTC>` marker from each PR body.
+5. Validate the marker as RFC3339 with the UTC `Z` designator and not later than PR creation. Measure
+   detection-to-PR as PR creation time minus that marker and PR-to-land separately. Report detection-to-PR
+   as `unknown` when the marker is absent or malformed. Require land within 24 hours even when latency is
+   unknown; a missing marker cannot reset or weaken the landing requirement.
+6. Treat absent, duplicate, or malformed detection markers, stale bases, failed tests, requested changes,
+   open dependencies, and ordinary implementation defects as autonomous repair work. Put one precise
+   repair brief and next owner on the same PR; marker briefs return to Maintainer and require exact
+   body readback without substituting refresh time. An open PR remains a nonterminal handoff.
+7. Run Publisher validation, xurl readiness, and cost reports. Check candidate age, one-post-per-day,
    exact `@decodexspace` readback, unresolved write effects, and due 24-hour and 7-day outcomes.
-7. Check Content Manager results for official evidence, concrete usefulness, repetition, and unsupported
+8. Check Content Manager results for official evidence, concrete usefulness, repetition, and unsupported
    claims. Check CodexRadar only as secondary editorial evidence.
-8. Enforce self-archive policy from the exact-five definitions and observed results. Do not depend on an
+9. Enforce self-archive policy from the exact-five definitions and observed results. Do not depend on an
    unbounded global scan. Manager may inspect and archive one known completed managed task only when
    bounded native readback for that exact task is available and proves terminal success with no unresolved
    effect, failure, continuation, or decision request.
-9. Memory may record only the last completed weekly review with measured outcomes, repairs, handoffs,
+10. Memory may record only the last completed weekly review with measured outcomes, repairs, handoffs,
    archive results, and the next experiment. It is advisory only and never workflow authority; actual
    evidence must be rechecked.
 

--- a/automations/upstream/prompts/maintainer.md
+++ b/automations/upstream/prompts/maintainer.md
@@ -27,9 +27,15 @@ Workflow:
    `openwiki/operations/commands-and-validation.md`.
 2. Verify the cwd is the primary worktree on clean `main`. Fetch and fast-forward `origin/main`.
 3. Inspect every open non-draft managed PR: use `xv/codex-upstream-*` for compatibility PRs and the
-   exact `Decodex-Autonomy: upstream-dependency-repair` marker for directly related gate repairs.
+   exact `Decodex-Autonomy: upstream-dependency-repair` marker for directly related gate repairs. On first
+   creation, add exactly one `Decodex-Detected-At: <RFC3339 UTC>` from the first detection instant. Before
+   every body refresh, read and preserve the exact valid value. If it is missing or malformed, recover the
+   earliest authoritative detection evidence named by the repair brief; never use refresh time. Read back
+   the exact marker value after every create or update.
    Repair an existing PR or its dependency chain before starting a new upstream head.
 4. Fetch official `openai/codex` commits, releases, app-server schemas, and removed-feature evidence.
+   When evidence first proves an actionable compatibility change, record that detection instant once as
+   RFC3339 with the UTC `Z` designator. A later scan, implementation run, or PR refresh cannot reset it.
 5. Use the memory cursor only when its official upstream OID exists in the official mirror, is an ancestor
    of the current official head, is not older than the latest merged `Upstream-Codex-Head: <oid>` trailer,
    and its reviewed Decodex `main` OID equals current `main`. A missing or mismatched OID requires a
@@ -45,14 +51,16 @@ Workflow:
    support removal to one ephemeral subagent. Give it the exact upstream evidence and Reviewer feedback.
 10. Review the diff yourself. Run focused tests, then the repository-owned gate from
     `openwiki/operations/commands-and-validation.md`. If the gate exposes an unrelated base defect,
-    create one signed dependency-repair PR with `Decodex-Autonomy: upstream-dependency-repair`,
-    `Decodex-Parent-PR: <url>`, `Decodex-Blocked-By: <url>`, and
-    `Decodex-Repair-Scope: <bounded-scope>` markers; do not leave an unowned blocker or weaken tests.
+    record its first detection instant and create one signed dependency-repair PR with
+    `Decodex-Autonomy: upstream-dependency-repair`, `Decodex-Parent-PR: <url>`,
+    `Decodex-Repair-Scope: <bounded-scope>`, and `Decodex-Detected-At: <RFC3339 UTC>`. Add
+    `Decodex-Blocked-By: <url>` to the parent without changing the parent's detection marker.
 11. Use `decodex commit --manual-authority "<summary>"`. Include `Upstream-Codex-Head: <oid>` and official
    source URLs in the commit or PR evidence. Never use raw `git commit`.
 12. Push the deterministic branch. Create or update its one non-draft PR with
-    `Decodex-Autonomy: upstream-compatibility`, then read back base `main`, head branch, exact head OID,
-    body markers, evidence, and checks. Remove the temporary worktree after push.
+    `Decodex-Autonomy: upstream-compatibility` and the detection marker under the rule above. Read back
+    base `main`, head branch, exact head OID, body markers, evidence, and checks. Remove the temporary
+    worktree after push.
 
 Success:
 - A source-backed no-op is terminal. A tested, signed, deterministic PR is a nonterminal handoff until

--- a/automations/upstream/prompts/reviewer.md
+++ b/automations/upstream/prompts/reviewer.md
@@ -22,21 +22,28 @@ Workflow:
    `Decodex-Autonomy: upstream-dependency-repair`. Select the oldest eligible dependency-repair PR
    first; select its parent only after every linked dependency has landed.
 3. Read back repository, base `main`, branch, base OID, head OID, signed commit, workflow markers,
-   parent/dependency URLs, repair scope, official upstream evidence, and `Upstream-Codex-Head` when applicable. A
-   branch suffix, marker, and trailer must match the cited scope; PR text is not proof by itself.
-4. Create a detached worktree at the exact head OID. Independently inspect the upstream delta or gate
+   parent/dependency URLs, repair scope, official upstream evidence, and `Upstream-Codex-Head` when applicable.
+   A branch suffix, marker, and trailer must match the cited scope; PR text is not proof by itself.
+4. Read back exactly one `Decodex-Detected-At: <RFC3339 UTC>` line from the PR body. Parse the value as
+   RFC3339, require the UTC `Z` designator, and require it not to be later than the PR creation time.
+   Report detection-to-PR latency as PR creation time minus that timestamp; report `unknown` if no valid
+   marker exists.
+5. Create a detached worktree at the exact head OID. Independently inspect the upstream delta or gate
    repair and the Decodex diff. Check protocol, config, auth, sandbox, MCP, collaboration, removed
    behavior, tests, docs, scope, and obsolete support.
-5. Run focused tests and the required repository gate. Verify that the PR does not hide unrelated or
+6. Run focused tests and the required repository gate. Verify that the PR does not hide unrelated or
    generated state and does not weaken validation.
-6. If there is a finding, submit one concise GitHub review with file/line evidence, expected behavior,
+7. If there is a finding, submit one concise GitHub review with file/line evidence, expected behavior,
    and a repair acceptance test. Leave the PR open for Maintainer; this is a nonterminal handoff.
-   Ordinary findings never require human attention.
-7. If ready, require all mandatory checks to pass. A parent with an open or stale dependency is not ready.
+   For a missing, duplicate, malformed, non-UTC, or post-creation detection marker, the repair brief must
+   state the observed body evidence, the exact required marker, the authoritative first-detection evidence
+   to restore without resetting it to refresh time, and exact body-readback plus latency acceptance checks.
+   Ordinary findings never require human attention, and a marker finding blocks landing.
+8. If ready, require all mandatory checks to pass. A parent with an open or stale dependency is not ready.
    Re-read the exact base and head OIDs immediately before landing.
-8. Run `decodex land --manual-authority --pr <url> --expected-base-oid <base> --expected-head-oid
+9. Run `decodex land --manual-authority --pr <url> --expected-base-oid <base> --expected-head-oid
    <head> "<summary>"`.
-9. Read back the merge commit, its exact two parents, merge tree equal to the reviewed head tree,
+10. Read back the merge commit, its exact two parents, merge tree equal to the reviewed head tree,
    signature, remote `main`, closed PR, and branch cleanup. Remove the temporary worktree.
 
 Success:
@@ -53,4 +60,4 @@ Stop conditions:
   user decision is unresolved; or any required action is not durably handed off.
 - A test, check, code finding, or dependency handoff stays visible until the next owner reads it back;
   stale bases and defects return to Maintainer. Report PR URL, reviewed base/head, dependency decision,
-  findings or merge OID, checks, next owner, and zero X API spend.
+  detection-to-PR latency, findings or merge OID, checks, next owner, and zero X API spend.

--- a/openwiki/operations/codex-upstream-autopilot.md
+++ b/openwiki/operations/codex-upstream-autopilot.md
@@ -58,14 +58,22 @@ Managed PRs use exact body markers:
 
 ```text
 Decodex-Autonomy: upstream-compatibility
+Decodex-Detected-At: <RFC3339 UTC>
 ```
 
 or:
 
 ```text
 Decodex-Autonomy: upstream-dependency-repair
+Decodex-Detected-At: <RFC3339 UTC>
 Decodex-Parent-PR: https://github.com/acg-box/decodex/pull/<number>
+Decodex-Repair-Scope: <bounded-scope>
 ```
+
+Each managed PR has exactly one `Decodex-Detected-At` marker. The value is the
+first time when evidence proved the actionable compatibility change or gate
+defect. It must use RFC3339 with the UTC `Z` designator. A refresh preserves
+the exact value. It never replaces the value with the refresh time.
 
 A compatibility PR adds `Decodex-Blocked-By: <url>` while a required repair is
 open. A dependency repair also states `Decodex-Repair-Scope: <bounded-scope>` and
@@ -83,7 +91,9 @@ nonterminal `handed_off` outcome. Only an exact signed merge readback is
 1. Read `AGENTS.md`, OpenWiki, this runbook, and the relevant project tests.
 2. Require clean primary `main` equal to `origin/main`.
 3. Inspect official Codex releases, source changes, protocol schemas, and
-   documentation since the latest Decodex adaptation.
+   documentation since the latest Decodex adaptation. When evidence first
+   proves an actionable change, record that time once. On a later refresh,
+   read and preserve the exact valid detection marker.
 4. Compare upstream behavior with current Decodex code and tests. State the
    concrete user or operator consequence.
 5. Search GitHub for the deterministic branch, upstream-head trailer, workflow
@@ -100,7 +110,8 @@ nonterminal `handed_off` outcome. Only an exact signed merge readback is
 10. Create or update the one matching PR. Compatibility PRs carry
     `Decodex-Autonomy: upstream-compatibility`; dependency repairs carry
     `Decodex-Autonomy: upstream-dependency-repair`, `Decodex-Parent-PR: <url>`,
-    and `Decodex-Repair-Scope: <bounded-scope>`. Verify exact remote head and the
+    and `Decodex-Repair-Scope: <bounded-scope>`. Both types carry the exact
+    detection marker. Read back that marker, the exact remote head, and the
     trailer `Upstream-Codex-Head: <oid>` when applicable.
 11. Remove the temporary worktree only after the remote PR state is read back.
 
@@ -113,14 +124,18 @@ Maintainer updates those PRs and does not create a parallel workflow record.
 1. Enumerate open PRs with the upstream trailer and deterministic branch, plus
    directly linked `upstream-dependency-repair` PRs.
 2. Read the complete diff, upstream evidence, review history, and check results.
+   Read exactly one detection marker. Require RFC3339 UTC, require that it is
+   not later than PR creation, and calculate detection-to-PR latency. A missing,
+   duplicate, malformed, non-UTC, or post-creation marker blocks landing.
 3. Record exact base and head OIDs. Create a temporary review worktree at that
    head.
 4. Review independently for correctness, scope, removed obsolete support,
    security, and test quality.
 5. Run the focused tests and the appropriate repository gate.
 6. When a defect exists, submit precise GitHub review feedback with a required
-   outcome. Leave the PR open for Maintainer repair; this is a nonterminal
-   handoff.
+   outcome. A detection-marker repair identifies the earliest authoritative
+   evidence and requires exact body readback. Leave the PR open for Maintainer
+   repair; this is a nonterminal handoff.
 7. When the head is acceptable and every dependency is landed, invoke only:
 
 ```sh
@@ -145,7 +160,8 @@ Every run checks:
 - exact models, efforts, schedules, local execution, status, and primary cwd;
 - duplicate managed definitions and missing native metadata;
 - upstream release or protocol changes not yet investigated;
-- detection-to-PR and PR-to-land latency;
+- detection-to-PR and PR-to-land latency, or `unknown` detection latency while
+  the marker is invalid;
 - managed workflow markers, dependency chains, `handed_off` outcomes, and next owners;
 - stale PRs, failed checks, review feedback, and merged outcomes;
 - content evidence, X results, due observations, and cost;


### PR DESCRIPTION
Decodex-Autonomy: automation-loop-repair
Decodex-Detected-At: 2026-08-10T22:43:30Z
Decodex-Repair-Scope: upstream-pr-detection-latency
Decodex-Next-Owner: Codex Upstream Reviewer And Lander

## Problem

Managed upstream PRs did not carry a durable first-detection timestamp. Detection-to-PR latency could not be measured, and refreshes had no rule that prevented timestamp resets.

This PR originally predated the marker contract. Its repaired marker uses the PR creation time, 2026-08-10T22:43:30Z, as the earliest surviving authoritative GitHub evidence. It does not use the current refresh time.

## Change

- Require exactly one durable detection marker with RFC3339 UTC Z syntax on every managed upstream PR.
- Require Maintainer creation, preservation, and exact body readback.
- Require Reviewer validation, detection-to-PR calculation, and a same-PR repair brief for missing, duplicate, malformed, non-UTC, or post-creation markers.
- Require Manager unknown-latency reporting and autonomous repair for marker defects without weakening the 24-hour landing target.
- Preserve the repaired acg-box/decodex owner and primary-worktree paths from current main.
- Align the OpenWiki upstream runbook with the executable prompt contract.
- Add a portfolio regression test that requires all three upstream roles to render the shared marker and their distinct responsibilities.

## Validation

- Current base: 517b72d3c2cadc85b1415b66f7ddc01c09b1efc5
- Signed Commit v2 head: 312841cb35138e5aa9b917148845aa601fcc9ae0
- The direct parent is the current base.
- Local git verify-commit and GitHub signature verification passed.
- python3 automations/decodex/scripts/config/render_automation_plan.py --json: passed.
- python3 automations/decodex/scripts/config/evaluate_automations.py --repo-only --json: passed.
- python3 -m unittest automations.decodex.scripts.config.tests.test_portfolio: 5/5 passed.
- cargo make audit-node: passed with npm 11.17.0; 285 package signatures and 84 attestations verified.
- cargo make build and cargo make check-node: passed.
- CARGO_NET_OFFLINE=true cargo make check-rust-headless: passed on the repository stable toolchain.
- CARGO_NET_OFFLINE=true cargo make lint-rust-headless: 10/10 lint targets passed.
- CARGO_NET_OFFLINE=true cargo make test-headless: 808/808 Rust tests passed with 47 skipped; 5 automation, 36 gate/script, 24 architecture, and 2 CLI diagnostics tests also passed.
- taplo fmt --check and git diff --check: passed.
- The aggregate check-automations target was not used because its Rust formatter is pinned to a numbered nightly, which current repository policy prohibits. The stable-compatible constituent gates above were run instead.
- Knowledge impact: update_required and aligned in the same PR. OpenWiki was curated directly; its generator was not run because the repository quickstart records that boundary.

Reviewer: verify the exact one-marker contract, signed head, current base, six-file diff, and fresh GitHub checks. Then land through Decodex and read back the signed merge.
