### PR TITLE
Repair quinn-proto security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,11 +2311,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4764,15 +4766,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -4912,6 +4915,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"


### PR DESCRIPTION
Decodex-Autonomy: upstream-dependency-repair
Decodex-Detected-At: 2026-08-11T10:43:58Z
Decodex-Parent-PR: https://github.com/acg-box/decodex/pull/1280
Decodex-Repair-Scope: quinn-proto-security-advisory
Decodex-Next-Owner: Codex Upstream Reviewer And Lander

## Repair brief

This refreshed head applies the reviewed lockfile-only repair directly to current main. It updates quinn-proto from 0.11.14 to the latest supportable compatible 0.11.x release, 0.11.16. Cargo reuses the existing getrandom 0.4.2, rand 0.10.2, rand_core 0.10.1, js-sys, and wasm-bindgen nodes and adds only rand_pcg 0.10.2. No manifest, source, workflow, documentation, or unrelated lock entry changed.

The package is present in the lock graph through the optional Reqwest HTTP/3 path. The locked workspace all-features/all-targets inverse-tree queries for quinn-proto 0.11.16 and rand_pcg 0.10.2 print no active workspace path, so this repair removes the supply-chain lock finding without claiming an active runtime exposure.

## Official evidence

- RustSec: RUSTSEC-2026-0185 / GHSA-4w2j-m93h-cj5j, patched in quinn-proto >=0.11.15
- Upstream release: https://github.com/quinn-rs/quinn/releases/tag/quinn-proto-0.11.16
- Verified annotated tag object: 4ac6688f0f6fed6db8193455416785fc2c5aa268
- Peeled source commit: a96949f6cd257c665f544626af4e8ce668a40b30
- Verified tag time: 2026-07-04T19:19:19Z
- Registry checksum: 2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560
- Required Rust version: 1.85
- New transitive rand_pcg 0.10.2 checksum: caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a

The cached crate checksums match Cargo.lock. rand_pcg declares no build script, binary, native code, or runtime downloader.

## Validation

- Current base: 283f1831863b6bcb9cefd6c07c7793c9338195a1
- Signed Commit v2 head: b081385c77c3421fd804d78ef9e1095296cba37e
- The direct parent is the current base.
- Local git verify-commit and GitHub signature verification passed.
- Baseline cargo audit: 3 vulnerabilities, including RUSTSEC-2026-0185.
- Final cargo audit: 2 vulnerabilities; RUSTSEC-2026-0185 is removed and only the pre-existing quick-xml findings remain.
- cargo make audit-node: passed with npm 11.17.0; 285 package signatures and 84 attestations verified.
- cargo make build and cargo make check-node: passed.
- CARGO_NET_OFFLINE=true cargo make check-rust-headless: passed on the repository stable toolchain.
- CARGO_NET_OFFLINE=true cargo make lint-rust-headless: 10/10 lint targets passed.
- CARGO_NET_OFFLINE=true cargo make test-headless: passed, including automation, gate-contract, headless Rust, 24 architecture, and 2 CLI diagnostics tests.
- taplo fmt --check and git diff --check: passed.
- The aggregate check-automations target was not used because its Rust formatter is pinned to a numbered nightly, which current repository policy prohibits. The stable-compatible constituent gates above were run instead; this lockfile-only diff has no Rust source formatting surface.
- risk_coverage: complete
- risk_delta: improved
- decision: proceed

Remaining vulnerabilities are RUSTSEC-2026-0194 and RUSTSEC-2026-0195 for quick-xml 0.30.0. They are unchanged and are tracked as the next dependency-policy lane in the current Goal.
