### PR TITLE
Restore stable Rust toolchain policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,11 @@ Start here:
 OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
 
 When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
+
+## Rust toolchain
+
+- Use the `stable` Rust compiler channel for every active Rust workspace.
+- Keep each active `rust-toolchain.toml` channel set to `"stable"`.
+- Do not replace `stable` with a numbered, beta, or nightly compiler channel unless the
+  user explicitly authorizes that change.
+- Build and test commands must not override this policy with a numbered toolchain.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.97.0"
+channel    = "stable"
 components = ["cargo", "clippy", "rust-analyzer", "rust-src", "rustc", "rustfmt"]
 profile    = "minimal"

--- a/scripts/macos/stage_decodex_gpui.sh
+++ b/scripts/macos/stage_decodex_gpui.sh
@@ -10,7 +10,7 @@ SIGN_IDENTITY=${DECODEX_GPUI_SIGN_IDENTITY:--}
 DEVELOPER_DIR=${DEVELOPER_DIR:-/Applications/Xcode-beta.app/Contents/Developer}
 export DEVELOPER_DIR
 
-cargo +1.97.0 build --locked --release --bin decodex-gpui
+cargo +stable build --locked --release --bin decodex-gpui
 rm -rf "$APP"
 mkdir -p "$MACOS"
 cp "$ROOT/apps/decodex-gpui/packaging/Info.plist" "$CONTENTS/Info.plist"

--- a/scripts/macos/stage_gpui_spike.sh
+++ b/scripts/macos/stage_gpui_spike.sh
@@ -9,7 +9,7 @@ CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
 SIGN_IDENTITY=${DECODEX_GPUI_SPIKE_SIGN_IDENTITY:--}
 
-cargo +1.97.0 build --manifest-path "$MANIFEST" --release --bin decodex-gpui-spike
+cargo +stable build --manifest-path "$MANIFEST" --release --bin decodex-gpui-spike
 rm -rf "$APP"
 mkdir -p "$MACOS"
 cp "$ROOT/spikes/gpui/packaging/Info.plist" "$CONTENTS/Info.plist"

--- a/spikes/gpui/README.md
+++ b/spikes/gpui/README.md
@@ -2,9 +2,9 @@
 
 This isolated workspace is the XY-1263 evidence harness, not the production Decodex UI.
 It pins GPUI and `gpui_platform` to Zed commit
-`aeeacf5439b2d30d01e38d65d767e6f31b255ecc` and Rust 1.97.0. The isolation keeps the
-pre-1.0 dependency graph out of the root runtime lockfile. The exact-pin replacement remains
-a candidate pending review and repository acceptance. A later 38/40 invalidated the initial
+`aeeacf5439b2d30d01e38d65d767e6f31b255ecc` and uses the stable Rust channel. The isolation
+keeps the pre-1.0 dependency graph out of the root runtime lockfile. The exact-pin replacement
+remains a candidate pending review and repository acceptance. A later 38/40 invalidated the initial
 10/10 stability claim, and a subsequent ad-hoc 40/40 lacked exact launch provenance. The
 current PID-bound harness then passed a fresh normalized current-main direct 40/40 with
 complete provenance and literal-zero outer receipts. All earlier results remain provenance
@@ -14,12 +14,12 @@ Run the deterministic and native probes from the repository root:
 
 ```sh
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
-  cargo +1.97.0 test --manifest-path spikes/gpui/Cargo.toml --release
+  cargo +stable test --manifest-path spikes/gpui/Cargo.toml --release
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
-  cargo +1.97.0 test --manifest-path spikes/gpui/Cargo.toml --release --lib \
+  cargo +stable test --manifest-path spikes/gpui/Cargo.toml --release --lib \
   workspace_headless_frame_benchmark -- --ignored --nocapture --test-threads=1
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
-  cargo +1.97.0 run --manifest-path spikes/gpui/Cargo.toml --release \
+  cargo +stable run --manifest-path spikes/gpui/Cargo.toml --release \
   --features visual-probe --bin render_probe -- /tmp/decodex-gpui-spike.png
 DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
   scripts/macos/stage_gpui_spike.sh

--- a/spikes/gpui/rust-toolchain.toml
+++ b/spikes/gpui/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.97.0"
+channel    = "stable"
 components = ["cargo", "clippy", "rustc", "rustfmt"]
 profile    = "minimal"

--- a/tests/scripts/test_gate_contract.py
+++ b/tests/scripts/test_gate_contract.py
@@ -160,13 +160,32 @@ class GateContractTests(unittest.TestCase):
             with self.subTest(task=task_name):
                 self.assertEqual(self.tasks[task_name]["args"], args)
 
-    def test_workspace_compiler_remains_separately_pinned(self) -> None:
-        with (REPO_ROOT / "rust-toolchain.toml").open("rb") as toolchain_file:
-            toolchain = tomllib.load(toolchain_file)["toolchain"]
+    def test_active_rust_toolchains_use_stable_channel(self) -> None:
+        toolchain_paths = [
+            Path("rust-toolchain.toml"),
+            Path("spikes/gpui/rust-toolchain.toml"),
+        ]
 
-        self.assertEqual(toolchain["channel"], "1.97.0")
-        self.assertIn("rustfmt", toolchain["components"])
-        self.assertNotEqual(toolchain["channel"], FORMATTER_TOOLCHAIN)
+        for toolchain_path in toolchain_paths:
+            with self.subTest(toolchain=toolchain_path):
+                with (REPO_ROOT / toolchain_path).open("rb") as toolchain_file:
+                    toolchain = tomllib.load(toolchain_file)["toolchain"]
+
+                self.assertEqual(toolchain["channel"], "stable")
+                self.assertIn("rustfmt", toolchain["components"])
+                self.assertNotEqual(toolchain["channel"], FORMATTER_TOOLCHAIN)
+
+    def test_native_gpui_build_scripts_use_stable_channel(self) -> None:
+        script_paths = [
+            Path("scripts/macos/stage_decodex_gpui.sh"),
+            Path("scripts/macos/stage_gpui_spike.sh"),
+        ]
+
+        for script_path in script_paths:
+            with self.subTest(script=script_path):
+                script = (REPO_ROOT / script_path).read_text(encoding="utf-8")
+                self.assertIn("cargo +stable build", script)
+                self.assertNotRegex(script, r"\bcargo \+\d")
 
     def test_blocking_aggregates_retain_every_non_vstyle_gate(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
Restores both active Rust toolchains to the stable channel, routes native GPUI build scripts through cargo +stable, and adds regression gates.

Validation:
- cargo make check (with the repository-required npm 11.17.0 and Xcode Beta developer directory)
- cargo +stable check --locked --manifest-path spikes/gpui/Cargo.toml --all-targets
- cargo make test-gate-contract