### PR TITLE
Move Decodex plugin tests out of runtime root

### DIFF
--- a/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
+++ b/openwiki/integrations/plugins-automations-and-auxiliary-tools.md
@@ -39,8 +39,9 @@ $CODEX_HOME/plugins/cache/hack-ink/<plugin>/<version>
 ```
 
 Each plugin manifest declares `package.include` and `package.exclude`. The sync
-script materializes only that runtime package contract; source-only assets such
-as `plugins/decodex/tests/` stay out of installed plugin cache entries.
+script materializes only that runtime package contract. Repository-only plugin
+tests live under `tests/scripts/`, outside the physical runtime root. The sync
+tests require every file under `plugins/*` to match its package contract.
 
 Commands:
 

--- a/plugins/decodex/.codex-plugin/plugin.json
+++ b/plugins/decodex/.codex-plugin/plugin.json
@@ -26,9 +26,7 @@
       "scripts/**",
       "skills/**"
     ],
-    "exclude": [
-      "tests/**"
-    ]
+    "exclude": []
   },
   "skills": "./skills/",
   "interface": {

--- a/tests/scripts/test_decodex_lifecycle_hook.py
+++ b/tests/scripts/test_decodex_lifecycle_hook.py
@@ -9,9 +9,9 @@ import unittest
 from pathlib import Path
 
 
-PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "decodex"
 HOOK_SCRIPT = PLUGIN_ROOT / "scripts" / "decodex_lifecycle_hook"
-REPO_ROOT = PLUGIN_ROOT.parents[1]
 
 
 class DecodexLifecycleHookTests(unittest.TestCase):

--- a/tests/scripts/test_sync_installable_plugins.py
+++ b/tests/scripts/test_sync_installable_plugins.py
@@ -24,6 +24,22 @@ def load_sync_module():
 
 
 class SyncInstallablePluginsTests(unittest.TestCase):
+    def test_plugin_roots_match_their_runtime_package_contract(self):
+        module = load_sync_module()
+
+        for plugin_root in module.plugin_sources(REPO_ROOT):
+            physical_files = {
+                path.relative_to(plugin_root)
+                for path in plugin_root.rglob("*")
+                if path.is_file()
+            }
+            packaged_files = {
+                path.relative_to(plugin_root)
+                for path in module.package_files(plugin_root)
+            }
+
+            self.assertEqual(physical_files, packaged_files, plugin_root)
+
     def test_sync_installs_plugins_without_global_repo_local_skills(self):
         module = load_sync_module()
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Move the lifecycle hook test out of the installable plugin runtime root.
- Enforce equality between physical plugin files and the package contract.
- Remove the obsolete tests exclusion and align OpenWiki.

## Validation
- 31 focused Python tests passed.
- Full headless repository gate passed with cargo make check-automations.
- plugin-eval reported 100/A with 2,085 total tokens and no test component.