### PR TITLE
Resolve quick-xml RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,9 +4737,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -8020,11 +8020,11 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
  "quick-xml",
  "x11",

--- a/spikes/gpui/Cargo.lock
+++ b/spikes/gpui/Cargo.lock
@@ -3993,9 +3993,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6419,11 +6419,11 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
  "quick-xml",
  "x11",


### PR DESCRIPTION
## Summary

- Upgrade `xcb` from 1.7.0 to 1.7.1 in the root and GPUI spike lockfiles.
- Select patched `quick-xml` 0.41.0 instead of vulnerable 0.30.0.
- Remove RUSTSEC-2026-0194 and RUSTSEC-2026-0195 from both audited lockfiles.

## Dependency policy

- Mode: roll. Scope: the existing `zed-scap -> xcb -> quick-xml` Linux/FreeBSD build-time chain.
- Source identity: `xcb` 1.7.1, crates.io checksum `a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566`, upstream tag commit `ad8cd4c07a769148a16ddec509f5f341f5058f00`, published 2026-08-09.
- Source identity: `quick-xml` 0.41.0, crates.io checksum `e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1`, MSRV 1.79.
- New packages: none. `bitflags` 2.13 was already present. The existing `xcb` build script reads packaged XML and optionally invokes local rustfmt; it has no downloader or network client. `quick-xml` has no build script or binaries.
- Risk coverage: reviewed the upstream 1.7.0..1.7.1 source diff, package manifests, checksums, target graph, build-script behavior, RustSec findings, and both lockfile deltas.
- Risk delta: two high-severity vulnerable lock entries become patched build-time entries; no application runtime dependency or feature changes.
- Decision: accept the upstream patch release.

## Validation

- Root `cargo audit`: 2 vulnerabilities -> 0.
- `spikes/gpui/Cargo.lock` audit: 2 vulnerabilities -> 0.
- Isolated `xcb` 1.7.1 compile: pass.
- Node audit/signatures: 285 signatures and 84 attestations; 0 vulnerabilities.
- Site build/check: pass.
- Stable headless Rust check: pass.
- Rust lint: 10/10 pass.
- Rust tests: 808/808 pass; 47 skipped.
- Architecture tests: 24/24 pass. CLI diagnostics: 2/2 pass.
- Linux cross-check reached unrelated native compilation and stopped because this macOS host has no `x86_64-linux-gnu-gcc`; the isolated changed crate compiled successfully.
- GPUI spike check reached the known unrelated host limitation: Xcode `metal` is unavailable.

Decodex-Autonomy: upstream-dependency-repair
Decodex-Detected-At: 2026-08-12T18:26:59Z
Decodex-Repair-Scope: quick-xml-rustsec-advisories
Decodex-Parent-PR: https://github.com/acg-box/decodex/pull/1281
Decodex-Next-Owner: Codex Upstream Reviewer And Lander