### PR TITLE
Make the GPUI workbench live and expose the account pool

### DIFF
--- a/apps/decodex-gpui/src/accounts.rs
+++ b/apps/decodex-gpui/src/accounts.rs
@@ -1,0 +1,853 @@
+//! Presentation-neutral ownership of the bounded GPUI account-pool surface.
+
+use std::{
+	sync::{
+		Arc, Mutex, MutexGuard,
+		atomic::{AtomicU64, Ordering},
+	},
+	time::{SystemTime, UNIX_EPOCH},
+};
+
+use sha2::{Digest, Sha256};
+use tokio::sync::Notify;
+
+use decodex_protocol::{
+	CURRENT_VERSION, AccountDto, AccountRoutingControlDto, AccountSelectionModeDto, AccountsResult,
+	CausationId, ClientCommandId, CommandEnvelope, CommandOutcome, CommandPayload, CommandReceipt,
+	CommandResultEnvelope, CorrelationId, EntityId, EntityRevision, EventEnvelope, EventPayload,
+	IdempotencyKey, QueryEnvelope, QueryId, QueryPayload, QueryResultEnvelope, QueryResultPayload,
+	ReceiptDisposition, ResultPayload, ServerId,
+};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Current bounded state rendered by the Accounts destination.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AccountsSnapshot {
+	pub(crate) load: AccountsLoadState,
+	pub(crate) command: AccountCommandState,
+	pub(crate) accounts: Vec<AccountDto>,
+	pub(crate) routing: Option<AccountRoutingControlDto>,
+	pub(crate) can_manage: bool,
+}
+
+/// Finite account-pool readback state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountsLoadState {
+	NeverRequested,
+	Loading,
+	Ready,
+	Offline,
+	Stale,
+	Unavailable,
+	Refused,
+}
+
+/// Finite state for the one possibly side-effecting account command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountCommandState {
+	Idle,
+	Sending,
+	AwaitingResult,
+	Accepted,
+	OutcomeUnknown,
+	Refused,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountInputError {
+	Offline,
+	Busy,
+	AccountMissing,
+	RoutingUnavailable,
+	IdentityUnavailable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountRouteOutcome {
+	Fresh,
+	Unmatched,
+	Refused,
+}
+
+/// Exactly one account query or command reserved for one retained-session generation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum AccountDispatch {
+	Query(QueryEnvelope),
+	Command(CommandEnvelope),
+}
+
+impl AccountDispatch {
+	pub(crate) fn query(&self) -> Option<&QueryEnvelope> {
+		match self {
+			Self::Query(envelope) => Some(envelope),
+			Self::Command(_) => None,
+		}
+	}
+
+	pub(crate) fn command(&self) -> Option<&CommandEnvelope> {
+		match self {
+			Self::Command(envelope) => Some(envelope),
+			Self::Query(_) => None,
+		}
+	}
+}
+
+/// Cloneable account-pool controller. It owns no transport or credential authority.
+#[derive(Clone)]
+pub(crate) struct AccountsController {
+	inner: Arc<AccountsInner>,
+}
+
+struct AccountsInner {
+	state: Mutex<State>,
+	notify: Notify,
+}
+
+impl AccountsController {
+	pub(crate) fn production() -> Self {
+		Self {
+			inner: Arc::new(AccountsInner {
+				state: Mutex::new(State::new()),
+				notify: Notify::new(),
+			}),
+		}
+	}
+
+	pub(crate) fn activate(&self) {
+		let mut state = self.lock();
+		if state.active {
+			return;
+		}
+		state.active = true;
+		state.ever_activated = true;
+		let queued = state.queue_list();
+		if state.session.is_none() {
+			state.load = AccountsLoadState::Offline;
+		}
+		drop(state);
+		if queued {
+			self.inner.notify.notify_one();
+		}
+	}
+
+	pub(crate) fn deactivate(&self) {
+		self.lock().active = false;
+	}
+
+	pub(crate) fn refresh(&self) -> bool {
+		let mut state = self.lock();
+		let queued = state.active && state.queue_list();
+		drop(state);
+		if queued {
+			self.inner.notify.notify_one();
+		}
+		queued
+	}
+
+	pub(crate) fn snapshot(&self) -> AccountsSnapshot {
+		self.lock().snapshot()
+	}
+
+	pub(crate) fn set_enabled(
+		&self,
+		account_id: &EntityId,
+		enabled: bool,
+	) -> Result<(), AccountInputError> {
+		let mut state = self.lock();
+		let account = state
+			.accounts
+			.iter()
+			.find(|account| &account.account_id == account_id)
+			.ok_or(AccountInputError::AccountMissing)?;
+		let revision = account.account_revision;
+		if account.enabled == enabled {
+			return Ok(());
+		}
+		state.queue_command(
+			CommandPayload::SetAccountEnabled { account_id: account_id.clone(), enabled },
+			Some(revision),
+		)?;
+		drop(state);
+		self.inner.notify.notify_one();
+		Ok(())
+	}
+
+	pub(crate) fn select_fixed(&self, account_id: &EntityId) -> Result<(), AccountInputError> {
+		let mut state = self.lock();
+		let account_revision = state
+			.accounts
+			.iter()
+			.find(|account| &account.account_id == account_id)
+			.map(|account| account.account_revision)
+			.ok_or(AccountInputError::AccountMissing)?;
+		let routing_revision = state
+			.routing
+			.as_ref()
+			.map(|routing| routing.revision)
+			.ok_or(AccountInputError::RoutingUnavailable)?;
+		state.queue_command(
+			CommandPayload::SetFixedAccountSelection {
+				account_id: account_id.clone(),
+				expected_account_revision: account_revision,
+			},
+			Some(routing_revision),
+		)?;
+		drop(state);
+		self.inner.notify.notify_one();
+		Ok(())
+	}
+
+	pub(crate) fn select_balanced(&self) -> Result<(), AccountInputError> {
+		let mut state = self.lock();
+		let routing_revision = state
+			.routing
+			.as_ref()
+			.map(|routing| routing.revision)
+			.ok_or(AccountInputError::RoutingUnavailable)?;
+		state.queue_command(
+			CommandPayload::SetBalancedAccountSelection,
+			Some(routing_revision),
+		)?;
+		drop(state);
+		self.inner.notify.notify_one();
+		Ok(())
+	}
+
+	pub(crate) fn bind_session(&self, generation: u64, server_id: ServerId) {
+		let mut state = self.lock();
+		let binding = SessionBinding { generation, server_id };
+		if state.session.as_ref() == Some(&binding) {
+			return;
+		}
+		state.latch_in_flight_outcome_unknown();
+		state.reset_query();
+		state.session = Some(binding);
+		let command_queued = state.pending_command.is_some();
+		let query_queued = state.active && state.queue_list();
+		if !state.active {
+			state.load = if state.ever_activated {
+				AccountsLoadState::Stale
+			} else {
+				AccountsLoadState::NeverRequested
+			};
+		}
+		drop(state);
+		if command_queued || query_queued {
+			self.inner.notify.notify_one();
+		}
+	}
+
+	pub(crate) fn session_ended(&self, generation: u64) {
+		let mut state = self.lock();
+		if !state.session.as_ref().is_some_and(|binding| binding.generation == generation) {
+			return;
+		}
+		state.latch_in_flight_outcome_unknown();
+		if state.pending_command.take().is_some()
+			&& state.command != AccountCommandState::OutcomeUnknown
+		{
+			state.command = AccountCommandState::Refused;
+		}
+		state.reset_query();
+		state.session = None;
+		state.load = if state.ever_activated {
+			AccountsLoadState::Offline
+		} else {
+			AccountsLoadState::NeverRequested
+		};
+	}
+
+	pub(crate) async fn next_dispatch(
+		&self,
+		generation: u64,
+		server_id: &ServerId,
+	) -> AccountDispatch {
+		loop {
+			let notified = self.inner.notify.notified();
+			if let Some(dispatch) = self.try_take_dispatch(generation, server_id) {
+				return dispatch;
+			}
+			notified.await;
+		}
+	}
+
+	fn try_take_dispatch(
+		&self,
+		generation: u64,
+		server_id: &ServerId,
+	) -> Option<AccountDispatch> {
+		let mut state = self.lock();
+		let binding = SessionBinding { generation, server_id: server_id.clone() };
+		if state.session.as_ref() != Some(&binding) {
+			return None;
+		}
+		if state.in_flight_command.is_none()
+			&& let Some(envelope) = state.pending_command.take()
+		{
+			state.in_flight_command = Some(InFlightCommand {
+				envelope: envelope.clone(),
+				binding,
+			});
+			return Some(AccountDispatch::Command(envelope));
+		}
+		if state.in_flight_query.is_none()
+			&& let Some(envelope) = state.pending_query.take()
+		{
+			state.in_flight_query = Some(InFlightQuery {
+				query_id: envelope.query_id.clone(),
+				binding,
+			});
+			return Some(AccountDispatch::Query(envelope));
+		}
+		None
+	}
+
+	pub(crate) fn command_send_failed(&self, dispatch: &AccountDispatch) {
+		let Some(command) = dispatch.command() else {
+			return;
+		};
+		let mut state = self.lock();
+		if state.in_flight_command.as_ref().is_some_and(|in_flight| {
+			in_flight.envelope.client_command_id == command.client_command_id
+		}) {
+			state.latch_in_flight_outcome_unknown();
+		}
+	}
+
+	pub(crate) fn command_sent(&self, dispatch: &AccountDispatch) {
+		let Some(command) = dispatch.command() else {
+			return;
+		};
+		let mut state = self.lock();
+		if state.in_flight_command.as_ref().is_some_and(|in_flight| {
+			in_flight.envelope.client_command_id == command.client_command_id
+		}) {
+			state.command = AccountCommandState::AwaitingResult;
+		}
+	}
+
+	pub(crate) fn apply_event(&self, event: &EventEnvelope) {
+		let mut state = self.lock();
+		match &event.payload {
+			EventPayload::AccountChanged { account }
+				if account.account_id == event.entity_id
+					&& account.account_revision == event.entity_revision =>
+			{
+				state.upsert_account((**account).clone());
+			},
+			EventPayload::AccountLoggedOut { account_id, tombstone_revision }
+				if account_id == &event.entity_id && tombstone_revision == &event.entity_revision =>
+			{
+				state.accounts.retain(|account| account.account_id != *account_id);
+			},
+			EventPayload::AccountRoutingChanged { routing }
+				if routing.revision == event.entity_revision =>
+			{
+				state.routing = Some(routing.clone());
+				state.sort_accounts();
+			},
+			_ => {},
+		}
+	}
+
+	pub(crate) fn route_query_result(
+		&self,
+		generation: u64,
+		server_id: &ServerId,
+		result: &QueryResultEnvelope,
+	) -> AccountRouteOutcome {
+		let mut state = self.lock();
+		let Some(in_flight) = state.in_flight_query.as_ref() else {
+			return AccountRouteOutcome::Unmatched;
+		};
+		if in_flight.query_id != result.query_id {
+			return AccountRouteOutcome::Unmatched;
+		}
+		let expected = SessionBinding { generation, server_id: server_id.clone() };
+		if in_flight.binding != expected
+			|| state.session.as_ref() != Some(&expected)
+			|| result.version != CURRENT_VERSION
+			|| result.server_id != *server_id
+		{
+			state.in_flight_query = None;
+			state.load = AccountsLoadState::Refused;
+			return AccountRouteOutcome::Refused;
+		}
+		state.in_flight_query = None;
+		match &result.payload {
+			QueryResultPayload::Accounts(AccountsResult::Available { accounts, routing }) => {
+				state.accounts = accounts.clone();
+				state.routing = routing.clone();
+				state.sort_accounts();
+				state.load = AccountsLoadState::Ready;
+				AccountRouteOutcome::Fresh
+			},
+			QueryResultPayload::Accounts(AccountsResult::Unavailable) => {
+				state.load = AccountsLoadState::Unavailable;
+				AccountRouteOutcome::Fresh
+			},
+			_ => {
+				state.load = AccountsLoadState::Refused;
+				AccountRouteOutcome::Refused
+			},
+		}
+	}
+
+	pub(crate) fn route_receipt(
+		&self,
+		generation: u64,
+		server_id: &ServerId,
+		receipt: &CommandReceipt,
+	) -> AccountRouteOutcome {
+		let mut state = self.lock();
+		let Some(in_flight) = state.in_flight_command.as_ref() else {
+			return AccountRouteOutcome::Unmatched;
+		};
+		if in_flight.envelope.client_command_id != receipt.client_command_id {
+			return AccountRouteOutcome::Unmatched;
+		}
+		let expected = SessionBinding { generation, server_id: server_id.clone() };
+		if in_flight.binding != expected
+			|| state.session.as_ref() != Some(&expected)
+			|| receipt.version != CURRENT_VERSION
+			|| receipt.server_id != *server_id
+			|| receipt.idempotency_key != in_flight.envelope.idempotency_key
+		{
+			state.latch_in_flight_outcome_unknown();
+			return AccountRouteOutcome::Refused;
+		}
+		match receipt.disposition {
+			ReceiptDisposition::Executed | ReceiptDisposition::Duplicate => {
+				state.command = AccountCommandState::AwaitingResult;
+			},
+			ReceiptDisposition::Refused => {
+				state.in_flight_command = None;
+				state.command = AccountCommandState::Refused;
+			},
+		}
+		AccountRouteOutcome::Fresh
+	}
+
+	pub(crate) fn route_command_result(
+		&self,
+		generation: u64,
+		server_id: &ServerId,
+		result: &CommandResultEnvelope,
+	) -> AccountRouteOutcome {
+		let mut state = self.lock();
+		let Some(in_flight) = state.in_flight_command.as_ref() else {
+			return AccountRouteOutcome::Unmatched;
+		};
+		if in_flight.envelope.client_command_id != result.client_command_id {
+			return AccountRouteOutcome::Unmatched;
+		}
+		let expected = SessionBinding { generation, server_id: server_id.clone() };
+		if in_flight.binding != expected
+			|| state.session.as_ref() != Some(&expected)
+			|| result.version != CURRENT_VERSION
+			|| result.server_id != *server_id
+			|| result.idempotency_key != in_flight.envelope.idempotency_key
+		{
+			state.latch_in_flight_outcome_unknown();
+			return AccountRouteOutcome::Refused;
+		}
+		let in_flight = state
+			.in_flight_command
+			.take()
+			.expect("matching account command remains in flight");
+		match result.outcome {
+			CommandOutcome::Succeeded => {
+				if state.apply_success(&in_flight.envelope, result) {
+					state.command = AccountCommandState::Accepted;
+					AccountRouteOutcome::Fresh
+				} else {
+					state.command = AccountCommandState::Refused;
+					AccountRouteOutcome::Refused
+				}
+			},
+			CommandOutcome::AcceptanceUnknown => {
+				state.command = AccountCommandState::OutcomeUnknown;
+				AccountRouteOutcome::Fresh
+			},
+			CommandOutcome::Rejected => {
+				state.command = AccountCommandState::Refused;
+				AccountRouteOutcome::Fresh
+			},
+		}
+	}
+
+	fn lock(&self) -> MutexGuard<'_, State> {
+		self.inner.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SessionBinding {
+	generation: u64,
+	server_id: ServerId,
+}
+
+struct InFlightQuery {
+	query_id: QueryId,
+	binding: SessionBinding,
+}
+
+struct InFlightCommand {
+	envelope: CommandEnvelope,
+	binding: SessionBinding,
+}
+
+struct State {
+	session: Option<SessionBinding>,
+	active: bool,
+	ever_activated: bool,
+	next_query_sequence: u64,
+	pending_query: Option<QueryEnvelope>,
+	in_flight_query: Option<InFlightQuery>,
+	pending_command: Option<CommandEnvelope>,
+	in_flight_command: Option<InFlightCommand>,
+	load: AccountsLoadState,
+	command: AccountCommandState,
+	accounts: Vec<AccountDto>,
+	routing: Option<AccountRoutingControlDto>,
+}
+
+impl State {
+	const fn new() -> Self {
+		Self {
+			session: None,
+			active: false,
+			ever_activated: false,
+			next_query_sequence: 0,
+			pending_query: None,
+			in_flight_query: None,
+			pending_command: None,
+			in_flight_command: None,
+			load: AccountsLoadState::NeverRequested,
+			command: AccountCommandState::Idle,
+			accounts: Vec::new(),
+			routing: None,
+		}
+	}
+
+	fn snapshot(&self) -> AccountsSnapshot {
+		AccountsSnapshot {
+			load: self.load,
+			command: self.command,
+			accounts: self.accounts.clone(),
+			routing: self.routing.clone(),
+			can_manage: self.session.is_some()
+				&& self.load == AccountsLoadState::Ready
+				&& self.pending_command.is_none()
+				&& self.in_flight_command.is_none()
+				&& !matches!(
+					self.command,
+					AccountCommandState::Sending
+						| AccountCommandState::AwaitingResult
+						| AccountCommandState::OutcomeUnknown
+				),
+		}
+	}
+
+	fn queue_list(&mut self) -> bool {
+		let Some(generation) = self.session.as_ref().map(|session| session.generation) else {
+			return false;
+		};
+		if self.pending_query.is_some() || self.in_flight_query.is_some() {
+			return false;
+		}
+		let Some(sequence) = self.next_query_sequence.checked_add(1) else {
+			self.load = AccountsLoadState::Refused;
+			return false;
+		};
+		self.next_query_sequence = sequence;
+		self.pending_query = Some(QueryEnvelope {
+			version: CURRENT_VERSION,
+			query_id: QueryId::new(format!("gpui-accounts/{generation}/{sequence}"))
+				.expect("bounded numeric account query identity"),
+			payload: QueryPayload::ListAccounts,
+		});
+		self.load = AccountsLoadState::Loading;
+		true
+	}
+
+	fn queue_command(
+		&mut self,
+		payload: CommandPayload,
+		expected_revision: Option<EntityRevision>,
+	) -> Result<(), AccountInputError> {
+		if self.session.is_none() {
+			return Err(AccountInputError::Offline);
+		}
+		if self.pending_command.is_some()
+			|| self.in_flight_command.is_some()
+			|| matches!(
+				self.command,
+				AccountCommandState::Sending
+					| AccountCommandState::AwaitingResult
+					| AccountCommandState::OutcomeUnknown
+			)
+		{
+			return Err(AccountInputError::Busy);
+		}
+		let identity = command_identity()?;
+		self.pending_command = Some(CommandEnvelope {
+			version: CURRENT_VERSION,
+			client_command_id: identity.client_command_id,
+			idempotency_key: identity.idempotency_key,
+			expected_revision,
+			correlation_id: identity.correlation_id,
+			causation_id: None::<CausationId>,
+			payload,
+		});
+		self.command = AccountCommandState::Sending;
+		Ok(())
+	}
+
+	fn reset_query(&mut self) {
+		self.pending_query = None;
+		self.in_flight_query = None;
+	}
+
+	fn latch_in_flight_outcome_unknown(&mut self) {
+		if self.in_flight_command.take().is_some() {
+			self.command = AccountCommandState::OutcomeUnknown;
+		}
+	}
+
+	fn upsert_account(&mut self, account: AccountDto) {
+		if let Some(existing) = self
+			.accounts
+			.iter_mut()
+			.find(|existing| existing.account_id == account.account_id)
+		{
+			if account.account_revision >= existing.account_revision {
+				*existing = account;
+			}
+		} else {
+			self.accounts.push(account);
+		}
+		self.sort_accounts();
+	}
+
+	fn sort_accounts(&mut self) {
+		if let Some(routing) = self.routing.as_ref() {
+			self.accounts.sort_by_key(|account| {
+				routing
+					.order
+					.iter()
+					.position(|account_id| account_id == &account.account_id)
+					.unwrap_or(usize::MAX)
+			});
+		} else {
+			self.accounts.sort_by(|left, right| left.alias.as_str().cmp(right.alias.as_str()));
+		}
+	}
+
+	fn apply_success(
+		&mut self,
+		command: &CommandEnvelope,
+		result: &CommandResultEnvelope,
+	) -> bool {
+		match (&command.payload, result.payload.as_ref()) {
+			(
+				CommandPayload::SetAccountEnabled { account_id, enabled },
+				Some(ResultPayload::AccountChanged { account }),
+			) if &account.account_id == account_id
+				&& account.enabled == *enabled
+				&& result.entity_revision == Some(account.account_revision) =>
+			{
+				self.upsert_account((**account).clone());
+				true
+			},
+			(
+				CommandPayload::SetFixedAccountSelection { account_id, .. },
+				Some(ResultPayload::AccountRoutingChanged { routing }),
+			) if matches!(&routing.mode, AccountSelectionModeDto::Fixed(selected) if selected == account_id)
+				&& result.entity_revision == Some(routing.revision) =>
+			{
+				self.routing = Some(routing.clone());
+				self.sort_accounts();
+				true
+			},
+			(
+				CommandPayload::SetBalancedAccountSelection,
+				Some(ResultPayload::AccountRoutingChanged { routing }),
+			) if routing.mode == AccountSelectionModeDto::Balanced
+				&& result.entity_revision == Some(routing.revision) =>
+			{
+				self.routing = Some(routing.clone());
+				self.sort_accounts();
+				true
+			},
+			_ => false,
+		}
+	}
+}
+
+struct CommandIdentity {
+	client_command_id: ClientCommandId,
+	idempotency_key: IdempotencyKey,
+	correlation_id: CorrelationId,
+}
+
+fn command_identity() -> Result<CommandIdentity, AccountInputError> {
+	let value = canonical_uuid_v4()?;
+	Ok(CommandIdentity {
+		client_command_id: ClientCommandId::new(format!("gpui-account/{value}"))
+			.expect("canonical account command identity is bounded"),
+		idempotency_key: IdempotencyKey::new(format!("account/{value}"))
+			.expect("canonical account idempotency key is bounded"),
+		correlation_id: CorrelationId::new(value)
+			.expect("canonical account correlation identity is bounded"),
+	})
+}
+
+fn canonical_uuid_v4() -> Result<String, AccountInputError> {
+	let sequence = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+	let nanos = SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.map_err(|_| AccountInputError::IdentityUnavailable)?
+		.as_nanos();
+	let mut digest = Sha256::new();
+	digest.update(std::process::id().to_be_bytes());
+	digest.update(nanos.to_be_bytes());
+	digest.update(sequence.to_be_bytes());
+	let mut bytes: [u8; 16] = digest.finalize()[..16]
+		.try_into()
+		.expect("SHA-256 always contains sixteen identity bytes");
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	Ok(format!(
+		"{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+		bytes[0],
+		bytes[1],
+		bytes[2],
+		bytes[3],
+		bytes[4],
+		bytes[5],
+		bytes[6],
+		bytes[7],
+		bytes[8],
+		bytes[9],
+		bytes[10],
+		bytes[11],
+		bytes[12],
+		bytes[13],
+		bytes[14],
+		bytes[15],
+	))
+}
+
+#[cfg(test)]
+mod tests {
+	use decodex_protocol::{
+		AccountLifecycleReadinessDto, AccountObservedStateDto, AccountQuotaStateDto,
+		AccountQuotaWindowDto, WireText,
+	};
+
+	use super::*;
+
+	fn server() -> ServerId {
+		ServerId::new("018f0f9e-7b6e-4a31-8f4c-1d2e3f405162")
+			.expect("test server identity is bounded")
+	}
+
+	fn account(id: &str, alias: &str, enabled: bool, revision: u64) -> AccountDto {
+		let quota = |duration_minutes| AccountQuotaWindowDto {
+			duration_minutes,
+			observed_at_unix_micros: None,
+			result: AccountQuotaStateDto::Unknown,
+		};
+		AccountDto {
+			account_id: EntityId::new(id).expect("test account identity is canonical"),
+			alias: WireText::new(alias).expect("test alias is bounded"),
+			enabled,
+			account_revision: EntityRevision(revision),
+			observed_state: AccountObservedStateDto::Available,
+			lifecycle_readiness: AccountLifecycleReadinessDto::Ready,
+			credential_binding: None,
+			unsettled_operation: None,
+			five_hour_quota: quota(300),
+			seven_day_quota: quota(10_080),
+		}
+	}
+
+	#[test]
+	fn activation_dispatches_one_account_list_for_the_bound_session() {
+		let controller = AccountsController::production();
+		let server = server();
+		controller.bind_session(4, server.clone());
+
+		assert!(controller.try_take_dispatch(4, &server).is_none());
+		controller.activate();
+
+		let dispatch = controller
+			.try_take_dispatch(4, &server)
+			.expect("activation queues exactly one account read");
+		assert!(matches!(
+			dispatch.query().map(|query| &query.payload),
+			Some(QueryPayload::ListAccounts)
+		));
+		assert!(controller.try_take_dispatch(4, &server).is_none());
+	}
+
+	#[test]
+	fn account_list_enables_revision_guarded_pool_management() {
+		let controller = AccountsController::production();
+		let server = server();
+		let first = account("10000000-0000-4000-8000-000000000001", "Primary", true, 3);
+		let second = account("10000000-0000-4000-8000-000000000002", "Reserve", true, 7);
+		controller.bind_session(2, server.clone());
+		controller.activate();
+		let AccountDispatch::Query(query) = controller
+			.try_take_dispatch(2, &server)
+			.expect("account query is reserved")
+		else {
+			panic!("account activation must query")
+		};
+		let routing = AccountRoutingControlDto {
+			revision: EntityRevision(5),
+			mode: AccountSelectionModeDto::Balanced,
+			order: vec![first.account_id.clone(), second.account_id.clone()],
+		};
+		assert_eq!(
+			controller.route_query_result(
+				2,
+				&server,
+				&QueryResultEnvelope {
+					version: CURRENT_VERSION,
+					server_id: server.clone(),
+					query_id: query.query_id,
+					payload: QueryResultPayload::Accounts(AccountsResult::Available {
+						accounts: vec![second.clone(), first.clone()],
+						routing: Some(routing),
+					}),
+				},
+			),
+			AccountRouteOutcome::Fresh
+		);
+		let snapshot = controller.snapshot();
+		assert!(snapshot.can_manage);
+		assert_eq!(snapshot.accounts, vec![first.clone(), second.clone()]);
+
+		controller
+			.select_fixed(&second.account_id)
+			.expect("ready account can become the fixed route");
+		let AccountDispatch::Command(command) = controller
+			.try_take_dispatch(2, &server)
+			.expect("fixed selection queues one command")
+		else {
+			panic!("fixed selection must dispatch a command")
+		};
+		assert_eq!(command.expected_revision, Some(EntityRevision(5)));
+		assert!(matches!(
+			command.payload,
+			CommandPayload::SetFixedAccountSelection {
+				ref account_id,
+				expected_account_revision: EntityRevision(7),
+			} if account_id == &second.account_id
+		));
+	}
+}

--- a/apps/decodex-gpui/src/bin/workbench_visual_capture.rs
+++ b/apps/decodex-gpui/src/bin/workbench_visual_capture.rs
@@ -1,6 +1,9 @@
 //! Deterministic native screenshot capture for the Codex Workbench design review.
 
 #[allow(dead_code)]
+#[path = "../accounts.rs"]
+mod accounts;
+#[allow(dead_code)]
 #[path = "../client_cache.rs"]
 mod client_cache;
 #[allow(dead_code)]

--- a/apps/decodex-gpui/src/client_lifecycle.rs
+++ b/apps/decodex-gpui/src/client_lifecycle.rs
@@ -22,6 +22,7 @@ use decodex_protocol::{
 };
 
 use crate::{
+	accounts::{AccountDispatch, AccountRouteOutcome, AccountsController},
 	client_cache::{
 		CacheAuthority, CacheError, CacheLimits, ClientCache, GenerationInspection,
 		ObjectCertainty, ObjectInput,
@@ -203,6 +204,7 @@ enum Delivery<C> {
 
 enum SessionStep<C> {
 	Delivery(Box<Result<Delivery<C>, RetainedSessionFailure>>),
+	Account(AccountDispatch),
 	Health(HealthDispatch),
 	History(HistoryDispatch),
 	QuickTask(QuickTaskDispatch),
@@ -324,6 +326,7 @@ pub(crate) struct ClientLifecycle {
 	cache_limits: CacheLimits,
 	cache_authority: CacheAuthority,
 	cache: Option<ClientCache>,
+	accounts: AccountsController,
 	health_query: HealthQuery,
 	history_pager: HistoryPager,
 	quick_tasks: QuickTasks,
@@ -386,6 +389,7 @@ impl ClientLifecycle {
 			cache_limits,
 			cache_authority,
 			cache,
+			accounts: AccountsController::production(),
 			health_query: HealthQuery::production(),
 			history_pager,
 			quick_tasks: QuickTasks::production(),
@@ -435,6 +439,11 @@ impl ClientLifecycle {
 	/// Clone the presentation-neutral Health controller before moving the lifecycle task.
 	pub(crate) fn health_query(&self) -> HealthQuery {
 		self.health_query.clone()
+	}
+
+	/// Clone the presentation-neutral account-pool controller.
+	pub(crate) fn accounts(&self) -> AccountsController {
+		self.accounts.clone()
 	}
 
 	/// Clone the presentation-neutral ordinary Quick Tasks controller.
@@ -497,6 +506,7 @@ impl ClientLifecycle {
 				requested_checkpoint.is_some(),
 				connected_checkpoint.as_ref(),
 			);
+			self.accounts.bind_session(generation, self.server_id.clone());
 			self.health_query.bind_session(generation, self.server_id.clone());
 			self.history_pager.bind_session(generation, self.server_id.clone());
 			self.quick_tasks.bind_session(generation, self.server_id.clone());
@@ -504,6 +514,7 @@ impl ClientLifecycle {
 			let failure =
 				self.run_connected_session(io, generation, connected_checkpoint.is_none()).await;
 
+			self.accounts.session_ended(generation);
 			self.health_query.session_ended(generation);
 			self.history_pager.session_ended(generation);
 			self.quick_tasks.session_ended(generation);
@@ -543,6 +554,7 @@ impl ClientLifecycle {
 		I: LifecycleIo,
 	{
 		loop {
+			let accounts = self.accounts.clone();
 			let health_query = self.health_query.clone();
 			let history_pager = self.history_pager.clone();
 			let quick_tasks = self.quick_tasks.clone();
@@ -550,6 +562,8 @@ impl ClientLifecycle {
 			let server_id = self.server_id.clone();
 			let step = tokio::select! {
 				delivery = io.next() => SessionStep::Delivery(Box::new(delivery)),
+				dispatch = accounts.next_dispatch(generation, &server_id),
+					if !requires_snapshot => SessionStep::Account(dispatch),
 				dispatch = health_query.next_dispatch(generation, &server_id),
 					if !requires_snapshot => SessionStep::Health(dispatch),
 				dispatch = history_pager.next_dispatch(generation, &server_id),
@@ -565,6 +579,20 @@ impl ClientLifecycle {
 			}
 
 			match step {
+				SessionStep::Account(dispatch) => {
+					if let Some(command) = dispatch.command() {
+						let send_result = io.send_command(command.clone()).await;
+						if let Err(failure) = send_result {
+							self.accounts.command_send_failed(&dispatch);
+							return failure;
+						}
+						self.accounts.command_sent(&dispatch);
+					} else if let Some(query) = dispatch.query()
+						&& let Err(failure) = io.send_query(query.clone()).await
+					{
+						return failure;
+					}
+				},
 				SessionStep::Health(dispatch) => {
 					if let Err(failure) = io.send_query(dispatch.envelope().clone()).await {
 						return failure;
@@ -653,6 +681,7 @@ impl ClientLifecycle {
 						}
 						self.quick_tasks.apply_event(&quick_task_event);
 						self.work_items.apply_event(&quick_task_event);
+						self.accounts.apply_event(&quick_task_event);
 						let checkpoint = match io.confirm_applied(confirmation) {
 							Ok(checkpoint) => checkpoint,
 							Err(_) => return self.confirmation_failure(),
@@ -669,12 +698,22 @@ impl ClientLifecycle {
 						}
 					},
 					Ok(Delivery::CommandReceipt(receipt)) => {
+						let _ = self.accounts.route_receipt(
+							generation,
+							&self.server_id,
+							&receipt,
+						);
 						let _ =
 							self.quick_tasks.route_receipt(generation, &self.server_id, &receipt);
 						let _ =
 							self.work_items.route_receipt(generation, &self.server_id, &receipt);
 					},
 					Ok(Delivery::CommandResult(result)) => {
+						let _ = self.accounts.route_command_result(
+							generation,
+							&self.server_id,
+							&result,
+						);
 						let _ = self.quick_tasks.route_command_result(
 							generation,
 							&self.server_id,
@@ -777,6 +816,10 @@ impl ClientLifecycle {
 		generation: u64,
 		result: QueryResultEnvelope,
 	) -> Result<(), RetainedSessionFailure> {
+		match self.accounts.route_query_result(generation, &self.server_id, &result) {
+			AccountRouteOutcome::Fresh | AccountRouteOutcome::Refused => return Ok(()),
+			AccountRouteOutcome::Unmatched => {},
+		}
 		match self.work_items.route_query_result(generation, &self.server_id, &result) {
 			WorkItemRouteOutcome::Fresh | WorkItemRouteOutcome::Refused => return Ok(()),
 			WorkItemRouteOutcome::Unmatched => {},

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -18,8 +18,9 @@ use decodex_protocol::{
 	CURRENT_VERSION, Channel, ClientProfile, CommandEnvelope, ConversationHistoryPage,
 	ConversationHistoryResult, CorrelationId, Cursor, DoctorReport, EntityId, EntityRevision,
 	EventEnvelope, EventPayload, HistoryCursorToken, QueryEnvelope, QueryPayload,
-	QueryResultEnvelope, QueryResultPayload, RetainedSessionConfig, RetainedSessionFailure,
-	ServerId, ServerInstanceId, SessionCheckpoint, SnapshotEnvelope, SnapshotItem, WireText,
+	QueryResultEnvelope, QueryResultPayload, QuickTaskState, RetainedSessionConfig,
+	RetainedSessionFailure, ServerId, ServerInstanceId, SessionCheckpoint, SnapshotEnvelope,
+	SnapshotItem, WireText,
 };
 
 use crate::{
@@ -2108,4 +2109,214 @@ fn test_fixture_uses_only_typed_bounded_cache_content() {
 	assert_eq!(inspection.records, 1);
 	assert!(!temporary.path().join("not-a-path").exists());
 	assert!(fs::read(client_cache_root(&root).join("current")).is_ok());
+}
+
+#[tokio::test]
+#[ignore = "requires the user's live Decodex daemon and creates two conversations plus one later turn"]
+async fn live_daemon_accepts_sequential_quick_tasks_and_returns_history() {
+	use crate::quick_tasks::{QuickTaskCommandState, QuickTasksLoadState};
+
+	let profile = ClientProfile::load_default(None).expect("the live profile is configured");
+	let config = profile.retained_session_config().expect("the live retained session is configured");
+	let mut lifecycle =
+		ClientLifecycle::production(config).expect("the production lifecycle is available");
+	let quick_tasks = lifecycle.quick_tasks();
+	let history = lifecycle.history_pager();
+	let cancellation = lifecycle.cancellation();
+	quick_tasks.activate();
+
+	let run = lifecycle.run();
+	tokio::pin!(run);
+	let ready_deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+	loop {
+		let snapshot = quick_tasks.snapshot();
+		if snapshot.load == QuickTasksLoadState::Ready && snapshot.can_submit {
+			break;
+		}
+		assert!(tokio::time::Instant::now() < ready_deadline, "Quick Tasks did not become ready");
+		tokio::select! {
+			result = &mut run => panic!("live lifecycle stopped before Quick Tasks became ready: {result:?}"),
+			() = tokio::time::sleep(Duration::from_millis(50)) => {},
+		}
+	}
+
+	let mut first_conversation = None;
+	let mut first_history_items = 0;
+	for ordinal in 1..=2 {
+		quick_tasks.begin_new();
+		quick_tasks
+			.create(&format!(
+				"Reply briefly with: Decodex sequential live smoke {ordinal} is working."
+			))
+			.expect("the live composer command is accepted for dispatch");
+		let accepted_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+		let conversation_id = loop {
+			let snapshot = quick_tasks.snapshot();
+			match snapshot.command {
+				QuickTaskCommandState::ManualRecovery(action) => {
+					panic!("the live daemon requested manual recovery before starting: {action:?}")
+				},
+				QuickTaskCommandState::OutcomeUnknown => {
+					panic!("the live daemon could not determine whether the command was accepted")
+				},
+				QuickTaskCommandState::Refused => {
+					panic!("the live daemon refused the composed Quick Task")
+				},
+				_ => {},
+			}
+			if let Some(conversation_id) = snapshot.selected.as_ref() {
+				let task = snapshot
+					.tasks
+					.iter()
+					.find(|task| &task.conversation_id == conversation_id)
+					.expect("the selected conversation has a projection");
+				if task.state == QuickTaskState::Ready {
+					break conversation_id.clone();
+				}
+			}
+			assert!(
+				tokio::time::Instant::now() < accepted_deadline,
+				"the live daemon did not finish the composed Quick Task; load={:?}, command={:?}, state={:?}",
+				snapshot.load,
+				snapshot.command,
+				snapshot.selected_task().map(|task| task.state),
+			);
+			tokio::select! {
+				result = &mut run => panic!("live lifecycle stopped before command acceptance: {result:?}"),
+				() = tokio::time::sleep(Duration::from_millis(50)) => {},
+			}
+		};
+
+		history.open(conversation_id.clone()).expect("the accepted conversation history opens");
+		let history_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+		let mut advanced_visible_items = 0;
+		let history_items = loop {
+			let snapshot = history.snapshot();
+			let visible_items = snapshot.visible.as_ref().map_or(0, |page| page.items.len());
+			if snapshot.visible_source == Some(HistoryPageSource::FreshServer) && visible_items > 0 {
+				match snapshot.cursor {
+					HistoryCursorObservation::NoContinuationObserved => {
+						assert_eq!(snapshot.conversation_id, Some(conversation_id.clone()));
+						break visible_items;
+					},
+					HistoryCursorObservation::ContinuationAvailable
+						if visible_items > advanced_visible_items =>
+					{
+						advanced_visible_items = visible_items;
+						assert_eq!(history.show_next(), HistoryNavigationResult::Moved);
+					},
+					_ => {},
+				}
+			}
+			assert!(
+				tokio::time::Instant::now() < history_deadline,
+				"the accepted conversation remained stuck without complete fresh history; load={:?}, source={:?}, cursor={:?}, visible_items={}, retained_pages={}",
+				snapshot.load,
+				snapshot.visible_source,
+				snapshot.cursor,
+				visible_items,
+				snapshot.retained_pages,
+			);
+			tokio::select! {
+				result = &mut run => panic!("live lifecycle stopped before history readback: {result:?}"),
+				() = tokio::time::sleep(Duration::from_millis(50)) => {},
+			}
+		};
+		if ordinal == 1 {
+			first_conversation = Some(conversation_id);
+			first_history_items = history_items;
+		}
+	}
+
+	let first_conversation = first_conversation.expect("the first live conversation completed");
+	assert!(quick_tasks.select(first_conversation.clone()));
+	let baseline_session_revision = quick_tasks
+		.snapshot()
+		.selected_task()
+		.and_then(|task| task.runtime_session_revision)
+		.expect("the completed first conversation has a RuntimeSession revision");
+	quick_tasks
+		.submit("Reply briefly with: Decodex same-thread rehydration is working.")
+		.expect("the later live turn is accepted for dispatch");
+	let continuation_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+	loop {
+		let snapshot = quick_tasks.snapshot();
+		match snapshot.command {
+			QuickTaskCommandState::ManualRecovery(action) => {
+				panic!("the live daemon requested manual recovery during rehydration: {action:?}")
+			},
+			QuickTaskCommandState::OutcomeUnknown => {
+				panic!("the live daemon could not determine the later-turn outcome")
+			},
+			QuickTaskCommandState::Refused => panic!("the live daemon refused the later live turn"),
+			_ => {},
+		}
+		if snapshot.selected_task().is_some_and(|task| {
+			task.state == QuickTaskState::Ready
+				&& task
+					.runtime_session_revision
+					.is_some_and(|revision| revision > baseline_session_revision)
+		})
+		{
+			break;
+		}
+		assert!(
+			tokio::time::Instant::now() < continuation_deadline,
+			"the later live turn did not advance its RuntimeSession; load={:?}, command={:?}, state={:?}",
+			snapshot.load,
+			snapshot.command,
+			snapshot.selected_task().map(|task| task.state),
+		);
+		tokio::select! {
+			result = &mut run => panic!("live lifecycle stopped before the later turn completed: {result:?}"),
+			() = tokio::time::sleep(Duration::from_millis(50)) => {},
+		}
+	}
+
+	history
+		.open(first_conversation.clone())
+		.expect("the rehydrated conversation history opens");
+	let continuation_history_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+	let mut advanced_visible_items = 0;
+	loop {
+		let snapshot = history.snapshot();
+		let visible_items = snapshot.visible.as_ref().map_or(0, |page| page.items.len());
+		if snapshot.visible_source == Some(HistoryPageSource::FreshServer) {
+			match snapshot.cursor {
+				HistoryCursorObservation::NoContinuationObserved
+					if visible_items > first_history_items =>
+				{
+					assert_eq!(snapshot.conversation_id, Some(first_conversation));
+					break;
+				},
+				HistoryCursorObservation::ContinuationAvailable
+					if visible_items > advanced_visible_items =>
+				{
+					advanced_visible_items = visible_items;
+					assert_eq!(history.show_next(), HistoryNavigationResult::Moved);
+				},
+				_ => {},
+			}
+		}
+		assert!(
+			tokio::time::Instant::now() < continuation_history_deadline,
+			"the rehydrated conversation history did not grow; load={:?}, source={:?}, cursor={:?}, visible_items={}, baseline_items={}, retained_pages={}",
+			snapshot.load,
+			snapshot.visible_source,
+			snapshot.cursor,
+			visible_items,
+			first_history_items,
+			snapshot.retained_pages,
+		);
+		tokio::select! {
+			result = &mut run => panic!("live lifecycle stopped before rehydrated history readback: {result:?}"),
+			() = tokio::time::sleep(Duration::from_millis(50)) => {},
+		}
+	}
+
+	cancellation.cancel();
+	let result = tokio::time::timeout(Duration::from_secs(5), &mut run)
+		.await
+		.expect("live lifecycle stops after cancellation");
+	assert_eq!(result, RunResult::Stopped);
 }

--- a/apps/decodex-gpui/src/history_pager.rs
+++ b/apps/decodex-gpui/src/history_pager.rs
@@ -24,6 +24,7 @@ use self::page_cache::{
 };
 
 const MAX_CANCELLED_REQUESTS: usize = 8;
+const MAX_INVALIDATED_CONVERSATIONS: usize = 64;
 const PRODUCTION_MAX_PAGE_BYTES: usize = 256 * 1_024;
 const PRODUCTION_MAX_WINDOW_BYTES: usize = 1_024 * 1_024;
 const PRODUCTION_MAX_WINDOW_ITEMS: usize = 32;
@@ -394,16 +395,17 @@ impl HistoryPager {
 		let mut state = self.lock();
 		let generation =
 			state.next_view_generation().ok_or(HistoryClosedReason::RequestIdentityExhausted)?;
+		let cache_eligible = !state.take_invalidated(&conversation_id);
 
 		state.cancel_in_flight(HistoryStaleReason::ConversationChanged);
-		state.active = Some(ActiveView::new(conversation_id, generation));
+		state.active = Some(ActiveView::new(conversation_id, generation, cache_eligible));
 		drop(state);
 		self.inner.notify.notify_one();
 
 		Ok(())
 	}
 
-	/// Reload the first bounded page only when the terminal event belongs to the open view.
+	/// Reload an open terminal Conversation or mark its cached head stale until the next open.
 	pub(crate) fn reload_if_open(
 		&self,
 		conversation_id: &EntityId,
@@ -411,8 +413,10 @@ impl HistoryPager {
 		let _commit_gate = self.lock_cache_publication_commit_gate();
 		let mut state = self.lock();
 		if !state.active.as_ref().is_some_and(|active| &active.conversation_id == conversation_id) {
+			state.invalidate(conversation_id.clone());
 			return Ok(false);
 		}
+		state.take_invalidated(conversation_id);
 		let generation =
 			state.next_view_generation().ok_or(HistoryClosedReason::RequestIdentityExhausted)?;
 		state.cancel_in_flight(HistoryStaleReason::ConversationChanged);
@@ -847,6 +851,7 @@ impl HistoryPager {
 					return HistoryRouteOutcome::Closed;
 				}
 
+				active.cache_reuse_allowed = true;
 				active.unavailable = None;
 				active.retry_request = None;
 				active.cache_publication_fence = cache_identity.clone();
@@ -1121,6 +1126,7 @@ struct PagerState {
 	send_in_flight: Option<HistorySendToken>,
 	active: Option<ActiveView>,
 	cancelled: VecDeque<CancelledRequest>,
+	invalidated: VecDeque<EntityId>,
 	last_stale_cancellation: Option<HistoryStaleCancellation>,
 }
 
@@ -1134,8 +1140,27 @@ impl PagerState {
 			send_in_flight: None,
 			active: None,
 			cancelled: VecDeque::new(),
+			invalidated: VecDeque::new(),
 			last_stale_cancellation: None,
 		}
+	}
+
+	fn invalidate(&mut self, conversation_id: EntityId) {
+		if let Some(index) = self.invalidated.iter().position(|current| current == &conversation_id) {
+			self.invalidated.remove(index);
+		}
+		self.invalidated.push_back(conversation_id);
+		while self.invalidated.len() > MAX_INVALIDATED_CONVERSATIONS {
+			self.invalidated.pop_front();
+		}
+	}
+
+	fn take_invalidated(&mut self, conversation_id: &EntityId) -> bool {
+		let Some(index) = self.invalidated.iter().position(|current| current == conversation_id) else {
+			return false;
+		};
+		self.invalidated.remove(index);
+		true
 	}
 
 	fn next_view_generation(&mut self) -> Option<u64> {
@@ -1368,13 +1393,14 @@ struct ActiveView {
 	retry_request: Option<PageRequest>,
 	unavailable: Option<HistoryAvailability>,
 	cache_lookup_armed: Option<PageRequest>,
+	cache_reuse_allowed: bool,
 	cache_publication_fence: Option<CacheOperationIdentity>,
 	provisional: Option<ProvisionalPage>,
 	cache_diagnostic: Option<HistoryCacheDiagnostic>,
 }
 
 impl ActiveView {
-	fn new(conversation_id: EntityId, generation: u64) -> Self {
+	fn new(conversation_id: EntityId, generation: u64, cache_eligible: bool) -> Self {
 		let initial = PageRequest::new(
 			generation,
 			PageKey::initial(conversation_id.clone()),
@@ -1390,7 +1416,8 @@ impl ActiveView {
 			in_flight: None,
 			retry_request: None,
 			unavailable: None,
-			cache_lookup_armed: Some(initial),
+			cache_lookup_armed: cache_eligible.then_some(initial),
+			cache_reuse_allowed: cache_eligible,
 			cache_publication_fence: None,
 			provisional: None,
 			cache_diagnostic: None,
@@ -1409,6 +1436,7 @@ impl ActiveView {
 		self.retry_request = None;
 		self.unavailable = None;
 		self.cache_lookup_armed = None;
+		self.cache_reuse_allowed = false;
 		self.cache_publication_fence = None;
 	}
 
@@ -1426,7 +1454,7 @@ impl ActiveView {
 		self.in_flight = None;
 		self.retry_request = None;
 		self.unavailable = unavailable;
-		self.cache_lookup_armed = Some(request);
+		self.cache_lookup_armed = self.cache_reuse_allowed.then_some(request);
 		self.cache_publication_fence = None;
 	}
 
@@ -1959,6 +1987,73 @@ mod tests {
 				reason: HistoryStaleReason::ConversationChanged,
 			})
 		);
+	}
+
+	#[test]
+	fn terminal_event_invalidates_cached_head_until_fresh_response() {
+		let temporary = TempDir::new_in(std::env::temp_dir())
+			.expect("host temporary directory accepts an isolated fixture");
+		let cache_parent = temporary.path().join("cache-parent");
+		let server_id = server("server-invalidated-cache");
+		let conversation_id = entity("conversation-invalidated-cache");
+		let cached_page = page(Some("cached-next"));
+		let fresh_page = page(Some("fresh-next"));
+
+		seed_cached_head(&cache_parent, &server_id, &conversation_id, &cached_page);
+
+		let pager = HistoryPager::production(&cache_parent, TEST_CACHE_SCHEMA_GENERATION);
+
+		pager.bind_session(SESSION_GENERATION, server_id.clone());
+		assert!(!pager
+			.reload_if_open(&conversation_id)
+			.expect("terminal invalidation remains bounded"));
+		pager.open(conversation_id).expect("invalidated conversation view opens");
+
+		let head = pager
+			.try_take_dispatch(SESSION_GENERATION, &server_id)
+			.expect("fresh head request is ready");
+		let send = pager.begin_send(&head).expect("current head enters the send phase");
+
+		assert!(pager.finish_send(&send));
+		pager.lookup_sent_request(&send);
+
+		let awaiting_fresh = pager.snapshot();
+
+		assert!(awaiting_fresh.visible.is_none());
+		assert_eq!(awaiting_fresh.visible_source, None);
+		assert_eq!(awaiting_fresh.cursor, HistoryCursorObservation::Unknown);
+
+		pager.session_ended(SESSION_GENERATION);
+		pager.bind_session(SESSION_GENERATION + 1, server_id.clone());
+		let replacement = pager
+			.try_take_dispatch(SESSION_GENERATION + 1, &server_id)
+			.expect("replacement session requests a fresh head");
+		let replacement_send = pager
+			.begin_send(&replacement)
+			.expect("replacement head enters the send phase");
+
+		assert!(pager.finish_send(&replacement_send));
+		pager.lookup_sent_request(&replacement_send);
+		assert!(pager.snapshot().visible.is_none());
+
+		assert!(matches!(
+			pager.route_result(
+				SESSION_GENERATION + 1,
+				&server_id,
+				result(
+					&replacement,
+					&server_id,
+					ConversationHistoryResult::Page(fresh_page.clone()),
+				),
+			),
+			HistoryRouteOutcome::Fresh
+		));
+
+		let fresh = pager.snapshot();
+
+		assert_eq!(fresh.visible, Some(fresh_page));
+		assert_eq!(fresh.visible_source, Some(HistoryPageSource::FreshServer));
+		assert_eq!(fresh.cursor, HistoryCursorObservation::ContinuationAvailable);
 	}
 
 	#[test]

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -1,5 +1,6 @@
 //! Production Decodex GPUI macOS composition root.
 
+mod accounts;
 #[cfg_attr(
 	not(test),
 	allow(
@@ -52,7 +53,7 @@ fn main() {
 					titlebar: Some(gpui::TitlebarOptions {
 						title: None,
 						appears_transparent: true,
-						traffic_light_position: Some(point(px(14.0), px(17.0))),
+						traffic_light_position: Some(point(px(14.0), px(14.0))),
 					}),
 					window_background: WindowBackgroundAppearance::Blurred,
 					app_owns_titlebar_drag: true,

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -10,12 +10,18 @@ use gpui::{
 };
 
 use decodex_protocol::{
-	AppServerCapability, ClientFailure, DoctorComponent, DoctorStatus, EntityId,
-	HistoryItemKindDto, HistoryItemStatusDto, HistoryPayloadDto, HistoryTurnRole,
-	QuickTaskRecoveryAction, QuickTaskState, WorkItemBoardCard, WorkItemState,
+	AccountDto, AccountLifecycleReadinessDto, AccountObservedStateDto, AccountQuotaStateDto,
+	AccountQuotaWindowDto, AccountSelectionModeDto, AppServerCapability, ClientFailure,
+	DoctorComponent, DoctorStatus, EntityId, HistoryItemKindDto, HistoryItemStatusDto,
+	HistoryPayloadDto, HistoryTurnRole, QuickTaskRecoveryAction, QuickTaskState, WorkItemBoardCard,
+	WorkItemState,
 };
 
 use crate::{
+	accounts::{
+		AccountCommandState, AccountInputError, AccountsController, AccountsLoadState,
+		AccountsSnapshot,
+	},
 	client_lifecycle::{
 		ClientLifecycle, CompatibilityReason, ConnectionView, LifecycleCancellation,
 		QuarantineReason, QuarantineRecovery,
@@ -33,7 +39,7 @@ use crate::{
 	work_items::{WorkItems, WorkItemsSnapshot},
 };
 
-const WORKBENCH_TOPBAR_HEIGHT: f32 = 48.0;
+const WORKBENCH_TOPBAR_HEIGHT: f32 = 42.0;
 const WORKBENCH_SESSION_SIDEBAR_WIDTH: f32 = 248.0;
 const WORKBENCH_INSPECTOR_WIDTH: f32 = 344.0;
 const LIFECYCLE_POLL: Duration = Duration::from_millis(40);
@@ -293,6 +299,9 @@ pub(crate) struct Shell {
 	composer: Entity<ComposerInput>,
 	factory: Entity<FactorySurface>,
 	settings: Entity<SettingsSurface>,
+	accounts_controller: AccountsController,
+	accounts: AccountsSnapshot,
+	account_status: Option<SharedString>,
 	health_query: HealthQuery,
 	health: HealthSnapshot,
 	quick_tasks: QuickTasks,
@@ -333,13 +342,14 @@ impl Shell {
 		})
 		.detach();
 		let settings = cx.new(SettingsSurface::new);
+		let accounts_controller = AccountsController::production();
+		let accounts = accounts_controller.snapshot();
 		let health_query = HealthQuery::production();
 		let health = health_query.snapshot();
 		let quick_tasks = QuickTasks::production();
 		quick_tasks.activate();
 		let quick = quick_tasks.snapshot();
 		let work_items = WorkItems::production();
-		work_items.activate();
 		let work = work_items.snapshot();
 		factory.update(cx, |factory, cx| factory.bind_work_items(work_items.clone(), cx));
 		window.focus(&root_focus, cx);
@@ -360,6 +370,9 @@ impl Shell {
 			composer,
 			factory,
 			settings,
+			accounts_controller,
+			accounts,
+			account_status: None,
 			health_query,
 			health,
 			quick_tasks,
@@ -379,8 +392,8 @@ impl Shell {
 	#[allow(dead_code)]
 	pub(crate) fn visual_workbench(window: &mut Window, cx: &mut Context<Self>) -> Self {
 		use decodex_protocol::{
-			ConversationHistoryPage, EntityRevision, ProjectSummary, QuickTaskSummary, WireText,
-			WorkItemBoardLeadId, WorkItemBoardProjectId, WorkItemBoardTitle,
+			AccountRoutingControlDto, ConversationHistoryPage, EntityRevision, ProjectSummary,
+			QuickTaskSummary, WireText, WorkItemBoardLeadId, WorkItemBoardProjectId, WorkItemBoardTitle,
 			WorkItemBoardWorkItemId, WorkItemPriority,
 		};
 
@@ -518,6 +531,68 @@ impl Shell {
 				),
 			],
 			can_mutate: true,
+		};
+		let visual_account = |id: &str,
+		                      alias: &str,
+		                      used_five_hour: u8,
+		                      used_seven_day: u8,
+		                      revision: u64| AccountDto {
+			account_id: EntityId::new(id).expect("visual account identity is canonical"),
+			alias: WireText::new(alias).expect("visual account alias is bounded"),
+			enabled: true,
+			account_revision: EntityRevision(revision),
+			observed_state: AccountObservedStateDto::Available,
+			lifecycle_readiness: AccountLifecycleReadinessDto::Ready,
+			credential_binding: None,
+			unsettled_operation: None,
+			five_hour_quota: AccountQuotaWindowDto {
+				duration_minutes: 300,
+				observed_at_unix_micros: Some(1_786_000_000_000_000),
+				result: AccountQuotaStateDto::Current {
+					used_percent: used_five_hour,
+					resets_at_unix_micros: 1_786_018_000_000_000,
+				},
+			},
+			seven_day_quota: AccountQuotaWindowDto {
+				duration_minutes: 10_080,
+				observed_at_unix_micros: Some(1_786_000_000_000_000),
+				result: AccountQuotaStateDto::Current {
+					used_percent: used_seven_day,
+					resets_at_unix_micros: 1_786_604_800_000_000,
+				},
+			},
+		};
+		let primary = visual_account(
+			"70000000-0000-4000-8000-000000000001",
+			"Primary",
+			64,
+			28,
+			12,
+		);
+		let reserve = visual_account(
+			"70000000-0000-4000-8000-000000000002",
+			"Build reserve",
+			18,
+			9,
+			7,
+		);
+		let research = visual_account(
+			"70000000-0000-4000-8000-000000000003",
+			"Research reserve",
+			91,
+			55,
+			4,
+		);
+		shell.accounts = AccountsSnapshot {
+			load: AccountsLoadState::Ready,
+			command: AccountCommandState::Idle,
+			accounts: vec![primary.clone(), reserve.clone(), research.clone()],
+			routing: Some(AccountRoutingControlDto {
+				revision: EntityRevision(6),
+				mode: AccountSelectionModeDto::Fixed(primary.account_id.clone()),
+				order: vec![primary.account_id, reserve.account_id, research.account_id],
+			}),
+			can_manage: true,
 		};
 
 		let item = |history_item_id: &str,
@@ -711,10 +786,8 @@ impl Shell {
 		if self.selected == Destination::QuickTasks {
 			self.quick_tasks.deactivate();
 		}
-		if matches!(self.selected, Destination::Factory | Destination::QuickTasks)
-			&& !matches!(destination, Destination::Factory | Destination::QuickTasks)
-		{
-			self.work_items.deactivate();
+		if self.selected == Destination::Accounts {
+			self.accounts_controller.deactivate();
 		}
 
 		self.selected = destination;
@@ -724,8 +797,9 @@ impl Shell {
 		if destination == Destination::QuickTasks {
 			self.quick_tasks.activate();
 		}
-		if matches!(destination, Destination::Factory | Destination::QuickTasks) {
-			self.work_items.activate();
+		if destination == Destination::Accounts {
+			self.accounts_controller.activate();
+			self.synchronize_accounts();
 		}
 		if destination == Destination::Settings {
 			self.settings.update(cx, SettingsSurface::refresh);
@@ -859,11 +933,68 @@ impl Shell {
 	fn bind_work_items(&mut self, work_items: WorkItems, cx: &mut Context<Self>) {
 		self.work_items.deactivate();
 		self.work_items = work_items;
-		if matches!(self.selected, Destination::Factory | Destination::QuickTasks) {
-			self.work_items.activate();
-		}
 		self.factory.update(cx, |factory, cx| factory.bind_work_items(self.work_items.clone(), cx));
 		self.synchronize_work_items(cx);
+	}
+
+	fn bind_accounts(&mut self, accounts: AccountsController, cx: &mut Context<Self>) {
+		self.accounts_controller.deactivate();
+		self.accounts_controller = accounts;
+		if self.selected == Destination::Accounts {
+			self.accounts_controller.activate();
+		}
+		self.synchronize_accounts();
+		cx.notify();
+	}
+
+	fn synchronize_accounts(&mut self) {
+		self.accounts = self.accounts_controller.snapshot();
+	}
+
+	fn refresh_accounts(&mut self, cx: &mut Context<Self>) {
+		if self.accounts_controller.refresh() {
+			self.account_status = None;
+			self.synchronize_accounts();
+			cx.notify();
+		}
+	}
+
+	fn set_account_enabled(
+		&mut self,
+		account_id: &EntityId,
+		enabled: bool,
+		cx: &mut Context<Self>,
+	) {
+		self.account_status = self
+			.accounts_controller
+			.set_enabled(account_id, enabled)
+			.err()
+			.map(account_input_error_label)
+			.map(Into::into);
+		self.synchronize_accounts();
+		cx.notify();
+	}
+
+	fn select_fixed_account(&mut self, account_id: &EntityId, cx: &mut Context<Self>) {
+		self.account_status = self
+			.accounts_controller
+			.select_fixed(account_id)
+			.err()
+			.map(account_input_error_label)
+			.map(Into::into);
+		self.synchronize_accounts();
+		cx.notify();
+	}
+
+	fn select_balanced_accounts(&mut self, cx: &mut Context<Self>) {
+		self.account_status = self
+			.accounts_controller
+			.select_balanced()
+			.err()
+			.map(account_input_error_label)
+			.map(Into::into);
+		self.synchronize_accounts();
+		cx.notify();
 	}
 
 	fn synchronize_work_items(&mut self, cx: &mut Context<Self>) {
@@ -1086,11 +1217,13 @@ pub(crate) fn retain_lifecycle(
 	let views = lifecycle.observe_views();
 	let initial_view = lifecycle.view();
 	let shell = window.entity(cx).expect("the production shell window remains open");
+	let accounts = lifecycle.accounts();
 	let health_query = lifecycle.health_query();
 	let quick_tasks = lifecycle.quick_tasks();
 	let work_items = lifecycle.work_items();
 	let history_pager = lifecycle.history_pager();
 	shell.update(cx, |shell, cx| {
+		shell.bind_accounts(accounts, cx);
 		shell.bind_health_query(health_query, cx);
 		shell.bind_quick_tasks(quick_tasks, history_pager, cx);
 		shell.bind_work_items(work_items, cx);
@@ -1160,11 +1293,16 @@ fn publish_views(
 		});
 	}
 	let _ = shell.update(cx, |shell, cx| {
+		let accounts = shell.accounts_controller.snapshot();
 		let health = shell.health_query.snapshot();
 		let quick = shell.quick_tasks.snapshot();
 		let work = shell.work_items.snapshot();
 		let history = shell.history_pager.as_ref().map(HistoryPager::snapshot);
 
+		if accounts != shell.accounts {
+			shell.accounts = accounts;
+			cx.notify();
+		}
 		if health != shell.health {
 			shell.health = health;
 			cx.notify();
@@ -1862,28 +2000,65 @@ fn placeholder_content(selected: Destination) -> AnyElement {
 		.into_any_element()
 }
 
-fn accounts_content(cx: &mut Context<Shell>) -> AnyElement {
+fn accounts_content(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
+	let snapshot = &shell.accounts;
+	let fixed = snapshot.routing.as_ref().and_then(|routing| match &routing.mode {
+		AccountSelectionModeDto::Fixed(account_id) => Some(account_id),
+		AccountSelectionModeDto::Balanced => None,
+	});
+	let balanced = snapshot
+		.routing
+		.as_ref()
+		.is_some_and(|routing| routing.mode == AccountSelectionModeDto::Balanced);
+	let can_manage = snapshot.can_manage;
+	let rows = snapshot
+		.accounts
+		.iter()
+		.enumerate()
+		.map(|(index, account)| {
+			account_pool_row(account, index, fixed == Some(&account.account_id), can_manage, cx)
+		})
+		.collect::<Vec<_>>();
+	let status = shell
+		.account_status
+		.as_ref()
+		.map(SharedString::to_string)
+		.or_else(|| account_command_label(snapshot.command).map(str::to_owned))
+		.unwrap_or_else(|| accounts_load_label(snapshot.load).to_owned());
+	let count = snapshot.accounts.len();
+	let available = snapshot
+		.accounts
+		.iter()
+		.filter(|account| {
+			account.enabled
+				&& account.observed_state == AccountObservedStateDto::Available
+				&& account.lifecycle_readiness == AccountLifecycleReadinessDto::Ready
+		})
+		.count();
+
 	div()
 		.flex_1()
 		.min_h_0()
-		.p_7()
+		.px_6()
+		.py_5()
 		.flex()
 		.justify_center()
 		.child(
 			div()
 				.w_full()
-				.max_w(px(820.0))
+				.max_w(px(900.0))
+				.min_h_0()
 				.flex()
 				.flex_col()
-				.gap_4()
+				.gap_3()
 				.child(
 					div()
-						.p_6()
+						.p_5()
 						.flex()
 						.items_center()
 						.justify_between()
 						.gap_6()
-						.rounded(px(14.0))
+						.rounded(px(13.0))
 						.border_1()
 						.border_color(rgba(0xffffff12))
 						.bg(rgba(ui_theme::SURFACE_RAISED_MATERIAL))
@@ -1892,7 +2067,7 @@ fn accounts_content(cx: &mut Context<Shell>) -> AnyElement {
 								.min_w_0()
 								.flex()
 								.flex_col()
-								.gap_2()
+								.gap_1()
 								.child(
 									div()
 										.flex()
@@ -1903,59 +2078,390 @@ fn accounts_content(cx: &mut Context<Shell>) -> AnyElement {
 											div()
 												.text_size(px(14.0))
 												.font_weight(FontWeight::SEMIBOLD)
-												.child("Codex account operations"),
+												.child("Account pool"),
+										)
+										.child(
+											div()
+										.font_family("SF Mono")
+										.text_size(px(8.0))
+										.text_color(rgb(WB_TEXT_FAINT))
+										.child(format!("{count} ACCOUNTS · {available} AVAILABLE")),
 										),
 								)
 								.child(
 									div()
-										.max_w(px(580.0))
-										.text_size(px(11.0))
-										.line_height(px(17.0))
+										.max_w(px(570.0))
+										.text_size(px(10.5))
+										.line_height(px(16.0))
 										.text_color(rgb(WB_TEXT_MUTED))
-										.child("Multi-account quota, routing, reauthentication, and recovery remain available through the signed menu bar companion."),
+										.child("Routing is chosen only for a new Codex conversation. Existing threads keep their bound account and cache affinity."),
 								),
 						)
 						.child(
 							div()
-								.id("accounts-open-settings")
-								.role(Role::Button)
-								.aria_label("Manage desktop surfaces")
-								.h(px(30.0))
-								.px_3()
 								.flex()
 								.items_center()
-								.rounded(px(8.0))
-								.border_1()
-								.border_color(rgba(0xffffff18))
-								.text_size(px(9.5))
-								.text_color(rgb(WB_TEXT_MUTED))
-								.cursor_pointer()
-								.hover(|element| {
-									element.bg(rgba(0xffffff0e)).text_color(rgb(WB_TEXT))
-								})
-								.active(|element| element.bg(rgba(0xffffff1c)).opacity(0.82))
-								.focus_visible(|element| element.border_color(rgb(WB_BLUE)))
-								.on_click(cx.listener(|shell, _, _, cx| {
-									shell.select_destination(Destination::Settings, cx);
-								}))
-								.child("Desktop settings"),
+								.gap_2()
+								.child(account_mode_button("Balanced", balanced, can_manage, cx))
+								.child(
+									div()
+										.id("accounts-refresh")
+										.role(Role::Button)
+										.aria_label("Refresh account pool")
+										.h(px(28.0))
+										.px_3()
+										.flex()
+										.items_center()
+										.rounded(px(7.0))
+										.border_1()
+										.border_color(rgba(0xffffff14))
+										.text_size(px(9.0))
+										.text_color(rgb(WB_TEXT_MUTED))
+										.cursor_pointer()
+										.hover(|element| {
+											element.bg(rgba(0xffffff0d)).text_color(rgb(WB_TEXT))
+										})
+										.active(|element| element.bg(rgba(0xffffff1b)).opacity(0.84))
+										.on_click(cx.listener(|shell, _, _, cx| {
+											shell.refresh_accounts(cx);
+										}))
+										.child("Refresh"),
+								),
 						),
 				)
 				.child(
 					div()
-						.p_5()
-						.rounded(px(12.0))
+						.id("account-list")
+						.flex_1()
+						.min_h_0()
+						.overflow_y_scroll()
+						.flex()
+						.flex_col()
+						.gap_2()
+						.when(count == 0, |list| {
+							list.child(
+								div()
+									.h(px(150.0))
+									.flex()
+									.flex_col()
+									.items_center()
+									.justify_center()
+									.gap_2()
+									.rounded(px(12.0))
+									.border_1()
+									.border_color(rgba(0xffffff0d))
+									.bg(rgba(0x0000001f))
+									.text_size(px(10.0))
+									.text_color(rgb(WB_TEXT_MUTED))
+									.child("No account projection is available yet.")
+									.child(
+										div()
+											.font_family("SF Mono")
+											.text_size(px(8.0))
+											.text_color(rgb(WB_TEXT_FAINT))
+											.child("Enroll or recover credentials from the menu bar surface."),
+									),
+							)
+						})
+						.children(rows),
+				)
+				.child(
+					div()
+						.h(px(28.0))
+						.px_3()
+						.flex()
+						.items_center()
+						.justify_between()
+						.rounded(px(8.0))
 						.border_1()
 						.border_color(rgba(0xffffff0d))
 						.bg(rgba(0x0000001f))
 						.font_family("SF Mono")
-						.text_size(px(8.5))
-						.line_height(px(14.0))
+						.text_size(px(8.0))
 						.text_color(rgb(WB_TEXT_FAINT))
-						.child("AUTHORITY BOUNDARY  ·  Decodex renders account readiness; the Codex app-server remains the account authority."),
+						.child(status)
+						.child("CREDENTIAL-NEGATIVE · DAEMON AUTHORITY"),
 				),
 		)
 		.into_any_element()
+}
+
+fn account_mode_button(
+	label: &'static str,
+	selected: bool,
+	can_manage: bool,
+	cx: &mut Context<Shell>,
+) -> AnyElement {
+	div()
+		.id("accounts-balanced")
+		.role(Role::Button)
+		.aria_label("Use balanced routing for new conversations")
+		.h(px(28.0))
+		.px_3()
+		.flex()
+		.items_center()
+		.rounded(px(7.0))
+		.border_1()
+		.border_color(if selected { rgba(0x60a5fa55) } else { rgba(0xffffff14) })
+		.bg(if selected { rgba(0x60a5fa16) } else { rgba(0x00000000) })
+		.text_size(px(9.0))
+		.text_color(if selected { rgb(WB_TEXT) } else { rgb(WB_TEXT_MUTED) })
+		.when(can_manage && !selected, |button| {
+			button
+				.cursor_pointer()
+				.hover(|element| element.bg(rgba(0xffffff0d)).text_color(rgb(WB_TEXT)))
+				.active(|element| element.bg(rgba(0xffffff1b)).opacity(0.84))
+				.on_click(cx.listener(|shell, _, _, cx| shell.select_balanced_accounts(cx)))
+		})
+		.child(label)
+		.into_any_element()
+}
+
+fn account_pool_row(
+	account: &AccountDto,
+	index: usize,
+	fixed: bool,
+	can_manage: bool,
+	cx: &mut Context<Shell>,
+) -> AnyElement {
+	let account_id = account.account_id.clone();
+	let toggle_account_id = account.account_id.clone();
+	let enabled = account.enabled;
+	let pin_enabled = can_manage && enabled && !fixed;
+	let toggle_enabled = can_manage;
+	let state_color = account_state_color(account);
+	let short_id = account.account_id.as_str().get(..8).unwrap_or(account.account_id.as_str());
+
+	div()
+		.id(("account-row", index))
+		.p_4()
+		.flex()
+		.items_center()
+		.gap_4()
+		.rounded(px(11.0))
+		.border_1()
+		.border_color(if fixed { rgba(0x60a5fa42) } else { rgba(0xffffff0f) })
+		.bg(if fixed { rgba(0x60a5fa0d) } else { rgba(ui_theme::SURFACE_MATERIAL) })
+		.child(
+			div()
+				.w(px(222.0))
+				.min_w(px(190.0))
+				.flex()
+				.items_center()
+				.gap_3()
+				.child(div().size(px(7.0)).rounded_full().bg(rgb(state_color)))
+				.child(
+					div()
+						.min_w_0()
+						.flex()
+						.flex_col()
+						.gap_1()
+						.child(
+							div()
+								.overflow_hidden()
+								.whitespace_nowrap()
+								.text_ellipsis()
+								.text_size(px(11.0))
+								.font_weight(FontWeight::SEMIBOLD)
+								.text_color(if enabled { rgb(WB_TEXT) } else { rgb(WB_TEXT_FAINT) })
+								.child(account.alias.as_str().to_owned()),
+						)
+						.child(
+							div()
+								.flex()
+								.items_center()
+								.gap_2()
+								.font_family("SF Mono")
+								.text_size(px(7.5))
+								.text_color(rgb(WB_TEXT_FAINT))
+								.child(account_readiness_label(account.lifecycle_readiness))
+								.child(format!("· {short_id}")),
+						),
+				),
+		)
+		.child(
+			div()
+				.flex_1()
+				.min_w_0()
+				.flex()
+				.items_center()
+				.gap_5()
+				.child(account_quota("5 HOUR", account.five_hour_quota))
+				.child(account_quota("7 DAY", account.seven_day_quota)),
+		)
+		.child(
+			div()
+				.flex()
+				.items_center()
+				.gap_2()
+				.child(
+					div()
+						.id(("account-pin", index))
+						.role(Role::Button)
+						.aria_label(format!("Route new conversations to {}", account.alias.as_str()))
+						.h(px(27.0))
+						.w(px(58.0))
+						.flex()
+						.items_center()
+						.justify_center()
+						.rounded(px(7.0))
+						.border_1()
+						.border_color(if fixed { rgba(0x60a5fa55) } else { rgba(0xffffff12) })
+						.bg(if fixed { rgba(0x60a5fa18) } else { rgba(0x00000000) })
+						.text_size(px(8.5))
+						.text_color(if fixed { rgb(WB_BLUE) } else { rgb(WB_TEXT_MUTED) })
+						.when(pin_enabled, |button| {
+							button
+								.cursor_pointer()
+								.hover(|element| {
+									element.bg(rgba(0xffffff0d)).text_color(rgb(WB_TEXT))
+								})
+								.active(|element| element.bg(rgba(0xffffff1b)).opacity(0.84))
+								.on_click(cx.listener(move |shell, _, _, cx| {
+									shell.select_fixed_account(&account_id, cx);
+								}))
+						})
+						.child(if fixed { "Pinned" } else { "Route" }),
+				)
+				.child(
+					div()
+						.id(("account-enabled", index))
+						.role(Role::Button)
+						.aria_label(format!(
+							"{} {}",
+							if enabled { "Disable" } else { "Enable" },
+							account.alias.as_str()
+						))
+						.h(px(27.0))
+						.w(px(58.0))
+						.flex()
+						.items_center()
+						.justify_center()
+						.rounded(px(7.0))
+						.border_1()
+						.border_color(if enabled { rgba(0x22c55e45) } else { rgba(0xffffff12) })
+						.bg(if enabled { rgba(0x22c55e12) } else { rgba(0x00000000) })
+						.text_size(px(8.5))
+						.text_color(if enabled { rgb(WB_GREEN) } else { rgb(WB_TEXT_FAINT) })
+						.when(toggle_enabled, |button| {
+							button
+								.cursor_pointer()
+								.hover(|element| {
+									element.bg(rgba(0xffffff0d)).text_color(rgb(WB_TEXT))
+								})
+								.active(|element| element.bg(rgba(0xffffff1b)).opacity(0.84))
+								.on_click(cx.listener(move |shell, _, _, cx| {
+									shell.set_account_enabled(&toggle_account_id, !enabled, cx);
+								}))
+						})
+						.child(if enabled { "Enabled" } else { "Disabled" }),
+				),
+		)
+		.into_any_element()
+}
+
+fn account_quota(label: &'static str, quota: AccountQuotaWindowDto) -> AnyElement {
+	let (detail, used, color) = match quota.result {
+		AccountQuotaStateDto::Current { used_percent, .. } => (
+			format!("{used_percent}% used"),
+			f32::from(used_percent),
+			if used_percent >= 90 { 0xef4444 } else if used_percent >= 70 { WB_AMBER } else { WB_BLUE },
+		),
+		AccountQuotaStateDto::Unknown => ("Unknown".to_owned(), 0.0, WB_TEXT_FAINT),
+		AccountQuotaStateDto::Error { .. } => ("Unavailable".to_owned(), 0.0, WB_TEXT_FAINT),
+	};
+	div()
+		.w(px(122.0))
+		.flex()
+		.flex_col()
+		.gap_1()
+		.child(
+			div()
+				.flex()
+				.items_center()
+				.justify_between()
+				.font_family("SF Mono")
+				.text_size(px(7.5))
+				.text_color(rgb(WB_TEXT_FAINT))
+				.child(label)
+				.child(detail),
+		)
+		.child(
+			div()
+				.h(px(3.0))
+				.w_full()
+				.rounded_full()
+				.bg(rgba(0xffffff0c))
+				.child(
+					div()
+						.h_full()
+						.w(px(used.clamp(0.0, 100.0) * 1.22))
+						.rounded_full()
+						.bg(rgb(color)),
+				),
+		)
+		.into_any_element()
+}
+
+fn account_state_color(account: &AccountDto) -> u32 {
+	if !account.enabled {
+		return WB_TEXT_FAINT;
+	}
+	match account.observed_state {
+		AccountObservedStateDto::Available => WB_GREEN,
+		AccountObservedStateDto::Unknown | AccountObservedStateDto::PluginUnready => WB_AMBER,
+		AccountObservedStateDto::Unavailable
+		| AccountObservedStateDto::Depleted
+		| AccountObservedStateDto::AuthFailed => 0xef4444,
+	}
+}
+
+fn account_readiness_label(readiness: AccountLifecycleReadinessDto) -> &'static str {
+	match readiness {
+		AccountLifecycleReadinessDto::Ready => "READY",
+		AccountLifecycleReadinessDto::CredentialAbsent => "NO CREDENTIAL",
+		AccountLifecycleReadinessDto::StoreUnavailable => "STORE UNAVAILABLE",
+		AccountLifecycleReadinessDto::StoreMismatch => "STORE MISMATCH",
+		AccountLifecycleReadinessDto::ProviderMismatch => "PROVIDER MISMATCH",
+		AccountLifecycleReadinessDto::OperationUnsettled => "OPERATION PENDING",
+		AccountLifecycleReadinessDto::CallbackCapabilityUnready => "CALLBACK UNREADY",
+		AccountLifecycleReadinessDto::Tombstoned => "LOGGED OUT",
+	}
+}
+
+fn accounts_load_label(load: AccountsLoadState) -> &'static str {
+	match load {
+		AccountsLoadState::NeverRequested => "Open Accounts to load the daemon-owned pool.",
+		AccountsLoadState::Loading => "Loading account pool…",
+		AccountsLoadState::Ready => "Account pool is synchronized.",
+		AccountsLoadState::Offline => "Account authority is offline.",
+		AccountsLoadState::Stale => "Showing retained account state; refresh after reconnect.",
+		AccountsLoadState::Unavailable => "The daemon could not return a safe account snapshot.",
+		AccountsLoadState::Refused => "The account response did not match this request.",
+	}
+}
+
+fn account_command_label(command: AccountCommandState) -> Option<&'static str> {
+	match command {
+		AccountCommandState::Idle => None,
+		AccountCommandState::Sending => Some("Sending account command…"),
+		AccountCommandState::AwaitingResult => Some("Waiting for durable account result…"),
+		AccountCommandState::Accepted => Some("Account pool updated."),
+		AccountCommandState::OutcomeUnknown => {
+			Some("Outcome is unknown. Refresh readback before another account change.")
+		},
+		AccountCommandState::Refused => Some("The account change was refused. Refresh and retry."),
+	}
+}
+
+fn account_input_error_label(error: AccountInputError) -> &'static str {
+	match error {
+		AccountInputError::Offline => "Account authority is offline.",
+		AccountInputError::Busy => "Wait for the current account change to finish.",
+		AccountInputError::AccountMissing => "That account is no longer in the current pool.",
+		AccountInputError::RoutingUnavailable => "Routing controls are unavailable. Refresh first.",
+		AccountInputError::IdentityUnavailable => "A command identity could not be created.",
+	}
 }
 
 fn quick_task_state_label(state: QuickTaskState) -> &'static str {
@@ -3393,7 +3899,7 @@ fn destination_content(
 	let content = if selected == Destination::Health {
 		health_content(&shell.health)
 	} else if selected == Destination::Accounts {
-		accounts_content(cx)
+		accounts_content(shell, cx)
 	} else {
 		placeholder_content(selected)
 	};
@@ -3453,6 +3959,7 @@ mod tests {
 
 	use super::*;
 	use crate::client_lifecycle::{CompatibilityReason, QuarantineReason, QuarantineRecovery};
+	use crate::work_items::WorkItemsLoadState;
 
 	fn open_shell(cx: &mut TestAppContext) -> (gpui::Entity<Shell>, &mut VisualTestContext) {
 		cx.update(bind_keys);
@@ -3589,6 +4096,17 @@ mod tests {
 	}
 
 	#[gpui::test]
+	fn workbench_does_not_activate_the_deferred_factory_protocol(cx: &mut TestAppContext) {
+		let (shell, _visual) = open_shell(cx);
+
+		assert_eq!(
+			shell.read_with(_visual, |shell, _| shell.work.load),
+			WorkItemsLoadState::NeverRequested,
+			"the default conversation surface must not send Factory-only queries"
+		);
+	}
+
+	#[gpui::test]
 	fn panel_shortcuts_toggle_both_workbench_sidebars(cx: &mut TestAppContext) {
 		let (shell, visual) = open_shell(cx);
 		assert!(shell.read_with(visual, |shell, _| shell.left_sidebar_visible));
@@ -3622,7 +4140,7 @@ mod tests {
 			visual.update(|window, cx| {
 				window.resize(size(px(width), px(height)));
 				window.draw(cx).clear();
-				assert_eq!(WORKBENCH_TOPBAR_HEIGHT, 48.0);
+				assert_eq!(WORKBENCH_TOPBAR_HEIGHT, 42.0);
 				assert_eq!(WORKBENCH_SESSION_SIDEBAR_WIDTH, 248.0);
 				assert_eq!(WORKBENCH_INSPECTOR_WIDTH, 344.0);
 			});

--- a/apps/decodex-gpui/src/work_items.rs
+++ b/apps/decodex-gpui/src/work_items.rs
@@ -148,6 +148,10 @@ impl WorkItems {
 		work_items
 	}
 
+	#[allow(
+		dead_code,
+		reason = "Factory activation remains gated until the retained session negotiates this capability"
+	)]
 	pub(crate) fn activate(&self) {
 		let mut state = self.lock();
 		state.active = true;

--- a/crates/decodex-runtime/src/quick_task.rs
+++ b/crates/decodex-runtime/src/quick_task.rs
@@ -58,7 +58,7 @@ use crate::{
 	ProcessGenerationControl, ProviderAttemptControl, ProviderAttemptReconciliation,
 	account_launch::{CapacityExhausted, RunnerCapacity},
 	account_service::{AccountLifecycleError, AccountProcessCredential, AccountService},
-	process_supervisor::FencedProcess,
+	process_supervisor::{FencedProcess, ProcessGenerationTermination},
 	provider_attempt_service::{
 		FreshRuntimeSessionResume, ProviderAttemptRuntimeAuthority, RuntimeSessionResumeRequest,
 		SuccessfulRuntimeSessionResume,
@@ -2681,16 +2681,33 @@ impl QuickTaskRuntime {
 		session.next_user_sequence =
 			context.logical_turn_sequence.saturating_add(sequence_increment);
 		let readback = session_readback(&session, QuickTaskLocalState::Ready, None);
-		if !self.restore_ready_if_active(&context.attempt_id, session) {
-			return Err(());
+		if self.retire_process(&session.process).await {
+			if !self.remove_active_if(&context.attempt_id, &session.conversation_id) {
+				return Err(());
+			}
+			self.emit(QuickTaskOutcome::Terminal {
+				readback,
+				turn_id: context.logical_turn_id.clone(),
+				state: terminal,
+				provider_turn_id: context.provider_turn_id.clone(),
+			})
+			.await;
+		} else {
+			let mut recovery = readback;
+			recovery.state = QuickTaskLocalState::ManualRecovery;
+			if !self.set_recovery_if_active(
+				&context.attempt_id,
+				recovery.clone(),
+				QuickTaskManualRecovery::ProcessUnavailable,
+			) {
+				return Err(());
+			}
+			self.emit(QuickTaskOutcome::ManualRecovery {
+				readback: recovery,
+				action: QuickTaskManualRecovery::ProcessUnavailable,
+			})
+			.await;
 		}
-		self.emit(QuickTaskOutcome::Terminal {
-			readback,
-			turn_id: context.logical_turn_id.clone(),
-			state: terminal,
-			provider_turn_id: context.provider_turn_id.clone(),
-		})
-		.await;
 		Ok(())
 	}
 
@@ -3082,11 +3099,21 @@ impl QuickTaskRuntime {
 	}
 
 	async fn terminate_process(&self, process: &FencedProcess) {
-		let _ = self
+		let _ = self.retire_process(process).await;
+	}
+
+	async fn retire_process(&self, process: &FencedProcess) -> bool {
+		matches!(
+			self
 			.inner
 			.process_generations
 			.terminate_exact(process.generation_id(), process.revision(), Duration::from_secs(5))
-			.await;
+			.await,
+			Ok(
+				ProcessGenerationTermination::PositiveDeathRecorded
+					| ProcessGenerationTermination::AlreadyDead
+			)
+		)
 	}
 
 	fn reserve_initial(&self, command: &CreateQuickTask) -> Result<(), Box<QuickTaskOutcome>> {
@@ -3674,24 +3701,44 @@ impl QuickTaskRuntime {
 		}
 	}
 
-	fn restore_ready_if_active(
+	fn remove_active_if(
 		&self,
 		attempt_id: &ProviderAttemptId,
-		session: LocalSession,
+		conversation_id: &ConversationId,
 	) -> bool {
 		let mut local = self.local();
-		if let Some(task) = local.get_mut(session.conversation_id.as_str()) {
-			let belongs = matches!(
+		let belongs = local.get(conversation_id.as_str()).is_some_and(|task| {
+			matches!(
 				&task.state,
 				LocalTaskState::Active { attempt_id: active_attempt_id, .. }
 					if active_attempt_id == attempt_id
-			);
-			if belongs {
-				task.state = LocalTaskState::Ready(session);
-				return true;
-			}
+			)
+		});
+		if belongs {
+			local.remove(conversation_id.as_str());
 		}
-		false
+		belongs
+	}
+
+	fn set_recovery_if_active(
+		&self,
+		attempt_id: &ProviderAttemptId,
+		readback: QuickTaskReadback,
+		action: QuickTaskManualRecovery,
+	) -> bool {
+		let mut local = self.local();
+		let Some(task) = local.get_mut(readback.conversation_id.as_str()) else {
+			return false;
+		};
+		if !matches!(
+			&task.state,
+			LocalTaskState::Active { attempt_id: active_attempt_id, .. }
+				if active_attempt_id == attempt_id
+		) {
+			return false;
+		}
+		task.state = LocalTaskState::Recovery { readback, action };
+		true
 	}
 
 	fn stop_active_worker(&self, attempt_id: &ProviderAttemptId, conversation_id: &ConversationId) {

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -90,6 +90,39 @@ evidence showed one failed user Turn, no active Turn, no Codex thread, no target
 ProcessGeneration, and no ProviderAttempt. The one-live-generation-per-account policy remains;
 cross-conversation process multiplexing is deferred.
 
+## Live GPUI workbench acceptance
+
+The current GPUI Workbench uses one retained same-UID protocol session for Conversation,
+Accounts, and Health. The Accounts destination shows bounded account lifecycle, quota,
+and routing controls. It does not read SQLite or expose credentials. The title bar is 42
+pixels high. Deterministic native captures cover the live Accounts destination and the
+transparent Workbench with the thinner title bar.
+
+The client does not activate the deferred WorkItem and Project query surface. Protocol
+V2.0 is strict, and an older daemon can close a retained session when it receives an
+unknown `ListProjects` query. The WorkItem controller stays dormant until a later
+capability-negotiation contract exists. This prevents the deferred factory surface from
+making Conversation history stay in loading state or making the whole Workbench appear
+offline.
+
+One ignored live integration test connected to the installed signed daemon and completed
+two new real Conversations in sequence. It then returned to the first Conversation,
+submitted a later Turn, and proved that its RuntimeSession revision and complete
+cursor-paged history advanced. The test read only bounded presentation state and did not
+emit an account, Conversation, Codex thread, or credential identifier.
+
+The runtime now retires the exact app-server process after positive provider terminal
+evidence and durable Turn terminalization. It records positive ProcessGeneration death
+before it publishes `Ready`. The later Turn rehydrates the original account and Codex
+thread in a fresh ProcessGeneration. After the three-turn live test, read-only SQLite
+inspection found zero non-dead ProcessGenerations and no app-server child owned by the
+daemon.
+
+A terminal event now refreshes history when its Conversation is open. If another
+Conversation is open, the pager records a bounded invalidation. The next open bypasses
+the cached head and waits for a fresh server page. A deterministic test proves that the
+old cached page cannot become visible after this invalidation.
+
 ## Final repository gates
 
 One complete `cargo make check` run finished successfully on the final source. It included:

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -24,7 +24,7 @@ one-shot transfer tool.
 - [Local database operations](operations/local-database.md): initialization, validation,
   installation, one-shot account transfer, rollback retention, and checks.
 - [SQLite implementation evidence](evidence/sqlite-local-product.md): current automated
-  evidence and the remaining live cutover gate.
+  evidence and signed live acceptance.
 - [Historical account lifecycle contract](specs/account-lifecycle-authority.md): retained
   domain semantics whose former server-store and redb ownership is superseded.
 - [ProcessGeneration authority](specs/process-generation-authority.md): durable pre-spawn
@@ -45,6 +45,7 @@ user message
 -> fenced ProcessGeneration
 -> fenced ProviderAttempt
 -> assistant history and positive terminal evidence
+-> exact app-server retirement and positive death evidence
 -> daemon restart
 -> later user message on the same Codex thread
 ```
@@ -60,6 +61,10 @@ replace Codex with a new agent kernel. It preserves exact account binding, pre-s
 fencing, one dispatch authorization, positive-only terminal evidence, and restart-safe
 ambiguity handling. One Conversation keeps its initially selected account even when the
 global routing default changes. Independent Conversations can use different accounts.
+Only one non-dead app-server generation can use an account at one time. After positive
+turn terminal evidence, the runtime retires that process before it publishes `Ready`. A
+later Turn starts a fresh process generation and rehydrates the same account and Codex
+thread. An idle completed Conversation does not reserve the account process slot.
 
 ## Deferred product surfaces
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -48,9 +48,13 @@ bounded inline value or a digest and length.
 11. A ProcessGeneration intent is committed before process creation. When an exact
     completed process-admission receipt exists but its target generation is absent, the
     request is positively known not to have spawned a process.
-12. V1 permits one non-dead ProcessGeneration per account. A second initial request for
-    that account fails before provider effect with `RestoreProcessReadiness`; it must not
-    become acceptance ambiguity.
+12. V1 permits one non-dead ProcessGeneration per account at one time. After positive
+    provider terminal evidence and atomic Turn terminalization, the runtime retires the
+    exact process and records positive death evidence before it publishes `Ready`. A
+    later Turn uses a fresh ProcessGeneration to rehydrate the same account and Codex
+    thread. A second request while the account still has a live generation fails before
+    provider effect with `RestoreProcessReadiness`; it must not become acceptance
+    ambiguity. An idle completed Turn must not reserve the account process slot.
 13. Account affinity is scoped to a Conversation. Its initial Routing Decision binds the
     RuntimeSession and Codex thread to one account. Later Turns do not re-evaluate global
     routing. Independent Conversations can bind to different accounts.
@@ -68,8 +72,9 @@ prevent an implicit duplicate effect.
 
 A terminal Quick Task keeps its Conversation, history, RuntimeSession, selected account,
 Codex thread, and next Turn sequence. A later user Turn can bind a SameThread continuation
-after the daemon restarts. If the bound account becomes depleted, V1 fails closed instead
-of switching the Conversation in place and losing provider cache affinity.
+after process retirement or after the daemon restarts. If the bound account becomes
+depleted, V1 fails closed instead of switching the Conversation in place and losing
+provider cache affinity.
 
 ## Credential boundary
 

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -1126,24 +1126,30 @@ receive a typed refusal before application payload handling.
 Large artifacts use authenticated HTTP, never WebSocket snapshots. Non-loopback binding
 remains disabled until authentication, TLS, authorization, and redaction gates pass.
 
-GPUI is the primary workspace. Current source opens a real shell and window with a
-bounded live Health destination. Every other destination remains a placeholder. The
-Quick Task and WorkItem contracts do not make their shell destinations live, and the
-app is not generally usable. Slice 1 delivers minimal Accounts, Conversation, and
-Health destinations with Quick Task. Slice 2 delivers
-Project, Work, and Run destinations for the bounded managed-work flow. Graph/timeline,
-automation, broad history presentation, and polish are later obligations. SwiftUI stays
-a thin accounts/run-health menubar client over the restricted protocol. GPUI caches are
-bounded, disposable, cursor-paginated, and keyed by server/schema/content hash; project
-opening never eagerly loads all history.
+GPUI is the primary workspace. Current source opens the transparent Workbench with live
+Conversation, Accounts, and Health destinations. One retained same-UID protocol session
+drives these destinations. Conversation creates and continues real Quick Tasks and reads
+bounded cursor-paged history. Accounts presents bounded lifecycle, quota, and routing
+controls without direct database access. The client keeps the deferred WorkItem and
+Project query surface dormant until capability negotiation exists. Project, Work, Run,
+graph, timeline, and automation remain later product slices. GPUI caches are bounded,
+disposable, cursor-paginated, and keyed by server, schema, and content hash. Opening a
+project never loads all history.
 
 ### GPUI history-page cache authority
 
-former server store remains product authority. The private `HistoryPageCache` is only GPUI-local,
-disposable presentation acceleration subordinate to `HistoryPager`. This first slice is
-dormant presentation infrastructure because no current shell destination renders
-`HistoryPager`. The pager keeps one active view and its existing four-page, 32-item,
-1 MiB in-memory window. This slice does not prove user-visible warm history.
+`decodexd` and bundled SQLite remain product authority. The private `HistoryPageCache` is
+only GPUI-local, disposable presentation acceleration subordinate to `HistoryPager`.
+Conversation renders the pager. The pager keeps one active view and its four-page,
+32-item, 1 MiB in-memory window. A terminal event refreshes an open Conversation. When
+another Conversation is open, the pager records a bounded invalidation and bypasses the
+cached head on the next open. A fresh server page must replace it.
+
+The remaining issue-specific implementation and acceptance text in this subsection is
+historical XY-1429 provenance. Its references to an unlanded or dormant slice, its old
+write set, and its deferred Conversation destination do not describe the current
+product. The current authority is the Local Product V1 contract and the live GPUI
+evidence page.
 
 `ClientLifecycle` owns one explicit GPUI cache parent. It starts with the lexical
 `std::env::temp_dir()`. On macOS only, when that path starts with the `/var` component,


### PR DESCRIPTION
Summary
- Keep Conversation, Accounts, and Health on one retained GPUI session while deferring unsupported factory queries.
- Add bounded account-pool routing controls and retain the accepted transparent Workbench with a 42 px title bar.
- Retire each app-server after positive terminal evidence and require fresh history after terminal invalidation.

Verification
- GPUI: 103 passed, 1 ignored in each production and visual-capture target.
- Runtime: 186 passed, 1 ignored.
- Real daemon smoke: two conversations plus a later same-thread turn, complete fresh history, zero non-dead process generations.
- Strict Clippy, architecture tests, SQLite gate, native captures, and signed release staging passed.

CI is not awaited, as requested; landing uses the Decodex CAS gate.
