### PR TITLE
Add app-server task refresh and execution controls

### DIFF
--- a/apps/decodex-cli/src/account.rs
+++ b/apps/decodex-cli/src/account.rs
@@ -1,4 +1,4 @@
-//! Operator account client over the same-UID V2.0 daemon protocol.
+//! Operator account client over the same-UID V2.1 daemon protocol.
 
 use std::path::{Path, PathBuf};
 

--- a/apps/decodex-cli/src/lib.rs
+++ b/apps/decodex-cli/src/lib.rs
@@ -115,7 +115,7 @@ pub enum Command {
 	/// Observe and consume reset cards through the common daemon authority.
 	#[command(subcommand)]
 	ResetCard(reset_card::ResetCardCommand),
-	/// Manage daemon-owned accounts through the same-UID V2.0 protocol.
+	/// Manage daemon-owned accounts through the same-UID V2.1 protocol.
 	#[command(subcommand)]
 	Account(account::AccountCommand),
 	/// Read or update the current user's local Codex Fast mode setting.

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -100,16 +100,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_0() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_1() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.0");
+		.expect("production lifecycle constructs at protocol V2.1");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 0);
+	assert_eq!(CURRENT_VERSION.minor, 1);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =

--- a/apps/decodex-gpui/src/quick_tasks.rs
+++ b/apps/decodex-gpui/src/quick_tasks.rs
@@ -17,8 +17,9 @@ use decodex_protocol::{
 	CommandPayload, CommandReceipt, CommandResultEnvelope, ConversationHistoryPage, CorrelationId,
 	EntityId, EntityRevision, EventEnvelope, EventPayload, HistoryText, IdempotencyKey,
 	QueryEnvelope, QueryId, QueryPayload, QueryResultEnvelope, QueryResultPayload,
-	QuickTaskListCursor, QuickTaskListResult, QuickTaskListSize, QuickTaskRecoveryAction,
-	QuickTaskResult, QuickTaskState, QuickTaskSummary, QuickTaskWorkingDirectory,
+	QuickTaskExecutionSettings, QuickTaskListCursor, QuickTaskListResult, QuickTaskListSize,
+	QuickTaskModel, QuickTaskReasoningEffort, QuickTaskRecoveryAction, QuickTaskResult,
+	QuickTaskState, QuickTaskSummary, QuickTaskWorkingDirectory,
 	ReceiptDisposition, ResultPayload, ServerId,
 };
 
@@ -26,6 +27,21 @@ const MAX_LIVE_DELTAS: usize = 64;
 const MAX_LIVE_DELTA_BYTES: usize = 64 * 1_024;
 const MAX_LIST_PAGES: usize = 32;
 const QUICK_TASK_WORKING_DIRECTORY_ENV: &str = "DECODEX_QUICK_TASK_WORKING_DIRECTORY";
+const QUICK_TASK_MODELS: &[&str] = &[
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+	"gpt-5.5",
+	"gpt-5.4",
+];
+const QUICK_TASK_EFFORTS: &[QuickTaskReasoningEffort] = &[
+	QuickTaskReasoningEffort::Low,
+	QuickTaskReasoningEffort::Medium,
+	QuickTaskReasoningEffort::High,
+	QuickTaskReasoningEffort::XHigh,
+	QuickTaskReasoningEffort::Max,
+	QuickTaskReasoningEffort::Ultra,
+];
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -38,6 +54,7 @@ pub(crate) struct QuickTasksSnapshot {
 	pub(crate) selected: Option<EntityId>,
 	pub(crate) live_deltas: Vec<QuickTaskLiveDelta>,
 	pub(crate) can_submit: bool,
+	pub(crate) execution: QuickTaskExecutionSettings,
 }
 
 impl QuickTasksSnapshot {
@@ -215,6 +232,73 @@ impl QuickTasks {
 		}
 	}
 
+	pub(crate) fn cycle_model(&self) {
+		let mut state = self.lock();
+		let current = state.execution.model.as_str();
+		let next = QUICK_TASK_MODELS
+			.iter()
+			.position(|model| *model == current)
+			.map_or(0, |index| (index + 1) % QUICK_TASK_MODELS.len());
+		state.execution.model = QuickTaskModel::new(QUICK_TASK_MODELS[next])
+			.expect("curated model identifier is valid");
+		state.clamp_effort_for_model();
+	}
+
+	pub(crate) fn cycle_reasoning_effort(&self) {
+		let mut state = self.lock();
+		let supported = supported_efforts(state.execution.model.as_str());
+		let next = supported
+			.iter()
+			.position(|effort| *effort == state.execution.reasoning_effort)
+			.map_or(0, |index| (index + 1) % supported.len());
+		state.execution.reasoning_effort = supported[next];
+	}
+
+	pub(crate) fn toggle_fast(&self) {
+		let mut state = self.lock();
+		state.execution.fast = !state.execution.fast;
+	}
+
+	/// Refresh the selected provider thread, or reload the active list when no task is selected.
+	pub(crate) fn refresh(&self) -> Result<(), QuickTaskInputError> {
+		let mut state = self.lock();
+		let selected = state.selected_task().cloned();
+		if selected.is_none() {
+			state.next_list_cursor = None;
+			let queued = state.queue_list();
+			drop(state);
+			if queued {
+				self.inner.notify.notify_one();
+				return Ok(());
+			}
+			return Err(QuickTaskInputError::Busy);
+		}
+		drop(state);
+		let task = selected.expect("selected task was checked");
+		if task.state != QuickTaskState::Ready {
+			return Err(QuickTaskInputError::NotReady);
+		}
+		self.queue_command(
+			CommandPayload::RefreshQuickTask { conversation_id: task.conversation_id },
+			Some(task.conversation_revision),
+			None,
+		)
+	}
+
+	pub(crate) fn archive_selected(&self) -> Result<(), QuickTaskInputError> {
+		let state = self.lock();
+		let task = state.selected_task().ok_or(QuickTaskInputError::NoSelection)?.clone();
+		drop(state);
+		if task.state != QuickTaskState::Ready {
+			return Err(QuickTaskInputError::NotReady);
+		}
+		self.queue_command(
+			CommandPayload::ArchiveQuickTask { conversation_id: task.conversation_id },
+			Some(task.conversation_revision),
+			None,
+		)
+	}
+
 	pub(crate) fn create(&self, message: &str) -> Result<(), QuickTaskInputError> {
 		let conversation_id = entity_id()?;
 		let working_directory = self
@@ -226,12 +310,19 @@ impl QuickTasks {
 			conversation_id: conversation_id.clone(),
 			message: message_text(message)?,
 			working_directory,
+			execution: self.lock().execution.clone(),
 		};
 		self.queue_command(payload, None, Some(conversation_id))
 	}
 
 	pub(crate) fn submit(&self, message: &str) -> Result<(), QuickTaskInputError> {
 		let state = self.lock();
+		if state.command == QuickTaskCommandState::OutcomeUnknown
+			|| state.pending_command.is_some()
+			|| state.in_flight_command.is_some()
+		{
+			return Err(QuickTaskInputError::Busy);
+		}
 		let task = state.selected_task().ok_or(QuickTaskInputError::NoSelection)?.clone();
 		if !task_accepts_turn(&task) && task_recovery_command(&task).is_none() {
 			return Err(QuickTaskInputError::NotReady);
@@ -252,6 +343,7 @@ impl QuickTasks {
 			turn_id,
 			message,
 			working_directory,
+			execution: self.lock().execution.clone(),
 		};
 		self.queue_command(payload, Some(task.conversation_revision), None)
 	}
@@ -457,6 +549,12 @@ impl QuickTasks {
 					text: delta.clone(),
 				});
 			},
+			EventPayload::QuickTaskArchived { conversation_id, .. } => {
+				state.remove_task(conversation_id);
+				if state.command == QuickTaskCommandState::Accepted {
+					state.command = QuickTaskCommandState::Idle;
+				}
+			},
 			_ => {},
 		}
 	}
@@ -613,6 +711,13 @@ impl QuickTasks {
 		let mut query_queued = false;
 		let outcome = match result.outcome {
 			CommandOutcome::Succeeded => {
+				if let Some(conversation_id) = accepted_archive_result(&in_flight, result) {
+					state.remove_task(&conversation_id);
+					state.routing_successor_reconciliation = None;
+					state.outcome_unknown_readback_generation = None;
+					state.command = QuickTaskCommandState::Accepted;
+					return QuickTaskRouteOutcome::Fresh;
+				}
 				let task = accepted_result_task(&in_flight, result);
 				let Some(task) = task else {
 					if state.routing_successor_reconciliation.is_some() {
@@ -701,10 +806,12 @@ struct State {
 	next_list_cursor: Option<QuickTaskListCursor>,
 	seen_list_cursors: Vec<QuickTaskListCursor>,
 	list_pages_accepted: usize,
+	list_accumulator: Vec<QuickTaskSummary>,
 	outcome_unknown_readback_generation: Option<u64>,
 	routing_successor_reconciliation: Option<RoutingSuccessorReconciliation>,
 	live_deltas: VecDeque<QuickTaskLiveDelta>,
 	live_delta_bytes: usize,
+	execution: QuickTaskExecutionSettings,
 }
 
 impl State {
@@ -726,10 +833,25 @@ impl State {
 			next_list_cursor: None,
 			seen_list_cursors: Vec::new(),
 			list_pages_accepted: 0,
+			list_accumulator: Vec::new(),
 			outcome_unknown_readback_generation: None,
 			routing_successor_reconciliation: None,
 			live_deltas: VecDeque::new(),
 			live_delta_bytes: 0,
+			execution: QuickTaskExecutionSettings::new(
+				QuickTaskModel::new("gpt-5.6-sol").expect("default model is valid"),
+				QuickTaskReasoningEffort::High,
+				false,
+			),
+		}
+	}
+
+	fn clamp_effort_for_model(&mut self) {
+		let supported = supported_efforts(self.execution.model.as_str());
+		if !supported.contains(&self.execution.reasoning_effort) {
+			self.execution.reasoning_effort = *supported
+				.last()
+				.expect("every curated model has a reasoning effort");
 		}
 	}
 
@@ -739,6 +861,7 @@ impl State {
 		self.next_list_cursor = None;
 		self.seen_list_cursors.clear();
 		self.list_pages_accepted = 0;
+		self.list_accumulator.clear();
 	}
 
 	fn queue_list(&mut self) -> bool {
@@ -748,6 +871,7 @@ impl State {
 		if self.next_list_cursor.is_none() {
 			self.seen_list_cursors.clear();
 			self.list_pages_accepted = 0;
+			self.list_accumulator.clear();
 		}
 		let after = self.next_list_cursor.clone();
 		let queued = self.queue_query(
@@ -860,26 +984,25 @@ impl State {
 					.is_some_and(|cursor| !self.seen_list_cursors.iter().any(|seen| seen == cursor))
 				{
 					self.next_list_cursor = None;
+					self.list_accumulator.clear();
 					self.load = QuickTasksLoadState::Refused;
 					return (QuickTaskRouteOutcome::Refused, false);
 				}
 				let Some(page_count) = self.list_pages_accepted.checked_add(1) else {
 					self.next_list_cursor = None;
+					self.list_accumulator.clear();
 					self.load = QuickTasksLoadState::Refused;
 					return (QuickTaskRouteOutcome::Refused, false);
 				};
 				self.list_pages_accepted = page_count;
-				if requested_after.is_none() {
-					self.replace_tasks(page.conversations.clone());
-				} else {
-					self.append_tasks(page.conversations.clone());
-				}
+				self.accumulate_tasks(page.conversations.clone());
 				match page.next_cursor.clone() {
 					Some(next_cursor)
 						if page_count >= MAX_LIST_PAGES
 							|| self.seen_list_cursors.iter().any(|seen| seen == &next_cursor) =>
 					{
 						self.next_list_cursor = None;
+						self.list_accumulator.clear();
 						self.load = QuickTasksLoadState::Refused;
 						(QuickTaskRouteOutcome::Refused, false)
 					},
@@ -891,6 +1014,8 @@ impl State {
 					},
 					None => {
 						self.next_list_cursor = None;
+						let tasks = std::mem::take(&mut self.list_accumulator);
+						self.replace_tasks(tasks);
 						self.load = QuickTasksLoadState::Ready;
 						if self.routing_successor_reconciliation.is_some()
 							&& self.command == QuickTaskCommandState::OutcomeUnknown
@@ -913,11 +1038,13 @@ impl State {
 			},
 			QueryResultPayload::QuickTasks(QuickTaskListResult::Unavailable { .. }) => {
 				self.next_list_cursor = None;
+				self.list_accumulator.clear();
 				self.load = QuickTasksLoadState::Unavailable;
 				(QuickTaskRouteOutcome::Fresh, false)
 			},
 			_ => {
 				self.next_list_cursor = None;
+				self.list_accumulator.clear();
 				self.load = QuickTasksLoadState::Refused;
 				(QuickTaskRouteOutcome::Refused, false)
 			},
@@ -1024,11 +1151,6 @@ impl State {
 				*task = existing.clone();
 			}
 		}
-		for existing in &self.tasks {
-			if !tasks.iter().any(|task| task.conversation_id == existing.conversation_id) {
-				tasks.push(existing.clone());
-			}
-		}
 		if let Some(requested) = self.requested_selection.as_ref()
 			&& tasks.iter().any(|task| &task.conversation_id == requested)
 		{
@@ -1038,7 +1160,13 @@ impl State {
 			.selected
 			.as_ref()
 			.is_some_and(|selected| tasks.iter().any(|task| &task.conversation_id == selected));
-		if !selected_is_present {
+		let preserves_unknown_successor_source = self
+			.routing_successor_reconciliation
+			.as_ref()
+			.is_some_and(|reconciliation| {
+				self.selected.as_ref() == Some(&reconciliation.source_conversation_id)
+			});
+		if !selected_is_present && !preserves_unknown_successor_source {
 			self.selected = if self.selection_suppressed {
 				None
 			} else {
@@ -1048,10 +1176,10 @@ impl State {
 		self.tasks = tasks;
 	}
 
-	fn append_tasks(&mut self, tasks: Vec<QuickTaskSummary>) {
+	fn accumulate_tasks(&mut self, tasks: Vec<QuickTaskSummary>) {
 		for task in tasks {
 			if let Some(existing) = self
-				.tasks
+				.list_accumulator
 				.iter_mut()
 				.find(|existing| existing.conversation_id == task.conversation_id)
 			{
@@ -1059,16 +1187,8 @@ impl State {
 					*existing = task;
 				}
 			} else {
-				self.tasks.push(task);
+				self.list_accumulator.push(task);
 			}
-		}
-		if let Some(requested) = self.requested_selection.as_ref()
-			&& self.tasks.iter().any(|task| &task.conversation_id == requested)
-		{
-			self.selected = self.requested_selection.take();
-		}
-		if self.selected.is_none() && !self.selection_suppressed {
-			self.selected = self.tasks.first().map(|task| task.conversation_id.clone());
 		}
 	}
 
@@ -1102,6 +1222,18 @@ impl State {
 		self.upsert_task(successor);
 		self.selected = Some(successor_conversation_id);
 		self.selection_suppressed = false;
+	}
+
+	fn remove_task(&mut self, conversation_id: &EntityId) {
+		self.tasks.retain(|task| &task.conversation_id != conversation_id);
+		self.live_deltas.retain(|delta| &delta.conversation_id != conversation_id);
+		if self.selected.as_ref() == Some(conversation_id) {
+			self.selected = if self.selection_suppressed {
+				None
+			} else {
+				self.tasks.first().map(|task| task.conversation_id.clone())
+			};
+		}
 	}
 
 	fn push_delta(&mut self, delta: QuickTaskLiveDelta) {
@@ -1165,7 +1297,16 @@ impl State {
 				&& self.pending_command.is_none()
 				&& self.in_flight_command.is_none()
 				&& self.command != QuickTaskCommandState::OutcomeUnknown,
+			execution: self.execution.clone(),
 		}
+	}
+}
+
+fn supported_efforts(model: &str) -> &'static [QuickTaskReasoningEffort] {
+	match model {
+		"gpt-5.6-sol" | "gpt-5.6-terra" => QUICK_TASK_EFFORTS,
+		"gpt-5.6-luna" => &QUICK_TASK_EFFORTS[..5],
+		_ => &QUICK_TASK_EFFORTS[..4],
 	}
 }
 
@@ -1242,7 +1383,8 @@ fn accepted_result_task(
 			CommandPayload::CreateQuickTask { .. }
 			| CommandPayload::ResumeQuickTaskRouting { .. }
 			| CommandPayload::ResumeQuickTaskEstablishment { .. }
-			| CommandPayload::SubmitQuickTaskTurn { .. },
+			| CommandPayload::SubmitQuickTaskTurn { .. }
+			| CommandPayload::RefreshQuickTask { .. },
 			Some(ResultPayload::QuickTaskConversationAccepted { conversation }),
 		) => conversation,
 		(
@@ -1259,6 +1401,29 @@ fn accepted_result_task(
 		return None;
 	}
 	Some(conversation.clone())
+}
+
+fn accepted_archive_result(
+	in_flight: &InFlightCommand,
+	result: &CommandResultEnvelope,
+) -> Option<EntityId> {
+	let command_conversation = match &in_flight.envelope.payload {
+		CommandPayload::ArchiveQuickTask { conversation_id }
+		| CommandPayload::RefreshQuickTask { conversation_id } => conversation_id,
+		_ => return None,
+	};
+	let Some(ResultPayload::QuickTaskArchived {
+		conversation_id,
+		conversation_revision,
+	}) = result.payload.as_ref()
+	else {
+		return None;
+	};
+	(command_conversation == conversation_id
+		&& in_flight.envelope.expected_revision?.0.checked_add(1)
+			== Some(conversation_revision.0)
+		&& result.entity_revision == Some(*conversation_revision))
+	.then(|| conversation_id.clone())
 }
 
 struct CommandIdentity {
@@ -1332,6 +1497,8 @@ fn command_conversation_id(payload: &CommandPayload) -> EntityId {
 		| CommandPayload::CreateQuickTaskRoutingSuccessor { conversation_id }
 		| CommandPayload::ResumeQuickTaskEstablishment { conversation_id }
 		| CommandPayload::SubmitQuickTaskTurn { conversation_id, .. }
+		| CommandPayload::RefreshQuickTask { conversation_id }
+		| CommandPayload::ArchiveQuickTask { conversation_id }
 		| CommandPayload::InterruptQuickTask { conversation_id, .. } => conversation_id.clone(),
 		_ => unreachable!("Quick Tasks queues only ordinary Quick Task commands"),
 	}
@@ -1487,6 +1654,171 @@ mod tests {
 		quick_tasks.command_sent(&dispatch);
 		quick_tasks.session_ended(1);
 		quick_tasks.bind_session(2, server_id.clone());
+	}
+
+	#[test]
+	fn complete_list_refresh_removes_a_projection_missing_from_current_authority() {
+		let (quick_tasks, server_id, task) = connected_quick_tasks();
+		let list = quick_tasks
+			.try_take_dispatch(1, &server_id)
+			.and_then(|dispatch| dispatch.query().cloned())
+			.expect("session binding queues an authoritative list read");
+		assert!(matches!(list.payload, QueryPayload::ListQuickTasks { .. }));
+		let result = QueryResultEnvelope {
+			version: CURRENT_VERSION,
+			server_id: server_id.clone(),
+			query_id: list.query_id,
+			payload: QueryResultPayload::QuickTasks(QuickTaskListResult::Available(
+				QuickTaskListPage::new(Vec::new(), None).expect("empty list page is valid"),
+			)),
+		};
+
+		assert_eq!(
+			quick_tasks.route_query_result(1, &server_id, &result),
+			QuickTaskRouteOutcome::Fresh
+		);
+		let snapshot = quick_tasks.snapshot();
+		assert!(snapshot.tasks.is_empty());
+		assert_eq!(snapshot.selected, None);
+		assert_eq!(snapshot.load, QuickTasksLoadState::Ready);
+		assert_ne!(snapshot.selected, Some(task.conversation_id));
+	}
+
+	#[test]
+	fn paginated_list_refresh_replaces_only_after_the_complete_readback() {
+		let (quick_tasks, server_id, selected) = connected_quick_tasks();
+		let first_page_task = QuickTaskSummary::new(
+			EntityId::new("00000000-0000-4000-8000-000000000003").expect("test ID is valid"),
+			EntityRevision(1),
+			2,
+			Some(
+				EntityId::new("00000000-0000-4000-8000-000000000004")
+					.expect("test session ID is valid"),
+			),
+			Some(EntityRevision(1)),
+			QuickTaskState::Ready,
+			None,
+			None,
+		)
+		.expect("test Quick Task is valid");
+		let cursor = QuickTaskListCursor::new(
+			first_page_task.projection_updated_at_micros,
+			first_page_task.conversation_id.clone(),
+		)
+		.expect("test list cursor is valid");
+		let first_query = quick_tasks
+			.try_take_dispatch(1, &server_id)
+			.and_then(|dispatch| dispatch.query().cloned())
+			.expect("session binding queues the first list page");
+		let first_result = QueryResultEnvelope {
+			version: CURRENT_VERSION,
+			server_id: server_id.clone(),
+			query_id: first_query.query_id,
+			payload: QueryResultPayload::QuickTasks(QuickTaskListResult::Available(
+				QuickTaskListPage::new(vec![first_page_task.clone()], Some(cursor.clone()))
+					.expect("first list page is valid"),
+			)),
+		};
+
+		assert_eq!(
+			quick_tasks.route_query_result(1, &server_id, &first_result),
+			QuickTaskRouteOutcome::Fresh
+		);
+		let partial = quick_tasks.snapshot();
+		assert_eq!(partial.tasks, vec![selected.clone()]);
+		assert_eq!(partial.selected, Some(selected.conversation_id.clone()));
+
+		let second_query = quick_tasks
+			.try_take_dispatch(1, &server_id)
+			.and_then(|dispatch| dispatch.query().cloned())
+			.expect("the cursor queues the second list page");
+		assert!(matches!(
+			second_query.payload,
+			QueryPayload::ListQuickTasks { after: Some(ref after), .. } if after == &cursor
+		));
+		let second_result = QueryResultEnvelope {
+			version: CURRENT_VERSION,
+			server_id: server_id.clone(),
+			query_id: second_query.query_id,
+			payload: QueryResultPayload::QuickTasks(QuickTaskListResult::Available(
+				QuickTaskListPage::new(vec![selected.clone()], None)
+					.expect("final list page is valid"),
+			)),
+		};
+
+		assert_eq!(
+			quick_tasks.route_query_result(1, &server_id, &second_result),
+			QuickTaskRouteOutcome::Fresh
+		);
+		let complete = quick_tasks.snapshot();
+		assert_eq!(complete.tasks, vec![first_page_task, selected.clone()]);
+		assert_eq!(complete.selected, Some(selected.conversation_id));
+		assert_eq!(complete.load, QuickTasksLoadState::Ready);
+	}
+
+	#[test]
+	fn archive_result_removes_the_exact_selected_task() {
+		let (quick_tasks, server_id, task) = connected_quick_tasks();
+		assert_eq!(quick_tasks.archive_selected(), Ok(()));
+		let dispatch = quick_tasks
+			.try_take_dispatch(1, &server_id)
+			.expect("archive command is dispatchable");
+		let command = dispatch.command().expect("archive dispatch is a command");
+		assert!(matches!(
+			&command.payload,
+			CommandPayload::ArchiveQuickTask { conversation_id }
+				if conversation_id == &task.conversation_id
+		));
+		assert_eq!(command.expected_revision, Some(task.conversation_revision));
+		quick_tasks.command_sent(&dispatch);
+		let result = CommandResultEnvelope {
+			version: CURRENT_VERSION,
+			server_id: server_id.clone(),
+			client_command_id: command.client_command_id.clone(),
+			idempotency_key: command.idempotency_key.clone(),
+			outcome: CommandOutcome::Succeeded,
+			entity_revision: Some(EntityRevision(2)),
+			payload: Some(ResultPayload::QuickTaskArchived {
+				conversation_id: task.conversation_id.clone(),
+				conversation_revision: EntityRevision(2),
+			}),
+			error: None,
+		};
+
+		assert_eq!(
+			quick_tasks.route_command_result(1, &server_id, &result),
+			QuickTaskRouteOutcome::Fresh
+		);
+		let snapshot = quick_tasks.snapshot();
+		assert!(snapshot.tasks.is_empty());
+		assert_eq!(snapshot.selected, None);
+	}
+
+	#[test]
+	fn selected_execution_controls_are_carried_by_each_subsequent_turn() {
+		let (quick_tasks, server_id, task) = connected_quick_tasks();
+		quick_tasks.cycle_model();
+		quick_tasks.cycle_reasoning_effort();
+		quick_tasks.toggle_fast();
+		let selected = quick_tasks.snapshot().execution;
+		assert_eq!(selected.model.as_str(), "gpt-5.6-terra");
+		assert_eq!(selected.reasoning_effort, QuickTaskReasoningEffort::XHigh);
+		assert!(selected.fast);
+
+		assert_eq!(quick_tasks.submit("Use the selected execution settings."), Ok(()));
+		let command = quick_tasks
+			.try_take_dispatch(1, &server_id)
+			.and_then(|dispatch| dispatch.command().cloned())
+			.expect("turn command is dispatchable");
+		assert_eq!(command.expected_revision, Some(task.conversation_revision));
+		assert!(matches!(
+			command.payload,
+			CommandPayload::SubmitQuickTaskTurn {
+				conversation_id,
+				execution,
+				..
+			} if conversation_id == task.conversation_id && execution == selected
+		));
 	}
 
 	#[test]

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -463,6 +463,12 @@ impl Shell {
 			selected: Some(conversation_id.clone()),
 			live_deltas: Vec::new(),
 			can_submit: true,
+			execution: decodex_protocol::QuickTaskExecutionSettings::new(
+				decodex_protocol::QuickTaskModel::new("gpt-5.6-sol")
+					.expect("visual model identifier is valid"),
+				decodex_protocol::QuickTaskReasoningEffort::High,
+				false,
+			),
 		};
 
 		let project_id = WorkItemBoardProjectId::new("40000000-0000-4000-8000-000000000001")
@@ -1049,6 +1055,9 @@ impl Shell {
 		cx: &mut Context<Self>,
 	) {
 		if self.quick_tasks.select(conversation_id.clone()) {
+			// Re-observe the selected app-server thread. SQLite is a local projection and
+			// another app-server client can change the provider state at any time.
+			let _ = self.quick_tasks.refresh();
 			self.creating_new = false;
 			self.opened_history = None;
 			self.synchronize_quick_tasks();
@@ -1086,6 +1095,46 @@ impl Shell {
 		if let Err(error) = self.quick_tasks.interrupt() {
 			self.input_status = Some(input_error_label(error).into());
 		}
+		self.synchronize_quick_tasks();
+		cx.notify();
+	}
+
+	fn refresh_quick_task(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+		self.input_status = self
+			.quick_tasks
+			.refresh()
+			.err()
+			.map(input_error_label)
+			.map(Into::into);
+		self.synchronize_quick_tasks();
+		cx.notify();
+	}
+
+	fn archive_quick_task(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+		self.input_status = self
+			.quick_tasks
+			.archive_selected()
+			.err()
+			.map(input_error_label)
+			.map(Into::into);
+		self.synchronize_quick_tasks();
+		cx.notify();
+	}
+
+	fn cycle_quick_task_model(&mut self, cx: &mut Context<Self>) {
+		self.quick_tasks.cycle_model();
+		self.synchronize_quick_tasks();
+		cx.notify();
+	}
+
+	fn cycle_quick_task_effort(&mut self, cx: &mut Context<Self>) {
+		self.quick_tasks.cycle_reasoning_effort();
+		self.synchronize_quick_tasks();
+		cx.notify();
+	}
+
+	fn toggle_quick_task_fast(&mut self, cx: &mut Context<Self>) {
+		self.quick_tasks.toggle_fast();
 		self.synchronize_quick_tasks();
 		cx.notify();
 	}
@@ -2559,7 +2608,7 @@ fn quick_task_load_status(load: QuickTasksLoadState) -> &'static str {
 	match load {
 		QuickTasksLoadState::NeverRequested => "Quick Tasks have not loaded.",
 		QuickTasksLoadState::Loading => "Loading Quick Tasks",
-		QuickTasksLoadState::Ready => "Codex state is current.",
+		QuickTasksLoadState::Ready => "Local task list loaded. Open or refresh a task for latest Codex state.",
 		QuickTasksLoadState::Offline => "Offline. Retained conversation state remains visible.",
 		QuickTasksLoadState::Unavailable => "Quick Task state is temporarily unavailable.",
 		QuickTasksLoadState::Refused => "Quick Task readback was refused.",
@@ -2575,6 +2624,8 @@ fn bound_work_item<'a>(
 
 fn quick_task_session_sidebar(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 	let selected = shell.quick.selected.clone();
+	let can_control = shell.quick.can_submit
+		&& shell.quick.selected_task().is_some_and(|task| task.state == QuickTaskState::Ready);
 	let rows = shell.quick.tasks.iter().enumerate().map(|(index, task)| {
 		let conversation_id = task.conversation_id.clone();
 		let short_id = task.conversation_id.as_str().chars().take(8).collect::<String>();
@@ -2674,26 +2725,80 @@ fn quick_task_session_sidebar(shell: &Shell, cx: &mut Context<Shell>) -> AnyElem
 				)
 				.child(
 					div()
-						.id("new-quick-task")
-						.role(Role::Button)
-						.aria_label("New conversation")
-						.h(px(27.0))
-						.px_2()
 						.flex()
 						.items_center()
-						.rounded(px(7.0))
-						.border_1()
-						.border_color(rgba(0xffffff14))
-						.text_size(px(8.5))
-						.text_color(rgb(WB_TEXT_MUTED))
-						.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
-						.active(|element| element.bg(rgba(0xffffff18)).opacity(0.82))
-						.focus_visible(|element| element.border_color(rgb(WB_BLUE)))
-						.cursor_pointer()
-						.on_click(cx.listener(|shell, _, window, cx| {
-							shell.start_new_quick_task(window, cx);
-						}))
-						.child("+ New"),
+						.gap_1()
+						.child(
+							div()
+								.id("refresh-quick-task")
+								.role(Role::Button)
+								.aria_label("Refresh selected Codex conversation")
+								.tooltip(|_, cx| {
+									cx.new(|_| ControlTooltip("Refresh selected thread from Codex"))
+										.into()
+								})
+								.size(px(27.0))
+								.flex()
+								.items_center()
+								.justify_center()
+								.rounded(px(7.0))
+								.text_size(px(12.0))
+								.text_color(rgb(WB_TEXT_MUTED))
+								.cursor_pointer()
+								.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+								.active(|element| element.bg(rgba(0xffffff18)).opacity(0.82))
+								.on_click(cx.listener(|shell, _, window, cx| {
+									shell.refresh_quick_task(window, cx);
+								}))
+								.child("↻"),
+						)
+						.child(
+							div()
+								.id("archive-quick-task")
+								.role(Role::Button)
+								.aria_label("Archive selected Codex conversation")
+								.tooltip(|_, cx| cx.new(|_| ControlTooltip("Archive selected thread")).into())
+								.h(px(27.0))
+								.px_2()
+								.flex()
+								.items_center()
+								.rounded(px(7.0))
+								.text_size(px(8.0))
+								.text_color(if can_control { rgb(WB_TEXT_MUTED) } else { rgb(WB_TEXT_FAINT) })
+								.when(can_control, |element| {
+									element
+										.cursor_pointer()
+										.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+										.active(|element| element.bg(rgba(0xffffff18)).opacity(0.82))
+										.on_click(cx.listener(|shell, _, window, cx| {
+											shell.archive_quick_task(window, cx);
+										}))
+								})
+								.child("Archive"),
+						)
+						.child(
+							div()
+								.id("new-quick-task")
+								.role(Role::Button)
+								.aria_label("New conversation")
+								.h(px(27.0))
+								.px_2()
+								.flex()
+								.items_center()
+								.rounded(px(7.0))
+								.border_1()
+								.border_color(rgba(0xffffff14))
+								.text_size(px(8.5))
+								.text_color(rgb(WB_TEXT_MUTED))
+								.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+								.active(|element| element.bg(rgba(0xffffff18)).opacity(0.82))
+								.focus_visible(|element| element.border_color(rgb(WB_BLUE)))
+								.cursor_pointer()
+								.on_click(cx.listener(|shell, _, window, cx| {
+									shell.start_new_quick_task(window, cx);
+								}))
+								.child("+ New"),
+						),
 				),
 		)
 		.child(
@@ -3535,6 +3640,9 @@ fn quick_task_composer(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 		shell.quick.can_submit && can_continue && (has_message || has_pre_session_recovery);
 	let can_interrupt =
 		shell.quick.can_submit && task.is_some_and(|task| task.state == QuickTaskState::Running);
+	let model_label = shell.quick.execution.model.as_str().to_owned();
+	let effort_label = shell.quick.execution.reasoning_effort.as_str().to_uppercase();
+	let fast_enabled = shell.quick.execution.fast;
 
 	let send = div()
 		.id("quick-task-send")
@@ -3590,16 +3698,75 @@ fn quick_task_composer(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 				}))
 		})
 		.child("Stop");
-	let context = task.map_or_else(
-		|| "New local session".to_owned(),
-		|task| {
-			format!(
-				"{} · conversation r{}",
-				quick_task_state_label(task.state),
-				task.conversation_revision.0
-			)
-		},
-	);
+	let model_control = div()
+		.id("quick-task-model")
+		.role(Role::Button)
+		.aria_label(format!("Model {model_label}; select next model"))
+		.tooltip(|_, cx| cx.new(|_| ControlTooltip("Model · click to cycle")).into())
+		.h(px(23.0))
+		.px_2()
+		.flex()
+		.items_center()
+		.rounded(px(6.0))
+		.border_1()
+		.border_color(rgba(0xffffff10))
+		.bg(rgba(0x00000018))
+		.font_family("SF Mono")
+		.text_size(px(8.0))
+		.text_color(rgb(WB_TEXT_MUTED))
+		.cursor_pointer()
+		.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+		.active(|element| element.opacity(0.72))
+		.on_click(cx.listener(|shell, _, _, cx| shell.cycle_quick_task_model(cx)))
+		.child(model_label);
+	let fast_control = div()
+		.id("quick-task-fast")
+		.role(Role::Button)
+		.aria_label(if fast_enabled { "Fast mode on" } else { "Fast mode off" })
+		.tooltip(|_, cx| cx.new(|_| ControlTooltip("Fast · priority service tier")).into())
+		.h(px(23.0))
+		.px_2()
+		.flex()
+		.items_center()
+		.gap_1()
+		.rounded(px(6.0))
+		.border_1()
+		.border_color(if fast_enabled { rgba(0xffa45d40) } else { rgba(0xffffff10) })
+		.bg(if fast_enabled { rgba(0xff8a3d16) } else { rgba(0x00000018) })
+		.font_family("SF Mono")
+		.text_size(px(8.0))
+		.text_color(if fast_enabled { rgb(WB_AMBER) } else { rgb(WB_TEXT_MUTED) })
+		.cursor_pointer()
+		.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+		.active(|element| element.opacity(0.72))
+		.on_click(cx.listener(|shell, _, _, cx| shell.toggle_quick_task_fast(cx)))
+		.child(div().size(px(4.0)).rounded_full().bg(if fast_enabled {
+			rgb(WB_AMBER)
+		} else {
+			rgb(WB_TEXT_FAINT)
+		}))
+		.child("Fast");
+	let effort_control = div()
+		.id("quick-task-effort")
+		.role(Role::Button)
+		.aria_label(format!("Reasoning effort {effort_label}; select next effort"))
+		.tooltip(|_, cx| cx.new(|_| ControlTooltip("Reasoning effort · click to cycle")).into())
+		.h(px(23.0))
+		.px_2()
+		.flex()
+		.items_center()
+		.rounded(px(6.0))
+		.border_1()
+		.border_color(rgba(0xffffff10))
+		.bg(rgba(0x00000018))
+		.font_family("SF Mono")
+		.text_size(px(8.0))
+		.text_color(rgb(WB_TEXT_MUTED))
+		.cursor_pointer()
+		.hover(|element| element.bg(rgba(0xffffff0a)).text_color(rgb(WB_TEXT)))
+		.active(|element| element.opacity(0.72))
+		.on_click(cx.listener(|shell, _, _, cx| shell.cycle_quick_task_effort(cx)))
+		.child(effort_label);
 	div()
 		.min_h(px(88.0))
 		.px_5()
@@ -3636,15 +3803,28 @@ fn quick_task_composer(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 								.min_w_0()
 								.flex()
 								.items_center()
-								.gap_2()
-								.text_size(px(8.5))
-								.text_color(rgb(WB_TEXT_FAINT))
-								.child(context)
-								.when(composer_len > 0, |element| {
-									element.child(format!("· {composer_len}/{MAX_COMPOSER_BYTES}"))
-								}),
+								.gap_1()
+								.child(model_control)
+								.child(fast_control)
+								.child(effort_control),
 						)
-						.child(div().flex().gap_2().child(interrupt).child(send)),
+						.child(
+							div()
+								.flex()
+								.items_center()
+								.gap_2()
+								.when(composer_len > 0, |element| {
+									element.child(
+										div()
+											.font_family("SF Mono")
+											.text_size(px(7.5))
+											.text_color(rgb(WB_TEXT_FAINT))
+											.child(format!("{composer_len}/{MAX_COMPOSER_BYTES}")),
+									)
+								})
+								.child(interrupt)
+								.child(send),
+						),
 				),
 		)
 		.into_any_element()

--- a/crates/decodex-codex/src/quick_task.rs
+++ b/crates/decodex-codex/src/quick_task.rs
@@ -361,6 +361,7 @@ pub struct QuickTaskThreadStartRequest {
 	model: QuickTaskModel,
 	cwd: ThreadCwd,
 	developer_instructions: QuickTaskInstructions,
+	fast: bool,
 }
 impl QuickTaskThreadStartRequest {
 	/// Accept explicit caller configuration for one durable thread.
@@ -373,7 +374,14 @@ impl QuickTaskThreadStartRequest {
 			model: QuickTaskModel::new(model)?,
 			cwd: ThreadCwd::from_protocol(cwd).map_err(|_| QuickTaskContractError::InvalidCwd)?,
 			developer_instructions: QuickTaskInstructions::new(developer_instructions)?,
+			fast: false,
 		})
+	}
+
+	/// Select request-scoped Codex Fast mode without changing global configuration.
+	pub const fn with_fast(mut self, fast: bool) -> Self {
+		self.fast = fast;
+		self
 	}
 
 	/// Caller-selected model sent to the app server.
@@ -401,12 +409,13 @@ impl Serialize for QuickTaskThreadStartRequest {
 	where
 		S: Serializer,
 	{
-		let mut request = serializer.serialize_struct("QuickTaskThreadStartRequest", 4)?;
+		let mut request = serializer.serialize_struct("QuickTaskThreadStartRequest", 5)?;
 
 		request.serialize_field("model", self.model.as_str())?;
 		request.serialize_field("cwd", self.cwd.as_str())?;
 		request.serialize_field("developerInstructions", self.developer_instructions.as_str())?;
 		request.serialize_field("ephemeral", &false)?;
+		request.serialize_field("serviceTier", &self.fast.then_some("priority"))?;
 		request.end()
 	}
 }
@@ -489,6 +498,7 @@ pub struct QuickTaskThreadResumeRequest {
 	model: QuickTaskModel,
 	cwd: ThreadCwd,
 	developer_instructions: QuickTaskInstructions,
+	fast: bool,
 }
 impl QuickTaskThreadResumeRequest {
 	/// Accept one exact thread and explicit caller configuration.
@@ -503,7 +513,14 @@ impl QuickTaskThreadResumeRequest {
 			model: QuickTaskModel::new(model)?,
 			cwd: ThreadCwd::from_protocol(cwd).map_err(|_| QuickTaskContractError::InvalidCwd)?,
 			developer_instructions: QuickTaskInstructions::new(developer_instructions)?,
+			fast: false,
 		})
+	}
+
+	/// Select request-scoped Codex Fast mode without changing global configuration.
+	pub const fn with_fast(mut self, fast: bool) -> Self {
+		self.fast = fast;
+		self
 	}
 
 	/// Exact caller-supplied thread.
@@ -536,13 +553,14 @@ impl Serialize for QuickTaskThreadResumeRequest {
 	where
 		S: Serializer,
 	{
-		let mut request = serializer.serialize_struct("QuickTaskThreadResumeRequest", 5)?;
+		let mut request = serializer.serialize_struct("QuickTaskThreadResumeRequest", 6)?;
 
 		request.serialize_field("threadId", self.thread_id.as_str())?;
 		request.serialize_field("model", self.model.as_str())?;
 		request.serialize_field("cwd", self.cwd.as_str())?;
 		request.serialize_field("developerInstructions", self.developer_instructions.as_str())?;
 		request.serialize_field("excludeTurns", &true)?;
+		request.serialize_field("serviceTier", &self.fast.then_some("priority"))?;
 		request.end()
 	}
 }
@@ -653,6 +671,7 @@ pub struct QuickTaskTurnStartRequest {
 	input: QuickTaskTurnInput,
 	model: QuickTaskModel,
 	reasoning_effort: QuickTaskReasoningEffort,
+	fast: bool,
 }
 impl QuickTaskTurnStartRequest {
 	/// Accept one bounded turn without selecting or defaulting model settings.
@@ -667,7 +686,14 @@ impl QuickTaskTurnStartRequest {
 			input,
 			model: QuickTaskModel::new(model)?,
 			reasoning_effort: QuickTaskReasoningEffort::new(reasoning_effort)?,
+			fast: false,
 		})
+	}
+
+	/// Select request-scoped Codex Fast mode without changing global configuration.
+	pub const fn with_fast(mut self, fast: bool) -> Self {
+		self.fast = fast;
+		self
 	}
 
 	/// Exact target thread.
@@ -695,12 +721,13 @@ impl Serialize for QuickTaskTurnStartRequest {
 	where
 		S: Serializer,
 	{
-		let mut request = serializer.serialize_struct("QuickTaskTurnStartRequest", 4)?;
+		let mut request = serializer.serialize_struct("QuickTaskTurnStartRequest", 5)?;
 
 		request.serialize_field("threadId", self.thread_id.as_str())?;
 		request.serialize_field("input", &QuickTaskTextInputs(self.input.items()))?;
 		request.serialize_field("model", self.model.as_str())?;
 		request.serialize_field("effort", self.reasoning_effort.as_str())?;
+		request.serialize_field("serviceTier", &self.fast.then_some("priority"))?;
 		request.end()
 	}
 }
@@ -1752,7 +1779,8 @@ mod tests {
 
 	use super::{
 		MAX_QUICK_TASK_RESPONSE_BYTES, QuickTaskContractError, QuickTaskThreadResumeRequest,
-		QuickTaskThreadStartRequest, QuickTaskTurnStatus,
+		QuickTaskThreadStartRequest, QuickTaskTurnInput, QuickTaskTurnStartRequest,
+		QuickTaskTurnStatus,
 		decode_quick_task_thread_archive_response, decode_quick_task_thread_resume_response,
 		decode_quick_task_thread_start_response, decode_quick_task_turn_interrupt_response,
 		decode_quick_task_turn_start_response,
@@ -1816,6 +1844,7 @@ mod tests {
 				"cwd": "/workspace",
 				"developerInstructions": "Follow the request.",
 				"excludeTurns": true,
+				"serviceTier": null,
 			})
 		);
 		let object = encoded.as_object().expect("request must remain an object");
@@ -1829,6 +1858,34 @@ mod tests {
 		] {
 			assert!(!object.contains_key(forbidden));
 		}
+	}
+
+	#[test]
+	fn fast_mode_is_explicitly_request_scoped_for_thread_start_and_resume() {
+		let start = serde_json::to_value(start_request().with_fast(true))
+			.expect("fast thread start request must serialize");
+		let resume = serde_json::to_value(resume_request().with_fast(true))
+			.expect("fast thread resume request must serialize");
+
+		assert_eq!(start.get("serviceTier"), Some(&json!("priority")));
+		assert_eq!(resume.get("serviceTier"), Some(&json!("priority")));
+	}
+
+	#[test]
+	fn turn_execution_settings_include_model_effort_and_explicit_fast_tier() {
+		let turn = QuickTaskTurnStartRequest::new(
+			exact_thread(),
+			QuickTaskTurnInput::text("Continue.").expect("turn input is valid"),
+			"gpt-5.6-terra",
+			"xhigh",
+		)
+		.expect("turn request is valid")
+		.with_fast(true);
+		let encoded = serde_json::to_value(turn).expect("turn request must serialize");
+
+		assert_eq!(encoded.get("model"), Some(&json!("gpt-5.6-terra")));
+		assert_eq!(encoded.get("effort"), Some(&json!("xhigh")));
+		assert_eq!(encoded.get("serviceTier"), Some(&json!("priority")));
 	}
 
 	#[test]

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -846,7 +846,7 @@ impl ResetCardClient {
 	}
 }
 
-/// Read-only V2.0 client for bounded canonical WorkItem board pages.
+/// Read-only V2.1 client for bounded canonical WorkItem board pages.
 pub struct WorkItemBoardClient {
 	transport: ResetCardClient,
 }
@@ -928,7 +928,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.0 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.1 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1162,7 +1162,7 @@ impl AccountClient {
 		.await
 	}
 
-	/// Execute one V2.0 lifecycle command exactly once on one connection.
+	/// Execute one V2.1 lifecycle command exactly once on one connection.
 	pub async fn execute(
 		&self,
 		payload: CommandPayload,
@@ -1798,12 +1798,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_0_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 0 });
+	fn protocol_constants_expose_only_the_exact_v2_1_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 1 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 0, maximum_minor: 0 },
+			SupportedVersions { major: 2, minimum_minor: 1, maximum_minor: 1 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}
@@ -2202,7 +2202,7 @@ max_entry_bytes = 0
 			),
 			(
 				Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor {
-					requested: ProtocolVersion { major: 2, minor: 1 },
+					requested: ProtocolVersion { major: 2, minor: 0 },
 					supported: SupportedVersions::current(),
 				}),
 				ClientFailure::ProtocolMinorMismatch,
@@ -2234,7 +2234,7 @@ max_entry_bytes = 0
 		let wrong_version = refusal(
 			"wrong-server",
 			Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor {
-				requested: ProtocolVersion { major: 2, minor: 1 },
+				requested: ProtocolVersion { major: 2, minor: 0 },
 				supported: SupportedVersions::current(),
 			}),
 		);
@@ -2293,7 +2293,7 @@ max_entry_bytes = 0
 		task.await.expect("test operation must succeed");
 
 		let wrong_welcome_version = typed(ServerMessage::Welcome(ServerWelcome {
-			version: ProtocolVersion { major: 2, minor: 1 },
+			version: ProtocolVersion { major: 2, minor: 0 },
 			supported: SupportedVersions::current(),
 			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			instance_id: None,
@@ -2379,7 +2379,7 @@ max_entry_bytes = 0
 		let encoded = serde_json::to_value(&wrong_report).expect("test operation must succeed");
 		let mut encoded = encoded.as_object().expect("test operation must succeed").clone();
 
-		encoded.insert("version".into(), serde_json::json!({"major": 2, "minor": 1}));
+		encoded.insert("version".into(), serde_json::json!({"major": 2, "minor": 0}));
 
 		wrong_report = serde_json::from_value(encoded.into()).expect("test operation must succeed");
 
@@ -2398,7 +2398,7 @@ max_entry_bytes = 0
 		let mut wrong_snapshot_version = initial(SERVER_ID);
 
 		wrong_snapshot_version[1] = typed(ServerMessage::Snapshot(SnapshotEnvelope {
-			version: ProtocolVersion { major: 2, minor: 1 },
+			version: ProtocolVersion { major: 2, minor: 0 },
 			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			cursor: Cursor(0),
 			items: Vec::new(),
@@ -2414,7 +2414,7 @@ max_entry_bytes = 0
 		task.await.expect("test operation must succeed");
 
 		let wrong_result_version = typed(ServerMessage::QueryResult(QueryResultEnvelope {
-			version: ProtocolVersion { major: 2, minor: 1 },
+			version: ProtocolVersion { major: 2, minor: 0 },
 			server_id: ServerId::new(SERVER_ID).expect("test operation must succeed"),
 			query_id: QueryId::new("decodex-cli-doctor").expect("test operation must succeed"),
 			payload: QueryResultPayload::DoctorStatus(report()),
@@ -2461,7 +2461,7 @@ max_entry_bytes = 0
 	async fn interleaved_events_verify_version_and_identity_and_preserve_valid_order() {
 		for (event, expected) in [
 			(
-				event(ProtocolVersion { major: 2, minor: 1 }, SERVER_ID),
+				event(ProtocolVersion { major: 2, minor: 0 }, SERVER_ID),
 				ClientFailure::ProtocolMinorMismatch,
 			),
 			(event(CURRENT_VERSION, "wrong-server"), ClientFailure::ServerIdentityMismatch),

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -22,9 +22,12 @@ pub use self::{
 		LocalTransportStream,
 	},
 	quick_task::{
-		MAX_QUICK_TASK_LIST_SIZE, MAX_QUICK_TASK_WORKING_DIRECTORY_BYTES, QuickTaskContractError,
+		MAX_QUICK_TASK_LIST_SIZE, MAX_QUICK_TASK_MODEL_BYTES,
+		MAX_QUICK_TASK_WORKING_DIRECTORY_BYTES, QuickTaskContractError,
+		QuickTaskExecutionSettings,
 		QuickTaskListCursor, QuickTaskListPage, QuickTaskListResult, QuickTaskListSize,
-		QuickTaskReadError, QuickTaskRecoveryAction, QuickTaskResult, QuickTaskState,
+		QuickTaskModel, QuickTaskReadError, QuickTaskReasoningEffort, QuickTaskRecoveryAction,
+		QuickTaskResult, QuickTaskState,
 		QuickTaskSummary, QuickTaskTurnOutcome, QuickTaskUnavailableReason,
 		QuickTaskWorkingDirectory,
 	},
@@ -77,7 +80,7 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 0 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 1 };
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated
@@ -173,7 +176,7 @@ mod tests {
 		assert_eq!(CURRENT_VERSION.negotiate(), Ok(CURRENT_VERSION));
 		assert_eq!(PREVIOUS_MINOR_VERSION.negotiate(), Ok(PREVIOUS_MINOR_VERSION));
 		assert!(matches!(
-			ProtocolVersion { major: 2, minor: 1 }.negotiate(),
+			ProtocolVersion { major: 2, minor: 0 }.negotiate(),
 			Err(VersionRefusal::UnsupportedMinor { .. })
 		));
 	}

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -77,7 +77,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.0 local endpoint authority.
+/// The complete V2.1 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,

--- a/crates/decodex-protocol/src/quick_task.rs
+++ b/crates/decodex-protocol/src/quick_task.rs
@@ -13,6 +13,8 @@ use crate::{EntityId, EntityRevision};
 pub const MAX_QUICK_TASK_LIST_SIZE: u16 = 64;
 /// Maximum UTF-8 bytes in one server-host Quick Task working-directory input.
 pub const MAX_QUICK_TASK_WORKING_DIRECTORY_BYTES: usize = 4_096;
+/// Maximum UTF-8 bytes in one explicit Codex model identifier.
+pub const MAX_QUICK_TASK_MODEL_BYTES: usize = 128;
 
 /// Closed, redacted reason that Quick Task execution was unavailable at daemon startup.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -47,6 +49,8 @@ pub enum QuickTaskContractError {
 	InvalidListSize,
 	/// A list cursor was not a positive canonical ordinary Conversation position.
 	InvalidCursor,
+	/// A model identifier was empty, oversized, or not a safe protocol label.
+	InvalidModel,
 	/// An ordinary Conversation or RuntimeSession projection was internally inconsistent.
 	InvalidProjection,
 }
@@ -56,8 +60,83 @@ impl Display for QuickTaskContractError {
 			Self::InvalidWorkingDirectory => "invalid Quick Task working directory",
 			Self::InvalidListSize => "invalid Quick Task list size",
 			Self::InvalidCursor => "invalid Quick Task list cursor",
+			Self::InvalidModel => "invalid Quick Task model",
 			Self::InvalidProjection => "invalid Quick Task conversation projection",
 		})
+	}
+}
+
+/// Bounded explicit Codex model used for the next Quick Task send.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct QuickTaskModel(String);
+impl QuickTaskModel {
+	/// Validate one model identifier without selecting a default.
+	pub fn new(value: impl Into<String>) -> Result<Self, QuickTaskContractError> {
+		let value = value.into();
+		if value.is_empty()
+			|| value.len() > MAX_QUICK_TASK_MODEL_BYTES
+			|| value.chars().any(|character| {
+				character.is_control()
+					|| !(character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.'))
+			})
+		{
+			return Err(QuickTaskContractError::InvalidModel);
+		}
+		Ok(Self(value))
+	}
+
+	/// Return the exact validated model identifier.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+impl<'de> Deserialize<'de> for QuickTaskModel {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+	}
+}
+
+/// Closed Codex reasoning effort exposed by the Quick Task controls.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuickTaskReasoningEffort {
+	Low,
+	Medium,
+	High,
+	XHigh,
+	Max,
+	Ultra,
+}
+impl QuickTaskReasoningEffort {
+	/// Return the exact app-server wire value.
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Low => "low",
+			Self::Medium => "medium",
+			Self::High => "high",
+			Self::XHigh => "xhigh",
+			Self::Max => "max",
+			Self::Ultra => "ultra",
+		}
+	}
+}
+
+/// Explicit execution settings carried on every user send.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct QuickTaskExecutionSettings {
+	pub model: QuickTaskModel,
+	pub reasoning_effort: QuickTaskReasoningEffort,
+	/// `true` maps to Codex's request-scoped `priority` service tier.
+	pub fast: bool,
+}
+impl QuickTaskExecutionSettings {
+	pub fn new(model: QuickTaskModel, reasoning_effort: QuickTaskReasoningEffort, fast: bool) -> Self {
+		Self { model, reasoning_effort, fast }
 	}
 }
 

--- a/crates/decodex-protocol/src/retained_session.rs
+++ b/crates/decodex-protocol/src/retained_session.rs
@@ -1443,7 +1443,7 @@ mod tests {
 				unreachable!()
 			};
 
-			wrong_version.version = ProtocolVersion { major: 2, minor: 1 };
+			wrong_version.version = ProtocolVersion { major: 2, minor: 0 };
 
 			send(&mut socket, ServerMessage::Welcome(wrong_version)).await;
 		})

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.0 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.1 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -22,11 +22,12 @@ use serde_json::Error;
 
 use crate::{
 	DoctorReport, ProtocolVersion, QuickTaskListCursor, QuickTaskListResult, QuickTaskListSize,
-	QuickTaskRecoveryAction, QuickTaskResult, QuickTaskSummary, QuickTaskTurnOutcome,
+	QuickTaskExecutionSettings, QuickTaskRecoveryAction, QuickTaskResult, QuickTaskSummary,
+	QuickTaskTurnOutcome,
 	QuickTaskWorkingDirectory, SupportedVersions, VersionRefusal,
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.0.
+/// Maximum UTF-8 size of any human-readable text carried by V2.1.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -151,7 +152,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded the V2.0 byte limit.
+/// A string-backed wire scalar exceeded the V2.1 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -167,7 +168,7 @@ impl Display for WireScalarTooLong {
 	}
 }
 
-/// Closed construction failures for the V2.0 WorkItem board contract.
+/// Closed construction failures for the V2.1 WorkItem board contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkItemBoardContractError {
 	/// An identity was not canonical lowercase RFC 9562 UUID-v4 text.
@@ -269,7 +270,7 @@ impl<'de> Deserialize<'de> for WorkItemBoardTitle {
 #[serde(transparent)]
 pub struct WorkItemBoardPageSize(u16);
 impl WorkItemBoardPageSize {
-	/// Construct a page size inside the closed V2.0 protocol bound.
+	/// Construct a page size inside the closed V2.1 protocol bound.
 	pub const fn new(value: u16) -> Result<Self, WorkItemBoardContractError> {
 		if value == 0 || value > MAX_WORK_ITEM_BOARD_PAGE_SIZE {
 			Err(WorkItemBoardContractError::InvalidPageSize)
@@ -546,7 +547,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.0 resume requires this field. Older hello envelopes can omit it
+	/// A V2.1 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -599,7 +600,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.0 welcome.
+	/// This is present in the exact-current V2.1 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1727,7 +1728,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.0 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.1 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -2262,7 +2263,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.0 protocol.
+/// Live queries available through the exact-current V2.1 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2357,7 +2358,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.0 protocol.
+/// Commands available through the exact-current V2.1 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2411,6 +2412,8 @@ pub enum CommandPayload {
 		message: HistoryText,
 		/// Untrusted server-host working directory selected for this process lineage.
 		working_directory: QuickTaskWorkingDirectory,
+		/// Explicit execution settings for this user send.
+		execution: QuickTaskExecutionSettings,
 	},
 	/// Resume the sole initial route for one routing-pending Conversation.
 	ResumeQuickTaskRouting {
@@ -2437,6 +2440,18 @@ pub enum CommandPayload {
 		message: HistoryText,
 		/// Untrusted server-host working directory used if the thread must be re-established.
 		working_directory: QuickTaskWorkingDirectory,
+		/// Explicit execution settings for this user send.
+		execution: QuickTaskExecutionSettings,
+	},
+	/// Reconcile one selected Decodex task with its exact Codex archive state.
+	RefreshQuickTask {
+		/// Stable logical Conversation identity.
+		conversation_id: EntityId,
+	},
+	/// Archive one selected exact Codex thread and its Decodex projection.
+	ArchiveQuickTask {
+		/// Stable logical Conversation identity.
+		conversation_id: EntityId,
 	},
 	/// Interrupt one exact active Quick Task turn.
 	InterruptQuickTask {
@@ -2648,6 +2663,13 @@ pub enum EventPayload {
 		/// Definite positive or failed outcome.
 		outcome: QuickTaskTurnOutcome,
 	},
+	/// One ordinary Conversation was verified archived and left the active projection.
+	QuickTaskArchived {
+		/// Stable logical Conversation identity.
+		conversation_id: EntityId,
+		/// Exact committed archived revision.
+		conversation_revision: EntityRevision,
+	},
 	/// A foundation system observation was refreshed.
 	SystemObservationRefreshed {
 		/// Small human-readable foundation status.
@@ -2777,6 +2799,13 @@ pub enum ResultPayload {
 		/// Complete current ordinary projection; completion later returns it to `ready`.
 		conversation: QuickTaskSummary,
 	},
+	/// One explicit refresh or archive verified that the Codex thread is archived.
+	QuickTaskArchived {
+		/// Stable logical Conversation identity.
+		conversation_id: EntityId,
+		/// Exact committed archived revision.
+		conversation_revision: EntityRevision,
+	},
 	/// A foundation system observation was refreshed.
 	SystemObservationRefreshed {
 		/// Small human-readable foundation status.
@@ -2835,7 +2864,7 @@ pub enum ResultPayload {
 	},
 }
 
-/// Typed live-query results available through the exact-current V2.0 protocol.
+/// Typed live-query results available through the exact-current V2.1 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -3768,12 +3797,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.0 wire encoding.
+/// Serialize a message using the only V2.1 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.0 wire encoding.
+/// Parse a client message using the only V2.1 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -3829,6 +3858,8 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 		| CommandPayload::CreateQuickTaskRoutingSuccessor { .. }
 		| CommandPayload::ResumeQuickTaskEstablishment { .. }
 		| CommandPayload::SubmitQuickTaskTurn { .. }
+		| CommandPayload::RefreshQuickTask { .. }
+		| CommandPayload::ArchiveQuickTask { .. }
 		| CommandPayload::InterruptQuickTask { .. } => validate_quick_task_command(command),
 		CommandPayload::RefreshSystemObservation { .. } => Ok(()),
 		CommandPayload::ConsumeResetCard { account_id, .. } => {
@@ -4041,6 +4072,14 @@ fn validate_quick_task_command(command: &CommandEnvelope) -> Result<(), &'static
 				Ok(())
 			} else {
 				Err("Quick Task interrupt identity or revision is invalid")
+			}
+		},
+		CommandPayload::RefreshQuickTask { conversation_id }
+		| CommandPayload::ArchiveQuickTask { conversation_id } => {
+			if positive_expected && is_canonical_uuid(conversation_id.as_str()) {
+				Ok(())
+			} else {
+				Err("Quick Task control identity or revision is invalid")
 			}
 		},
 		_ => unreachable!("Quick Task validation requires a Quick Task command"),
@@ -4608,6 +4647,11 @@ mod tests {
 			message: HistoryText::new("route this request").expect("bounded message"),
 			working_directory: QuickTaskWorkingDirectory::new("/tmp/work")
 				.expect("bounded working directory"),
+			execution: crate::QuickTaskExecutionSettings::new(
+				crate::QuickTaskModel::new("gpt-5.6-sol").expect("bounded model"),
+				crate::QuickTaskReasoningEffort::High,
+				false,
+			),
 		};
 		assert_eq!(
 			serde_json::to_value(&create).unwrap(),
@@ -4617,6 +4661,11 @@ mod tests {
 					"conversation_id": source.as_str(),
 					"message": "route this request",
 					"working_directory": "/tmp/work",
+					"execution": {
+						"model": "gpt-5.6-sol",
+						"reasoning_effort": "high",
+						"fast": false,
+					},
 				},
 			}),
 		);
@@ -4804,7 +4853,7 @@ mod tests {
 			}),
 		);
 		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 1, minor: 5 }));
-		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 1 }));
+		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 2 }));
 		assert!(command.is_supported_in(CURRENT_VERSION));
 		assert!(
 			serde_json::from_value::<CommandPayload>(serde_json::json!({
@@ -5275,7 +5324,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":0},"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":1},"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -5284,7 +5333,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":0},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":1},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -5326,7 +5375,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":0},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":1},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5569,7 +5618,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 1 };
+		let future = crate::ProtocolVersion { major: 2, minor: 2 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -743,6 +743,20 @@ impl AttestedAppServerLaunch {
 		profile.bind(working_directory, binding, timeout, guard)
 	}
 
+	/// Bind one explicit thread-control launch to the same final directory descriptor check.
+	pub(crate) fn bind_selected_control_working_directory(
+		profile: AttestedAppServerProfile,
+		working_directory: PathBuf,
+		binding: AccountBinding,
+		timeout: Duration,
+		guard: RunnerPermit,
+		pre_spawn_check: Arc<dyn QuickTaskPreSpawnCheck>,
+	) -> Result<Self, ProbeError> {
+		let mut launch = profile.bind(working_directory, binding, timeout, guard)?;
+		launch.quick_task_pre_spawn_check = Some(pre_spawn_check);
+		Ok(launch)
+	}
+
 	/// Derive all durable pre-spawn facts that belong to the opaque launch authority.
 	pub(crate) fn derive_intent(
 		&self,
@@ -980,6 +994,34 @@ impl AttestedProcessChild {
 		self.process
 			.quick_task_request(wire, self.timeout, true, decode_quick_task_turn_interrupt_response)
 			.map(|success: QuickTaskProcessSuccess<QuickTaskTurnInterruptResponse>| success.events)
+	}
+
+	/// Read one exact durable thread for explicit user reconciliation.
+	pub(crate) fn read_exact_ordinary_thread(
+		&mut self,
+		thread_id: &ExactThreadId,
+	) -> Result<ExactThreadReadResult, QuickTaskProcessError> {
+		self.require_ordinary_turns_initialized()?;
+		self.process
+			.read_exact_thread(thread_id, self.timeout)
+			.map_err(|_| QuickTaskProcessError::Unavailable)
+	}
+
+	/// Reconcile one exact archive mutation through same-process pre/post readback.
+	pub(crate) fn archive_exact_ordinary_thread(
+		&mut self,
+		thread_id: &ExactThreadId,
+	) -> Result<ArchiveReconciliationOutcome, QuickTaskProcessError> {
+		self.require_ordinary_turns_initialized()?;
+		Ok(self.process.reconcile_archive(thread_id, self.timeout))
+	}
+
+	/// Confirm bounded process cleanup after an explicit control operation.
+	pub(crate) fn shutdown(self) -> Result<(), QuickTaskProcessError> {
+		self.process
+			.shutdown(Duration::from_secs(1))
+			.map(|_| ())
+			.map_err(|_| QuickTaskProcessError::Unavailable)
 	}
 
 	fn require_ordinary_turns_initialized(&self) -> Result<(), QuickTaskProcessError> {

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -41,7 +41,7 @@ use decodex_protocol::{
 	HistoryPayloadDto, HistoryQueryError, HistorySideEffectState, HistoryText, HistoryTurnRole,
 	MAX_HISTORY_PAGE_SIZE, ProjectListResult, QueryEnvelope, QueryPayload, QueryResultPayload,
 	QuickTaskListCursor, QuickTaskListPage, QuickTaskListResult, QuickTaskReadError,
-	QuickTaskRecoveryAction,
+	QuickTaskExecutionSettings as QuickTaskExecutionSettingsDto, QuickTaskRecoveryAction,
 	QuickTaskResult, QuickTaskState, QuickTaskSummary, QuickTaskTurnOutcome,
 	ResetCardDescriptorDto, ResetCardError, ResetCardInventoryResult, ResetCardObservationDto,
 	ResetCardOperationResult, ResetCardOutcome, ResultPayload, Sha256Digest, SnapshotItem,
@@ -68,7 +68,10 @@ use crate::{
 	},
 	managed_repository_runtime::ManagedRepositoryCapability,
 	quick_task::{
-		CreateQuickTask, QuickTaskCapability, QuickTaskLocalState, QuickTaskManualRecovery,
+		ControlQuickTask, CreateQuickTask, QuickTaskCapability,
+		QuickTaskControlOutcome,
+		QuickTaskExecutionSettings as RuntimeQuickTaskExecutionSettings, QuickTaskLocalState,
+		QuickTaskManualRecovery,
 		QuickTaskOutcome, QuickTaskProjection, QuickTaskReadback, QuickTaskRuntime,
 		QuickTaskTerminalState, RecoverQuickTask, SubmitQuickTaskTurn,
 	},
@@ -1005,7 +1008,8 @@ impl ServiceApplication {
 			.into_iter()
 			.map(|projection| match projection {
 				OrdinaryTaskConversationProjection::Current(row) => Ok(row),
-				OrdinaryTaskConversationProjection::RoutingSuccessorRedirect { .. } => Err(()),
+				OrdinaryTaskConversationProjection::Archived { .. }
+				| OrdinaryTaskConversationProjection::RoutingSuccessorRedirect { .. } => Err(()),
 			})
 			.collect::<Result<Vec<_>, _>>()
 		{
@@ -1098,6 +1102,7 @@ impl ServiceApplication {
 				_ =>
 					QuickTaskResult::Unavailable { error: QuickTaskReadError::IntegrityUnavailable },
 			},
+			OrdinaryTaskConversationProjection::Archived { .. } => QuickTaskResult::NotFound,
 		}
 	}
 
@@ -1152,7 +1157,12 @@ impl ServiceApplication {
 		runtime: &QuickTaskRuntime,
 		command: &CommandEnvelope,
 	) -> Result<QuickTaskOutcome, CommandError> {
-		let CommandPayload::CreateQuickTask { conversation_id, message, working_directory } =
+		let CommandPayload::CreateQuickTask {
+			conversation_id,
+			message,
+			working_directory,
+			execution,
+		} =
 			&command.payload
 		else {
 			return Err(quick_task_conflict());
@@ -1170,6 +1180,7 @@ impl ServiceApplication {
 				conversation_id,
 				message: message.as_str().to_owned(),
 				working_directory: working_directory.as_str().to_owned(),
+				execution: runtime_execution_settings(execution),
 			})
 			.await)
 	}
@@ -1238,6 +1249,7 @@ impl ServiceApplication {
 			.map_err(|_| application_unavailable("Quick Task readback is unavailable"))?
 			.ok_or_else(quick_task_conflict)?;
 		match projection {
+			OrdinaryTaskConversationProjection::Archived { .. } => Err(quick_task_conflict()),
 			OrdinaryTaskConversationProjection::RoutingSuccessorRedirect {
 				source_conversation_id: redirected_source,
 				source_revision,
@@ -1332,6 +1344,7 @@ impl ServiceApplication {
 			turn_id,
 			message,
 			working_directory,
+			execution,
 		} = &command.payload
 		else {
 			return Err(quick_task_conflict());
@@ -1352,6 +1365,7 @@ impl ServiceApplication {
 				turn_id,
 				message: message.as_str().to_owned(),
 				working_directory: working_directory.as_str().to_owned(),
+				execution: runtime_execution_settings(execution),
 			})
 			.await)
 	}
@@ -1384,6 +1398,72 @@ impl ServiceApplication {
 		Ok(runtime.interrupt(&conversation_id))
 	}
 
+	async fn execute_control_quick_task(
+		&self,
+		runtime: &QuickTaskRuntime,
+		command: &CommandEnvelope,
+	) -> Result<ApplicationPublication, CommandError> {
+		let (conversation_id, archive) = match &command.payload {
+			CommandPayload::RefreshQuickTask { conversation_id } => (conversation_id, false),
+			CommandPayload::ArchiveQuickTask { conversation_id } => (conversation_id, true),
+			_ => return Err(quick_task_conflict()),
+		};
+		let core_id =
+			ConversationId::new(conversation_id.as_str()).map_err(|_| quick_task_conflict())?;
+		let row = self.quick_task_command_row(&core_id, command.expected_revision).await?;
+		if row.runtime_session_id.is_none()
+			|| row.active_turn_id.is_some()
+			|| row.has_active_provider_attempt
+			|| row.has_unknown_provider_attempt
+		{
+			return Err(quick_task_busy());
+		}
+		match runtime
+			.control_thread(ControlQuickTask {
+				operation_key: command.idempotency_key.as_str().to_owned(),
+				conversation_id: core_id,
+				expected_conversation_revision: row.conversation_revision,
+				archive,
+			})
+			.await
+		{
+			QuickTaskControlOutcome::Current => {
+				let QuickTaskResult::Available(conversation) =
+					self.quick_task_get(conversation_id).await
+				else {
+					return Err(application_unavailable(
+						"Quick Task refresh readback is unavailable",
+					));
+				};
+				quick_task_command_publication(conversation, false)
+			},
+			QuickTaskControlOutcome::Archived { conversation_revision } => {
+				let revision = EntityRevision(
+					u64::try_from(conversation_revision).map_err(|_| quick_task_conflict())?,
+				);
+				Ok(ApplicationPublication {
+					channel: Channel::ConversationStream,
+					entity_id: conversation_id.clone(),
+					entity_revision: revision,
+					result: ResultPayload::QuickTaskArchived {
+						conversation_id: conversation_id.clone(),
+						conversation_revision: revision,
+					},
+					event: EventPayload::QuickTaskArchived {
+						conversation_id: conversation_id.clone(),
+						conversation_revision: revision,
+					},
+				})
+			},
+			QuickTaskControlOutcome::Busy => Err(quick_task_busy()),
+			QuickTaskControlOutcome::Conflict => Err(quick_task_conflict()),
+			QuickTaskControlOutcome::OutcomeUnknown => Err(CommandError::AcceptanceUnknown),
+			QuickTaskControlOutcome::Unavailable => Err(application_unavailable(
+				"Quick Task thread control is unavailable",
+			)),
+		}
+	}
+
 	async fn execute_quick_task(
 		&self,
 		command: &CommandEnvelope,
@@ -1397,6 +1477,12 @@ impl ServiceApplication {
 				return Err(CommandError::QuickTaskUnavailable { unavailable_reason: *reason });
 			},
 		};
+		if matches!(
+			&command.payload,
+			CommandPayload::RefreshQuickTask { .. } | CommandPayload::ArchiveQuickTask { .. }
+		) {
+			return self.execute_control_quick_task(runtime, command).await;
+		}
 		let outcome = match &command.payload {
 			CommandPayload::CreateQuickTask { .. } =>
 				self.execute_create_quick_task(runtime, command).await?,
@@ -1490,6 +1576,8 @@ impl Application for ServiceApplication {
 			| CommandPayload::CreateQuickTaskRoutingSuccessor { .. }
 			| CommandPayload::ResumeQuickTaskEstablishment { .. }
 			| CommandPayload::SubmitQuickTaskTurn { .. }
+			| CommandPayload::RefreshQuickTask { .. }
+			| CommandPayload::ArchiveQuickTask { .. }
 			| CommandPayload::InterruptQuickTask { .. } => self.execute_quick_task(command).await,
 			CommandPayload::EnrollAccountFromSharedCodex { .. }
 			| CommandPayload::ImportAccountCredentialFile { .. }
@@ -1878,6 +1966,16 @@ fn quick_task_command_publication(
 		result,
 		event: EventPayload::QuickTaskConversationChanged { conversation },
 	})
+}
+
+fn runtime_execution_settings(
+	settings: &QuickTaskExecutionSettingsDto,
+) -> RuntimeQuickTaskExecutionSettings {
+	RuntimeQuickTaskExecutionSettings {
+		model: settings.model.as_str().to_owned(),
+		reasoning_effort: settings.reasoning_effort.as_str().to_owned(),
+		fast: settings.fast,
+	}
 }
 
 fn quick_task_routing_successor_publication(

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.0 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.1 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Quick Task owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.

--- a/crates/decodex-runtime/src/quick_task.rs
+++ b/crates/decodex-runtime/src/quick_task.rs
@@ -21,7 +21,8 @@ use std::{
 };
 
 use decodex_codex::{
-	ExactThreadId, MAX_QUICK_TASK_INPUT_BYTES, QuickTaskThreadResumeRequest,
+	ArchiveReconciliationOutcome, ExactThreadId, MAX_QUICK_TASK_INPUT_BYTES,
+	QuickTaskThreadResumeRequest,
 	QuickTaskThreadStartRequest, QuickTaskTurnInput, QuickTaskTurnInterruptRequest,
 	QuickTaskTurnStartRequest, QuickTaskTurnStatus, TurnStatus,
 };
@@ -38,8 +39,10 @@ use decodex_core::{
 	RuntimeSessionState, TurnId, TurnRole, compile_context_pack,
 };
 use decodex_database::{
-	AdmitInitialQuickTaskTurn, AuthorizeProviderDispatchOutcome, BindRuntimeSessionThreadOutcome,
-	CommandIdentity, CreateQuickTaskConversation, FenceRuntimeSessionThreadStart,
+	AdmitInitialQuickTaskTurn, ArchiveQuickTaskConversation,
+	ArchiveQuickTaskConversationOutcome, AuthorizeProviderDispatchOutcome,
+	BindRuntimeSessionThreadOutcome, CommandIdentity, CreateQuickTaskConversation,
+	FenceRuntimeSessionThreadStart,
 	FenceRuntimeSessionThreadStartOutcome, FreshQuickTaskProcessGeneration,
 	InitialQuickTaskTurnAdmissionOutcome, OrdinaryRuntimeSessionResumeReadback,
 	PrepareQuickTaskProcessGeneration, PrepareQuickTaskProcessGenerationOutcome,
@@ -287,7 +290,15 @@ fn selected_directory_from_descriptor(descriptor: i32) -> Result<File, ()> {
 	Ok(unsafe { File::from_raw_fd(descriptor) })
 }
 
-/// First ordinary Turn input. Model and reasoning come from the selected Task RoleProfile.
+/// Explicit request-scoped execution settings carried on every user send.
+#[derive(Clone)]
+pub(crate) struct QuickTaskExecutionSettings {
+	pub model: String,
+	pub reasoning_effort: String,
+	pub fast: bool,
+}
+
+/// First ordinary Turn input. Settings are explicit and survive pre-session recovery.
 pub(crate) struct CreateQuickTask {
 	pub operation_key: String,
 	pub correlation_id: String,
@@ -295,6 +306,7 @@ pub(crate) struct CreateQuickTask {
 	pub conversation_id: ConversationId,
 	pub message: String,
 	pub working_directory: String,
+	pub execution: QuickTaskExecutionSettings,
 }
 
 /// Public recovery coordinates. Message, directory, and route authority come from durable state.
@@ -315,6 +327,25 @@ pub(crate) struct SubmitQuickTaskTurn {
 	pub turn_id: TurnId,
 	pub message: String,
 	pub working_directory: String,
+	pub execution: QuickTaskExecutionSettings,
+}
+
+/// Explicit selected-thread reconciliation request.
+pub(crate) struct ControlQuickTask {
+	pub operation_key: String,
+	pub conversation_id: ConversationId,
+	pub expected_conversation_revision: i64,
+	pub archive: bool,
+}
+
+/// Closed selected-thread control result.
+pub(crate) enum QuickTaskControlOutcome {
+	Current,
+	Archived { conversation_revision: i64 },
+	Busy,
+	Conflict,
+	OutcomeUnknown,
+	Unavailable,
 }
 
 struct InitialQuickTaskExecution {
@@ -325,6 +356,7 @@ struct InitialQuickTaskExecution {
 	turn_id: TurnId,
 	message: String,
 	working_directory: String,
+	execution: QuickTaskExecutionSettings,
 }
 
 /// Daemon-local projection. It is never serialized or accepted as durable authority.
@@ -528,6 +560,7 @@ struct LocalSession {
 	process: FencedProcess,
 	model: String,
 	reasoning_effort: String,
+	fast: bool,
 	working_directory: String,
 	instructions: String,
 	next_user_sequence: i64,
@@ -737,6 +770,11 @@ impl QuickTaskRuntime {
 			conversation_id: command.conversation_id,
 			message: request.message,
 			working_directory: request.working_directory,
+			execution: QuickTaskExecutionSettings {
+				model: request.model,
+				reasoning_effort: request.reasoning_effort,
+				fast: request.fast,
+			},
 		};
 		let _ = self
 			.run_reserved_initial(
@@ -768,6 +806,11 @@ impl QuickTaskRuntime {
 				conversation_id: command.conversation_id,
 				message: request.message,
 				working_directory: request.working_directory,
+				execution: QuickTaskExecutionSettings {
+					model: request.model,
+					reasoning_effort: request.reasoning_effort,
+					fast: request.fast,
+				},
 			},
 			command.expected_conversation_revision,
 			action,
@@ -807,6 +850,9 @@ impl QuickTaskRuntime {
 				"Quick Task",
 				&command.message,
 				&command.working_directory,
+				&command.execution.model,
+				&command.execution.reasoning_effort,
+				if command.execution.fast { "priority" } else { "default" },
 			],
 		) {
 			Ok(command) => command,
@@ -822,6 +868,9 @@ impl QuickTaskRuntime {
 					title: "Quick Task".to_owned(),
 					message: command.message.clone(),
 					working_directory: command.working_directory.clone(),
+					model: command.execution.model.clone(),
+					reasoning_effort: command.execution.reasoning_effort.clone(),
+					fast: command.execution.fast,
 				},
 			)
 			.await
@@ -907,6 +956,7 @@ impl QuickTaskRuntime {
 			turn_id,
 			message: command.message,
 			working_directory: command.working_directory,
+			execution: command.execution,
 		};
 		let working_directory = command.working_directory.clone();
 		let Some(session) = plan.runtime_session.clone() else {
@@ -1131,10 +1181,12 @@ impl QuickTaskRuntime {
 			..created.clone()
 		};
 		let request = match QuickTaskThreadStartRequest::new(
-			session.profile_snapshot.model.clone(),
+			command.execution.model.clone(),
 			working_directory.clone(),
 			session.profile_snapshot.instructions.clone(),
-		) {
+		)
+		.map(|request| request.with_fast(command.execution.fast))
+		{
 			Ok(request) => request,
 			Err(_) => {
 				self.terminate_process(&process).await;
@@ -1316,8 +1368,9 @@ impl QuickTaskRuntime {
 			has_acknowledged_turn: false,
 			account_id: selected_account_id,
 			process,
-			model: session.profile_snapshot.model,
-			reasoning_effort: session.profile_snapshot.reasoning_effort,
+			model: command.execution.model.clone(),
+			reasoning_effort: command.execution.reasoning_effort.clone(),
+			fast: command.execution.fast,
 			working_directory,
 			instructions: session.profile_snapshot.instructions,
 			next_user_sequence: 2,
@@ -1501,10 +1554,12 @@ impl QuickTaskRuntime {
 			..created.clone()
 		};
 		let request = match QuickTaskThreadStartRequest::new(
-			runtime_session.profile_snapshot.model.clone(),
+			command.execution.model.clone(),
 			working_directory.clone(),
 			runtime_session.profile_snapshot.instructions.clone(),
-		) {
+		)
+		.map(|request| request.with_fast(command.execution.fast))
+		{
 			Ok(request) => request,
 			Err(_) => {
 				self.terminate_process(&process).await;
@@ -1653,8 +1708,9 @@ impl QuickTaskRuntime {
 			has_acknowledged_turn: false,
 			account_id: selected_account_id,
 			process,
-			model: runtime_session.profile_snapshot.model,
-			reasoning_effort: runtime_session.profile_snapshot.reasoning_effort,
+			model: command.execution.model.clone(),
+			reasoning_effort: command.execution.reasoning_effort.clone(),
+			fast: command.execution.fast,
 			working_directory,
 			instructions: runtime_session.profile_snapshot.instructions,
 			next_user_sequence: turn_sequence.saturating_add(1),
@@ -1861,6 +1917,7 @@ impl QuickTaskRuntime {
 			session.working_directory.clone(),
 			session.instructions.clone(),
 		)
+		.map(|request| request.with_fast(session.fast))
 		.map_err(|_| SameThreadResumeRefusal::IncompatibleThread)?;
 		let resumed =
 			self.resume_thread(&session.process, request).await.map_err(|error| match error {
@@ -1895,7 +1952,7 @@ impl QuickTaskRuntime {
 		if self.is_shutting_down() {
 			return QuickTaskOutcome::Unavailable;
 		}
-		let session = match self.reserve_later_turn(&command) {
+		let mut session = match self.reserve_later_turn(&command) {
 			Ok(session) => session,
 			Err(outcome) => match *outcome {
 				outcome @ QuickTaskOutcome::ManualRecovery {
@@ -1905,6 +1962,9 @@ impl QuickTaskRuntime {
 				outcome => return outcome,
 			},
 		};
+		session.model.clone_from(&command.execution.model);
+		session.reasoning_effort.clone_from(&command.execution.reasoning_effort);
+		session.fast = command.execution.fast;
 		let admitted = match self.admit_later_turn(&command, session).await {
 			Ok(admitted) => admitted,
 			Err(outcome) => return *outcome,
@@ -2128,7 +2188,9 @@ impl QuickTaskRuntime {
 			input,
 			session.model.clone(),
 			session.reasoning_effort.clone(),
-		) {
+		)
+		.map(|request| request.with_fast(session.fast))
+		{
 			Ok(request) => request,
 			Err(_) => {
 				return self
@@ -2753,6 +2815,206 @@ impl QuickTaskRuntime {
 			_ => None,
 		};
 		Some(QuickTaskProjection { readback, recovery })
+	}
+
+	/// Refresh or archive one exact selected Codex thread without dispatching a model turn.
+	pub(crate) async fn control_thread(
+		&self,
+		command: ControlQuickTask,
+	) -> QuickTaskControlOutcome {
+		if self.is_shutting_down() || command.expected_conversation_revision <= 0 {
+			return QuickTaskControlOutcome::Unavailable;
+		}
+		{
+			let local = self.local();
+			if let Some(task) = local.get(command.conversation_id.as_str()) {
+				match &task.state {
+					LocalTaskState::Active { .. }
+					| LocalTaskState::Preparing(_)
+					| LocalTaskState::Establishing => return QuickTaskControlOutcome::Busy,
+					LocalTaskState::Recovery { .. } => return QuickTaskControlOutcome::Conflict,
+					LocalTaskState::Ready(_) => {},
+				}
+			}
+		}
+		let session = match self
+			.inner
+			.store
+			.read_ordinary_runtime_session_for_resume(&command.conversation_id)
+			.await
+		{
+			Ok(Some(session)) => session,
+			Ok(None) => return QuickTaskControlOutcome::Conflict,
+			Err(_) => return QuickTaskControlOutcome::Unavailable,
+		};
+		if session.conversation_revision != command.expected_conversation_revision
+			|| session.has_active_turn
+			|| session.has_unresolved_provider_attempt
+		{
+			return QuickTaskControlOutcome::Conflict;
+		}
+		let request = match self.inner.store.read_quick_task_request(&command.conversation_id).await {
+			Ok(Some(request)) => request,
+			Ok(None) => return QuickTaskControlOutcome::Conflict,
+			Err(_) => return QuickTaskControlOutcome::Unavailable,
+		};
+		let archived = match self
+			.observe_control_thread(
+				&command.operation_key,
+				&session.source_account_id,
+				session.source_account_revision,
+				&request.working_directory,
+				&session.codex_thread_id,
+				command.archive,
+			)
+			.await
+		{
+			Ok(archived) => archived,
+			Err(outcome) => return outcome,
+		};
+		if !archived {
+			return QuickTaskControlOutcome::Current;
+		}
+		let persistence = match exact_command(
+			"archive-conversation",
+			&command.operation_key,
+			&[
+				command.conversation_id.as_str(),
+				&session.conversation_revision.to_string(),
+				session.runtime_session_id.as_str(),
+				&session.runtime_session_revision.to_string(),
+				session.codex_thread_id.as_str(),
+			],
+		) {
+			Ok(command) => command,
+			Err(()) => return QuickTaskControlOutcome::Conflict,
+		};
+		let archived = match self
+			.inner
+			.store
+			.archive_quick_task_conversation(
+				&persistence,
+				&ArchiveQuickTaskConversation {
+					conversation_id: command.conversation_id.clone(),
+					expected_conversation_revision: session.conversation_revision,
+					runtime_session_id: session.runtime_session_id,
+					expected_runtime_session_revision: session.runtime_session_revision,
+				},
+			)
+			.await
+		{
+			Ok(ArchiveQuickTaskConversationOutcome::Applied(archived))
+			| Ok(ArchiveQuickTaskConversationOutcome::Replayed(archived)) => archived,
+			Ok(ArchiveQuickTaskConversationOutcome::Rejected) => {
+				return QuickTaskControlOutcome::Conflict;
+			},
+			Err(_) => return QuickTaskControlOutcome::OutcomeUnknown,
+		};
+		let process = {
+			let mut local = self.local();
+			local.remove(command.conversation_id.as_str()).and_then(|task| match task.state {
+				LocalTaskState::Ready(session) => Some(session.process),
+				_ => None,
+			})
+		};
+		if let Some(process) = process {
+			self.terminate_process(&process).await;
+		}
+		QuickTaskControlOutcome::Archived {
+			conversation_revision: archived.conversation_revision,
+		}
+	}
+
+	async fn observe_control_thread(
+		&self,
+		operation_key: &str,
+		account_id: &AccountId,
+		account_revision: i64,
+		working_directory: &str,
+		thread_id: &str,
+		archive: bool,
+	) -> Result<bool, QuickTaskControlOutcome> {
+		let credential = self
+			.inner
+			.accounts
+			.process_credential(account_id, account_revision)
+			.await
+			.map_err(|_| QuickTaskControlOutcome::Unavailable)?;
+		let profile = self.inner.launch_profile.clone();
+		let capacity = Arc::clone(&self.inner.capacity);
+		let accounts = Arc::clone(&self.inner.accounts);
+		let runtime = tokio::runtime::Handle::current();
+		let account_id = account_id.clone();
+		let working_directory = working_directory.to_owned();
+		let thread_id = thread_id.to_owned();
+		let generation_id = ProcessGenerationId::new(derived_uuid(
+			"thread-control-process",
+			&[operation_key, thread_id.as_str()],
+		))
+		.map_err(|_| QuickTaskControlOutcome::Conflict)?;
+		task::spawn_blocking(move || {
+			let selected = Arc::new(
+				SelectedWorkingDirectory::acquire(&working_directory)
+					.map_err(|()| QuickTaskControlOutcome::Unavailable)?,
+			);
+			let callback: Arc<dyn ProcessAccountRefreshCallback> =
+				Arc::new(QuickTaskRefreshCallback {
+					accounts,
+					runtime,
+					generation_id,
+				});
+			let binding = AccountBinding::shared_home_bound(
+				account_id.clone(),
+				credential.binding,
+				callback,
+			)
+			.map_err(|_| QuickTaskControlOutcome::Unavailable)?;
+			let vault = QuickTaskCredentialVault {
+				account_id: account_id.clone(),
+				stored: credential.stored,
+			};
+			let permit = capacity
+				.reserve(account_id, account_revision)
+				.map_err(|_| QuickTaskControlOutcome::Unavailable)?;
+			let launch = AttestedAppServerLaunch::bind_selected_control_working_directory(
+				profile,
+				working_directory.into(),
+				binding,
+				PROCESS_TIMEOUT,
+				permit,
+				selected,
+			)
+			.map_err(|_| QuickTaskControlOutcome::Unavailable)?;
+			let mut child = launch.spawn().map_err(|_| QuickTaskControlOutcome::Unavailable)?;
+			if child.initialize_ordinary_turns(&vault).is_err() {
+				let _ = child.shutdown();
+				return Err(QuickTaskControlOutcome::Unavailable);
+			}
+			drop(credential.launch_guard);
+			let thread_id = ExactThreadId::new(thread_id)
+				.map_err(|_| QuickTaskControlOutcome::Conflict)?;
+			let observation = if archive {
+				match child
+					.archive_exact_ordinary_thread(&thread_id)
+					.map_err(|_| QuickTaskControlOutcome::OutcomeUnknown)
+				{
+					Ok(ArchiveReconciliationOutcome::Archived)
+					| Ok(ArchiveReconciliationOutcome::AlreadyArchived) => Ok(true),
+					Ok(ArchiveReconciliationOutcome::Unverified(_)) | Err(_) => {
+						Err(QuickTaskControlOutcome::OutcomeUnknown)
+					},
+				}
+			} else {
+				child
+					.read_exact_ordinary_thread(&thread_id)
+					.map(|readback| readback.facts.archived)
+					.map_err(|_| QuickTaskControlOutcome::Unavailable)
+			};
+			child.shutdown().map_err(|_| QuickTaskControlOutcome::OutcomeUnknown)?;
+			observation
+		})
+		.await
+		.map_err(|_| QuickTaskControlOutcome::Unavailable)?
 	}
 
 	pub(crate) async fn next_event(&self) -> Option<QuickTaskOutcome> {
@@ -3472,8 +3734,9 @@ impl QuickTaskRuntime {
 			has_acknowledged_turn: true,
 			account_id: readback.source_account_id,
 			process,
-			model: readback.model,
-			reasoning_effort: readback.reasoning_effort,
+			model: command.execution.model.clone(),
+			reasoning_effort: command.execution.reasoning_effort.clone(),
+			fast: command.execution.fast,
 			working_directory,
 			instructions: readback.instructions,
 			next_user_sequence: sequence.saturating_add(1),

--- a/crates/decodex-runtime/src/websocket.rs
+++ b/crates/decodex-runtime/src/websocket.rs
@@ -54,7 +54,6 @@ const PUBLICATION_INSTANCE_MINIMUM_VERSION: ProtocolVersion =
 
 const fn supports_publication_instance(version: ProtocolVersion) -> bool {
 	version.major == PUBLICATION_INSTANCE_MINIMUM_VERSION.major
-		&& version.minor == PUBLICATION_INSTANCE_MINIMUM_VERSION.minor
 }
 
 type WebSocket = WebSocketStream<LocalTransportStream>;

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -360,14 +360,14 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 1 },
+			version: ProtocolVersion { major: 2, minor: 2 },
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
 		}),
 	)
 	.await;
 	let ServerMessage::Refusal(refusal) = receive(&mut future).await else {
-		panic!("expected V2.1 minor-version refusal");
+		panic!("expected V2.2 minor-version refusal");
 	};
 	assert!(matches!(
 		refusal.refusal,
@@ -390,7 +390,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 1 },
+			ProtocolVersion { major: 2, minor: 2 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -477,7 +477,7 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 
 	drop(client);
 
-	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 1 }).await;
+	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 2 }).await;
 	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
 		panic!("expected minor-version refusal");
 	};
@@ -495,8 +495,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 0);
-	assert_eq!(welcome.supported.maximum_minor, 0);
+	assert_eq!(welcome.supported.minimum_minor, 1);
+	assert_eq!(welcome.supported.maximum_minor, 1);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
@@ -519,7 +519,7 @@ async fn post_negotiation_payload_envelopes_require_exact_current_version() {
 	send(
 		&mut client,
 		ClientMessage::Query(QueryEnvelope {
-			version: ProtocolVersion { major: 2, minor: 1 },
+			version: ProtocolVersion { major: 2, minor: 2 },
 			query_id: QueryId::new("future-query").expect("bounded query ID"),
 			payload: QueryPayload::GetDoctorStatus,
 		}),

--- a/database/migrations/0003_quick_task_execution_controls.sql
+++ b/database/migrations/0003_quick_task_execution_controls.sql
@@ -1,0 +1,10 @@
+ALTER TABLE quick_task_requests
+ADD COLUMN model TEXT NOT NULL DEFAULT 'gpt-5.6-sol'
+CHECK (length(CAST(model AS BLOB)) BETWEEN 1 AND 128);
+
+ALTER TABLE quick_task_requests
+ADD COLUMN reasoning_effort TEXT NOT NULL DEFAULT 'high'
+CHECK (reasoning_effort IN ('low', 'medium', 'high', 'xhigh', 'max', 'ultra'));
+
+ALTER TABLE quick_task_requests
+ADD COLUMN fast INTEGER NOT NULL DEFAULT 0 CHECK (fast IN (0, 1));

--- a/database/src/conversations.rs
+++ b/database/src/conversations.rs
@@ -25,6 +25,9 @@ pub struct CreateQuickTaskConversation {
 	pub title: String,
 	pub message: String,
 	pub working_directory: String,
+	pub model: String,
+	pub reasoning_effort: String,
+	pub fast: bool,
 }
 
 /// Immutable original request coordinates.
@@ -32,6 +35,32 @@ pub struct CreateQuickTaskConversation {
 pub struct QuickTaskRequest {
 	pub message: String,
 	pub working_directory: String,
+	pub model: String,
+	pub reasoning_effort: String,
+	pub fast: bool,
+}
+
+/// Exact active projection that may be closed after provider archive verification.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArchiveQuickTaskConversation {
+	pub conversation_id: ConversationId,
+	pub expected_conversation_revision: i64,
+	pub runtime_session_id: RuntimeSessionId,
+	pub expected_runtime_session_revision: i64,
+}
+
+/// Durable archived projection returned by the atomic local close.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArchivedQuickTaskConversation {
+	pub conversation_id: ConversationId,
+	pub conversation_revision: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ArchiveQuickTaskConversationOutcome {
+	Applied(ArchivedQuickTaskConversation),
+	Replayed(ArchivedQuickTaskConversation),
+	Rejected,
 }
 
 /// Create a new routing conversation after a waiting or no-route decision.
@@ -169,6 +198,10 @@ pub struct OrdinaryTaskConversationReadback {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OrdinaryTaskConversationProjection {
 	Current(OrdinaryTaskConversationReadback),
+	Archived {
+		conversation_id: ConversationId,
+		conversation_revision: i64,
+	},
 	RoutingSuccessorRedirect {
 		source_conversation_id: ConversationId,
 		source_revision: i64,
@@ -313,15 +346,18 @@ impl SqliteStore {
 				.execute(
 					"INSERT INTO quick_task_requests (
 				   conversation_id, operation_key, correlation_id, initial_turn_id,
-				   message, working_directory, created_at_micros
-				 ) VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6)",
+					 message, working_directory, model, reasoning_effort, fast, created_at_micros
+				 ) VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
 					params![
 						create.conversation_id.as_str(),
 						command.key,
 						initial_turn_id,
 						create.message,
 						create.working_directory,
-						now
+						create.model,
+						create.reasoning_effort,
+						create.fast,
+						now,
 					],
 				)
 				.map_err(sql_error)?;
@@ -353,7 +389,7 @@ impl SqliteStore {
 		self.run(move |connection| {
 			connection
 				.query_row(
-					"SELECT q.message, q.working_directory
+					"SELECT q.message, q.working_directory, q.model, q.reasoning_effort, q.fast
 				 FROM quick_task_requests AS q
 				 JOIN conversations AS c USING (conversation_id)
 				 WHERE q.conversation_id = ?1 AND c.state = 'active'",
@@ -362,11 +398,125 @@ impl SqliteStore {
 						Ok(QuickTaskRequest {
 							message: row.get(0)?,
 							working_directory: row.get(1)?,
+							model: row.get(2)?,
+							reasoning_effort: row.get(3)?,
+							fast: row.get(4)?,
 						})
 					},
 				)
 				.optional()
 				.map_err(sql_error)
+		})
+		.await
+	}
+
+	/// Atomically close one provider-verified archived Conversation and its sole active session.
+	pub async fn archive_quick_task_conversation(
+		&self,
+		command: &CommandIdentity,
+		request: &ArchiveQuickTaskConversation,
+	) -> Result<ArchiveQuickTaskConversationOutcome, StoreError> {
+		if request.expected_conversation_revision <= 0
+			|| request.expected_runtime_session_revision <= 0
+		{
+			return Err(StoreError::InvalidInput("Quick Task archive coordinates are invalid"));
+		}
+		let command = command.clone();
+		let request = request.clone();
+		self.run(move |connection| {
+			let transaction = connection
+				.transaction_with_behavior(TransactionBehavior::Immediate)
+				.map_err(sql_error)?;
+			if let Some(response) = read_receipt(
+				&transaction,
+				&command,
+				"archive_quick_task_conversation",
+				request.conversation_id.as_str(),
+			)? {
+				let archived = serde_json::from_str(&response)
+					.map_err(|_| incompatible("Quick Task archive receipt"))?;
+				transaction.commit().map_err(sql_error)?;
+				return Ok(ArchiveQuickTaskConversationOutcome::Replayed(archived));
+			}
+			let authority = transaction
+				.query_row(
+					"SELECT c.revision, s.revision,
+					        EXISTS (SELECT 1 FROM turns AS t WHERE t.conversation_id = c.conversation_id
+					                AND t.status = 'active'),
+					        EXISTS (SELECT 1 FROM provider_attempts AS p
+					                WHERE p.conversation_id = c.conversation_id
+					                  AND p.state IN ('prepared', 'dispatch_authorized', 'unknown'))
+					 FROM conversations AS c
+					 JOIN runtime_sessions AS s ON s.conversation_id = c.conversation_id
+					 WHERE c.conversation_id = ?1 AND c.kind = 'ordinary_task' AND c.state = 'active'
+					   AND s.runtime_session_id = ?2 AND s.state = 'active'",
+					params![request.conversation_id.as_str(), request.runtime_session_id.as_str()],
+					|row| {
+						Ok((
+							row.get::<_, i64>(0)?,
+							row.get::<_, i64>(1)?,
+							row.get::<_, bool>(2)?,
+							row.get::<_, bool>(3)?,
+						))
+					},
+				)
+				.optional()
+				.map_err(sql_error)?;
+			let Some((conversation_revision, session_revision, active_turn, active_attempt)) =
+				authority
+			else {
+				return Ok(ArchiveQuickTaskConversationOutcome::Rejected);
+			};
+			if conversation_revision != request.expected_conversation_revision
+				|| session_revision != request.expected_runtime_session_revision
+				|| active_turn
+				|| active_attempt
+			{
+				return Ok(ArchiveQuickTaskConversationOutcome::Rejected);
+			}
+			let now = unix_micros().map_err(StoreError::from)?;
+			let session_changed = transaction
+				.execute(
+					"UPDATE runtime_sessions SET state = 'ended', revision = revision + 1,
+					 updated_at_micros = ?3, ended_at_micros = ?3
+					 WHERE runtime_session_id = ?1 AND revision = ?2 AND state = 'active'",
+					params![
+						request.runtime_session_id.as_str(),
+						request.expected_runtime_session_revision,
+						now,
+					],
+				)
+				.map_err(sql_error)?;
+			let conversation_changed = transaction
+				.execute(
+					"UPDATE conversations SET state = 'archived', revision = revision + 1,
+					 updated_at_micros = ?3 WHERE conversation_id = ?1 AND revision = ?2
+					 AND state = 'active'",
+					params![
+						request.conversation_id.as_str(),
+						request.expected_conversation_revision,
+						now,
+					],
+				)
+				.map_err(sql_error)?;
+			if session_changed != 1 || conversation_changed != 1 {
+				return Ok(ArchiveQuickTaskConversationOutcome::Rejected);
+			}
+			let archived = ArchivedQuickTaskConversation {
+				conversation_id: request.conversation_id,
+				conversation_revision: request.expected_conversation_revision + 1,
+			};
+			write_receipt(
+				&transaction,
+				&command,
+				"archive_quick_task_conversation",
+				archived.conversation_id.as_str(),
+				&serde_json::to_string(&archived)
+					.map_err(|_| incompatible("Quick Task archive receipt"))?,
+				now,
+			)?;
+			transaction.commit().map_err(sql_error)?;
+			Ok(ArchiveQuickTaskConversationOutcome::Applied(archived))
 		})
 		.await
 	}
@@ -402,7 +552,8 @@ impl SqliteStore {
 				return Ok(QuickTaskRoutingSuccessorOutcome::Replayed(successor));
 			}
 			let source = transaction.query_row(
-				"SELECT c.title, q.message, q.working_directory, d.routing_decision_id,
+				"SELECT c.title, q.message, q.working_directory, q.model, q.reasoning_effort,
+				        q.fast, d.routing_decision_id,
 				        d.decision_kind, c.revision
 				 FROM conversations AS c
 				 JOIN quick_task_requests AS q USING (conversation_id)
@@ -412,10 +563,11 @@ impl SqliteStore {
 				params![request.source_conversation_id.as_str()],
 				|row| Ok((
 					row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?,
-					row.get::<_, String>(3)?, row.get::<_, String>(4)?, row.get::<_, i64>(5)?,
+					row.get::<_, String>(3)?, row.get::<_, String>(4)?, row.get::<_, bool>(5)?,
+					row.get::<_, String>(6)?, row.get::<_, String>(7)?, row.get::<_, i64>(8)?,
 				)),
 			).optional().map_err(sql_error)?;
-			let Some((title, message, working_directory, routing_decision_id, decision_kind, revision)) = source else {
+			let Some((title, message, working_directory, model, reasoning_effort, fast, routing_decision_id, decision_kind, revision)) = source else {
 				return Ok(QuickTaskRoutingSuccessorOutcome::Rejected {
 					code: "source_authority_unavailable".to_owned(), replayed: false,
 				});
@@ -441,9 +593,9 @@ impl SqliteStore {
 			transaction.execute(
 				"INSERT INTO quick_task_requests (
 				 conversation_id, operation_key, correlation_id, causation_id, initial_turn_id,
-				 message, working_directory, created_at_micros
-				 ) VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7)",
-				params![successor_id, key, request.source_conversation_id.as_str(), initial_turn_id, message, working_directory, now],
+				 message, working_directory, model, reasoning_effort, fast, created_at_micros
+				 ) VALUES (?1, ?2, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+				params![successor_id, key, request.source_conversation_id.as_str(), initial_turn_id, message, working_directory, model, reasoning_effort, fast, now],
 			).map_err(sql_error)?;
 			transaction.execute(
 				"INSERT INTO conversation_routing_successors (
@@ -561,6 +713,8 @@ impl SqliteStore {
 	}
 }
 
+
+
 fn validate_quick_task_conversation(
 	create: &CreateQuickTaskConversation,
 ) -> Result<(), StoreError> {
@@ -572,6 +726,13 @@ fn validate_quick_task_conversation(
 		|| create.working_directory.len() > 4_096
 		|| !create.working_directory.starts_with('/')
 		|| create.working_directory.chars().any(char::is_control)
+		|| create.model.is_empty()
+		|| create.model.len() > 128
+		|| create.model.chars().any(char::is_control)
+		|| !matches!(
+			create.reasoning_effort.as_str(),
+			"low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+		)
 	{
 		return Err(StoreError::InvalidInput("initial Quick Task Conversation request is invalid"));
 	}
@@ -975,15 +1136,20 @@ fn conversation_projection(
 				|row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
 			)
 			.optional()
-			.map_err(sql_error)?
-			.ok_or_else(|| incompatible("routing successor redirect"))?;
-		return Ok(OrdinaryTaskConversationProjection::RoutingSuccessorRedirect {
-			source_conversation_id: conversation_id,
-			source_revision: row.2,
-			successor_conversation_id: ConversationId::new(successor.0)
-				.map_err(|_| incompatible("routing successor identity"))?,
-			successor_conversation_revision: successor.1,
-		});
+			.map_err(sql_error)?;
+		return match successor {
+			Some(successor) => Ok(OrdinaryTaskConversationProjection::RoutingSuccessorRedirect {
+				source_conversation_id: conversation_id,
+				source_revision: row.2,
+				successor_conversation_id: ConversationId::new(successor.0)
+					.map_err(|_| incompatible("routing successor identity"))?,
+				successor_conversation_revision: successor.1,
+			}),
+			None => Ok(OrdinaryTaskConversationProjection::Archived {
+				conversation_id,
+				conversation_revision: row.2,
+			}),
+		};
 	}
 	if row.1 != "active" || row.2 <= 0 || row.3 <= 0 {
 		return Err(incompatible("ordinary Task Conversation lifecycle"));
@@ -1878,5 +2044,162 @@ impl SqliteStore {
 			Ok(revision)
 		})
 		.await
+	}
+}
+
+#[cfg(test)]
+mod archive_tests {
+	use decodex_core::{ConversationId, RuntimeSessionId};
+	use rusqlite::params;
+	use tempfile::tempdir;
+
+	use super::{
+		ArchiveQuickTaskConversation, ArchiveQuickTaskConversationOutcome,
+		CreateQuickTaskConversation, OrdinaryTaskConversationProjection,
+	};
+	use crate::{CommandIdentity, SqliteStore, error::sqlite_error};
+
+	const CONVERSATION_ID: &str = "30000000-0000-4000-8000-000000000001";
+	const RUNTIME_SESSION_ID: &str = "40000000-0000-4000-8000-000000000001";
+	const ACCOUNT_ID: &str = "10000000-0000-4000-8000-000000000001";
+
+	#[tokio::test]
+	async fn verified_archive_atomically_closes_the_projection_and_replays_exactly() {
+		let directory = tempdir().expect("temporary database directory");
+		let store = SqliteStore::open_test(&directory.path().join("decodex.sqlite3"))
+			.expect("initialize database");
+		let conversation_id = ConversationId::new(CONVERSATION_ID).expect("conversation ID");
+		let runtime_session_id =
+			RuntimeSessionId::new(RUNTIME_SESSION_ID).expect("RuntimeSession ID");
+		store
+			.create_quick_task_conversation(
+				&CommandIdentity::new("create-archive-fixture", b"create archive fixture")
+					.expect("create command"),
+				&CreateQuickTaskConversation {
+					conversation_id: conversation_id.clone(),
+					title: "Archive fixture".to_owned(),
+					message: "Archive this task.".to_owned(),
+					working_directory: "/tmp".to_owned(),
+					model: "gpt-5.6-sol".to_owned(),
+					reasoning_effort: "high".to_owned(),
+					fast: true,
+				},
+			)
+			.await
+			.expect("create conversation");
+		store
+			.with_connection(|connection| {
+				connection
+					.execute(
+						"INSERT INTO account_identities (account_id, created_at_micros)
+						 VALUES (?1, 1)",
+						params![ACCOUNT_ID],
+					)
+					.map_err(sqlite_error)?;
+				connection
+					.execute(
+						"INSERT INTO accounts (
+						 account_id, display_label, enabled, state, revision, provider,
+						 provider_account_id, created_at_micros, updated_at_micros
+						 ) VALUES (?1, 'Archive fixture', 1, 'available', 1, 'chatgpt',
+						 'archive-fixture-provider', 1, 1)",
+						params![ACCOUNT_ID],
+					)
+					.map_err(sqlite_error)?;
+				connection
+					.execute(
+						"INSERT INTO runtime_sessions (
+						 runtime_session_id, conversation_id, account_id, account_revision,
+						 account_snapshot_id, account_display_label, account_observed_state,
+						 credential_binding_json, profile_snapshot_id, profile_revision,
+						 profile_role, model, reasoning_effort, instructions, service_tier,
+						 instructions_sha256, codex_thread_id, state, thread_start_request_id,
+						 thread_start_request_sha256, thread_start_response_id,
+						 thread_start_response_sha256, has_acknowledged_turn, revision,
+						 created_at_micros, updated_at_micros
+						 ) VALUES (
+						 ?1, ?2, ?3, 1, '41000000-0000-4000-8000-000000000001',
+						 'Archive fixture', 'available', '{}',
+						 '42000000-0000-4000-8000-000000000001', 1, 'task', 'gpt-5.6-sol',
+						 'high', 'Follow the request.', 'priority',
+						 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+						 'codex-thread-1', 'active', 1,
+						 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 1,
+						 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+						 1, 7, 1, 1
+						 )",
+						params![RUNTIME_SESSION_ID, CONVERSATION_ID, ACCOUNT_ID],
+					)
+					.map_err(sqlite_error)?;
+				Ok(())
+			})
+			.expect("seed active RuntimeSession");
+
+		let archive = ArchiveQuickTaskConversation {
+			conversation_id: conversation_id.clone(),
+			expected_conversation_revision: 1,
+			runtime_session_id: runtime_session_id.clone(),
+			expected_runtime_session_revision: 7,
+		};
+		let command =
+			CommandIdentity::new("archive-fixture", b"archive fixture").expect("archive command");
+		let archived = match store
+			.archive_quick_task_conversation(&command, &archive)
+			.await
+			.expect("archive verified conversation")
+		{
+			ArchiveQuickTaskConversationOutcome::Applied(archived) => archived,
+			other => panic!("archive was not applied: {other:?}"),
+		};
+		assert_eq!(archived.conversation_revision, 2);
+		assert!(matches!(
+			store
+				.archive_quick_task_conversation(&command, &archive)
+				.await
+				.expect("replay archive command"),
+			ArchiveQuickTaskConversationOutcome::Replayed(ref replayed)
+				if replayed == &archived
+		));
+
+		let exact = store
+			.read_ordinary_task_conversations(Some(&conversation_id), None, 1)
+			.await
+			.expect("read exact archived projection");
+		assert!(matches!(
+			exact.as_slice(),
+			[OrdinaryTaskConversationProjection::Archived {
+				conversation_id: exact_id,
+				conversation_revision: 2,
+			}] if exact_id == &conversation_id
+		));
+		assert!(
+			store
+				.read_ordinary_task_conversations(None, None, 65)
+				.await
+				.expect("list active projections")
+				.is_empty()
+		);
+		assert_eq!(
+			store
+				.read_quick_task_request(&conversation_id)
+				.await
+				.expect("read archived request"),
+			None
+		);
+		let session: (String, i64, Option<i64>) = store
+			.with_connection(|connection| {
+				connection
+					.query_row(
+						"SELECT state, revision, ended_at_micros FROM runtime_sessions
+						 WHERE runtime_session_id = ?1",
+						params![RUNTIME_SESSION_ID],
+						|row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+					)
+					.map_err(sqlite_error)
+			})
+			.expect("read ended RuntimeSession");
+		assert_eq!(session.0, "ended");
+		assert_eq!(session.1, 8);
+		assert!(session.2.is_some());
 	}
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -34,7 +34,9 @@ pub use self::{
 		ContextPackRecord, ContinuationPlanEffect, PlanContinuation, PlanInitialThreadContinuation,
 	},
 	conversations::{
-		AdmitInitialQuickTaskTurn, CreateQuickTaskConversation, CreateQuickTaskRoutingSuccessor,
+		AdmitInitialQuickTaskTurn, ArchiveQuickTaskConversation,
+		ArchiveQuickTaskConversationOutcome, ArchivedQuickTaskConversation,
+		CreateQuickTaskConversation, CreateQuickTaskRoutingSuccessor,
 		HistoryCursor, HistoryEntry, HistoryPage, InitialQuickTaskTurnAdmissionOutcome,
 		InitialQuickTaskTurnAdmissionReadback, InitialQuickTaskTurnAdmissionRejection,
 		OrdinaryTaskConversationCursor, OrdinaryTaskConversationProjection,

--- a/database/src/migrations.rs
+++ b/database/src/migrations.rs
@@ -6,7 +6,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{DatabaseError, error::sqlite_error};
 
 pub(crate) const APPLICATION_ID: i64 = 0x4443_5831;
-const CURRENT_SCHEMA_VERSION: i64 = 2;
+const CURRENT_SCHEMA_VERSION: i64 = 3;
 
 struct Migration {
 	version: i64,
@@ -24,6 +24,11 @@ const MIGRATIONS: &[Migration] = &[
 		version: 2,
 		name: "nonempty_task_instructions",
 		sql: include_str!("../migrations/0002_nonempty_task_instructions.sql"),
+	},
+	Migration {
+		version: 3,
+		name: "quick_task_execution_controls",
+		sql: include_str!("../migrations/0003_quick_task_execution_controls.sql"),
 	},
 ];
 

--- a/database/tests/quick_task_restart.rs
+++ b/database/tests/quick_task_restart.rs
@@ -92,6 +92,9 @@ async fn quick_task_continues_on_the_same_thread_after_sqlite_reopen_without_dup
 				title: "SQLite restart proof".to_owned(),
 				message: "Start the persisted task.".to_owned(),
 				working_directory: temporary.path().display().to_string(),
+				model: "gpt-5.6-sol".to_owned(),
+				reasoning_effort: "high".to_owned(),
+				fast: false,
 			},
 		)
 		.await
@@ -469,6 +472,9 @@ async fn quick_task_continues_on_the_same_thread_after_sqlite_reopen_without_dup
 				title: "Independent account affinity proof".to_owned(),
 				message: "Start an independent task.".to_owned(),
 				working_directory: temporary.path().display().to_string(),
+				model: "gpt-5.6-sol".to_owned(),
+				reasoning_effort: "high".to_owned(),
+				fast: false,
 			},
 		)
 		.await

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -1,3 +1,18 @@
+---
+type: "Evidence"
+title: "SQLite Local-Product Evidence"
+description: "Accepted automated and live evidence for the bundled SQLite product, app-server freshness boundary, Quick Task controls, and process retirement."
+tags: [local-product, sqlite, evidence, quick-task]
+openwiki:
+  roles: [testing, architecture, workflow]
+  change_kinds: [lifecycle, public-api, validation]
+  source_paths: [crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/account_launch/process.rs, crates/decodex-protocol/src/quick_task.rs, apps/decodex-gpui/src/quick_tasks.rs]
+  symbols: [control_thread, reconcile_archive, QuickTaskExecutionSettings]
+  test_paths: [database/tests/quick_task_restart.rs]
+  invariants: [Lossy external thread turns are not imported during lifecycle refresh.; Archive commits only after positive post-readback.; RestoreProcessReadiness is pre-effect.]
+  validation_commands: [cargo make check]
+---
+
 # SQLite Local-Product Evidence
 
 Status: accepted implementation and signed live-cutover evidence.
@@ -49,8 +64,8 @@ conversations and do not break the cache affinity of an existing conversation.
 
 The obsolete server-store crate and its compatibility configuration were deleted. A repository
 reverse scan finds no remaining source, configuration, documentation, or dependency reference to
-that removed implementation. The current local-database gate passed with schema version 2, WAL,
-both migration digests, and the exact 28-table inventory. `cargo test --workspace --all-targets`
+that removed implementation. The current local-database gate passed with schema version 3, WAL,
+all three migration digests, and the exact 28-table inventory. `cargo test --workspace --all-targets`
 also passed on stable Rust with the Xcode beta Metal toolchain.
 
 ## Signed live acceptance
@@ -99,7 +114,7 @@ pixels high. Deterministic native captures cover the live Accounts destination a
 transparent Workbench with the thinner title bar.
 
 The client does not activate the deferred WorkItem and Project query surface. Protocol
-V2.0 is strict, and an older daemon can close a retained session when it receives an
+V2.1 is strict, and an older daemon can close a retained session when it receives an
 unknown `ListProjects` query. The WorkItem controller stays dormant until a later
 capability-negotiation contract exists. This prevents the deferred factory surface from
 making Conversation history stay in loading state or making the whole Workbench appear
@@ -123,6 +138,44 @@ Conversation is open, the pager records a bounded invalidation. The next open by
 the cached head and waits for a fresh server page. A deterministic test proves that the
 old cached page cannot become visible after this invalidation.
 
+## App-server freshness and execution controls
+
+The selected-thread refresh boundary treats Codex Desktop and Decodex as app-server
+clients. It does not synchronize the two UIs. An exact account-bound `thread/read`
+re-observes the selected thread lifecycle. External archive readback atomically archives
+the local Conversation and ends its RuntimeSession. A Decodex archive uses same-process
+pre-read, `thread/archive`, and post-read before the local transition. The active SQLite
+list no longer retains rows absent from a complete current local page.
+
+The generated schema from the installed Codex app-server confirms `thread/read`,
+`thread/archive`, `model/list`, and request-scoped `model`, `effort`, and `serviceTier`
+fields. Fast maps to `serviceTier = "priority"`; Fast off sends an explicit null. The
+GPUI carries its selected model, reasoning effort, and Fast value on each new or later
+Turn without changing global Codex configuration. External visible turns remain outside
+this lifecycle-refresh milestone because `thread/read(includeTurns=true)` is explicitly
+lossy and cannot prove complete history or tool effects.
+
+Protocol V2.1 carries the new controls and archive event. SQLite schema version 3 adds
+the original Quick Task execution settings. The local database gate passed with all
+three migration digests, WAL, the exact 28-table inventory, and the `model`,
+`reasoning_effort`, and `fast` request columns.
+
+Focused implementation evidence is split across `crates/decodex-runtime/src/quick_task.rs`
+(exact control sequencing and process retirement),
+`crates/decodex-runtime/src/account_launch/process.rs` (thread read/archive readback),
+`crates/decodex-protocol/src/quick_task.rs` (wire settings and recovery action), and
+`apps/decodex-gpui/src/quick_tasks.rs` (bounded list, settings, and archive command
+presentation). The narrow checks are the Quick Task, process reconciliation, protocol,
+and database restart suites; use the workspace gate only when a change crosses package
+or generated-schema boundaries.
+
+Final milestone validation passed `cargo test --workspace --all-targets --all-features`,
+strict workspace Clippy, the schema-3 local database gate, and the vNext architecture
+tests. The installed Codex executable also passed the ignored live read-only probe,
+which negotiates schema/version and read-only RPCs without dispatching a Turn. The
+deterministic native Workbench capture includes the refresh, Archive, model, Fast, and
+reasoning controls without changing the existing shell layout.
+
 ## Final repository gates
 
 One complete `cargo make check` run finished successfully on the final source. It included:
@@ -131,7 +184,7 @@ One complete `cargo make check` run finished successfully on the final source. I
   vulnerabilities, site build, and Astro diagnostics with zero errors, warnings, or hints;
 - all-feature, all-target workspace compilation, Rust formatting, Taplo formatting, and strict
   Clippy checks for all 12 active Rust packages;
-- the schema-V2 local database gate with both immutable migration digests, WAL, foreign keys,
+- the schema-V3 local database gate with all three immutable migration digests, WAL, foreign keys,
   integrity checks, owner-private mode, and the exact 28-table inventory;
 - 833 passed nextest tests with three declared skips, including the globally isolated
   full-daemon signal tests; and

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,3 +1,14 @@
+---
+type: "Reference"
+title: "OpenWiki Quickstart"
+description: "Entry point for Decodex local-product architecture, SQLite authority, Quick Task execution, app-server freshness, operations, and validation."
+tags: [repository, local-product, navigation]
+openwiki:
+  roles: [repository, architecture, workflow]
+  change_kinds: [navigation]
+  source_paths: [crates/decodex-runtime/src/quick_task.rs, crates/decodex-protocol/src/quick_task.rs, database/src/lib.rs]
+---
+
 # OpenWiki Quickstart
 
 Decodex is a local agent factory above Codex app-server. Codex remains the execution
@@ -33,6 +44,12 @@ one-shot transfer tool.
   attempt, positive-only outcome evidence, and replay prohibition.
 - [Execution coordination](specs/execution-coordinator-authority.md): the small stateless
   sequencer used by Quick Task.
+
+For the current app-server freshness boundary and Quick Task controls, start with the
+[local product contract](specs/local-product-v1.md) and its [SQLite evidence](evidence/sqlite-local-product.md).
+The contract covers exact selected-thread read/archive reconciliation, the deliberately
+lossy history boundary, request-scoped model/effort/Fast settings, and the
+`RestoreProcessReadiness` pre-effect rejection.
 
 ## Current usable slice
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -1,3 +1,18 @@
+---
+type: "Specification"
+title: "Local Product V1 Contract"
+description: "Normative SQLite milestone contract for app-server freshness, Quick Task execution, lifecycle safety, and deferred product capabilities."
+tags: [local-product, sqlite, quick-task, app-server]
+openwiki:
+  roles: [architecture, domain, workflow]
+  change_kinds: [lifecycle, public-api, runtime]
+  source_paths: [crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/account_launch/process.rs, crates/decodex-protocol/src/quick_task.rs]
+  symbols: [QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread]
+  test_paths: [database/tests/quick_task_restart.rs]
+  invariants: [Exact thread lifecycle readback precedes local archive commit.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.]
+  validation_commands: [cargo test --workspace --all-targets]
+---
+
 # Local Product V1 Contract
 
 Status: normative contract for the current SQLite milestone.
@@ -10,6 +25,54 @@ Owner: [SQLite local-product decision](../decisions/sqlite-local-product.md).
 same-UID Unix WebSocket protocol. They do not open product storage or credential files.
 Codex app-server remains the provider execution kernel, with one Codex thread bound to
 one Decodex RuntimeSession.
+
+## App-server freshness boundary
+
+Codex Desktop and Decodex are clients of Codex app-server. Codex Desktop is not a
+second state authority or a synchronization peer. SQLite owns Decodex product facts,
+but its projection of a bound Codex thread can become stale when another app-server
+client changes that thread.
+
+Decodex re-observes one selected thread by exact thread ID through its bound account.
+The current V1 refresh contract covers thread lifecycle. If exact app-server readback
+reports that the thread is archived, one SQLite transaction archives the Conversation
+and ends its active RuntimeSession. Decodex removes that Conversation from the active
+task list. A Decodex archive command uses exact pre-read, archive, and post-read in one
+account-bound app-server process before it commits the same local transition. The
+runtime refuses refresh/archive while a turn, establishment, or unresolved provider
+attempt is active, and commits the local archive only after the exact provider result
+is positive and the expected Conversation and RuntimeSession revisions still match.
+
+The local Conversation list is a SQLite read and does not assert current provider
+freshness. Opening or explicitly refreshing a selected task requests a provider
+readback. V1 does not continuously poll every account and thread. App-server
+`thread/read(includeTurns=true)` exposes visible but lossy history; it is not complete
+history or tool-effect authority. V1 therefore does not import arbitrary external
+turns during lifecycle refresh. A later history-merge contract must define identity,
+completeness, provenance, and effect safety before it can update normalized history.
+
+## Quick Task execution controls
+
+Every user send carries `QuickTaskExecutionSettings`: an explicit model, reasoning
+effort, and `fast` flag. The protocol maps `fast: true` to the request-scoped Codex
+`serviceTier = "priority"`; `fast: false` sends an explicit null. These settings are
+part of each create or continuation request and do not mutate global Codex configuration.
+The GPUI owns presentation and submits the settings; `decodexd` remains the authority
+that validates the account, working directory, process fence, and provider attempt
+before dispatch. A request whose account still owns a live non-dead generation is
+rejected with `RestoreProcessReadiness` before provider effect rather than being
+classified as acceptance ambiguity.
+
+Change navigation: the public settings and recovery values are in
+`crates/decodex-protocol/src/quick_task.rs` (`QuickTaskExecutionSettings`,
+`QuickTaskRecoveryAction`); Codex request decoding is in
+`crates/decodex-codex/src/quick_task.rs`; orchestration and exact thread control are in
+`crates/decodex-runtime/src/quick_task.rs` and
+`crates/decodex-runtime/src/account_launch/process.rs`; GPUI submission and archive
+selection are in `apps/decodex-gpui/src/quick_tasks.rs`. Focused coverage is in the
+corresponding Quick Task, process reconciliation, protocol, and database tests; use
+`cargo test --workspace --all-targets` only when a package or wire change crosses the
+workspace boundary.
 
 ## Storage boundary
 
@@ -58,6 +121,12 @@ bounded inline value or a digest and length.
 13. Account affinity is scoped to a Conversation. Its initial Routing Decision binds the
     RuntimeSession and Codex thread to one account. Later Turns do not re-evaluate global
     routing. Independent Conversations can bind to different accounts.
+14. Each user send carries an explicit model, reasoning effort, and Fast selection.
+    Fast maps to the request-scoped Codex `priority` service tier. Fast off sends a null
+    service tier and does not mutate global Codex configuration.
+15. Provider archive readback can close a local Conversation only when no Turn or
+    ProviderAttempt is unresolved and exact Conversation and RuntimeSession revisions
+    still match.
 
 An absent or stale quota fact represents unknown capacity. Fixed routing admits an
 otherwise-ready account unless a current fact proves depletion. Balanced routing prefers
@@ -112,5 +181,6 @@ Acceptance requires:
 - a daemon restart followed by a later response on the same Conversation and Codex
   thread, with no duplicate ProviderAttempt dispatch;
 - protocol-only GPUI and CLI operation;
+- exact selected-thread refresh, verified archive, and request-scoped execution controls;
 - focused and workspace-wide tests; and
 - current OpenWiki and local database gates.

--- a/openwiki/specs/vnext-authority.md
+++ b/openwiki/specs/vnext-authority.md
@@ -1121,7 +1121,7 @@ One authenticated, versioned WebSocket multiplexes `control/ack/result`,
 ID, idempotency key, and optional expected revision. Events carry protocol major/minor,
 server ID, resumable monotonic sequence, entity ID/revision, correlation/causation, and
 payload type. Reconnect is snapshot plus cursor-resumed deltas with backpressure. The
-current local product accepts exact protocol V2.0 only; other major or minor revisions
+current local product accepts exact protocol V2.1 only; other major or minor revisions
 receive a typed refusal before application payload handling.
 Large artifacts use authenticated HTTP, never WebSocket snapshots. Non-loopback binding
 remains disabled until authentication, TLS, authorization, and redaction gates pass.

--- a/scripts/vnext/local_database_gate.py
+++ b/scripts/vnext/local_database_gate.py
@@ -23,6 +23,11 @@ MIGRATIONS = (
         "nonempty_task_instructions",
         ROOT / "database/migrations/0002_nonempty_task_instructions.sql",
     ),
+    (
+        3,
+        "quick_task_execution_controls",
+        ROOT / "database/migrations/0003_quick_task_execution_controls.sql",
+    ),
 )
 DATABASE_RELATIVE_PATH = Path("server/decodex.sqlite3")
 APPLICATION_ID = 0x4443_5831
@@ -153,6 +158,10 @@ def inspect_database(path: Path) -> dict[str, object]:
         task_profile = connection.execute(
             "SELECT revision, instructions FROM role_profiles WHERE role = 'task'"
         ).fetchone()
+        quick_task_request_columns = {
+            row[1]: (row[2], row[3], row[4])
+            for row in connection.execute("PRAGMA table_info(quick_task_requests)")
+        }
         tables = frozenset(
             row[0]
             for row in connection.execute(
@@ -174,6 +183,9 @@ def inspect_database(path: Path) -> dict[str, object]:
         raise GateFailure("SQLite migration ledger differs")
     if task_profile is None or task_profile[0] != 2 or not task_profile[1]:
         raise GateFailure("Task RoleProfile does not satisfy the executable contract")
+    for column in ("model", "reasoning_effort", "fast"):
+        if column not in quick_task_request_columns:
+            raise GateFailure("Quick Task execution settings are missing")
     if tables != REQUIRED_TABLES:
         raise GateFailure("SQLite table inventory differs")
     return {
@@ -182,6 +194,11 @@ def inspect_database(path: Path) -> dict[str, object]:
         "migration_sha256": [migration[2] for migration in expected_migrations],
         "schema_version": user_version,
         "table_count": len(tables),
+        "quick_task_execution_columns": sorted(
+            column
+            for column in ("model", "reasoning_effort", "fast")
+            if column in quick_task_request_columns
+        ),
     }
 
 

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -58,10 +58,16 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
                 self.assertRegex(migration, rf"CREATE TABLE {re.escape(table)}\s*\(")
         migrations = read("database/src/migrations.rs")
         repair = read("database/migrations/0002_nonempty_task_instructions.sql")
+        execution_controls = read(
+            "database/migrations/0003_quick_task_execution_controls.sql"
+        )
         self.assertIn("schema_migrations", migrations)
         self.assertIn("0002_nonempty_task_instructions.sql", migrations)
+        self.assertIn("0003_quick_task_execution_controls.sql", migrations)
         self.assertIn("BETWEEN 1 AND 65536", repair)
         self.assertIn("Follow the user request for this task.", repair)
+        for column in ("model", "reasoning_effort", "fast"):
+            self.assertIn(f"ADD COLUMN {column}", execution_controls)
         self.assertIn("TransactionBehavior::Immediate", migrations)
         self.assertIn("PRAGMA foreign_keys = ON", migrations)
         self.assertIn("PRAGMA synchronous = FULL", migrations)


### PR DESCRIPTION
Implements exact selected-thread lifecycle refresh and verified archive against Codex app-server. Adds request-scoped model, reasoning effort, and Fast controls, SQLite schema 3 persistence, GPUI controls, protocol V2.1, OpenWiki evidence, and complete validation.