### PR TITLE
Package a compatible menu bar and omit unavailable quotas

### DIFF
--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -688,6 +688,11 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(
 			script.contains(#"NATIVE_CLIENT_NAME="libdecodex_app_client_ffi.dylib""#)
 		)
+		XCTAssertTrue(
+			script.contains(
+				#"BUNDLE_ID="${DECODEX_APP_BUNDLE_ID:-space.decodex.app}""#
+			)
+		)
 		XCTAssertTrue(script.contains("-p decodex-app-client-ffi"))
 		XCTAssertTrue(
 			script.contains(#"cp "$NATIVE_CLIENT_BINARY" "$APP_NATIVE_CLIENT""#)
@@ -710,6 +715,39 @@ final class ResetCardArchitectureTests: XCTestCase {
 				"Build script still packages retired component \(retiredPackageTerm)."
 			)
 		}
+	}
+
+	func testGPUIBundleBuildsAndEmbedsTheMenuBarFromTheSameCheckout() throws {
+		let testsURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+		let repositoryURL =
+			testsURL
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+		let script = try String(
+			contentsOf: repositoryURL.appendingPathComponent(
+				"scripts/macos/stage_decodex_gpui.sh"
+			),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(
+			script.contains(#"LOGIN_ITEMS="$CONTENTS/Library/LoginItems""#)
+		)
+		XCTAssertTrue(
+			script.contains(#"MENUBAR_APP="$LOGIN_ITEMS/DecodexMenuBar.app""#)
+		)
+		XCTAssertTrue(
+			script.contains("DECODEX_APP_BUNDLE_ID=box.acg.decodex.menubar")
+		)
+		XCTAssertTrue(
+			script.contains(#"apps/decodex-app/script/build_and_run.sh" stage"#)
+		)
+		XCTAssertTrue(
+			script.contains(#"cp -R "$MENUBAR_SOURCE_APP" "$MENUBAR_APP""#)
+		)
 	}
 
 	func testLoginRecoveryUsesNativeBrowserOAuthAndNoPanelDisappearCancel() throws {

--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -5,7 +5,8 @@ MODE="${1:-run}"
 PRODUCT_NAME="Decodex"
 EXECUTABLE_NAME="DecodexApp"
 NATIVE_CLIENT_NAME="libdecodex_app_client_ffi.dylib"
-BUNDLE_ID="space.decodex.app"
+BUNDLE_ID="${DECODEX_APP_BUNDLE_ID:-space.decodex.app}"
+BUNDLE_DISPLAY_NAME="${DECODEX_APP_DISPLAY_NAME:-Decodex}"
 MIN_SYSTEM_VERSION="27.0"
 DEFAULT_SIGN_IDENTITY="x@acg.box"
 
@@ -93,7 +94,7 @@ write_info_plist() {
   <key>CFBundleName</key>
   <string>$PRODUCT_NAME</string>
   <key>CFBundleDisplayName</key>
-  <string>$PRODUCT_NAME</string>
+  <string>$BUNDLE_DISPLAY_NAME</string>
   <key>CFBundleIconFile</key>
   <string>${APP_ICON_NAME%.icns}</string>
   <key>CFBundlePackageType</key>

--- a/apps/decodex-gpui/src/settings_surface.rs
+++ b/apps/decodex-gpui/src/settings_surface.rs
@@ -12,7 +12,6 @@ use gpui::{
 
 use crate::ui_theme;
 
-#[cfg(not(test))]
 const MENUBAR_BUNDLE_ID: &str = "box.acg.decodex.menubar";
 #[cfg(not(test))]
 const MENUBAR_PREFERENCE_KEY: &str = "decodex.operator.menubar-enabled";
@@ -548,6 +547,7 @@ mod tests {
 	fn embedded_bundle_is_below_the_outer_app_contents_directory() {
 		let bundle = embedded_menubar_bundle();
 		assert!(bundle.ends_with(MENUBAR_RELATIVE_BUNDLE));
+		assert_eq!(MENUBAR_BUNDLE_ID, "box.acg.decodex.menubar");
 	}
 
 	#[gpui::test]

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -2335,8 +2335,14 @@ fn account_pool_row(
 				.flex()
 				.items_center()
 				.gap_5()
-				.child(account_quota("5 HOUR", account.five_hour_quota))
-				.child(account_quota("7 DAY", account.seven_day_quota)),
+				.children(
+					[
+						account_quota("5 HOUR", account.five_hour_quota),
+						account_quota("7 DAY", account.seven_day_quota),
+					]
+					.into_iter()
+					.flatten(),
+				),
 		)
 		.child(
 			div()
@@ -2409,17 +2415,16 @@ fn account_pool_row(
 		.into_any_element()
 }
 
-fn account_quota(label: &'static str, quota: AccountQuotaWindowDto) -> AnyElement {
-	let (detail, used, color) = match quota.result {
-		AccountQuotaStateDto::Current { used_percent, .. } => (
-			format!("{used_percent}% used"),
-			f32::from(used_percent),
-			if used_percent >= 90 { 0xef4444 } else if used_percent >= 70 { WB_AMBER } else { WB_BLUE },
-		),
-		AccountQuotaStateDto::Unknown => ("Unknown".to_owned(), 0.0, WB_TEXT_FAINT),
-		AccountQuotaStateDto::Error { .. } => ("Unavailable".to_owned(), 0.0, WB_TEXT_FAINT),
+fn account_quota(label: &'static str, quota: AccountQuotaWindowDto) -> Option<AnyElement> {
+	let AccountQuotaStateDto::Current { used_percent, .. } = quota.result else {
+		return None;
 	};
-	div()
+	let detail = format!("{used_percent}% used");
+	let used = f32::from(used_percent);
+	let color =
+		if used_percent >= 90 { 0xef4444 } else if used_percent >= 70 { WB_AMBER } else { WB_BLUE };
+	Some(
+		div()
 		.w(px(122.0))
 		.flex()
 		.flex_col()
@@ -2449,7 +2454,8 @@ fn account_quota(label: &'static str, quota: AccountQuotaWindowDto) -> AnyElemen
 						.bg(rgb(color)),
 				),
 		)
-		.into_any_element()
+		.into_any_element(),
+	)
 }
 
 fn account_state_color(account: &AccountDto) -> u32 {
@@ -4218,6 +4224,44 @@ mod tests {
 			let view = ConnectionView::Incompatible(CompatibilityReason::Startup(failure));
 			assert_eq!(connection_presentation(view).detail, detail);
 		}
+	}
+
+	#[test]
+	fn account_quota_renders_only_a_current_provider_window() {
+		let quota = |result| AccountQuotaWindowDto {
+			duration_minutes: 300,
+			observed_at_unix_micros: None,
+			result,
+		};
+
+		assert!(account_quota("5 HOUR", quota(AccountQuotaStateDto::Unknown)).is_none());
+		assert!(
+			account_quota(
+				"5 HOUR",
+				AccountQuotaWindowDto {
+					observed_at_unix_micros: Some(1),
+					result: AccountQuotaStateDto::Error {
+						error: decodex_protocol::AccountQuotaErrorDto::UnsupportedWindow,
+					},
+					..quota(AccountQuotaStateDto::Unknown)
+				},
+			)
+			.is_none()
+		);
+		assert!(
+			account_quota(
+				"5 HOUR",
+				AccountQuotaWindowDto {
+					observed_at_unix_micros: Some(1),
+					result: AccountQuotaStateDto::Current {
+						used_percent: 42,
+						resets_at_unix_micros: 2,
+					},
+					..quota(AccountQuotaStateDto::Unknown)
+				},
+			)
+			.is_some()
+		);
 	}
 
 	#[test]

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -176,6 +176,38 @@ which negotiates schema/version and read-only RPCs without dispatching a Turn. T
 deterministic native Workbench capture includes the refresh, Archive, model, Fast, and
 reasoning controls without changing the existing shell layout.
 
+## Desktop account surfaces and atomic packaging
+
+GPUI and the Swift menu-bar companion remain separate same-UID processes. Both use the
+daemon-owned account model through the current typed Rust protocol. Swift reaches that
+protocol only through its embedded `decodex-app-client-ffi` library; neither UI reads the
+SQLite database or credential bytes.
+
+A live failure probe found that the separately installed menu-bar bundle was one protocol
+minor behind the running daemon. Its embedded FFI returned `protocol_minor_mismatch` for
+`list_accounts`, while the current source bridge returned all six account rows. The GPUI
+staging path now builds the Swift companion from the same checkout and embeds it at
+`Contents/Library/LoginItems/DecodexMenuBar.app`. The companion has the fixed bundle identity
+`box.acg.decodex.menubar`, which is the identity controlled by GPUI Settings. This makes the
+two desktop surfaces one release artifact without combining their process or authority
+boundaries.
+
+Quota presentation follows one rule on both surfaces: render a window only when the provider
+has supplied a current value. An absent, unknown, unsupported, or failed five-hour observation
+does not create a synthetic `5 HOUR` row. It remains a typed protocol fact for routing and
+diagnostics.
+
+The staged nested bundle passed strict deep code-signature verification. A direct call through
+its embedded FFI negotiated the running daemon, returned `available`, and read six accounts.
+The older installed FFI remained the negative control and continued to return the typed minor
+version mismatch.
+
+Final acceptance from the task checkout included 983 Rust tests with five intentional skips,
+215 Swift tests, 30 desktop architecture and contract tests, the two real CLI diagnostics tests,
+the SQLite local-database gate, and a stable-toolchain workspace check. Every applicable test and
+gate passed. The staged application also passed strict deep code-signature verification before
+the live FFI readback.
+
 ## Final repository gates
 
 One complete `cargo make check` run finished successfully on the final source. It included:

--- a/scripts/macos/stage_decodex_gpui.sh
+++ b/scripts/macos/stage_decodex_gpui.sh
@@ -6,21 +6,42 @@ STAGE_ROOT=${DECODEX_GPUI_STAGE_DIR:-"$ROOT/target/decodex-gpui"}
 APP="$STAGE_ROOT/Decodex.app"
 CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
+LOGIN_ITEMS="$CONTENTS/Library/LoginItems"
+MENUBAR_APP="$LOGIN_ITEMS/DecodexMenuBar.app"
+MENUBAR_STAGE_ROOT="$STAGE_ROOT/menubar"
+MENUBAR_SOURCE_APP="$MENUBAR_STAGE_ROOT/Decodex.app"
 SIGN_IDENTITY=${DECODEX_GPUI_SIGN_IDENTITY:--}
 DEVELOPER_DIR=${DEVELOPER_DIR:-/Applications/Xcode-beta.app/Contents/Developer}
 export DEVELOPER_DIR
 
 cargo +stable build --locked --release --bin decodex-gpui
 rm -rf "$APP"
-mkdir -p "$MACOS"
+mkdir -p "$MACOS" "$LOGIN_ITEMS"
 cp "$ROOT/apps/decodex-gpui/packaging/Info.plist" "$CONTENTS/Info.plist"
 cp "$ROOT/target/release/decodex-gpui" "$MACOS/decodex-gpui"
 chmod 755 "$MACOS/decodex-gpui"
+
+if [ "$SIGN_IDENTITY" = "-" ]; then
+	DECODEX_APP_STAGE_DIR="$MENUBAR_STAGE_ROOT" \
+	DECODEX_APP_BUNDLE_ID=box.acg.decodex.menubar \
+	DECODEX_APP_DISPLAY_NAME="Decodex Menu Bar" \
+		"$ROOT/apps/decodex-app/script/build_and_run.sh" stage
+else
+	DECODEX_APP_STAGE_DIR="$MENUBAR_STAGE_ROOT" \
+	DECODEX_APP_BUNDLE_ID=box.acg.decodex.menubar \
+	DECODEX_APP_DISPLAY_NAME="Decodex Menu Bar" \
+	DECODEX_APP_SIGN_IDENTITY="$SIGN_IDENTITY" \
+		"$ROOT/apps/decodex-app/script/build_and_run.sh" stage
+fi
+cp -R "$MENUBAR_SOURCE_APP" "$MENUBAR_APP"
 
 codesign --force --options runtime --timestamp=none --sign "$SIGN_IDENTITY" "$APP"
 codesign --verify --deep --strict --verbose=2 "$APP"
 plutil -lint "$CONTENTS/Info.plist"
 test "$(plutil -extract CFBundleIdentifier raw "$CONTENTS/Info.plist")" = box.acg.decodex
 test "$(plutil -extract CFBundleExecutable raw "$CONTENTS/Info.plist")" = decodex-gpui
+test "$(plutil -extract CFBundleIdentifier raw "$MENUBAR_APP/Contents/Info.plist")" = box.acg.decodex.menubar
+test "$(plutil -extract CFBundleExecutable raw "$MENUBAR_APP/Contents/Info.plist")" = DecodexApp
+test -f "$MENUBAR_APP/Contents/Frameworks/libdecodex_app_client_ffi.dylib"
 
 printf '%s\n' "$APP"


### PR DESCRIPTION
## Summary

- hide provider quota windows that have no current observation
- build and embed the Swift menu-bar companion from the same checkout as GPUI
- keep the standalone menu app packaging contract compatible
- record the protocol mismatch diagnosis and acceptance evidence in OpenWiki

## Validation

- cargo +stable nextest run --workspace --all-targets --all-features (983 passed; 5 skipped)
- swift test --package-path apps/decodex-app (215 passed)
- stable workspace check
- local database and CLI diagnostics gates
- standalone and embedded macOS bundle staging, strict signature verification, and live FFI readback