### PR TITLE
Repeatable Program Loop V1

### DIFF
--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -100,16 +100,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_2() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_3() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.2");
+		.expect("production lifecycle constructs at protocol V2.3");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 2);
+	assert_eq!(CURRENT_VERSION.minor, 3);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =

--- a/apps/decodex-gpui/src/factory_surface.rs
+++ b/apps/decodex-gpui/src/factory_surface.rs
@@ -12,9 +12,9 @@ use gpui::{
 };
 
 use decodex_protocol::{
-	EntityId, ProgramCycleDraftDto, ProgramNodeDto, ProgramNodeKind, ProgramReviewClassification,
-	ProgramReviewDraftDto, QuickTaskWorkingDirectory, WireText, WorkItemBoardCard,
-	WorkItemBoardProjectId, WorkItemState,
+	EntityId, MAX_PROGRAM_NODES, ProgramContinuationDraftDto, ProgramCycleDraftDto, ProgramNodeDto,
+	ProgramNodeKind, ProgramReviewClassification, ProgramReviewDraftDto, QuickTaskWorkingDirectory,
+	WireText, WorkItemBoardCard, WorkItemBoardProjectId, WorkItemState,
 };
 
 use crate::{
@@ -31,6 +31,7 @@ use crate::{
 
 const REPLAY_HEIGHT: f32 = 134.0;
 const FACTORY_MIN_WIDTH: f32 = 1_180.0;
+const COMPLETE_PROGRAM_CYCLE_NODE_COST: usize = 9;
 
 const SURFACE: u32 = ui_theme::CANVAS;
 const SURFACE_OVERLAY: u32 = ui_theme::SURFACE_OVERLAY;
@@ -278,6 +279,53 @@ impl ProgramReviewInputs {
 	}
 }
 
+struct ProgramContinuationInputs {
+	signal_source: Entity<ComposerInput>,
+	signal: Entity<ComposerInput>,
+	claim: Entity<ComposerInput>,
+	proposal: Entity<ComposerInput>,
+	objective: Entity<ComposerInput>,
+	work_item_title: Entity<ComposerInput>,
+	work_item_instructions: Entity<ComposerInput>,
+	working_directory: Entity<ComposerInput>,
+}
+
+impl ProgramContinuationInputs {
+	fn new(cx: &mut Context<FactorySurface>) -> Self {
+		let input = |index, placeholder, label, cx: &mut Context<FactorySurface>| {
+			cx.new(|cx| ComposerInput::with_placeholder(index, placeholder, label, cx))
+		};
+		Self {
+			signal_source: input(20, "Review, observation, or external source", "Signal source", cx),
+			signal: input(21, "What changed since the prior Review", "Signal summary", cx),
+			claim: input(22, "What the new signal implies", "Claim", cx),
+			proposal: input(23, "Finite proposed response", "Proposal", cx),
+			objective: input(24, "Observable outcome for this cycle", "Objective", cx),
+			work_item_title: input(25, "One concrete Codex task", "Work item title", cx),
+			work_item_instructions: input(
+				26,
+				"Exact instructions for Codex",
+				"Work item instructions",
+				cx,
+			),
+			working_directory: input(27, "/absolute/path/to/repository", "Working directory", cx),
+		}
+	}
+
+	fn all(&self) -> [&Entity<ComposerInput>; 8] {
+		[
+			&self.signal_source,
+			&self.signal,
+			&self.claim,
+			&self.proposal,
+			&self.objective,
+			&self.work_item_title,
+			&self.work_item_instructions,
+			&self.working_directory,
+		]
+	}
+}
+
 /// One self-contained native surface. Its state is presentation-only.
 pub(crate) struct FactorySurface {
 	mode: FactoryMode,
@@ -300,9 +348,11 @@ pub(crate) struct FactorySurface {
 	program_selection: Option<EntityId>,
 	program_inputs: ProgramCreationInputs,
 	program_review_inputs: ProgramReviewInputs,
+	program_continuation_inputs: ProgramContinuationInputs,
 	program_review_classification: ProgramReviewClassification,
 	program_status: Option<SharedString>,
 	program_intake_visible: bool,
+	program_continuation_visible: bool,
 }
 
 impl EventEmitter<FactoryEvent> for FactorySurface {}
@@ -342,7 +392,13 @@ impl FactorySurface {
 		}
 		let program_inputs = ProgramCreationInputs::new(cx);
 		let program_review_inputs = ProgramReviewInputs::new(cx);
-		for input in program_inputs.all().into_iter().chain(program_review_inputs.all()) {
+		let program_continuation_inputs = ProgramContinuationInputs::new(cx);
+		for input in program_inputs
+			.all()
+			.into_iter()
+			.chain(program_review_inputs.all())
+			.chain(program_continuation_inputs.all())
+		{
 			cx.subscribe(input, |surface, _, _: &ComposerEvent, cx| {
 				surface.program_status = None;
 				cx.notify();
@@ -371,9 +427,11 @@ impl FactorySurface {
 			program_selection: None,
 			program_inputs,
 			program_review_inputs,
+			program_continuation_inputs,
 			program_review_classification: ProgramReviewClassification::OutcomeProgress,
 			program_status: None,
 			program_intake_visible: false,
+			program_continuation_visible: false,
 		}
 	}
 
@@ -591,9 +649,92 @@ impl FactorySurface {
 		if programs.select(program_id) {
 			self.programs_snapshot = Some(programs.snapshot());
 			self.program_selection = None;
+			self.program_continuation_visible = false;
 			self.program_status = None;
 			cx.notify();
 		}
+	}
+
+	fn continue_program(&mut self, cx: &mut Context<Self>) {
+		let Some(programs) = self.programs.as_ref() else {
+			return;
+		};
+		let Some(cycle) = self.programs_snapshot.as_ref().and_then(|snapshot| snapshot.cycle.as_ref())
+		else {
+			self.program_status = Some("No Program cycle is selected.".into());
+			cx.notify();
+			return;
+		};
+		let Some(predecessor) = cycle.nodes.last().filter(|node| node.kind == ProgramNodeKind::Review)
+		else {
+			self.program_status = Some("The current cycle needs a Review before continuation.".into());
+			cx.notify();
+			return;
+		};
+		let build = || -> Result<ProgramContinuationDraftDto, ProgramInputError> {
+			let text = |input: &Entity<ComposerInput>| {
+				let value = input.read(cx).content().trim().to_owned();
+				if value.is_empty() {
+					return Err(ProgramInputError::InvalidDraft);
+				}
+				WireText::new(value).map_err(|_| ProgramInputError::InvalidDraft)
+			};
+			let objective = text(&self.program_continuation_inputs.objective)?;
+			let working_directory = QuickTaskWorkingDirectory::new(
+				self.program_continuation_inputs
+					.working_directory
+					.read(cx)
+					.content()
+					.trim()
+					.to_owned(),
+			)
+			.map_err(|_| ProgramInputError::InvalidDraft)?;
+			Ok(ProgramContinuationDraftDto {
+				program_id: cycle.program.program_id.clone(),
+				predecessor_review_id: predecessor.id.clone(),
+				signal_id: entity_id()?,
+				claim_id: entity_id()?,
+				proposal_id: entity_id()?,
+				objective_id: entity_id()?,
+				work_item_id: entity_id()?,
+				signal_source: text(&self.program_continuation_inputs.signal_source)?,
+				signal_summary: text(&self.program_continuation_inputs.signal)?,
+				signal_observed_at_micros: current_micros()?,
+				claim_statement: text(&self.program_continuation_inputs.claim)?,
+				proposal_summary: text(&self.program_continuation_inputs.proposal)?,
+				proposal_expected_effect: objective.clone(),
+				proposal_risk: WireText::new(
+					"The finite WorkItem may not produce the stated observable outcome.",
+				)
+				.expect("fixed Program risk is bounded"),
+				proposal_evidence_need: WireText::new(
+					"A settled Codex run, deterministic validation, and external evidence.",
+				)
+				.expect("fixed Program evidence need is bounded"),
+				objective_outcome: objective.clone(),
+				acceptance_criteria: vec![objective],
+				validation_criteria: vec![
+					WireText::new(
+						"The bound Quick Task settles and the review cites reproducible evidence.",
+					)
+					.expect("fixed Program validation criterion is bounded"),
+				],
+				work_item_title: text(&self.program_continuation_inputs.work_item_title)?,
+				work_item_instructions: text(
+					&self.program_continuation_inputs.work_item_instructions,
+				)?,
+				working_directory,
+			})
+		};
+		match build().and_then(|draft| programs.continue_program(draft, cycle.program.revision)) {
+			Ok(()) => {
+				self.program_continuation_visible = false;
+				self.program_status = Some("Appending the next Program cycle…".into());
+			},
+			Err(error) => self.program_status = Some(program_error_label(error).into()),
+		}
+		self.programs_snapshot = Some(programs.snapshot());
+		cx.notify();
 	}
 
 	fn refresh_program(&mut self, cx: &mut Context<Self>) {
@@ -620,6 +761,7 @@ impl FactorySurface {
 		let Some(work_item) = cycle
 			.nodes
 			.iter()
+			.rev()
 			.find(|node| node.kind == ProgramNodeKind::WorkItem && node.state.as_str() == "ready")
 		else {
 			self.program_status = Some("The Program WorkItem is not ready to start.".into());
@@ -657,7 +799,7 @@ impl FactorySurface {
 			return;
 		};
 		let Some(work_item) =
-			cycle.nodes.iter().find(|node| node.kind == ProgramNodeKind::WorkItem)
+			cycle.nodes.iter().rev().find(|node| node.kind == ProgramNodeKind::WorkItem)
 		else {
 			return;
 		};
@@ -1124,11 +1266,22 @@ impl FactorySurface {
 			.program_selection
 			.as_ref()
 			.and_then(|selected| cycle.nodes.iter().find(|node| &node.id == selected));
-		let has_review = cycle.nodes.iter().any(|node| node.kind == ProgramNodeKind::Review);
-		let run_ready = cycle
-			.nodes
-			.iter()
-			.any(|node| node.kind == ProgramNodeKind::Run && node.state.as_str() == "ready");
+		let latest_work_item = cycle.nodes.iter().rev().find(|node| node.kind == ProgramNodeKind::WorkItem);
+		let latest_run = latest_work_item
+			.and_then(|work_item| work_item.conversation_id.as_ref())
+			.and_then(|conversation_id| {
+				cycle.nodes.iter().find(|node| {
+					node.kind == ProgramNodeKind::Run
+						&& node.conversation_id.as_ref() == Some(conversation_id)
+				})
+			});
+		let can_review = latest_work_item.is_some_and(|node| node.state.as_str() == "running")
+			&& latest_run.is_some_and(|node| node.state.as_str() == "ready");
+		let can_continue = cycle.program.state.as_str() == "active"
+			&& cycle.nodes.last().is_some_and(|node| node.kind == ProgramNodeKind::Review)
+			&& cycle.nodes.len().saturating_add(COMPLETE_PROGRAM_CYCLE_NODE_COST)
+				<= MAX_PROGRAM_NODES
+			&& snapshot.can_mutate;
 
 		div()
 			.id("program-factory-canvas")
@@ -1188,7 +1341,7 @@ impl FactorySurface {
 					)
 					.child(self.program_graph(cycle, cx)),
 			)
-			.child(self.program_inspector(selected_node, cycle, run_ready && !has_review, cx))
+			.child(self.program_inspector(selected_node, cycle, can_review, can_continue, cx))
 			.into_any_element()
 	}
 
@@ -1303,15 +1456,19 @@ impl FactorySurface {
 		snapshot: &ProgramsSnapshot,
 		cx: &mut Context<Self>,
 	) -> AnyElement {
-		let work_item_ready = cycle
+		let current_work_item = cycle
 			.nodes
 			.iter()
-			.any(|node| node.kind == ProgramNodeKind::WorkItem && node.state.as_str() == "ready");
-		let conversation_id = cycle
+			.rev()
+			.find(|node| node.kind == ProgramNodeKind::WorkItem);
+		let work_item_ready =
+			current_work_item.is_some_and(|node| node.state.as_str() == "ready");
+		let conversation_id = current_work_item.and_then(|node| node.conversation_id.clone());
+		let cycle_count = cycle
 			.nodes
 			.iter()
-			.find(|node| node.kind == ProgramNodeKind::Run)
-			.and_then(|node| node.conversation_id.clone());
+			.filter(|node| node.kind == ProgramNodeKind::Signal)
+			.count();
 		div()
 			.id("program-pulse")
 			.w(px(258.0))
@@ -1356,6 +1513,7 @@ impl FactorySurface {
 					),
 			)
 			.child(program_pulse_section("REVIEW POLICY", cycle.review_policy.as_str()))
+			.child(program_pulse_section("CURRENT CYCLE", &format!("C{cycle_count}")))
 			.child(program_pulse_section(
 				"NON-GOAL",
 				cycle.non_goals.first().map_or("None", WireText::as_str),
@@ -1409,6 +1567,12 @@ impl FactorySurface {
 		cx: &mut Context<Self>,
 	) -> AnyElement {
 		let selected = self.program_selection.clone();
+		let cycle_count = cycle
+			.nodes
+			.iter()
+			.filter(|node| node.kind == ProgramNodeKind::Signal)
+			.count();
+		let mut current_cycle = 0;
 		let mut graph = div()
 			.id("program-graph-strip")
 			.flex_1()
@@ -1431,6 +1595,13 @@ impl FactorySurface {
 					.unwrap_or("relates");
 				graph = graph.child(program_edge(relation));
 			}
+			if node.kind == ProgramNodeKind::Signal {
+				current_cycle += 1;
+				graph = graph.child(program_cycle_boundary(
+					current_cycle,
+					current_cycle == cycle_count,
+				));
+			}
 			graph = graph.child(program_node_card(node, selected.as_ref() == Some(&node.id), cx));
 		}
 		graph.into_any_element()
@@ -1441,6 +1612,7 @@ impl FactorySurface {
 		selected: Option<&ProgramNodeDto>,
 		cycle: &decodex_protocol::ProgramCycleDto,
 		can_review: bool,
+		can_continue: bool,
 		cx: &mut Context<Self>,
 	) -> AnyElement {
 		let mut panel = div()
@@ -1515,7 +1687,108 @@ impl FactorySurface {
 		if can_review {
 			panel = panel.child(self.program_review_form(cycle, cx));
 		}
+		if can_continue {
+			panel = if self.program_continuation_visible {
+				panel.child(self.program_continuation_form(cycle, cx))
+			} else {
+				panel.child(program_action_button(
+					"show-program-continuation",
+					"CONTINUE PROGRAM",
+					GREEN,
+					true,
+					cx,
+					|surface, cx| {
+						surface.program_continuation_visible = true;
+						cx.notify();
+					},
+				))
+			};
+		}
 		panel.into_any_element()
+	}
+
+	fn program_continuation_form(
+		&self,
+		cycle: &decodex_protocol::ProgramCycleDto,
+		cx: &mut Context<Self>,
+	) -> AnyElement {
+		let labels = [
+			"SIGNAL SOURCE",
+			"SIGNAL",
+			"CLAIM",
+			"PROPOSAL",
+			"OBJECTIVE",
+			"WORK ITEM",
+			"CODEX INSTRUCTIONS",
+			"WORKING DIRECTORY",
+		];
+		let fields = self
+			.program_continuation_inputs
+			.all()
+			.into_iter()
+			.zip(labels)
+			.enumerate()
+			.map(|(index, (input, label))| program_input_field(index + 20, label, input.clone()));
+		let next_cycle = cycle
+			.nodes
+			.iter()
+			.filter(|node| node.kind == ProgramNodeKind::Signal)
+			.count()
+			+ 1;
+		div()
+			.mt_3()
+			.pt_4()
+			.flex()
+			.flex_col()
+			.gap_2()
+			.border_t_1()
+			.border_color(rgba(0xffffff12))
+			.child(
+				div()
+					.flex()
+					.items_center()
+					.justify_between()
+					.child(
+						div()
+							.text_size(px(11.0))
+							.font_weight(FontWeight::SEMIBOLD)
+							.child(format!("NEXT CYCLE · C{next_cycle}")),
+					)
+					.child(
+						div()
+							.font_family("SF Mono")
+							.text_size(px(7.5))
+							.text_color(rgb(TEXT_FAINT))
+							.child(format!("REV {}", cycle.program.revision.0)),
+					),
+			)
+			.child(
+				div()
+					.text_size(px(8.5))
+					.text_color(rgb(TEXT_FAINT))
+					.child("Manual continuation preserves the prior Review and replaces any unresolved Objective."),
+			)
+			.children(fields)
+			.child(program_action_button(
+				"append-program-cycle",
+				"APPEND CYCLE",
+				GREEN,
+				true,
+				cx,
+				|surface, cx| surface.continue_program(cx),
+			))
+			.child(program_action_button(
+				"cancel-program-continuation",
+				"CANCEL",
+				TEXT_MUTED,
+				true,
+				cx,
+				|surface, cx| {
+					surface.program_continuation_visible = false;
+					cx.notify();
+				},
+			))
+			.into_any_element()
 	}
 
 	fn program_review_form(
@@ -2498,7 +2771,11 @@ impl FactorySurface {
 		};
 		let selected = self.program_selection.clone();
 		let origin = cycle.nodes.iter().filter_map(|node| node.observed_at_micros).min();
+		let mut cycle_number = 0;
 		let moments = cycle.nodes.iter().enumerate().map(|(index, node)| {
+			if node.kind == ProgramNodeKind::Signal {
+				cycle_number += 1;
+			}
 			let node_id = node.id.clone();
 			let active = selected.as_ref() == Some(&node.id);
 			let color = program_node_color(node.kind);
@@ -2544,7 +2821,7 @@ impl FactorySurface {
 						.font_family("SF Mono")
 						.text_size(px(7.5))
 						.text_color(rgb(TEXT_FAINT))
-						.child(time),
+						.child(format!("C{cycle_number} · {time}")),
 				)
 		});
 		div()
@@ -3409,6 +3686,32 @@ fn program_edge(label: &str) -> AnyElement {
 		.into_any_element()
 }
 
+fn program_cycle_boundary(number: usize, current: bool) -> AnyElement {
+	div()
+		.w(px(54.0))
+		.min_w(px(54.0))
+		.flex()
+		.flex_col()
+		.items_center()
+		.gap_1()
+		.child(
+			div()
+				.font_family("SF Mono")
+				.text_size(px(8.0))
+				.font_weight(FontWeight::SEMIBOLD)
+				.text_color(rgb(if current { GREEN } else { TEXT_FAINT }))
+				.child(format!("C{number}")),
+		)
+		.child(
+			div()
+				.font_family("SF Mono")
+				.text_size(px(6.5))
+				.text_color(rgb(TEXT_FAINT))
+				.child(if current { "CURRENT" } else { "HISTORY" }),
+		)
+		.into_any_element()
+}
+
 fn program_node_card(
 	node: &ProgramNodeDto,
 	selected: bool,
@@ -3501,6 +3804,7 @@ const fn node_kind_label(kind: ProgramNodeKind) -> &'static str {
 
 const fn relation_label(kind: decodex_protocol::ProgramRelationKind) -> &'static str {
 	match kind {
+		decodex_protocol::ProgramRelationKind::Continues => "continues",
 		decodex_protocol::ProgramRelationKind::Observes => "observes",
 		decodex_protocol::ProgramRelationKind::Supports => "supports",
 		decodex_protocol::ProgramRelationKind::Justifies => "justifies",

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
 			.open_window(
 				WindowOptions {
 					titlebar: Some(gpui::TitlebarOptions {
-						title: None,
+						title: Some("Decodex".into()),
 						appears_transparent: true,
 						traffic_light_position: Some(point(px(14.0), px(14.0))),
 					}),

--- a/apps/decodex-gpui/src/programs.rs
+++ b/apps/decodex-gpui/src/programs.rs
@@ -14,10 +14,10 @@ use tokio::sync::Notify;
 use decodex_protocol::{
 	CURRENT_VERSION, CausationId, ClientCommandId, CommandEnvelope, CommandOutcome, CommandPayload,
 	CommandReceipt, CommandResultEnvelope, CorrelationId, EntityId, EventEnvelope, EventPayload,
-	IdempotencyKey, ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult, ProgramListResult,
-	ProgramNodeKind, ProgramReviewDraftDto, ProgramSummaryDto, QueryEnvelope, QueryId,
-	QueryPayload, QueryResultEnvelope, QueryResultPayload, ReceiptDisposition, ResultPayload,
-	ServerId,
+	EntityRevision, IdempotencyKey, ProgramContinuationDraftDto, ProgramCycleDraftDto,
+	ProgramCycleDto, ProgramCycleResult, ProgramListResult, ProgramNodeKind, ProgramReviewDraftDto,
+	ProgramSummaryDto, QueryEnvelope, QueryId, QueryPayload, QueryResultEnvelope,
+	QueryResultPayload, ReceiptDisposition, ResultPayload, ServerId,
 };
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
@@ -161,6 +161,15 @@ impl Programs {
 		let deterministic_id = id("81000000-0000-4000-8000-000000000007");
 		let external_id = id("81000000-0000-4000-8000-000000000008");
 		let review_id = id("81000000-0000-4000-8000-000000000009");
+		let signal_2_id = id("81000000-0000-4000-8000-000000000010");
+		let claim_2_id = id("81000000-0000-4000-8000-000000000011");
+		let proposal_2_id = id("81000000-0000-4000-8000-000000000012");
+		let objective_2_id = id("81000000-0000-4000-8000-000000000013");
+		let work_item_2_id = id("81000000-0000-4000-8000-000000000014");
+		let conversation_2_id = id("10000000-0000-4000-8000-000000000002");
+		let deterministic_2_id = id("81000000-0000-4000-8000-000000000015");
+		let external_2_id = id("81000000-0000-4000-8000-000000000016");
+		let review_2_id = id("81000000-0000-4000-8000-000000000017");
 		let nodes = vec![
 			node(
 				signal_id.clone(),
@@ -264,6 +273,108 @@ impl Programs {
 				Vec::new(),
 				8,
 			),
+			node(
+				signal_2_id.clone(),
+				ProgramNodeKind::Signal,
+				"Signal",
+				"The first loop was safe, but the Program could not continue in place.",
+				"observed",
+				Some("First Program Review"),
+				None,
+				Vec::new(),
+				9,
+			),
+			node(
+				claim_2_id.clone(),
+				ProgramNodeKind::Claim,
+				"Claim",
+				"Review-linked continuation can preserve one durable Program identity.",
+				"current",
+				None,
+				None,
+				Vec::new(),
+				10,
+			),
+			node(
+				proposal_2_id.clone(),
+				ProgramNodeKind::Proposal,
+				"Proposal",
+				"Append one exact next cycle after the terminal Review.",
+				"non_executable",
+				None,
+				None,
+				vec![
+					field("Expected effect", "Repeatable causal progress in one Program"),
+					field("Risk", "Branching or duplicate continuation"),
+				],
+				11,
+			),
+			node(
+				objective_2_id.clone(),
+				ProgramNodeKind::Objective,
+				"Objective",
+				"Continue, execute, review, and reopen a second cycle.",
+				"achieved",
+				None,
+				None,
+				vec![field("Validation", "Exact predecessor, revision, and restart readback")],
+				12,
+			),
+			node(
+				work_item_2_id.clone(),
+				ProgramNodeKind::WorkItem,
+				"Prove Repeatable Program Loop V1",
+				"Exercise one additional cycle through the ordinary Quick Task path.",
+				"done",
+				None,
+				Some(conversation_2_id.clone()),
+				vec![field("Working directory", "/Users/x/code/acg-box/decodex")],
+				13,
+			),
+			node(
+				conversation_2_id.clone(),
+				ProgramNodeKind::Run,
+				"Codex Quick Task",
+				"The second cycle reused the existing app-server worker path.",
+				"ready",
+				None,
+				Some(conversation_2_id.clone()),
+				Vec::new(),
+				14,
+			),
+			node(
+				deterministic_2_id.clone(),
+				ProgramNodeKind::Evidence,
+				"Deterministic validation",
+				"Continuation, projection, and restart checks passed.",
+				"deterministic_validation",
+				Some("Repository gates"),
+				None,
+				Vec::new(),
+				15,
+			),
+			node(
+				external_2_id.clone(),
+				ProgramNodeKind::Evidence,
+				"External evidence",
+				"The exact second Codex conversation remained linked after restart.",
+				"external",
+				Some("Local GPUI dogfood"),
+				None,
+				Vec::new(),
+				16,
+			),
+			node(
+				review_2_id.clone(),
+				ProgramNodeKind::Review,
+				"Program Review",
+				"The Program now preserves repeatable causal progress.",
+				"capability_progress",
+				None,
+				None,
+				Vec::new(),
+				17,
+			),
 		];
 		let edge = |from: EntityId, to: EntityId, kind| ProgramEdgeDto { from, to, kind };
 		let edges = vec![
@@ -277,15 +388,30 @@ impl Programs {
 			edge(work_item_id, external_id.clone(), ProgramRelationKind::Produces),
 			edge(deterministic_id, review_id.clone(), ProgramRelationKind::Supports),
 			edge(external_id, review_id.clone(), ProgramRelationKind::Supports),
-			edge(review_id, program_id.clone(), ProgramRelationKind::Validates),
+			edge(review_id.clone(), program_id.clone(), ProgramRelationKind::Validates),
+			edge(review_id, signal_2_id.clone(), ProgramRelationKind::Continues),
+			edge(signal_2_id, claim_2_id.clone(), ProgramRelationKind::Supports),
+			edge(claim_2_id, proposal_2_id.clone(), ProgramRelationKind::Justifies),
+			edge(proposal_2_id, objective_2_id.clone(), ProgramRelationKind::Proposes),
+			edge(objective_2_id, work_item_2_id.clone(), ProgramRelationKind::DecomposesTo),
+			edge(work_item_2_id.clone(), conversation_2_id, ProgramRelationKind::Executes),
+			edge(
+				work_item_2_id.clone(),
+				deterministic_2_id.clone(),
+				ProgramRelationKind::Produces,
+			),
+			edge(work_item_2_id, external_2_id.clone(), ProgramRelationKind::Produces),
+			edge(deterministic_2_id, review_2_id.clone(), ProgramRelationKind::Supports),
+			edge(external_2_id, review_2_id.clone(), ProgramRelationKind::Supports),
+			edge(review_2_id, program_id.clone(), ProgramRelationKind::Validates),
 		];
 		let program = ProgramSummaryDto {
 			program_id: program_id.clone(),
 			name: text("Adaptive Factory Spine"),
 			purpose: text("Make several Codex tasks one explainable feedback system."),
 			state: ProgramState::Active,
-			revision: EntityRevision(2),
-			updated_at_micros: 1_786_000_000_000_008,
+			revision: EntityRevision(4),
+			updated_at_micros: 1_786_000_000_000_017,
 		};
 		let cycle = ProgramCycleDto::new(
 			program.clone(),
@@ -385,6 +511,19 @@ impl Programs {
 		self.queue_command(
 			CommandPayload::CreateProgramCycle { draft: Box::new(draft) },
 			Some(program_id),
+			None,
+		)
+	}
+
+	pub(crate) fn continue_program(
+		&self,
+		continuation: ProgramContinuationDraftDto,
+		expected_revision: EntityRevision,
+	) -> Result<(), ProgramInputError> {
+		self.queue_command(
+			CommandPayload::ContinueProgram { continuation: Box::new(continuation) },
+			None,
+			Some(expected_revision),
 		)
 	}
 
@@ -392,13 +531,18 @@ impl Programs {
 		&self,
 		review: ProgramReviewDraftDto,
 	) -> Result<(), ProgramInputError> {
-		self.queue_command(CommandPayload::RecordProgramReview { review: Box::new(review) }, None)
+		self.queue_command(
+			CommandPayload::RecordProgramReview { review: Box::new(review) },
+			None,
+			None,
+		)
 	}
 
 	fn queue_command(
 		&self,
 		payload: CommandPayload,
 		selected: Option<EntityId>,
+		expected_revision: Option<EntityRevision>,
 	) -> Result<(), ProgramInputError> {
 		let mut state = self.lock();
 		if state.session.is_none() {
@@ -419,7 +563,7 @@ impl Programs {
 			version: CURRENT_VERSION,
 			client_command_id: identity.client_command_id,
 			idempotency_key: identity.idempotency_key,
-			expected_revision: None,
+			expected_revision,
 			correlation_id: identity.correlation_id,
 			causation_id: None::<CausationId>,
 			payload,
@@ -930,6 +1074,11 @@ fn command_matches_cycle(command: &CommandEnvelope, cycle: &ProgramCycleDto) -> 
 	match &command.payload {
 		CommandPayload::CreateProgramCycle { draft } =>
 			cycle.program.program_id == draft.program_id,
+		CommandPayload::ContinueProgram { continuation } =>
+			cycle.program.program_id == continuation.program_id
+				&& cycle.nodes.iter().any(|node| {
+					node.kind == ProgramNodeKind::Signal && node.id == continuation.signal_id
+				}),
 		CommandPayload::RecordProgramReview { review } =>
 			cycle.program.program_id == review.program_id
 				&& cycle
@@ -1000,7 +1149,8 @@ fn canonical_uuid_v4() -> Result<String, ProgramInputError> {
 #[cfg(test)]
 mod tests {
 	use decodex_protocol::{
-		Channel, Cursor, EntityRevision, ProgramState, QuickTaskState, QuickTaskSummary, WireText,
+		Channel, Cursor, EntityRevision, ProgramState, QuickTaskState, QuickTaskSummary,
+		QuickTaskWorkingDirectory, WireText,
 	};
 
 	use super::*;
@@ -1011,6 +1161,34 @@ mod tests {
 		assert_eq!(id.as_str().len(), 36);
 		assert_eq!(&id.as_str()[14..15], "4");
 		assert!(matches!(&id.as_str()[19..20], "8" | "9" | "a" | "b"));
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[test]
+	fn visual_program_preserves_two_review_linked_cycles() {
+		let snapshot = Programs::visual_closed_cycle().snapshot();
+		let cycle = snapshot.cycle.expect("visual Program cycle");
+
+		assert_eq!(
+			cycle.nodes.iter().filter(|node| node.kind == ProgramNodeKind::Signal).count(),
+			2
+		);
+		assert_eq!(
+			cycle.nodes.iter().filter(|node| node.kind == ProgramNodeKind::Review).count(),
+			2
+		);
+		assert!(cycle.edges.iter().any(|edge| {
+			edge.kind == decodex_protocol::ProgramRelationKind::Continues
+				&& cycle
+					.nodes
+					.iter()
+					.any(|node| node.id == edge.from && node.kind == ProgramNodeKind::Review)
+				&& cycle
+					.nodes
+					.iter()
+					.any(|node| node.id == edge.to && node.kind == ProgramNodeKind::Signal)
+		}));
+		assert_eq!(cycle.program.revision, EntityRevision(4));
 	}
 
 	#[test]
@@ -1033,6 +1211,54 @@ mod tests {
 
 		state.upsert_summary(summary(older, 3));
 		assert_eq!(state.programs[0].program_id.as_str(), older);
+	}
+
+	#[test]
+	fn continuation_dispatch_carries_the_exact_program_revision() {
+		let programs = Programs::production();
+		let server_id = ServerId::new("program-continuation-test").expect("server identity");
+		programs.bind_session(7, server_id.clone());
+		let id = |value: &str| EntityId::new(value).expect("canonical Program identity");
+		let text = |value: &str| WireText::new(value).expect("bounded Program text");
+		let continuation = ProgramContinuationDraftDto {
+			program_id: id("81000000-0000-4000-8000-000000000001"),
+			predecessor_review_id: id("81000000-0000-4000-8000-000000000002"),
+			signal_id: id("81000000-0000-4000-8000-000000000003"),
+			claim_id: id("81000000-0000-4000-8000-000000000004"),
+			proposal_id: id("81000000-0000-4000-8000-000000000005"),
+			objective_id: id("81000000-0000-4000-8000-000000000006"),
+			work_item_id: id("81000000-0000-4000-8000-000000000007"),
+			signal_source: text("Operator review"),
+			signal_summary: text("The first cycle exposed the next finite gap."),
+			signal_observed_at_micros: 1,
+			claim_statement: text("One next cycle can close that gap."),
+			proposal_summary: text("Append one bounded continuation."),
+			proposal_expected_effect: text("The Program advances without losing history."),
+			proposal_risk: text("The next WorkItem might not settle."),
+			proposal_evidence_need: text("A settled run and two evidence classes."),
+			objective_outcome: text("The second cycle is complete."),
+			acceptance_criteria: vec![text("The second cycle is visible.")],
+			validation_criteria: vec![text("Restart readback has no duplicate.")],
+			work_item_title: text("Exercise the second Program cycle"),
+			work_item_instructions: text("Complete one finite local verification task."),
+			working_directory: QuickTaskWorkingDirectory::new("/tmp/decodex")
+				.expect("working directory"),
+		};
+
+		programs
+			.continue_program(continuation.clone(), EntityRevision(2))
+			.expect("continuation is queued");
+		let dispatch = programs
+			.try_take_dispatch(7, &server_id)
+			.expect("continuation dispatch is ready");
+		let command = dispatch.command().expect("continuation is a command");
+
+		assert_eq!(command.expected_revision, Some(EntityRevision(2)));
+		assert!(matches!(
+			&command.payload,
+			CommandPayload::ContinueProgram { continuation: queued }
+				if queued.as_ref() == &continuation
+		));
 	}
 
 	#[test]

--- a/crates/decodex-core/src/lib.rs
+++ b/crates/decodex-core/src/lib.rs
@@ -156,8 +156,8 @@ pub use self::{
 	},
 	program::{
 		MAX_OBJECTIVE_CRITERIA, MAX_PROGRAM_CONTEXT_BYTES, MAX_PROGRAM_CONTEXT_DECISIONS,
-		MAX_PROGRAM_NAME_BYTES, MAX_PROGRAM_OBSERVATIONS, MAX_PROGRAM_TEXT_BYTES,
-		MAX_PROGRAM_TIMESTAMP_MICROSECONDS, MAX_REVIEW_CADENCE_DAYS, Objective,
+		MAX_PROGRAM_NAME_BYTES, MAX_PROGRAM_OBSERVATIONS, MAX_PROGRAM_PROJECTION_NODES,
+		MAX_PROGRAM_TEXT_BYTES, MAX_PROGRAM_TIMESTAMP_MICROSECONDS, MAX_REVIEW_CADENCE_DAYS, Objective,
 		ObjectiveCompletionEvidence, ObjectiveEvidenceId, ObjectiveId, ObjectiveState, Program,
 		ProgramClaimId, ProgramContext, ProgramContextDecision, ProgramContextInput,
 		ProgramCorrelationId, ProgramError, ProgramEvidenceId, ProgramEvidenceKind, ProgramId,

--- a/crates/decodex-core/src/program.rs
+++ b/crates/decodex-core/src/program.rs
@@ -75,6 +75,8 @@ pub const MAX_PROGRAM_TEXT_BYTES: usize = 4_096;
 pub const MAX_OBJECTIVE_CRITERIA: usize = 32;
 /// Maximum metrics or signals on one Program.
 pub const MAX_PROGRAM_OBSERVATIONS: usize = 64;
+/// Maximum nodes in one bounded Program causal projection.
+pub const MAX_PROGRAM_PROJECTION_NODES: usize = 128;
 /// Maximum recent decisions in one compiled Program context.
 pub const MAX_PROGRAM_CONTEXT_DECISIONS: usize = 64;
 /// Maximum deterministic compiled Program-context bytes.

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -846,7 +846,7 @@ impl ResetCardClient {
 	}
 }
 
-/// Read-only V2.2 client for bounded canonical WorkItem board pages.
+/// Read-only V2.3 client for bounded canonical WorkItem board pages.
 pub struct WorkItemBoardClient {
 	transport: ResetCardClient,
 }
@@ -928,7 +928,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.2 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.3 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1162,7 +1162,7 @@ impl AccountClient {
 		.await
 	}
 
-	/// Execute one V2.2 lifecycle command exactly once on one connection.
+	/// Execute one V2.3 lifecycle command exactly once on one connection.
 	pub async fn execute(
 		&self,
 		payload: CommandPayload,
@@ -1798,12 +1798,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_2_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 2 });
+	fn protocol_constants_expose_only_the_exact_v2_3_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 3 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 2, maximum_minor: 2 },
+			SupportedVersions { major: 2, minimum_minor: 3, maximum_minor: 3 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -24,8 +24,9 @@ pub use self::{
 	},
 	program_cycle::{
 		MAX_PROGRAM_EDGES, MAX_PROGRAM_LIST_ITEMS, MAX_PROGRAM_LIST_VALUES, MAX_PROGRAM_NODES,
-		ProgramCycleContractError, ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult,
-		ProgramEdgeDto, ProgramEvidenceDraftDto, ProgramListResult, ProgramNodeDto,
+			ProgramContinuationDraftDto, ProgramCycleContractError, ProgramCycleDraftDto,
+			ProgramCycleDto, ProgramCycleResult, ProgramEdgeDto, ProgramEvidenceDraftDto,
+			ProgramListResult, ProgramNodeDto,
 		ProgramNodeFieldDto, ProgramNodeKind, ProgramRelationKind, ProgramReviewClassification,
 		ProgramReviewDraftDto, ProgramState, ProgramSummaryDto,
 	},
@@ -86,7 +87,7 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 2 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 3 };
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -77,7 +77,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.2 local endpoint authority.
+/// The complete V2.3 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,

--- a/crates/decodex-protocol/src/program_cycle.rs
+++ b/crates/decodex-protocol/src/program_cycle.rs
@@ -2,7 +2,9 @@
 
 use std::collections::HashSet;
 
-pub use decodex_core::{ProgramReviewClassification, ProgramState};
+pub use decodex_core::{
+	MAX_PROGRAM_PROJECTION_NODES as MAX_PROGRAM_NODES, ProgramReviewClassification, ProgramState,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -12,8 +14,6 @@ use crate::{
 
 /// Maximum Programs returned by one local selector query.
 pub const MAX_PROGRAM_LIST_ITEMS: usize = 64;
-/// Maximum causal nodes in one Program projection.
-pub const MAX_PROGRAM_NODES: usize = 128;
 /// Maximum causal edges in one Program projection.
 pub const MAX_PROGRAM_EDGES: usize = 256;
 /// Maximum bounded list items in one creation contract.
@@ -92,6 +92,74 @@ impl ProgramCycleDraftDto {
 			}
 		}
 		validate_list(&self.non_goals)?;
+		validate_list(&self.acceptance_criteria)?;
+		validate_list(&self.validation_criteria)?;
+		validate_joined_field(&self.acceptance_criteria)?;
+		validate_joined_field(&self.validation_criteria)?;
+		if self.signal_observed_at_micros <= 0 {
+			return Err(ProgramCycleContractError::InvalidTime);
+		}
+		Ok(())
+	}
+}
+
+/// One exact next semantic cycle for an existing reviewed Program.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProgramContinuationDraftDto {
+	pub program_id: EntityId,
+	pub predecessor_review_id: EntityId,
+	pub signal_id: EntityId,
+	pub claim_id: EntityId,
+	pub proposal_id: EntityId,
+	pub objective_id: EntityId,
+	pub work_item_id: EntityId,
+	pub signal_source: WireText,
+	pub signal_summary: WireText,
+	pub signal_observed_at_micros: i64,
+	pub claim_statement: WireText,
+	pub proposal_summary: WireText,
+	pub proposal_expected_effect: WireText,
+	pub proposal_risk: WireText,
+	pub proposal_evidence_need: WireText,
+	pub objective_outcome: WireText,
+	pub acceptance_criteria: Vec<WireText>,
+	pub validation_criteria: Vec<WireText>,
+	pub work_item_title: WireText,
+	pub work_item_instructions: WireText,
+	pub working_directory: QuickTaskWorkingDirectory,
+}
+
+impl ProgramContinuationDraftDto {
+	pub(crate) fn validate(&self) -> Result<(), ProgramCycleContractError> {
+		let ids = [
+			self.program_id.as_str(),
+			self.predecessor_review_id.as_str(),
+			self.signal_id.as_str(),
+			self.claim_id.as_str(),
+			self.proposal_id.as_str(),
+			self.objective_id.as_str(),
+			self.work_item_id.as_str(),
+		];
+		if ids.iter().copied().collect::<HashSet<_>>().len() != ids.len() {
+			return Err(ProgramCycleContractError::InvalidIdentity);
+		}
+		for value in [
+			&self.signal_source,
+			&self.signal_summary,
+			&self.claim_statement,
+			&self.proposal_summary,
+			&self.proposal_expected_effect,
+			&self.proposal_risk,
+			&self.proposal_evidence_need,
+			&self.objective_outcome,
+			&self.work_item_title,
+			&self.work_item_instructions,
+		] {
+			if value.as_str().is_empty() || value.as_str().chars().any(char::is_control) {
+				return Err(ProgramCycleContractError::InvalidText);
+			}
+		}
 		validate_list(&self.acceptance_criteria)?;
 		validate_list(&self.validation_criteria)?;
 		validate_joined_field(&self.acceptance_criteria)?;
@@ -205,6 +273,7 @@ pub struct ProgramNodeDto {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProgramRelationKind {
+	Continues,
 	Observes,
 	Supports,
 	Justifies,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.2 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.3 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -26,12 +26,12 @@ use crate::{
 	QuickTaskSummary, QuickTaskTurnOutcome, QuickTaskWorkingDirectory, SupportedVersions,
 	VersionRefusal,
 	program_cycle::{
-		ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult, ProgramListResult,
-		ProgramReviewDraftDto,
+		ProgramContinuationDraftDto, ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult,
+		ProgramListResult, ProgramReviewDraftDto,
 	},
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.2.
+/// Maximum UTF-8 size of any human-readable text carried by V2.3.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -156,7 +156,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded the V2.2 byte limit.
+/// A string-backed wire scalar exceeded the V2.3 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -172,7 +172,7 @@ impl Display for WireScalarTooLong {
 	}
 }
 
-/// Closed construction failures for the V2.2 WorkItem board contract.
+/// Closed construction failures for the V2.3 WorkItem board contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkItemBoardContractError {
 	/// An identity was not canonical lowercase RFC 9562 UUID-v4 text.
@@ -274,7 +274,7 @@ impl<'de> Deserialize<'de> for WorkItemBoardTitle {
 #[serde(transparent)]
 pub struct WorkItemBoardPageSize(u16);
 impl WorkItemBoardPageSize {
-	/// Construct a page size inside the closed V2.2 protocol bound.
+	/// Construct a page size inside the closed V2.3 protocol bound.
 	pub const fn new(value: u16) -> Result<Self, WorkItemBoardContractError> {
 		if value == 0 || value > MAX_WORK_ITEM_BOARD_PAGE_SIZE {
 			Err(WorkItemBoardContractError::InvalidPageSize)
@@ -550,7 +550,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.2 resume requires this field. Older hello envelopes can omit it
+	/// A V2.3 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -603,7 +603,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.2 welcome.
+	/// This is present in the exact-current V2.3 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1731,7 +1731,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.2 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.3 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -2262,7 +2262,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.2 protocol.
+/// Live queries available through the exact-current V2.3 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2364,7 +2364,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.2 protocol.
+/// Commands available through the exact-current V2.3 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2372,6 +2372,11 @@ pub enum CommandPayload {
 	CreateProgramCycle {
 		/// Complete V1 Program charter and finite causal chain.
 		draft: Box<ProgramCycleDraftDto>,
+	},
+	/// Append one manually accepted next cycle to an exact reviewed Program revision.
+	ContinueProgram {
+		/// Complete next-cycle input with an exact predecessor Review.
+		continuation: Box<ProgramContinuationDraftDto>,
 	},
 	/// Atomically attach required Evidence and one classified Program Review.
 	RecordProgramReview {
@@ -2893,7 +2898,7 @@ pub enum ResultPayload {
 	},
 }
 
-/// Typed live-query results available through the exact-current V2.2 protocol.
+/// Typed live-query results available through the exact-current V2.3 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -3830,12 +3835,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.2 wire encoding.
+/// Serialize a message using the only V2.3 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.2 wire encoding.
+/// Parse a client message using the only V2.3 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -3880,6 +3885,13 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 		CommandPayload::CreateProgramCycle { draft } => {
 			if command.expected_revision.is_some() || draft.validate().is_err() {
 				Err("Program cycle create contract is invalid")
+			} else {
+				Ok(())
+			}
+		},
+		CommandPayload::ContinueProgram { continuation } => {
+			if !positive_expected || continuation.validate().is_err() {
+				Err("Program continuation contract is invalid")
 			} else {
 				Ok(())
 			}
@@ -4485,7 +4497,8 @@ mod tests {
 		IdempotencyKey, MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
 		MAX_HISTORY_METADATA_KEY_BYTES, MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE,
 		MAX_IDEMPOTENCY_KEY_BYTES, MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES,
-		MAX_WORK_ITEM_BOARD_PAGE_SIZE, ProgramCycleDraftDto, QueryId, QueryResultPayload,
+		MAX_WORK_ITEM_BOARD_PAGE_SIZE, ProgramContinuationDraftDto, ProgramCycleDraftDto, QueryId,
+		QueryResultPayload,
 		QuickTaskRecoveryAction, QuickTaskState, QuickTaskSummary, QuickTaskWorkingDirectory,
 		ResetCardDescriptorDto, ResetCardOutcome, ResultPayload, ServerId, ServerInstanceId,
 		Sha256Digest, WireText, WorkItemBoardContractError, WorkItemBoardLeadId, WorkItemBoardPage,
@@ -4670,6 +4683,55 @@ mod tests {
 		});
 		let encoded = serde_json::to_string(&message).unwrap();
 		assert_eq!(decode_client_message(&encoded).unwrap(), message);
+
+		let continuation = ProgramContinuationDraftDto {
+			program_id: draft.program_id.clone(),
+			predecessor_review_id: entity("71000000-0000-4000-8000-000000000001"),
+			signal_id: entity("81000000-0000-4000-8000-000000000001"),
+			claim_id: entity("82000000-0000-4000-8000-000000000001"),
+			proposal_id: entity("83000000-0000-4000-8000-000000000001"),
+			objective_id: entity("84000000-0000-4000-8000-000000000001"),
+			work_item_id: entity("85000000-0000-4000-8000-000000000001"),
+			signal_source: text("first cycle Review"),
+			signal_summary: text("The first cycle exposed a bounded next gap"),
+			signal_observed_at_micros: 2,
+			claim_statement: text("One next cycle can close the gap"),
+			proposal_summary: text("Append one exact next cycle"),
+			proposal_expected_effect: text("The Program retains one identity"),
+			proposal_risk: text("A stale append could branch history"),
+			proposal_evidence_need: text("Restart and replay evidence"),
+			objective_outcome: text("Two cycles remain ordered"),
+			acceptance_criteria: vec![text("Prior nodes remain immutable")],
+			validation_criteria: vec![text("Replay creates no duplicate")],
+			work_item_title: text("Continue the Program"),
+			work_item_instructions: text("Execute one finite next step"),
+			working_directory: QuickTaskWorkingDirectory::new("/tmp/decodex").unwrap(),
+		};
+		let continuation_message = ClientMessage::Command(CommandEnvelope {
+			version: CURRENT_VERSION,
+			client_command_id: ClientCommandId::new("program-continue").unwrap(),
+			idempotency_key: IdempotencyKey::new("program/continue").unwrap(),
+			expected_revision: Some(EntityRevision(2)),
+			correlation_id: CorrelationId::new(ids[0]).unwrap(),
+			causation_id: None,
+			payload: CommandPayload::ContinueProgram {
+				continuation: Box::new(continuation.clone()),
+			},
+		});
+		let encoded = serde_json::to_string(&continuation_message).unwrap();
+		assert_eq!(decode_client_message(&encoded).unwrap(), continuation_message);
+		let missing_revision = ClientMessage::Command(CommandEnvelope {
+			version: CURRENT_VERSION,
+			client_command_id: ClientCommandId::new("program-continue-stale").unwrap(),
+			idempotency_key: IdempotencyKey::new("program/continue-stale").unwrap(),
+			expected_revision: None,
+			correlation_id: CorrelationId::new(ids[0]).unwrap(),
+			causation_id: None,
+			payload: CommandPayload::ContinueProgram { continuation: Box::new(continuation) },
+		});
+		assert!(
+			decode_client_message(&serde_json::to_string(&missing_revision).unwrap()).is_err()
+		);
 
 		let mut invalid = draft;
 		invalid.work_item_id = invalid.objective_id.clone();
@@ -4958,7 +5020,7 @@ mod tests {
 			}),
 		);
 		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 1, minor: 5 }));
-		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 3 }));
+		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 4 }));
 		assert!(command.is_supported_in(CURRENT_VERSION));
 		assert!(
 			serde_json::from_value::<CommandPayload>(serde_json::json!({
@@ -5429,7 +5491,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":2},"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":3},"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -5438,7 +5500,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":2},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":3},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -5480,7 +5542,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":2},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":3},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5723,7 +5785,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 3 };
+		let future = crate::ProtocolVersion { major: 2, minor: 4 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -1,6 +1,7 @@
 //! Application-service seam used by the transport without exposing infrastructure.
 
 use std::{
+	collections::{HashMap, HashSet},
 	future::{self, Future},
 	pin::Pin,
 	sync::Arc,
@@ -21,8 +22,9 @@ use decodex_core::{
 use decodex_database::{
 	AccountAdministrationOutcome, AccountCommandKind, AccountCommandReceiptClaim,
 	AccountCommandReceiptLease, AccountLifecycleRejection, CommandIdentity,
-	CreateProgramCycle as StoreCreateProgramCycle, DatabaseError, HistoryCursor, HistoryEntry,
-	OrdinaryTaskConversationCursor, OrdinaryTaskConversationProjection,
+	ContinueProgram as StoreContinueProgram, CreateProgramCycle as StoreCreateProgramCycle,
+	DatabaseError, HistoryCursor, HistoryEntry, OrdinaryTaskConversationCursor,
+	OrdinaryTaskConversationProjection,
 	OrdinaryTaskConversationReadback, OrdinaryTaskPreSessionState, ProgramCycleRecord,
 	ProgramEvidenceInput, ProgramSummaryRecord, RecordProgramReview, RoutingControlOutcome,
 	SqliteStore, StoreError,
@@ -43,9 +45,11 @@ use decodex_protocol::{
 	HistoryArtifactReference, HistoryArtifactRevision, HistoryBlobLength, HistoryBlobReference,
 	HistoryCursorToken, HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto,
 	HistoryPayloadDto, HistoryQueryError, HistorySideEffectState, HistoryText, HistoryTurnRole,
-	MAX_HISTORY_PAGE_SIZE, ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult,
-	ProgramEdgeDto, ProgramListResult, ProgramNodeDto, ProgramNodeFieldDto, ProgramNodeKind,
-	ProgramRelationKind, ProgramReviewDraftDto, ProgramSummaryDto, ProjectListResult,
+	MAX_HISTORY_PAGE_SIZE, ProgramContinuationDraftDto, ProgramCycleDraftDto,
+	ProgramCycleDto,
+		ProgramCycleResult, ProgramEdgeDto, ProgramListResult, ProgramNodeDto, ProgramNodeFieldDto,
+		ProgramNodeKind, ProgramRelationKind, ProgramReviewDraftDto, ProgramSummaryDto,
+		ProjectListResult,
 	QueryEnvelope, QueryPayload, QueryResultPayload,
 	QuickTaskExecutionSettings as QuickTaskExecutionSettingsDto, QuickTaskListCursor,
 	QuickTaskListPage, QuickTaskListResult, QuickTaskReadError, QuickTaskRecoveryAction,
@@ -1022,6 +1026,16 @@ impl ServiceApplication {
 				.create_program_cycle(&identity, &store_program_create(draft)?)
 				.await
 				.map_err(program_command_error)?,
+			CommandPayload::ContinueProgram { continuation } => {
+				let expected_revision = command
+					.expected_revision
+					.ok_or_else(|| application_unavailable("Program revision is required"))?;
+				let continuation = store_program_continuation(continuation, expected_revision)?;
+				store
+					.continue_program(&identity, &continuation)
+					.await
+					.map_err(program_command_error)?
+			},
 			CommandPayload::RecordProgramReview { review } => store
 				.record_program_review(&identity, &store_program_review(review)?)
 				.await
@@ -1670,7 +1684,8 @@ impl Application for ServiceApplication {
 	) -> Result<ApplicationPublication, CommandError> {
 		match &command.payload {
 			CommandPayload::CreateProgramCycle { .. }
-			| CommandPayload::RecordProgramReview { .. } => self.execute_program_command(command).await,
+				| CommandPayload::ContinueProgram { .. }
+				| CommandPayload::RecordProgramReview { .. } => self.execute_program_command(command).await,
 			CommandPayload::RegisterProject { .. }
 			| CommandPayload::CreateWorkItem { .. }
 			| CommandPayload::StartWorkItem { .. }
@@ -2133,6 +2148,51 @@ fn store_program_create(
 	})
 }
 
+fn store_program_continuation(
+	continuation: &ProgramContinuationDraftDto,
+	expected_revision: EntityRevision,
+) -> Result<StoreContinueProgram, CommandError> {
+	Ok(StoreContinueProgram {
+		program_id: ProgramId::new(continuation.program_id.as_str())
+			.map_err(|_| application_unavailable("Program identity is invalid"))?,
+		predecessor_review_id: ProgramReviewId::new(continuation.predecessor_review_id.as_str())
+			.map_err(|_| application_unavailable("Review identity is invalid"))?,
+		expected_revision: expected_revision.0,
+		signal_id: ProgramObservationId::new(continuation.signal_id.as_str())
+			.map_err(|_| application_unavailable("Signal identity is invalid"))?,
+		claim_id: ProgramClaimId::new(continuation.claim_id.as_str())
+			.map_err(|_| application_unavailable("Claim identity is invalid"))?,
+		proposal_id: ProgramProposalId::new(continuation.proposal_id.as_str())
+			.map_err(|_| application_unavailable("Proposal identity is invalid"))?,
+		objective_id: ObjectiveId::new(continuation.objective_id.as_str())
+			.map_err(|_| application_unavailable("Objective identity is invalid"))?,
+		work_item_id: WorkItemId::new(continuation.work_item_id.as_str())
+			.map_err(|_| application_unavailable("WorkItem identity is invalid"))?,
+		signal_source: continuation.signal_source.as_str().to_owned(),
+		signal_summary: continuation.signal_summary.as_str().to_owned(),
+		signal_observed_at_micros: continuation.signal_observed_at_micros,
+		claim_statement: continuation.claim_statement.as_str().to_owned(),
+		proposal_summary: continuation.proposal_summary.as_str().to_owned(),
+		proposal_expected_effect: continuation.proposal_expected_effect.as_str().to_owned(),
+		proposal_risk: continuation.proposal_risk.as_str().to_owned(),
+		proposal_evidence_need: continuation.proposal_evidence_need.as_str().to_owned(),
+		objective_outcome: continuation.objective_outcome.as_str().to_owned(),
+		acceptance_criteria: continuation
+			.acceptance_criteria
+			.iter()
+			.map(|value| value.as_str().to_owned())
+			.collect(),
+		validation_criteria: continuation
+			.validation_criteria
+			.iter()
+			.map(|value| value.as_str().to_owned())
+			.collect(),
+		work_item_title: continuation.work_item_title.as_str().to_owned(),
+		work_item_instructions: continuation.work_item_instructions.as_str().to_owned(),
+		working_directory: continuation.working_directory.as_str().to_owned(),
+	})
+}
+
 fn store_program_review(
 	review: &ProgramReviewDraftDto,
 ) -> Result<RecordProgramReview, CommandError> {
@@ -2174,6 +2234,7 @@ fn program_cycle_dto(
 	record: ProgramCycleRecord,
 	run_states: &[(ConversationId, &'static str)],
 ) -> Result<ProgramCycleDto, ()> {
+	let node_order = program_node_order(&record)?;
 	let program = ProgramSummaryDto {
 		program_id: entity(record.program.program_id.as_str())?,
 		name: wire(record.program.name)?,
@@ -2190,11 +2251,11 @@ fn program_cycle_dto(
 
 	for signal in record.signals {
 		let signal_id = entity(signal.signal_id.as_str())?;
-		edges.push(ProgramEdgeDto {
-			from: program.program_id.clone(),
-			to: signal_id.clone(),
-			kind: ProgramRelationKind::Observes,
-		});
+		let (from, kind) = match signal.predecessor_review_id {
+			Some(review_id) => (entity(review_id.as_str())?, ProgramRelationKind::Continues),
+			None => (program.program_id.clone(), ProgramRelationKind::Observes),
+		};
+		edges.push(ProgramEdgeDto { from, to: signal_id.clone(), kind });
 		nodes.push(ProgramNodeDto {
 			id: signal_id,
 			kind: ProgramNodeKind::Signal,
@@ -2367,7 +2428,131 @@ fn program_cycle_dto(
 		});
 	}
 
+	let positions = node_order
+		.iter()
+		.enumerate()
+		.map(|(index, id)| (id.as_str(), index))
+		.collect::<HashMap<_, _>>();
+	if positions.len() != nodes.len()
+		|| nodes.iter().any(|node| !positions.contains_key(node.id.as_str()))
+	{
+		return Err(());
+	}
+	nodes.sort_by_key(|node| positions[node.id.as_str()]);
 	ProgramCycleDto::new(program, non_goals, review_policy, nodes, edges).map_err(|_| ())
+}
+
+fn program_node_order(record: &ProgramCycleRecord) -> Result<Vec<String>, ()> {
+	let roots = record
+		.signals
+		.iter()
+		.filter(|signal| signal.predecessor_review_id.is_none())
+		.collect::<Vec<_>>();
+	if roots.len() != 1 {
+		return Err(());
+	}
+	let mut successors = HashMap::new();
+	for signal in &record.signals {
+		if let Some(predecessor) = &signal.predecessor_review_id
+			&& successors.insert(predecessor.as_str(), signal).is_some()
+		{
+			return Err(());
+		}
+	}
+	let mut claims = HashMap::new();
+	for claim in &record.claims {
+		if claims.insert(claim.signal_id.as_str(), claim).is_some() {
+			return Err(());
+		}
+	}
+	let mut proposals = HashMap::new();
+	for proposal in &record.proposals {
+		if proposals.insert(proposal.claim_id.as_str(), proposal).is_some() {
+			return Err(());
+		}
+	}
+	let mut objectives = HashMap::new();
+	for objective in &record.objectives {
+		if objectives.insert(objective.proposal_id.as_str(), objective).is_some() {
+			return Err(());
+		}
+	}
+	let mut work_items = HashMap::new();
+	for work_item in &record.work_items {
+		if work_items.insert(work_item.objective_id.as_str(), work_item).is_some() {
+			return Err(());
+		}
+	}
+	let mut reviews = HashMap::new();
+	for review in &record.reviews {
+		if reviews.insert(review.work_item_id.as_str(), review).is_some() {
+			return Err(());
+		}
+	}
+	let mut evidence = HashMap::<&str, Vec<_>>::new();
+	for item in &record.evidence {
+		evidence.entry(item.work_item_id.as_str()).or_default().push(item);
+	}
+
+	let mut order = Vec::new();
+	let mut visited_signals = HashSet::new();
+	let mut signal = roots[0];
+	loop {
+		if !visited_signals.insert(signal.signal_id.as_str()) {
+			return Err(());
+		}
+		order.push(signal.signal_id.as_str().to_owned());
+		let claim = claims.get(signal.signal_id.as_str()).ok_or(())?;
+		order.push(claim.claim_id.as_str().to_owned());
+		let proposal = proposals.get(claim.claim_id.as_str()).ok_or(())?;
+		order.push(proposal.proposal_id.as_str().to_owned());
+		let objective = objectives.get(proposal.proposal_id.as_str()).ok_or(())?;
+		order.push(objective.objective_id.as_str().to_owned());
+		let work_item = work_items.get(objective.objective_id.as_str()).ok_or(())?;
+		order.push(work_item.work_item_id.as_str().to_owned());
+		if let Some(conversation_id) = &work_item.conversation_id {
+			order.push(conversation_id.as_str().to_owned());
+		}
+		let item_evidence = evidence.get(work_item.work_item_id.as_str()).map_or(&[][..], Vec::as_slice);
+		let Some(review) = reviews.get(work_item.work_item_id.as_str()).copied() else {
+			if !item_evidence.is_empty() {
+				return Err(());
+			}
+			break;
+		};
+		let evidence_ids = item_evidence
+			.iter()
+			.map(|item| item.evidence_id.as_str())
+			.collect::<HashSet<_>>();
+		if item_evidence.len() != 2
+			|| !evidence_ids.contains(review.deterministic_evidence_id.as_str())
+			|| !evidence_ids.contains(review.external_evidence_id.as_str())
+		{
+			return Err(());
+		}
+		order.push(review.deterministic_evidence_id.as_str().to_owned());
+		order.push(review.external_evidence_id.as_str().to_owned());
+		order.push(review.review_id.as_str().to_owned());
+		let Some(next) = successors.get(review.review_id.as_str()).copied() else {
+			break;
+		};
+		signal = next;
+	}
+
+	let expected = record.signals.len()
+		+ record.claims.len()
+		+ record.proposals.len()
+		+ record.objectives.len()
+		+ record.work_items.len()
+		+ record.work_items.iter().filter(|item| item.conversation_id.is_some()).count()
+		+ record.evidence.len()
+		+ record.reviews.len();
+	if order.len() != expected
+		|| order.iter().map(String::as_str).collect::<HashSet<_>>().len() != expected
+	{
+		return Err(());
+	}
+	Ok(order)
 }
 
 fn field(label: &str, value: impl Into<String>) -> Result<ProgramNodeFieldDto, ()> {
@@ -2399,6 +2584,15 @@ const fn quick_task_state_text(state: QuickTaskState) -> &'static str {
 fn program_command_error(error: StoreError) -> CommandError {
 	match error {
 		StoreError::IdempotencyConflict => CommandError::IdempotencyConflict,
+		StoreError::RevisionConflict { expected: Some(expected), actual: Some(actual), .. } => {
+			match (u64::try_from(expected), u64::try_from(actual)) {
+				(Ok(expected), Ok(actual)) => CommandError::ExpectedRevisionMismatch {
+					expected: EntityRevision(expected),
+					actual: EntityRevision(actual),
+				},
+				_ => application_unavailable("Program command conflicts with current state"),
+			}
+		},
 		StoreError::Database(_) | StoreError::Incompatible(_) =>
 			application_unavailable("Program storage is unavailable"),
 		_ => application_unavailable("Program command conflicts with current state"),
@@ -3602,15 +3796,21 @@ mod tests {
 		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationKind,
 		AccountOperationPhase, AccountOperationStatus, AccountProvider, AccountQuotaDisposition,
 		AccountQuotaWindow, AccountQuotaWindowObservation, AccountRecord, AccountState,
-		ConversationId, ProviderIdentity, RuntimeSessionState,
+		ConversationId, ObjectiveId, ObjectiveState, ProgramClaimId, ProgramEvidenceId,
+		ProgramEvidenceKind, ProgramId, ProgramObservationId, ProgramProposalId,
+		ProgramReviewClassification, ProgramReviewId, ProgramState, ProviderIdentity,
+		RuntimeSessionState, WorkItemId, WorkItemState,
 	};
 	use decodex_database::{
 		AccountLifecycleRejection, AccountProfileDailyUsage, AccountProfileSnapshot,
-		OrdinaryTaskConversationReadback, OrdinaryTaskPreSessionState,
+		OrdinaryTaskConversationReadback, OrdinaryTaskPreSessionState, ProgramCharterRecord,
+		ProgramClaimRecord, ProgramCycleRecord, ProgramEvidenceRecord, ProgramObjectiveRecord,
+		ProgramProposalRecord, ProgramReviewRecord, ProgramSignalRecord, ProgramWorkItemRecord,
 	};
 	use decodex_protocol::{
 		AccountCommandRejectionDto, AccountProfileEmailDto, AccountQuotaStateDto, CommandError,
-		QuickTaskRecoveryAction, QuickTaskState, ResetCardError, ResetCardOperationResult,
+		ProgramNodeKind, ProgramRelationKind, QuickTaskRecoveryAction, QuickTaskState, ResetCardError,
+		ResetCardOperationResult,
 	};
 
 	use super::{
@@ -3619,8 +3819,217 @@ mod tests {
 		StoredAccountCommandOutcome, account_dto, account_lifecycle_command_error,
 		account_profile_dto, account_profile_unavailable_dto, decode_account_command_receipt,
 		encode_account_command_receipt, lifecycle_rejection, operation_query_result,
-		protocol_reset_error, quick_task_summary_from_row, quota_dto,
+		program_cycle_dto, protocol_reset_error, quick_task_summary_from_row, quota_dto,
 	};
+
+	#[test]
+	fn repeatable_program_projection_follows_review_lineage() {
+		let program_id = ProgramId::new("30000000-0000-4000-8000-000000000001").unwrap();
+		let signal_1 = ProgramObservationId::new("31000000-0000-4000-8000-000000000001").unwrap();
+		let claim_1 = ProgramClaimId::new("32000000-0000-4000-8000-000000000001").unwrap();
+		let proposal_1 = ProgramProposalId::new("33000000-0000-4000-8000-000000000001").unwrap();
+		let objective_1 = ObjectiveId::new("34000000-0000-4000-8000-000000000001").unwrap();
+		let work_1 = WorkItemId::new("35000000-0000-4000-8000-000000000001").unwrap();
+		let deterministic =
+			ProgramEvidenceId::new("36000000-0000-4000-8000-000000000001").unwrap();
+		let external = ProgramEvidenceId::new("37000000-0000-4000-8000-000000000001").unwrap();
+		let review_1 = ProgramReviewId::new("38000000-0000-4000-8000-000000000001").unwrap();
+		let signal_2 = ProgramObservationId::new("41000000-0000-4000-8000-000000000001").unwrap();
+		let claim_2 = ProgramClaimId::new("42000000-0000-4000-8000-000000000001").unwrap();
+		let proposal_2 = ProgramProposalId::new("43000000-0000-4000-8000-000000000001").unwrap();
+		let objective_2 = ObjectiveId::new("44000000-0000-4000-8000-000000000001").unwrap();
+		let work_2 = WorkItemId::new("45000000-0000-4000-8000-000000000001").unwrap();
+		let record = ProgramCycleRecord {
+			program: ProgramCharterRecord {
+				program_id: program_id.clone(),
+				name: "Repeatable Program".into(),
+				purpose: "Keep one causal identity".into(),
+				non_goals: vec!["No scheduler".into()],
+				review_policy: "Review each finite cycle".into(),
+				state: ProgramState::Active,
+				revision: 3,
+				created_at_micros: 1,
+				updated_at_micros: 3,
+			},
+			signals: vec![
+				ProgramSignalRecord {
+					signal_id: signal_1.clone(),
+					program_id: program_id.clone(),
+					predecessor_review_id: None,
+					source: "operator".into(),
+					summary: "first signal".into(),
+					observed_at_micros: 1,
+					created_at_micros: 1,
+				},
+				ProgramSignalRecord {
+					signal_id: signal_2.clone(),
+					program_id: program_id.clone(),
+					predecessor_review_id: Some(review_1.clone()),
+					source: "review".into(),
+					summary: "second signal".into(),
+					observed_at_micros: 2,
+					created_at_micros: 2,
+				},
+			],
+			claims: vec![
+				ProgramClaimRecord {
+					claim_id: claim_1.clone(),
+					program_id: program_id.clone(),
+					signal_id: signal_1,
+					statement: "first claim".into(),
+					revision: 1,
+					created_at_micros: 1,
+					updated_at_micros: 1,
+				},
+				ProgramClaimRecord {
+					claim_id: claim_2.clone(),
+					program_id: program_id.clone(),
+					signal_id: signal_2.clone(),
+					statement: "second claim".into(),
+					revision: 1,
+					created_at_micros: 2,
+					updated_at_micros: 2,
+				},
+			],
+			proposals: vec![
+				ProgramProposalRecord {
+					proposal_id: proposal_1.clone(),
+					program_id: program_id.clone(),
+					claim_id: claim_1,
+					summary: "first proposal".into(),
+					expected_effect: "first effect".into(),
+					risk: "first risk".into(),
+					evidence_need: "first evidence".into(),
+					revision: 1,
+					created_at_micros: 1,
+					updated_at_micros: 1,
+				},
+				ProgramProposalRecord {
+					proposal_id: proposal_2.clone(),
+					program_id: program_id.clone(),
+					claim_id: claim_2,
+					summary: "second proposal".into(),
+					expected_effect: "second effect".into(),
+					risk: "second risk".into(),
+					evidence_need: "second evidence".into(),
+					revision: 1,
+					created_at_micros: 2,
+					updated_at_micros: 2,
+				},
+			],
+			objectives: vec![
+				ProgramObjectiveRecord {
+					objective_id: objective_1.clone(),
+					program_id: program_id.clone(),
+					proposal_id: proposal_1,
+					outcome: "first outcome".into(),
+					acceptance_criteria: vec!["first acceptance".into()],
+					validation_criteria: vec!["first validation".into()],
+					state: ObjectiveState::Abandoned,
+					revision: 2,
+					created_at_micros: 1,
+					updated_at_micros: 2,
+				},
+				ProgramObjectiveRecord {
+					objective_id: objective_2.clone(),
+					program_id: program_id.clone(),
+					proposal_id: proposal_2,
+					outcome: "second outcome".into(),
+					acceptance_criteria: vec!["second acceptance".into()],
+					validation_criteria: vec!["second validation".into()],
+					state: ObjectiveState::Active,
+					revision: 1,
+					created_at_micros: 2,
+					updated_at_micros: 2,
+				},
+			],
+			work_items: vec![
+				ProgramWorkItemRecord {
+					work_item_id: work_1.clone(),
+					program_id: program_id.clone(),
+					objective_id: objective_1,
+					title: "first work".into(),
+					instructions: "complete first work".into(),
+					working_directory: "/tmp/decodex".into(),
+					state: WorkItemState::Done,
+					revision: 3,
+					conversation_id: None,
+					created_at_micros: 1,
+					updated_at_micros: 2,
+				},
+				ProgramWorkItemRecord {
+					work_item_id: work_2,
+					program_id: program_id.clone(),
+					objective_id: objective_2,
+					title: "second work".into(),
+					instructions: "complete second work".into(),
+					working_directory: "/tmp/decodex".into(),
+					state: WorkItemState::Ready,
+					revision: 1,
+					conversation_id: None,
+					created_at_micros: 2,
+					updated_at_micros: 2,
+				},
+			],
+			evidence: vec![
+				ProgramEvidenceRecord {
+					evidence_id: deterministic.clone(),
+					program_id: program_id.clone(),
+					work_item_id: work_1.clone(),
+					kind: ProgramEvidenceKind::DeterministicValidation,
+					source: "test".into(),
+					summary: "checks passed".into(),
+					observed_at_micros: 2,
+					created_at_micros: 2,
+				},
+				ProgramEvidenceRecord {
+					evidence_id: external.clone(),
+					program_id: program_id.clone(),
+					work_item_id: work_1.clone(),
+					kind: ProgramEvidenceKind::External,
+					source: "provider".into(),
+					summary: "provider settled".into(),
+					observed_at_micros: 2,
+					created_at_micros: 2,
+				},
+			],
+			reviews: vec![ProgramReviewRecord {
+				review_id: review_1.clone(),
+				program_id,
+				work_item_id: work_1,
+				deterministic_evidence_id: deterministic,
+				external_evidence_id: external,
+				classification: ProgramReviewClassification::KnowledgeProgress,
+				rationale: "continue with the next bounded gap".into(),
+				created_at_micros: 2,
+			}],
+		};
+
+		let projection = program_cycle_dto(record, &[]).expect("two-cycle projection");
+		assert_eq!(
+			projection.nodes.iter().map(|node| node.kind).collect::<Vec<_>>(),
+			vec![
+				ProgramNodeKind::Signal,
+				ProgramNodeKind::Claim,
+				ProgramNodeKind::Proposal,
+				ProgramNodeKind::Objective,
+				ProgramNodeKind::WorkItem,
+				ProgramNodeKind::Evidence,
+				ProgramNodeKind::Evidence,
+				ProgramNodeKind::Review,
+				ProgramNodeKind::Signal,
+				ProgramNodeKind::Claim,
+				ProgramNodeKind::Proposal,
+				ProgramNodeKind::Objective,
+				ProgramNodeKind::WorkItem,
+			]
+		);
+		assert!(projection.edges.iter().any(|edge| {
+			edge.from.as_str() == review_1.as_str()
+				&& edge.to.as_str() == signal_2.as_str()
+				&& edge.kind == ProgramRelationKind::Continues
+		}));
+	}
 
 	#[cfg(any())]
 	const BOARD_PROJECT: &str = "10000000-0000-4000-8000-000000000001";

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.2 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.3 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Quick Task owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -360,14 +360,14 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 3 },
+				version: ProtocolVersion { major: 2, minor: 4 },
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
 		}),
 	)
 	.await;
 	let ServerMessage::Refusal(refusal) = receive(&mut future).await else {
-		panic!("expected V2.3 minor-version refusal");
+		panic!("expected V2.4 minor-version refusal");
 	};
 	assert!(matches!(
 		refusal.refusal,
@@ -390,7 +390,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 3 },
+			ProtocolVersion { major: 2, minor: 4 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -477,7 +477,7 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 
 	drop(client);
 
-	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 3 }).await;
+	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 4 }).await;
 	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
 		panic!("expected minor-version refusal");
 	};
@@ -495,8 +495,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 2);
-	assert_eq!(welcome.supported.maximum_minor, 2);
+	assert_eq!(welcome.supported.minimum_minor, 3);
+	assert_eq!(welcome.supported.maximum_minor, 3);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
@@ -519,7 +519,7 @@ async fn post_negotiation_payload_envelopes_require_exact_current_version() {
 	send(
 		&mut client,
 		ClientMessage::Query(QueryEnvelope {
-			version: ProtocolVersion { major: 2, minor: 3 },
+			version: ProtocolVersion { major: 2, minor: 4 },
 			query_id: QueryId::new("future-query").expect("bounded query ID"),
 			payload: QueryPayload::GetDoctorStatus,
 		}),

--- a/database/migrations/0006_repeatable_program_loop.sql
+++ b/database/migrations/0006_repeatable_program_loop.sql
@@ -1,0 +1,36 @@
+ALTER TABLE program_signals
+ADD COLUMN predecessor_review_id TEXT REFERENCES program_reviews(review_id);
+
+CREATE UNIQUE INDEX program_signals_one_root_per_program
+ON program_signals(program_id)
+WHERE predecessor_review_id IS NULL;
+
+CREATE UNIQUE INDEX program_signals_one_continuation_per_review
+ON program_signals(predecessor_review_id)
+WHERE predecessor_review_id IS NOT NULL;
+
+CREATE TRIGGER program_signal_predecessor_same_program_insert
+BEFORE INSERT ON program_signals
+WHEN NEW.predecessor_review_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM program_reviews
+    WHERE review_id = NEW.predecessor_review_id
+      AND program_id = NEW.program_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'program Signal predecessor must be a Review in the same Program');
+END;
+
+CREATE TRIGGER program_signal_predecessor_same_program_update
+BEFORE UPDATE OF program_id, predecessor_review_id ON program_signals
+WHEN NEW.predecessor_review_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM program_reviews
+    WHERE review_id = NEW.predecessor_review_id
+      AND program_id = NEW.program_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'program Signal predecessor must be a Review in the same Program');
+END;

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -58,7 +58,8 @@ pub use self::{
 		ProcessGenerationMutationOutcome, ProcessGenerationRejection,
 	},
 	program_cycles::{
-		CreateProgramCycle, ProgramCharterRecord, ProgramClaimRecord, ProgramCycleRecord,
+		ContinueProgram, CreateProgramCycle, ProgramCharterRecord, ProgramClaimRecord,
+		ProgramCycleRecord,
 		ProgramEvidenceInput, ProgramEvidenceRecord, ProgramObjectiveRecord, ProgramProposalRecord,
 		ProgramReviewRecord, ProgramSignalRecord, ProgramSummaryRecord, ProgramWorkItemRecord,
 		RecordProgramReview,

--- a/database/src/migrations.rs
+++ b/database/src/migrations.rs
@@ -6,7 +6,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{DatabaseError, error::sqlite_error};
 
 pub(crate) const APPLICATION_ID: i64 = 0x4443_5831;
-const CURRENT_SCHEMA_VERSION: i64 = 5;
+const CURRENT_SCHEMA_VERSION: i64 = 6;
 
 struct Migration {
 	version: i64,
@@ -39,6 +39,11 @@ const MIGRATIONS: &[Migration] = &[
 		version: 5,
 		name: "adaptive_factory_spine",
 		sql: include_str!("../migrations/0005_adaptive_factory_spine.sql"),
+	},
+	Migration {
+		version: 6,
+		name: "repeatable_program_loop",
+		sql: include_str!("../migrations/0006_repeatable_program_loop.sql"),
 	},
 ];
 

--- a/database/src/program_cycles.rs
+++ b/database/src/program_cycles.rs
@@ -9,7 +9,7 @@ use decodex_core::{
 	ConversationId, ObjectiveId, ObjectiveState, ProgramClaimId, ProgramEvidenceId,
 	ProgramEvidenceKind, ProgramId, ProgramObservationId, ProgramProposalId,
 	ProgramReviewClassification, ProgramReviewId, ProgramState, WorkItemId, WorkItemState,
-	contains_credential_material,
+	MAX_PROGRAM_PROJECTION_NODES, contains_credential_material,
 };
 use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
 use serde::{Deserialize, Serialize};
@@ -17,10 +17,12 @@ use serde::{Deserialize, Serialize};
 use crate::{CommandIdentity, SqliteStore, StoreError};
 
 const CREATE_OPERATION: &str = "create_program_cycle";
+const CONTINUE_OPERATION: &str = "continue_program";
 const REVIEW_OPERATION: &str = "record_program_review";
 const MAX_LIST_ITEMS: usize = 32;
 const MAX_TEXT_BYTES: usize = 4_096;
 const MAX_INSTRUCTION_BYTES: usize = 16_384;
+const COMPLETE_PROGRAM_CYCLE_NODE_COST: usize = 9;
 
 /// Complete pre-execution semantic chain created atomically for V1.
 #[derive(Clone, Debug)]
@@ -35,6 +37,33 @@ pub struct CreateProgramCycle {
 	pub purpose: String,
 	pub non_goals: Vec<String>,
 	pub review_policy: String,
+	pub signal_source: String,
+	pub signal_summary: String,
+	pub signal_observed_at_micros: i64,
+	pub claim_statement: String,
+	pub proposal_summary: String,
+	pub proposal_expected_effect: String,
+	pub proposal_risk: String,
+	pub proposal_evidence_need: String,
+	pub objective_outcome: String,
+	pub acceptance_criteria: Vec<String>,
+	pub validation_criteria: Vec<String>,
+	pub work_item_title: String,
+	pub work_item_instructions: String,
+	pub working_directory: String,
+}
+
+/// One exact next semantic cycle appended to an existing reviewed Program.
+#[derive(Clone, Debug)]
+pub struct ContinueProgram {
+	pub program_id: ProgramId,
+	pub predecessor_review_id: ProgramReviewId,
+	pub expected_revision: u64,
+	pub signal_id: ProgramObservationId,
+	pub claim_id: ProgramClaimId,
+	pub proposal_id: ProgramProposalId,
+	pub objective_id: ObjectiveId,
+	pub work_item_id: WorkItemId,
 	pub signal_source: String,
 	pub signal_summary: String,
 	pub signal_observed_at_micros: i64,
@@ -102,6 +131,7 @@ pub struct ProgramCharterRecord {
 pub struct ProgramSignalRecord {
 	pub signal_id: ProgramObservationId,
 	pub program_id: ProgramId,
+	pub predecessor_review_id: Option<ProgramReviewId>,
 	pub source: String,
 	pub summary: String,
 	pub observed_at_micros: i64,
@@ -205,6 +235,30 @@ pub struct ProgramCycleRecord {
 	pub reviews: Vec<ProgramReviewRecord>,
 }
 
+struct ProgramStep<'a> {
+	program_id: &'a ProgramId,
+	predecessor_review_id: Option<&'a ProgramReviewId>,
+	signal_id: &'a ProgramObservationId,
+	claim_id: &'a ProgramClaimId,
+	proposal_id: &'a ProgramProposalId,
+	objective_id: &'a ObjectiveId,
+	work_item_id: &'a WorkItemId,
+	signal_source: &'a str,
+	signal_summary: &'a str,
+	signal_observed_at_micros: i64,
+	claim_statement: &'a str,
+	proposal_summary: &'a str,
+	proposal_expected_effect: &'a str,
+	proposal_risk: &'a str,
+	proposal_evidence_need: &'a str,
+	objective_outcome: &'a str,
+	acceptance_criteria: &'a [String],
+	validation_criteria: &'a [String],
+	work_item_title: &'a str,
+	work_item_instructions: &'a str,
+	working_directory: &'a str,
+}
+
 impl SqliteStore {
 	/// Atomically create one complete pre-execution semantic chain.
 	pub async fn create_program_cycle(
@@ -246,8 +300,6 @@ impl SqliteStore {
 				return Err(StoreError::InvalidInput("Signal observation is in the future"));
 			}
 			let non_goals = encode_list(&create.non_goals)?;
-			let acceptance = encode_list(&create.acceptance_criteria)?;
-			let validation = encode_list(&create.validation_criteria)?;
 			transaction
 				.execute(
 					"INSERT INTO programs (
@@ -264,104 +316,40 @@ impl SqliteStore {
 					],
 				)
 				.map_err(sql_error)?;
-			for (entity_id, kind) in [
-				(create.program_id.as_str(), "program"),
-				(create.signal_id.as_str(), "signal"),
-				(create.claim_id.as_str(), "claim"),
-				(create.proposal_id.as_str(), "proposal"),
-				(create.objective_id.as_str(), "objective"),
-				(create.work_item_id.as_str(), "work_item"),
-			] {
 				transaction
 					.execute(
 						"INSERT INTO program_entities (entity_id, program_id, kind)
-					 VALUES (?1, ?2, ?3)",
-						params![entity_id, create.program_id.as_str(), kind],
+						 VALUES (?1, ?1, 'program')",
+						params![create.program_id.as_str()],
 					)
 					.map_err(sql_error)?;
-			}
-			transaction
-				.execute(
-					"INSERT INTO program_signals (
-				 signal_id, program_id, source, summary, observed_at_micros, created_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-					params![
-						create.signal_id.as_str(),
-						create.program_id.as_str(),
-						create.signal_source,
-						create.signal_summary,
-						create.signal_observed_at_micros,
-						now
-					],
-				)
-				.map_err(sql_error)?;
-			transaction
-				.execute(
-					"INSERT INTO program_claims (
-				 claim_id, program_id, signal_id, statement, revision, created_at_micros,
-				 updated_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, 1, ?5, ?5)",
-					params![
-						create.claim_id.as_str(),
-						create.program_id.as_str(),
-						create.signal_id.as_str(),
-						create.claim_statement,
-						now
-					],
-				)
-				.map_err(sql_error)?;
-			transaction
-				.execute(
-					"INSERT INTO program_proposals (
-				 proposal_id, program_id, claim_id, summary, expected_effect, risk, evidence_need,
-				 executable, revision, created_at_micros, updated_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 1, ?8, ?8)",
-					params![
-						create.proposal_id.as_str(),
-						create.program_id.as_str(),
-						create.claim_id.as_str(),
-						create.proposal_summary,
-						create.proposal_expected_effect,
-						create.proposal_risk,
-						create.proposal_evidence_need,
-						now
-					],
-				)
-				.map_err(sql_error)?;
-			transaction
-				.execute(
-					"INSERT INTO program_objectives (
-				 objective_id, program_id, proposal_id, outcome, acceptance_criteria_json,
-				 validation_criteria_json, state, revision, created_at_micros, updated_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', 1, ?7, ?7)",
-					params![
-						create.objective_id.as_str(),
-						create.program_id.as_str(),
-						create.proposal_id.as_str(),
-						create.objective_outcome,
-						acceptance,
-						validation,
-						now
-					],
-				)
-				.map_err(sql_error)?;
-			transaction
-				.execute(
-					"INSERT INTO program_work_items (
-				 work_item_id, program_id, objective_id, title, instructions, working_directory,
-				 state, revision, created_at_micros, updated_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'ready', 1, ?7, ?7)",
-					params![
-						create.work_item_id.as_str(),
-						create.program_id.as_str(),
-						create.objective_id.as_str(),
-						create.work_item_title,
-						create.work_item_instructions,
-						create.working_directory,
-						now
-					],
-				)
-				.map_err(sql_error)?;
+				insert_program_step(
+					&transaction,
+					&ProgramStep {
+						program_id: &create.program_id,
+						predecessor_review_id: None,
+						signal_id: &create.signal_id,
+						claim_id: &create.claim_id,
+						proposal_id: &create.proposal_id,
+						objective_id: &create.objective_id,
+						work_item_id: &create.work_item_id,
+						signal_source: &create.signal_source,
+						signal_summary: &create.signal_summary,
+						signal_observed_at_micros: create.signal_observed_at_micros,
+						claim_statement: &create.claim_statement,
+						proposal_summary: &create.proposal_summary,
+						proposal_expected_effect: &create.proposal_expected_effect,
+						proposal_risk: &create.proposal_risk,
+						proposal_evidence_need: &create.proposal_evidence_need,
+						objective_outcome: &create.objective_outcome,
+						acceptance_criteria: &create.acceptance_criteria,
+						validation_criteria: &create.validation_criteria,
+						work_item_title: &create.work_item_title,
+						work_item_instructions: &create.work_item_instructions,
+						working_directory: &create.working_directory,
+					},
+					now,
+				)?;
 			let record = read_program_cycle(&transaction, &create.program_id)?
 				.ok_or_else(|| incompatible("created Program cycle"))?;
 			write_receipt(
@@ -371,6 +359,191 @@ impl SqliteStore {
 				create.program_id.as_str(),
 				&serde_json::to_string(&record)
 					.map_err(|_| incompatible("Program create receipt"))?,
+				now,
+			)?;
+			transaction.commit().map_err(sql_error)?;
+			Ok(record)
+		})
+			.await
+	}
+
+	/// Atomically append one exact next cycle to a reviewed active Program.
+	pub async fn continue_program(
+		&self,
+		command: &CommandIdentity,
+		continuation: &ContinueProgram,
+	) -> Result<ProgramCycleRecord, StoreError> {
+		validate_continuation(continuation)?;
+		let command = command.clone();
+		let continuation = continuation.clone();
+		self.run(move |connection| {
+			let transaction = connection
+				.transaction_with_behavior(TransactionBehavior::Immediate)
+				.map_err(sql_error)?;
+			if let Some(response) = read_receipt(
+				&transaction,
+				&command,
+				CONTINUE_OPERATION,
+				continuation.signal_id.as_str(),
+			)? {
+				let record = serde_json::from_str(&response)
+					.map_err(|_| incompatible("Program continuation receipt"))?;
+				transaction.commit().map_err(sql_error)?;
+				return Ok(record);
+			}
+
+			let expected_revision = i64::try_from(continuation.expected_revision)
+				.map_err(|_| StoreError::InvalidInput("Program revision is invalid"))?;
+			let current = transaction
+				.query_row(
+					"SELECT state, revision FROM programs WHERE program_id = ?1",
+					params![continuation.program_id.as_str()],
+					|row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+				)
+				.optional()
+				.map_err(sql_error)?;
+			let Some((state, actual_revision)) = current else {
+				return Err(StoreError::InvalidInput("Program does not exist"));
+			};
+			if actual_revision != expected_revision {
+				return Err(StoreError::RevisionConflict {
+					entity: format!("program/{}", continuation.program_id),
+					expected: Some(expected_revision),
+					actual: Some(actual_revision),
+				});
+			}
+			if state != "active" {
+				return Err(StoreError::InvalidInput("Program is not active"));
+			}
+			let projection_nodes: i64 = transaction
+				.query_row(
+					"SELECT
+					   (SELECT COUNT(*) FROM program_entities
+					    WHERE program_id = ?1 AND kind != 'program')
+					 + (SELECT COUNT(*) FROM program_work_item_executions AS execution
+					    JOIN program_work_items AS item USING (work_item_id)
+					    WHERE item.program_id = ?1)",
+					params![continuation.program_id.as_str()],
+					|row| row.get(0),
+				)
+				.map_err(sql_error)?;
+			let projection_nodes = usize::try_from(projection_nodes)
+				.map_err(|_| incompatible("Program projection node count"))?;
+			if projection_nodes.saturating_add(COMPLETE_PROGRAM_CYCLE_NODE_COST)
+				> MAX_PROGRAM_PROJECTION_NODES
+			{
+				return Err(StoreError::CapacityExhausted("Program projection"));
+			}
+
+			let unreviewed: i64 = transaction
+				.query_row(
+					"SELECT COUNT(*) FROM program_work_items AS item
+					 LEFT JOIN program_reviews AS review USING (work_item_id)
+					 WHERE item.program_id = ?1 AND review.review_id IS NULL",
+					params![continuation.program_id.as_str()],
+					|row| row.get(0),
+				)
+				.map_err(sql_error)?;
+			if unreviewed != 0 {
+				return Err(StoreError::InvalidInput(
+					"Program already has an unreviewed cycle",
+				));
+			}
+			let terminal_reviews: i64 = transaction
+				.query_row(
+					"SELECT COUNT(*) FROM program_reviews AS review
+					 LEFT JOIN program_signals AS signal
+					   ON signal.predecessor_review_id = review.review_id
+					 WHERE review.program_id = ?1 AND signal.signal_id IS NULL",
+					params![continuation.program_id.as_str()],
+					|row| row.get(0),
+				)
+				.map_err(sql_error)?;
+			if terminal_reviews != 1 {
+				return Err(incompatible("Program terminal Review lineage"));
+			}
+			let predecessor_objective = transaction
+				.query_row(
+					"SELECT item.objective_id FROM program_reviews AS review
+					 JOIN program_work_items AS item USING (work_item_id)
+					 WHERE review.review_id = ?1 AND review.program_id = ?2
+					   AND NOT EXISTS (
+					     SELECT 1 FROM program_signals AS signal
+					     WHERE signal.predecessor_review_id = review.review_id
+					   )",
+					params![
+						continuation.predecessor_review_id.as_str(),
+						continuation.program_id.as_str()
+					],
+					|row| row.get::<_, String>(0),
+				)
+				.optional()
+				.map_err(sql_error)?
+				.ok_or(StoreError::InvalidInput(
+					"Program predecessor is not the terminal Review",
+				))?;
+
+			let now = now_micros()?;
+			if continuation.signal_observed_at_micros > now {
+				return Err(StoreError::InvalidInput("Signal observation is in the future"));
+			}
+			transaction
+				.execute(
+					"UPDATE program_objectives SET state = 'abandoned', revision = revision + 1,
+					 updated_at_micros = ?2 WHERE objective_id = ?1 AND state = 'active'",
+					params![predecessor_objective, now],
+				)
+				.map_err(sql_error)?;
+			insert_program_step(
+				&transaction,
+				&ProgramStep {
+					program_id: &continuation.program_id,
+					predecessor_review_id: Some(&continuation.predecessor_review_id),
+					signal_id: &continuation.signal_id,
+					claim_id: &continuation.claim_id,
+					proposal_id: &continuation.proposal_id,
+					objective_id: &continuation.objective_id,
+					work_item_id: &continuation.work_item_id,
+					signal_source: &continuation.signal_source,
+					signal_summary: &continuation.signal_summary,
+					signal_observed_at_micros: continuation.signal_observed_at_micros,
+					claim_statement: &continuation.claim_statement,
+					proposal_summary: &continuation.proposal_summary,
+					proposal_expected_effect: &continuation.proposal_expected_effect,
+					proposal_risk: &continuation.proposal_risk,
+					proposal_evidence_need: &continuation.proposal_evidence_need,
+					objective_outcome: &continuation.objective_outcome,
+					acceptance_criteria: &continuation.acceptance_criteria,
+					validation_criteria: &continuation.validation_criteria,
+					work_item_title: &continuation.work_item_title,
+					work_item_instructions: &continuation.work_item_instructions,
+					working_directory: &continuation.working_directory,
+				},
+				now,
+			)?;
+			let changed = transaction
+				.execute(
+					"UPDATE programs SET revision = revision + 1, updated_at_micros = ?3
+					 WHERE program_id = ?1 AND revision = ?2 AND state = 'active'",
+					params![continuation.program_id.as_str(), expected_revision, now],
+				)
+				.map_err(sql_error)?;
+			if changed != 1 {
+				return Err(StoreError::RevisionConflict {
+					entity: format!("program/{}", continuation.program_id),
+					expected: Some(expected_revision),
+					actual: None,
+				});
+			}
+			let record = read_program_cycle(&transaction, &continuation.program_id)?
+				.ok_or_else(|| incompatible("continued Program"))?;
+			write_receipt(
+				&transaction,
+				&command,
+				CONTINUE_OPERATION,
+				continuation.signal_id.as_str(),
+				&serde_json::to_string(&record)
+					.map_err(|_| incompatible("Program continuation receipt"))?,
 				now,
 			)?;
 			transaction.commit().map_err(sql_error)?;
@@ -579,6 +752,115 @@ impl SqliteStore {
 	}
 }
 
+fn insert_program_step(
+	transaction: &Transaction<'_>,
+	step: &ProgramStep<'_>,
+	created_at_micros: i64,
+) -> Result<(), StoreError> {
+	let acceptance_criteria_json = encode_list(step.acceptance_criteria)?;
+	let validation_criteria_json = encode_list(step.validation_criteria)?;
+	for (entity_id, kind) in [
+		(step.signal_id.as_str(), "signal"),
+		(step.claim_id.as_str(), "claim"),
+		(step.proposal_id.as_str(), "proposal"),
+		(step.objective_id.as_str(), "objective"),
+		(step.work_item_id.as_str(), "work_item"),
+	] {
+		transaction
+			.execute(
+				"INSERT INTO program_entities (entity_id, program_id, kind)
+				 VALUES (?1, ?2, ?3)",
+				params![entity_id, step.program_id.as_str(), kind],
+			)
+			.map_err(sql_error)?;
+	}
+	transaction
+		.execute(
+			"INSERT INTO program_signals (
+			 signal_id, program_id, predecessor_review_id, source, summary,
+			 observed_at_micros, created_at_micros
+			 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+			params![
+				step.signal_id.as_str(),
+				step.program_id.as_str(),
+				step.predecessor_review_id.map(ProgramReviewId::as_str),
+				step.signal_source,
+				step.signal_summary,
+				step.signal_observed_at_micros,
+				created_at_micros
+			],
+		)
+		.map_err(sql_error)?;
+	transaction
+		.execute(
+			"INSERT INTO program_claims (
+			 claim_id, program_id, signal_id, statement, revision, created_at_micros,
+			 updated_at_micros
+			 ) VALUES (?1, ?2, ?3, ?4, 1, ?5, ?5)",
+			params![
+				step.claim_id.as_str(),
+				step.program_id.as_str(),
+				step.signal_id.as_str(),
+				step.claim_statement,
+				created_at_micros
+			],
+		)
+		.map_err(sql_error)?;
+	transaction
+		.execute(
+			"INSERT INTO program_proposals (
+			 proposal_id, program_id, claim_id, summary, expected_effect, risk, evidence_need,
+			 executable, revision, created_at_micros, updated_at_micros
+			 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 1, ?8, ?8)",
+			params![
+				step.proposal_id.as_str(),
+				step.program_id.as_str(),
+				step.claim_id.as_str(),
+				step.proposal_summary,
+				step.proposal_expected_effect,
+				step.proposal_risk,
+				step.proposal_evidence_need,
+				created_at_micros
+			],
+		)
+		.map_err(sql_error)?;
+	transaction
+		.execute(
+			"INSERT INTO program_objectives (
+			 objective_id, program_id, proposal_id, outcome, acceptance_criteria_json,
+			 validation_criteria_json, state, revision, created_at_micros, updated_at_micros
+			 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', 1, ?7, ?7)",
+			params![
+				step.objective_id.as_str(),
+				step.program_id.as_str(),
+				step.proposal_id.as_str(),
+				step.objective_outcome,
+				acceptance_criteria_json,
+				validation_criteria_json,
+				created_at_micros
+			],
+		)
+		.map_err(sql_error)?;
+	transaction
+		.execute(
+			"INSERT INTO program_work_items (
+			 work_item_id, program_id, objective_id, title, instructions, working_directory,
+			 state, revision, created_at_micros, updated_at_micros
+			 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'ready', 1, ?7, ?7)",
+			params![
+				step.work_item_id.as_str(),
+				step.program_id.as_str(),
+				step.objective_id.as_str(),
+				step.work_item_title,
+				step.work_item_instructions,
+				step.working_directory,
+				created_at_micros
+			],
+		)
+		.map_err(sql_error)?;
+	Ok(())
+}
+
 pub(crate) fn bind_program_work_item_execution(
 	transaction: &Transaction<'_>,
 	work_item_id: &WorkItemId,
@@ -636,6 +918,34 @@ fn validate_create(create: &CreateProgramCycle) -> Result<(), StoreError> {
 	validate_list(&create.acceptance_criteria)?;
 	validate_list(&create.validation_criteria)?;
 	if create.signal_observed_at_micros <= 0 || !valid_absolute_path(&create.working_directory) {
+		return Err(StoreError::InvalidInput("Program time or working directory is invalid"));
+	}
+	Ok(())
+}
+
+fn validate_continuation(continuation: &ContinueProgram) -> Result<(), StoreError> {
+	if continuation.expected_revision == 0 {
+		return Err(StoreError::InvalidInput("Program revision is invalid"));
+	}
+	for value in [
+		&continuation.signal_source,
+		&continuation.signal_summary,
+		&continuation.claim_statement,
+		&continuation.proposal_summary,
+		&continuation.proposal_expected_effect,
+		&continuation.proposal_risk,
+		&continuation.proposal_evidence_need,
+		&continuation.objective_outcome,
+	] {
+		validate_text(value, MAX_TEXT_BYTES)?;
+	}
+	validate_text(&continuation.work_item_title, 256)?;
+	validate_text(&continuation.work_item_instructions, MAX_INSTRUCTION_BYTES)?;
+	validate_list(&continuation.acceptance_criteria)?;
+	validate_list(&continuation.validation_criteria)?;
+	if continuation.signal_observed_at_micros <= 0
+		|| !valid_absolute_path(&continuation.working_directory)
+	{
 		return Err(StoreError::InvalidInput("Program time or working directory is invalid"));
 	}
 	Ok(())
@@ -801,7 +1111,8 @@ fn read_program_cycle(
 	};
 	let signals = query_rows(
 		connection,
-		"SELECT signal_id, source, summary, observed_at_micros, created_at_micros
+		"SELECT signal_id, predecessor_review_id, source, summary, observed_at_micros,
+		 created_at_micros
 		 FROM program_signals WHERE program_id = ?1 ORDER BY created_at_micros, signal_id",
 		program_id.as_str(),
 		|row| {
@@ -809,10 +1120,15 @@ fn read_program_cycle(
 				signal_id: ProgramObservationId::new(row.get::<_, String>(0)?)
 					.map_err(|_| rusqlite::Error::InvalidQuery)?,
 				program_id: program_id.clone(),
-				source: row.get(1)?,
-				summary: row.get(2)?,
-				observed_at_micros: row.get(3)?,
-				created_at_micros: row.get(4)?,
+				predecessor_review_id: row
+					.get::<_, Option<String>>(1)?
+					.map(ProgramReviewId::new)
+					.transpose()
+					.map_err(|_| rusqlite::Error::InvalidQuery)?,
+				source: row.get(2)?,
+				summary: row.get(3)?,
+				observed_at_micros: positive_time_sql(row.get(4)?)?,
+				created_at_micros: positive_time_sql(row.get(5)?)?,
 			})
 		},
 	)?;
@@ -1182,6 +1498,38 @@ mod tests {
 		}
 	}
 
+	fn continuation_fixture(
+		create: &CreateProgramCycle,
+		predecessor_review_id: ProgramReviewId,
+		expected_revision: u64,
+	) -> ContinueProgram {
+		ContinueProgram {
+			program_id: create.program_id.clone(),
+			predecessor_review_id,
+			expected_revision,
+			signal_id: id("51000000-0000-4000-8000-000000000001", ProgramObservationId::new),
+			claim_id: id("52000000-0000-4000-8000-000000000001", ProgramClaimId::new),
+			proposal_id: id("53000000-0000-4000-8000-000000000001", ProgramProposalId::new),
+			objective_id: id("54000000-0000-4000-8000-000000000001", ObjectiveId::new),
+			work_item_id: WorkItemId::new("55000000-0000-4000-8000-000000000001")
+				.expect("WorkItem identity"),
+			signal_source: "first cycle Review".to_owned(),
+			signal_summary: "The first cycle exposed the next bounded gap.".to_owned(),
+			signal_observed_at_micros: 1,
+			claim_statement: "A second finite cycle can close that gap.".to_owned(),
+			proposal_summary: "Append one exact next semantic chain.".to_owned(),
+			proposal_expected_effect: "The Program keeps one identity across cycles.".to_owned(),
+			proposal_risk: "A stale client could branch the history.".to_owned(),
+			proposal_evidence_need: "Restart and idempotency evidence.".to_owned(),
+			objective_outcome: "Two ordered cycles survive restart.".to_owned(),
+			acceptance_criteria: vec!["The first cycle remains queryable.".to_owned()],
+			validation_criteria: vec!["A replay creates no second Signal.".to_owned()],
+			work_item_title: "Prove repeatable Program continuation".to_owned(),
+			work_item_instructions: "Implement and verify one exact next cycle.".to_owned(),
+			working_directory: "/tmp/decodex".to_owned(),
+		}
+	}
+
 	#[tokio::test]
 	async fn create_cycle_is_atomic_replayable_and_restart_safe() {
 		let directory = tempdir().expect("temporary directory");
@@ -1259,7 +1607,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn evidence_backed_review_closes_the_cycle_and_reopens_without_replay() {
+	async fn reviewed_program_continues_once_and_reopens_without_replay() {
 		let directory = tempdir().expect("temporary directory");
 		let path = directory.path().join("decodex.sqlite3");
 		let store = SqliteStore::open_test(&path).expect("initialize store");
@@ -1354,8 +1702,8 @@ mod tests {
 				summary: "The bound provider turn settled successfully.".to_owned(),
 				observed_at_micros: 1,
 			},
-			classification: ProgramReviewClassification::CapabilityProgress,
-			rationale: "The closed loop is now a reusable product capability.".to_owned(),
+			classification: ProgramReviewClassification::KnowledgeProgress,
+			rationale: "The first cycle found the next bounded gap.".to_owned(),
 		};
 		let command =
 			CommandIdentity::new("program-review-1", b"program review").expect("review command");
@@ -1367,11 +1715,103 @@ mod tests {
 			store.record_program_review(&command, &review).await.expect("review replay"),
 			reviewed
 		);
+		assert_eq!(reviewed.objectives[0].state, ObjectiveState::Active);
+
+		let continuation = continuation_fixture(
+			&create,
+			review.review_id.clone(),
+			reviewed.program.revision,
+		);
+		let continue_command = CommandIdentity::new("program-continue-1", b"program continue")
+			.expect("continuation command");
+		let continued = store
+			.continue_program(&continue_command, &continuation)
+			.await
+			.expect("continue reviewed Program");
+		assert_eq!(continued.program.revision, 3);
+		assert_eq!(continued.signals.len(), 2);
+		assert_eq!(continued.work_items.len(), 2);
+		assert_eq!(continued.objectives[0].state, ObjectiveState::Abandoned);
+		assert_eq!(continued.objectives[1].state, ObjectiveState::Active);
+		assert_eq!(
+			continued.signals[1].predecessor_review_id.as_ref(),
+			Some(&review.review_id)
+		);
+		assert_eq!(
+			store
+				.continue_program(&continue_command, &continuation)
+				.await
+				.expect("continuation replay"),
+			continued
+		);
+
+		let mut stale = continuation.clone();
+		stale.signal_id = id("61000000-0000-4000-8000-000000000001", ProgramObservationId::new);
+		assert!(matches!(
+			store
+				.continue_program(
+					&CommandIdentity::new("program-continue-stale", b"stale continue")
+						.expect("stale command"),
+					&stale,
+				)
+				.await,
+			Err(StoreError::RevisionConflict { expected: Some(2), actual: Some(3), .. })
+		));
+		let mut parallel = stale;
+		parallel.expected_revision = 3;
+		assert!(matches!(
+			store
+				.continue_program(
+					&CommandIdentity::new("program-continue-parallel", b"parallel continue")
+						.expect("parallel command"),
+					&parallel,
+				)
+				.await,
+			Err(StoreError::InvalidInput("Program already has an unreviewed cycle"))
+		));
+		store
+			.with_connection(|connection| {
+				let mut insert = connection
+					.prepare(
+						"INSERT INTO program_entities (entity_id, program_id, kind)
+						 VALUES (?1, ?2, 'evidence')",
+					)
+					.map_err(|_| crate::DatabaseError::Unavailable)?;
+				for index in 0..106 {
+					insert
+						.execute(params![
+							format!("90000000-0000-4000-8000-{index:012}"),
+							create.program_id.as_str()
+						])
+						.map_err(|_| crate::DatabaseError::Unavailable)?;
+				}
+				Ok(())
+			})
+			.expect("fill the bounded projection fixture");
+		assert_eq!(
+			store
+				.continue_program(&continue_command, &continuation)
+				.await
+				.expect("accepted continuation replay bypasses capacity preflight"),
+			continued
+		);
+		assert!(matches!(
+			store
+				.continue_program(
+					&CommandIdentity::new("program-continue-capacity", b"capacity continue")
+						.expect("capacity command"),
+					&parallel,
+				)
+				.await,
+			Err(StoreError::CapacityExhausted("Program projection"))
+		));
 		store
 			.with_connection(|connection| {
 				connection
 					.execute_batch(
-						"DELETE FROM provider_attempt_positive_evidence
+						"DELETE FROM program_entities
+						 WHERE entity_id LIKE '90000000-0000-4000-8000-%';
+						 DELETE FROM provider_attempt_positive_evidence
 						 WHERE attempt_id = '37000000-0000-4000-8000-000000000001';
 						 DELETE FROM provider_attempts
 						 WHERE attempt_id = '37000000-0000-4000-8000-000000000001';",
@@ -1382,8 +1822,15 @@ mod tests {
 		drop(store);
 		let reopened = SqliteStore::open_test(&path).expect("reopen store");
 		assert_eq!(
-			reopened.program_cycle(&create.program_id).await.expect("read reviewed cycle"),
-			Some(reviewed)
+			reopened.program_cycle(&create.program_id).await.expect("read continued Program"),
+			Some(continued.clone())
+		);
+		assert_eq!(
+			reopened
+				.continue_program(&continue_command, &continuation)
+				.await
+				.expect("continuation replay after restart"),
+			continued
 		);
 	}
 

--- a/openwiki/decisions/adaptive-program-extension-architecture.md
+++ b/openwiki/decisions/adaptive-program-extension-architecture.md
@@ -1,16 +1,16 @@
 # Adaptive Program And Extension Architecture
 
-Status: accepted product direction; Adaptive Factory Spine V1 is implemented.
+Status: accepted product direction; Repeatable Program Loop V1 is implemented.
 
 Date: 2026-08-15.
 
 This decision guides factory work above the local Quick Task foundation. The bounded
-Adaptive Factory Spine V1 is current product capability. Dynamic multi-agent work,
+Repeatable Program Loop V1 is current product capability. Dynamic multi-agent work,
 automation, consequential external actions, and an extension runtime remain target
 direction only. Current implemented behavior is defined by the
 [OpenWiki quickstart](../quickstart.md), the
 [local product V1 contract](../specs/local-product-v1.md), and the
-[Adaptive Factory Spine V1 evidence](../evidence/adaptive-factory-spine-v1.md).
+[Repeatable Program Loop V1 evidence](../evidence/repeatable-program-loop-v1.md).
 
 ## Decision
 
@@ -43,6 +43,12 @@ Proposal, finite Objective, WorkItem, two Evidence records, and classified Revie
 binds the WorkItem to an ordinary Quick Task and derives a synchronized GPUI causal
 graph and timeline. The general WorkItem board, ManagedRun, automation, dynamic agents,
 general ontology tooling, and extensions remain deferred.
+
+Repeatable Program Loop V1 keeps the Program identity and prior cycle records. After an
+exact terminal Review, an operator can append one finite next Signal, Claim, Proposal,
+Objective, and WorkItem. The next WorkItem uses the same Quick Task and provider-safety
+path. Three real cycles now prove this sequential feedback loop. They do not prove an
+extension contract, automatic stewardship, or a benefit from multiple agents.
 
 Implementation must extend this current base. It must not copy the unlanded historical
 PostgreSQL factory branch or reactivate the frozen `apps/decodex` runtime.
@@ -330,7 +336,7 @@ accepted policy and provider-specific safeguards.
 
 ## Delivery sequence
 
-### Milestone 1: Adaptive Factory Spine V1 — implemented
+### Milestone 1: Adaptive Factory Spine and Repeatable Program Loop V1 — implemented
 
 Prove one real closed Program cycle through the existing Codex Quick Task path:
 
@@ -353,6 +359,13 @@ ordinary Quick Task command, one aggregate Review command, and two Program queri
 does not expose a mutation API for each ontology noun. This keeps the first semantic
 spine small and makes partial chain construction impossible.
 
+The repeatable increment adds one `ContinueProgram` aggregate command. It requires the
+exact terminal predecessor Review and expected Program revision. It appends one complete
+pre-execution cycle, permits at most one unreviewed cycle, and keeps the same Program.
+Two additional real provider-backed cycles completed after the original cycle. The
+total ProviderAttempt count increased by exactly two, and a daemon restart did not add
+an entity, Conversation, or attempt.
+
 ### Milestone 2: Extension Contract V1
 
 Extract only the vocabulary proven by two built-in fixtures:
@@ -363,6 +376,10 @@ Extract only the vocabulary proven by two built-in fixtures:
 Add namespaced schema registration, immutable pack versions and digests, declared
 permissions, host-rendered ViewSpecs, and capability inspection. Keep packs built in
 until the contract survives both fixtures.
+
+This is the next candidate milestone. It must remain bounded to two built-in fixtures.
+It must not add a public SDK, registry, scheduler, arbitrary executable plugin host, or
+dynamic multi-agent runtime.
 
 ### Milestone 3: MCP Action Gateway
 
@@ -489,8 +506,12 @@ Reduce or change this direction when repeated real cycles show any of the follow
   time; or
 - GPUI delivery cost prevents the first real closed loop from reaching dogfood.
 
-Review this decision after three complete Decodex dogfood Program cycles and after the
-second built-in Domain Pack. Do not design a public SDK before that review.
+The first review trigger is complete: three Decodex dogfood Program cycles retained one
+Program, used one provider attempt per added cycle, and produced evidence-backed
+Reviews. This supports the sequential Program model. It does not yet validate automatic
+cycle creation, multi-agent execution, or reusable domain extension semantics. Review
+again after the second built-in Domain Pack. Do not design a public SDK before that
+review.
 
 ## Curation note
 

--- a/openwiki/evidence/adaptive-factory-spine-v1.md
+++ b/openwiki/evidence/adaptive-factory-spine-v1.md
@@ -14,12 +14,16 @@ openwiki:
 
 # Adaptive Factory Spine V1 Evidence
 
-Status: implemented and locally verified.
+Status: historical implemented baseline; superseded by Repeatable Program Loop V1.
 
 Date: 2026-08-15.
 
 This page contains no credential, account identity, Conversation identity, provider
 thread identity, or provider Turn identity.
+
+This page records the original one-cycle milestone and its V2.2/schema-5 evidence. The
+current V2.3/schema-6 behavior is in
+[Repeatable Program Loop V1 evidence](repeatable-program-loop-v1.md).
 
 ## Delivered boundary
 

--- a/openwiki/evidence/repeatable-program-loop-v1.md
+++ b/openwiki/evidence/repeatable-program-loop-v1.md
@@ -1,0 +1,107 @@
+---
+type: "Evidence"
+title: "Repeatable Program Loop V1 Evidence"
+description: "Implementation, restart, replay, GPUI, and three-cycle live evidence for manual sequential Program continuation."
+tags: [adaptive-factory, program, ontology, graph, sqlite, gpui, evidence]
+openwiki:
+  roles: [testing, architecture, workflow]
+  change_kinds: [lifecycle, public-api, validation]
+  source_paths: [database/migrations/0006_repeatable_program_loop.sql, database/src/program_cycles.rs, crates/decodex-protocol/src/program_cycle.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs]
+  test_paths: [database/src/program_cycles.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs]
+  invariants: [SQLite is the only Program authority.; Continuation binds the exact predecessor Review and Program revision.; One Program has at most one unreviewed cycle.; One Review has at most one successor Signal.; Continued WorkItems use the ordinary Quick Task provider path.; Unknown provider outcomes never authorize automatic replay.; GPUI derives cycle order from accepted causal lineage.]
+  validation_commands: [python3 scripts/vnext/local_database_gate.py, python3 -m unittest tests/scripts/test_vnext_architecture.py, DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo test -p decodex-core -p decodex-protocol -p decodex-database -p decodex-runtime -p decodex-gpui -p decodexd --all-targets --features decodex-gpui/visual-capture --no-fail-fast, DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo clippy -p decodex-core -p decodex-protocol -p decodex-database -p decodex-runtime -p decodex-gpui -p decodexd --all-targets --features decodex-gpui/visual-capture -- -D warnings]
+---
+
+# Repeatable Program Loop V1 Evidence
+
+Status: implemented and locally verified.
+
+Date: 2026-08-15.
+
+This page contains no credential, account identity, Conversation identity, provider
+thread identity, or provider Turn identity.
+
+## Delivered boundary
+
+One active reviewed Program can append one finite next cycle:
+
+```text
+prior Review -> Signal -> Claim -> Proposal -> Objective -> WorkItem
+             -> Codex Quick Task -> Evidence -> next Review
+```
+
+Migration 0006 adds one nullable predecessor Review reference to a Signal. The root
+Signal has no predecessor. Each later Signal has one exact predecessor Review. Partial
+unique indexes permit one root Signal per Program and one successor Signal per Review.
+SQLite triggers reject cross-Program lineage. The migration is additive and does not
+rewrite the first cycle.
+
+`ContinueProgram` is one aggregate V2.3 command. It uses the command envelope's positive
+expected revision instead of adding a second revision field. One immediate SQLite
+transaction verifies the active Program, exact terminal Review, and absence of an
+unreviewed cycle. It appends the next five semantic records and advances the Program
+revision. Replay returns the existing receipt. Stale, duplicate, non-sequential, and
+parallel input is rejected.
+
+The command does not run the WorkItem. The operator starts it through the ordinary Quick
+Task command. Existing Routing Decision, RuntimeSession, ProcessGeneration,
+ProviderAttempt, account affinity, and no-replay rules remain the only execution path.
+A Review still requires positive terminal provider evidence plus deterministic and
+external Evidence.
+
+Runtime reconstructs each cycle from its causal Review-to-Signal lineage. GPUI derives
+`C1`, `C2`, and later labels from ordered Signal boundaries. It shows all retained
+cycles, marks the current cycle, and opens the exact Conversation for the current
+WorkItem. SQLite remains the semantic authority; the graph remains a projection.
+
+## Deterministic evidence
+
+Focused persistence tests cover a successful continuation, idempotent replay before and
+after SQLite reopen, stale revision refusal, parallel unreviewed-cycle refusal, and
+explicit abandonment of an unresolved prior Objective. Protocol tests cover V2.3
+validation and stable wire fixtures. Runtime tests cover ordered two-cycle projection.
+GPUI tests cover the exact revision and payload, two cycle boundaries, the `Continues`
+edge, and current WorkItem conversation selection.
+
+The local database gate reports schema version 6, six exact migration digests, WAL,
+`quick_check`, foreign-key integrity, the predecessor lineage column, and 39 tables. The
+vNext architecture suite passes 10 tests. Strict Clippy passes with warnings denied for
+all affected packages. The complete affected-package and native visual checks are the
+terminal acceptance commands listed in this page's metadata.
+
+## Three-cycle live dogfood
+
+The current user database was copied with SQLite online backup before migration from
+schema version 5. The owner-private backup passed `integrity_check`. The live baseline
+contained one reviewed Program cycle and 43 total ProviderAttempts.
+
+Cycle 2 appended one successor to the exact first Review. Its bound read-only Codex
+Quick Task created ProviderAttempt 44 and reached `succeeded` with positive terminal
+evidence. A client connection ended after provider acceptance. Readback found the same
+Conversation and attempt, so the probe did not resend. It completed the existing cycle
+with an evidence-backed `capability_progress` Review. The Program reached revision 4
+with two Signals, two WorkItems, and two Reviews.
+
+The daemon then stopped cleanly and was started again through its LaunchAgent. The V2.3
+doctor readback reported all eight required core checks as Ready. Before the next cycle,
+the Program remained at revision 4 and ProviderAttempt count remained 44. Restart did
+not add a semantic entity, Conversation, or attempt.
+
+Cycle 3 appended one successor to the exact second Review. Its bound read-only Codex
+Quick Task created ProviderAttempt 45 and reached `succeeded`. The final Review produced
+Program revision 6 with exactly three Signals, three WorkItems, and three Reviews. The
+two added cycles therefore created exactly two provider attempts. All three cycles kept
+one Program identity and immutable predecessor history.
+
+## Finding and next boundary
+
+The result supports a small sequential Program aggregate. A separate Cycle table,
+scheduler, graph database, or Manager process was not required. Exact lineage plus one
+aggregate command was enough to make the long-lived Program operational.
+
+This evidence does not validate automatic continuation, background stewardship,
+dynamic multi-agent execution, a general WorkItem board, MCP actions, a public Extension
+SDK, a registry, or a programmatic plugin host. The next candidate milestone is the
+bounded Extension Contract V1 pressure test with two built-in domain fixtures. It must
+reuse this Program and provider-safety kernel and remain built in until both fixtures
+prove one shared contract.

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -24,7 +24,7 @@ credential fingerprint.
 
 ## Implemented evidence
 
-- `database/` owns one bundled SQLite connection, five immutable migrations, digest ledger,
+- `database/` owns one bundled SQLite connection, six immutable migrations, digest ledger,
   exact schema inventory verification, WAL, full synchronous mode, foreign keys,
   integrity checks, no-follow open, and owner-private file creation.
 - Unit tests cover initialization, reopen, migration tamper refusal, exact credential
@@ -175,8 +175,8 @@ the pre-existing malformed-cycle tests pass together. After this correction, the
 complete GPUI package passed 120 tests with two live tests ignored.
 
 The client does not activate the deferred general WorkItem and Project query surface.
-Protocol V2.2 is exact-current. The Adaptive Program controller uses only its bounded
-V2.2 Program commands and queries. The unrelated WorkItem board controller stays
+Protocol V2.3 is exact-current. The Adaptive Program controller uses only its bounded
+V2.3 Program commands and queries. The unrelated WorkItem board controller stays
 dormant. This keeps deferred Factory surfaces from affecting Conversation history or
 the Workbench connection.
 
@@ -260,13 +260,14 @@ remain outside this lifecycle-refresh milestone because
 or tool effects. Only one positively client-ID-correlated Decodex Turn may repair its own
 terminal state and assistant suffix.
 
-Protocol V2.2 carries the controls, archive event, and bounded Program aggregate. SQLite
+Protocol V2.3 carries the controls, archive event, and bounded Program aggregate. SQLite
 schema version 3 adds the original Quick Task execution settings. Schema version 4 adds
 the migration-owned `context_packs` table. Schema version 5 adds the Program, Signal,
 Claim, Proposal, Objective, WorkItem binding, Evidence, Review, and semantic identity
-tables, for five migration digests and an exact 39-table inventory. The schema-5 local
-database gate passed with WAL, `quick_check`, foreign-key verification, all five exact
-migration digests, and the 39-table inventory.
+tables. Schema version 6 adds exact predecessor Review lineage for continued Signals,
+root and successor uniqueness, and same-Program lineage guards. It retains the exact
+39-table inventory. The schema-6 local database gate passed with WAL, `quick_check`,
+foreign-key verification, all six exact migration digests, and the 39-table inventory.
 
 Focused implementation evidence is split across `crates/decodex-runtime/src/quick_task.rs`
 (exact control sequencing and process retirement),

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -45,10 +45,14 @@ one-shot transfer tool.
 - [Execution coordination](specs/execution-coordinator-authority.md): the small stateless
   sequencer used by Quick Task.
 - [Adaptive Program and extension architecture](decisions/adaptive-program-extension-architecture.md):
-  the implemented Adaptive Factory Spine V1, plus the accepted direction for dynamic
+  the implemented repeatable Program loop, plus the accepted direction for dynamic
   agents, bounded external actions, and future Domain Packs.
+- [Repeatable Program Loop V1 evidence](evidence/repeatable-program-loop-v1.md): the
+  continuation contract, restart and replay proof, repeated GPUI projection, and live
+  three-cycle dogfood record.
 - [Adaptive Factory Spine V1 evidence](evidence/adaptive-factory-spine-v1.md): the exact
-  current Program boundary, causal projection, restart proof, and local dogfood record.
+  historical first-cycle boundary, causal projection, restart proof, and local dogfood
+  record.
 
 For the current app-server freshness boundary and Quick Task controls, start with the
 [local product contract](specs/local-product-v1.md) and its [SQLite evidence](evidence/sqlite-local-product.md).
@@ -88,11 +92,12 @@ turn terminal evidence, the runtime retires that process before it publishes `Re
 later Turn starts a fresh process generation and rehydrates the same account and Codex
 thread. An idle completed Conversation does not reserve the account process slot.
 
-The Factory also supports one bounded Adaptive Program cycle:
+The Factory also supports one manually repeated Adaptive Program loop:
 
 ```text
 Program -> Signal -> Claim -> Proposal -> Objective -> WorkItem
-        -> Codex Quick Task -> Evidence -> Program Review
+        -> Codex Quick Task -> Evidence -> Review
+        -> Signal -> Claim -> Proposal -> Objective -> WorkItem -> ...
 ```
 
 SQLite owns the Program charter and every semantic identity. A Program WorkItem starts
@@ -100,7 +105,9 @@ through the ordinary Quick Task path and binds the resulting Conversation in the
 transaction. The Factory derives one causal graph and timeline from the authoritative
 aggregate. It does not use a graph database or a second execution engine. A Review can
 close only after the bound WorkItem has positive terminal provider evidence and the
-user supplies deterministic and external Evidence.
+user supplies deterministic and external Evidence. An explicit continuation binds the
+exact prior Review and Program revision. It appends one finite next cycle and permits at
+most one unreviewed cycle. No timer or automatic continuation exists.
 
 ## Deferred product surfaces
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -164,13 +164,20 @@ APIs, and fixtures. The V1 schema persists:
 Large history content continues to use the content-addressed blob owner. SQLite stores a
 bounded inline value or a digest and length.
 
-## Adaptive Factory Spine V1
+## Repeatable Program Loop V1
 
-The current protocol accepts exact V2.2 clients. It adds one bounded Program aggregate
-above the existing Quick Task execution path. The aggregate contains one Program
-charter, one sourced Signal, one Claim, one non-executable Proposal, one finite
-Objective, and one ready WorkItem. One command creates this pre-execution chain in one
-SQLite transaction.
+The current protocol accepts exact V2.3 clients. It adds one bounded, manually repeated
+Program aggregate above the existing Quick Task execution path. The initial command
+creates one Program charter, one sourced Signal, one Claim, one non-executable Proposal,
+one finite Objective, and one ready WorkItem in one SQLite transaction.
+
+After one cycle has an exact terminal Review, `ContinueProgram` can append one next
+Signal, Claim, non-executable Proposal, finite Objective, and ready WorkItem. The command
+must carry the current positive Program revision and the exact predecessor Review. One
+Review can have at most one successor Signal, and one Program can have at most one
+unreviewed cycle. A stale revision, non-terminal predecessor, duplicate successor, or
+parallel unreviewed cycle is rejected. An explicit next Objective marks an unresolved
+prior Objective as `abandoned`; it does not rewrite prior semantic rows.
 
 Starting the WorkItem creates an ordinary Quick Task with an exact WorkItem cause. The
 Conversation and WorkItem binding commit in the same SQLite transaction. The existing
@@ -186,8 +193,10 @@ ProviderAttempt evidence. The accepted classifications are `outcome_progress`,
 
 GPUI reads the aggregate through the retained same-UID protocol. It derives the Program
 pulse, causal graph, inspector, timeline, Evidence view, and Conversation navigation
-from the same stable identities. The graph is a projection. It is not scheduling
-authority or a separate store.
+from the same stable identities. It shows every retained cycle in causal order, derives
+cycle numbers from Signal boundaries, marks the current cycle, and opens the exact
+Conversation bound to the selected WorkItem. The graph is a projection. It is not
+scheduling authority or a separate store.
 
 ## Execution invariants
 
@@ -252,6 +261,13 @@ authority or a separate store.
 25. Positive terminal evidence and Conversation terminalization are restart-safe. If
     only the evidence transaction committed, a later sync finishes the exact pending
     terminalization without another provider request.
+26. Program continuation requires the exact terminal predecessor Review and current
+    Program revision. One Review has at most one successor Signal.
+27. A Program has at most one unreviewed cycle. Continuation appends one complete
+    pre-execution chain atomically and never schedules it.
+28. A continued WorkItem uses the ordinary Quick Task, ProcessGeneration, and
+    ProviderAttempt path. Restart and command replay cannot create a second semantic
+    entity, Conversation, or provider attempt.
 
 An absent or stale quota fact represents unknown capacity. Fixed routing admits an
 otherwise-ready account unless a current fact proves depletion. Balanced routing prefers
@@ -277,9 +293,10 @@ a same-account starting RuntimeSession. Reopening SQLite reconstructs the same p
 plan from migration-owned metadata plus the content-addressed blob. The current Turn is
 not one of the pack sources; it remains the separate final request input.
 
-A daemon restart also reopens the same Program identities, WorkItem binding, Evidence,
-and Review. Reopening or querying a Program does not dispatch a provider request.
-Unknown ProviderAttempt state keeps the existing no-automatic-replay rule.
+A daemon restart also reopens every Program cycle, WorkItem binding, Evidence, and
+Review. It reconstructs cycle order from predecessor Review links. Reopening or querying
+a Program does not dispatch a provider request. Unknown ProviderAttempt state keeps the
+existing no-automatic-replay rule.
 
 ## Credential boundary
 
@@ -320,8 +337,8 @@ Acceptance requires:
 - local-history-first Conversation opening, immediate queued-prompt projection, and
   Turn-level adjacent assistant-fragment coalescing;
 - exact selected-thread refresh, verified archive, and request-scoped execution controls;
-- one restart-safe Program cycle with a bound Quick Task, two Evidence records, a
-  classified Review, and synchronized causal projections;
+- one restart-safe Program with at least three sequential cycles, one bound Quick Task
+  and classified evidence-backed Review per cycle, and synchronized causal projections;
 - archived-thread rejection with retained composer content and no implicit resend;
 - bounded stale-local reconciliation without changing unresolved provider evidence;
 - focused and workspace-wide tests; and

--- a/scripts/vnext/local_database_gate.py
+++ b/scripts/vnext/local_database_gate.py
@@ -38,6 +38,11 @@ MIGRATIONS = (
         "adaptive_factory_spine",
         ROOT / "database/migrations/0005_adaptive_factory_spine.sql",
     ),
+    (
+        6,
+        "repeatable_program_loop",
+        ROOT / "database/migrations/0006_repeatable_program_loop.sql",
+    ),
 )
 DATABASE_RELATIVE_PATH = Path("server/decodex.sqlite3")
 APPLICATION_ID = 0x4443_5831
@@ -183,6 +188,10 @@ def inspect_database(path: Path) -> dict[str, object]:
             row[1]: (row[2], row[3], row[4])
             for row in connection.execute("PRAGMA table_info(quick_task_requests)")
         }
+        program_signal_columns = {
+            row[1]: (row[2], row[3], row[4])
+            for row in connection.execute("PRAGMA table_info(program_signals)")
+        }
         tables = frozenset(
             row[0]
             for row in connection.execute(
@@ -207,6 +216,8 @@ def inspect_database(path: Path) -> dict[str, object]:
     for column in ("model", "reasoning_effort", "fast"):
         if column not in quick_task_request_columns:
             raise GateFailure("Quick Task execution settings are missing")
+    if "predecessor_review_id" not in program_signal_columns:
+        raise GateFailure("Program continuation lineage is missing")
     if tables != REQUIRED_TABLES:
         raise GateFailure("SQLite table inventory differs")
     return {
@@ -220,6 +231,7 @@ def inspect_database(path: Path) -> dict[str, object]:
             for column in ("model", "reasoning_effort", "fast")
             if column in quick_task_request_columns
         ),
+        "program_continuation_lineage": "predecessor_review_id",
     }
 
 


### PR DESCRIPTION
## Outcome

- append one exact review-linked Program cycle without changing Program identity
- preserve immutable history and reuse the existing Quick Task/provider safety path
- show retained cycles and the current cycle in GPUI
- document schema 6, protocol V2.3, and three-cycle dogfood evidence

## Verification

- complete affected-package test matrix passed
- strict Clippy passed with warnings denied
- schema-6 local database gate passed
- 10/10 vNext architecture tests passed
- signed native bundle, visual capture, daemon restart, and no-duplicate live readback verified

CI is intentionally not required for this user-authorized landing.