### PR TITLE
Support Codex native worktrees in standalone commit and land

### DIFF
--- a/apps/decodex-cli/src/local_git.rs
+++ b/apps/decodex-cli/src/local_git.rs
@@ -75,6 +75,13 @@ struct RepositoryLayout {
 	is_primary: bool,
 }
 
+struct WorktreeEntry {
+	path: PathBuf,
+	branch: Option<String>,
+	bare: bool,
+	prunable: bool,
+}
+
 pub(crate) fn execute_commit(command: &CommitCommand) -> Result<String, String> {
 	require_manual_authority(command.manual_authority)?;
 	let summary = normalized_summary(&command.summary)?;
@@ -208,30 +215,120 @@ fn commit_record(summary: &str, landed: bool) -> Result<String, String> {
 }
 
 fn repository_layout(cwd: &Path) -> Result<RepositoryLayout, String> {
-	let checkout = PathBuf::from(git_stdout(cwd, &["rev-parse", "--show-toplevel"])?);
-	let common_dir = PathBuf::from(git_stdout(
+	let checkout = canonical_git_path(cwd, &["rev-parse", "--show-toplevel"], "checkout")?;
+	let common_dir = canonical_git_path(
 		&checkout,
 		&["rev-parse", "--path-format=absolute", "--git-common-dir"],
-	)?);
-	let primary = common_dir
-		.parent()
-		.ok_or_else(|| String::from("Git common directory has no repository root"))?
-		.to_path_buf();
-	let checkout = checkout
-		.canonicalize()
-		.map_err(|error| format!("checkout path cannot be canonicalized: {error}"))?;
-	let primary = primary
+		"Git common directory",
+	)?;
+	let inventory = worktree_inventory(&checkout)?;
+	let primary_entry =
+		inventory.first().ok_or_else(|| String::from("Git worktree inventory is empty"))?;
+
+	if primary_entry.bare || primary_entry.prunable {
+		return Err(String::from("Git main worktree is not an available checkout"));
+	}
+
+	let primary = primary_entry
+		.path
 		.canonicalize()
 		.map_err(|error| format!("primary path cannot be canonicalized: {error}"))?;
-	let is_primary = checkout == primary;
+	let primary_top_level =
+		canonical_git_path(&primary, &["rev-parse", "--show-toplevel"], "primary checkout")?;
+	let primary_common_dir = canonical_git_path(
+		&primary,
+		&["rev-parse", "--path-format=absolute", "--git-common-dir"],
+		"primary Git common directory",
+	)?;
 
-	if !is_primary {
-		checkout
-			.strip_prefix(primary.join(".worktrees"))
-			.map_err(|_| String::from("task worktree is outside `<repo>/.worktrees`"))?;
+	if primary_top_level != primary || primary_common_dir != common_dir {
+		return Err(String::from(
+			"Git main worktree and checkout do not share one exact repository",
+		));
+	}
+
+	let matching_entries = inventory
+		.iter()
+		.enumerate()
+		.filter_map(|(index, entry)| {
+			entry.path.canonicalize().ok().filter(|path| path == &checkout).map(|_| (index, entry))
+		})
+		.collect::<Vec<_>>();
+
+	if matching_entries.len() != 1 {
+		return Err(String::from(
+			"checkout is not one exact registered Git worktree of this repository",
+		));
+	}
+
+	let (checkout_index, checkout_entry) = matching_entries[0];
+
+	if checkout_entry.bare || checkout_entry.prunable {
+		return Err(String::from("registered Git worktree is not an available checkout"));
+	}
+
+	let is_primary = checkout_index == 0;
+
+	if is_primary != (checkout == primary) {
+		return Err(String::from("Git worktree inventory primary identity mismatch"));
 	}
 
 	Ok(RepositoryLayout { checkout, primary, is_primary })
+}
+
+fn canonical_git_path(cwd: &Path, args: &[&str], label: &str) -> Result<PathBuf, String> {
+	PathBuf::from(git_stdout(cwd, args)?)
+		.canonicalize()
+		.map_err(|error| format!("{label} path cannot be canonicalized: {error}"))
+}
+
+fn worktree_inventory(cwd: &Path) -> Result<Vec<WorktreeEntry>, String> {
+	let output = command_output("git", cwd, &["worktree", "list", "--porcelain", "-z"])?;
+	let stdout = String::from_utf8(output.stdout)
+		.map_err(|error| format!("Git worktree inventory is not UTF-8: {error}"))?;
+	let mut inventory = Vec::new();
+	let mut current: Option<WorktreeEntry> = None;
+
+	for field in stdout.split('\0') {
+		if field.is_empty() {
+			if let Some(entry) = current.take() {
+				inventory.push(entry);
+			}
+			continue;
+		}
+
+		if let Some(path) = field.strip_prefix("worktree ") {
+			if current.is_some() || path.is_empty() || !Path::new(path).is_absolute() {
+				return Err(String::from("Git worktree inventory is malformed"));
+			}
+			current = Some(WorktreeEntry {
+				path: PathBuf::from(path),
+				branch: None,
+				bare: false,
+				prunable: false,
+			});
+			continue;
+		}
+
+		let entry =
+			current.as_mut().ok_or_else(|| String::from("Git worktree inventory is malformed"))?;
+
+		if let Some(branch) = field.strip_prefix("branch ") {
+			if entry.branch.replace(branch.to_owned()).is_some() {
+				return Err(String::from("Git worktree inventory branch is duplicated"));
+			}
+		} else if field == "bare" {
+			entry.bare = true;
+		} else if field == "prunable" || field.starts_with("prunable ") {
+			entry.prunable = true;
+		}
+	}
+
+	if current.is_some() {
+		return Err(String::from("Git worktree inventory record is unterminated"));
+	}
+
+	Ok(inventory)
 }
 
 fn require_staged_only_changes(checkout: &Path) -> Result<(), String> {
@@ -609,16 +706,11 @@ fn preflight_lane_cleanup(
 	expected_head_oid: &str,
 ) -> Result<(), String> {
 	let branch_ref = format!("refs/heads/{branch}");
-	let worktree_inventory = git_stdout(&layout.primary, &["worktree", "list", "--porcelain"])?;
-	let mut current_worktree: Option<&str> = None;
 
-	for line in worktree_inventory.lines() {
-		if let Some(path) = line.strip_prefix("worktree ") {
-			current_worktree = Some(path);
-		} else if line == format!("branch {branch_ref}") {
-			let path = current_worktree
-				.ok_or_else(|| String::from("task branch worktree inventory is malformed"))?;
-			let observed = Path::new(path)
+	for entry in worktree_inventory(&layout.primary)? {
+		if entry.branch.as_deref() == Some(&branch_ref) {
+			let observed = entry
+				.path
 				.canonicalize()
 				.map_err(|_| String::from("task branch worktree cannot be canonicalized"))?;
 

--- a/apps/decodex-cli/tests/local_commit.rs
+++ b/apps/decodex-cli/tests/local_commit.rs
@@ -18,67 +18,136 @@ use tokio as _;
 use toml_edit as _;
 
 #[test]
-fn local_commit_binary_signs_an_exact_record_through_the_commit_message_hook() {
-	let temp = TempDir::new().expect("temporary directory should create");
-	let origin = temp.path().join("origin.git");
-	let primary = temp.path().join("repo");
-	let checkout = primary.join(".worktrees/commit");
-	let hooks = temp.path().join("hooks");
-	let hook_marker = temp.path().join("commit-msg-ran");
+fn local_commit_keeps_in_repository_worktree_compatibility() {
+	assert_local_commit_succeeds(WorktreeLocation::InRepository);
+}
 
-	fs::create_dir_all(&hooks).expect("hooks directory should create");
-	run_checked(Command::new("git").args([
-		"init",
-		"--bare",
-		"--initial-branch=main",
-		origin.to_str().expect("origin path should be UTF-8"),
-	]));
-	run_checked(Command::new("git").args([
-		"clone",
-		origin.to_str().expect("origin path should be UTF-8"),
-		primary.to_str().expect("primary path should be UTF-8"),
-	]));
-	git_checked(&primary, &["config", "user.name", "Decodex Tests"]);
-	git_checked(&primary, &["config", "user.email", "decodex-tests@example.com"]);
-	git_checked(
-		&primary,
-		&["config", "core.hooksPath", hooks.to_str().expect("hooks path should be UTF-8")],
-	);
-	fs::write(primary.join("README.md"), "base\n").expect("base file should write");
-	git_checked(&primary, &["add", "README.md"]);
-	git_checked(&primary, &["commit", "-m", "base"]);
-	git_checked(&primary, &["push", "-u", "origin", "main"]);
-	configure_signing(temp.path(), &primary);
-	git_checked(
-		&primary,
-		&[
-			"worktree",
-			"add",
-			"-b",
-			"xv/local-commit",
-			checkout.to_str().expect("checkout path should be UTF-8"),
-		],
-	);
-	write_commit_message_hook(&hooks, &hook_marker);
-	fs::write(checkout.join("feature.txt"), "feature\n").expect("feature file should write");
-	git_checked(&checkout, &["add", "feature.txt"]);
+#[test]
+fn local_commit_accepts_an_external_native_style_registered_worktree() {
+	assert_local_commit_succeeds(WorktreeLocation::ExternalNative);
+}
 
-	let output = Command::new(env!("CARGO_BIN_EXE_decodex"))
-		.current_dir(&checkout)
-		.args(["commit", "Exact local candidate", "--manual-authority"])
-		.output()
-		.expect("Decodex binary should start");
+#[test]
+fn local_commit_rejects_the_primary_checkout_before_mutation() {
+	let fixture = Fixture::new(WorktreeLocation::InRepository);
+	let head_before = git(&fixture.primary, &["rev-parse", "HEAD"]);
+
+	fs::write(fixture.primary.join("README.md"), "primary change\n")
+		.expect("primary change should write");
+	git_checked(&fixture.primary, &["add", "README.md"]);
+
+	let output = fixture.run_commit(&fixture.primary);
+
+	assert_failure_contains(&output, "must run from an isolated task worktree");
+	assert_eq!(git(&fixture.primary, &["rev-parse", "HEAD"]), head_before);
+	assert!(!fixture.hook_marker.exists(), "commit hook must not run");
+}
+
+#[test]
+fn local_commit_rejects_an_unregistered_checkout_with_shared_git_state() {
+	let fixture = Fixture::new(WorktreeLocation::InRepository);
+	let unregistered = fixture.temp.path().join("unregistered/native/repo");
+
+	fs::create_dir_all(&unregistered).expect("unregistered checkout should create");
+	fs::copy(fixture.checkout.join(".git"), unregistered.join(".git"))
+		.expect("linked worktree Git pointer should copy");
+
+	let output = fixture.run_commit(&unregistered);
+
+	assert_failure_contains(&output, "not one exact registered Git worktree");
+	assert!(!fixture.hook_marker.exists(), "commit hook must not run");
+}
+
+#[derive(Clone, Copy)]
+enum WorktreeLocation {
+	InRepository,
+	ExternalNative,
+}
+
+struct Fixture {
+	temp: TempDir,
+	primary: std::path::PathBuf,
+	checkout: std::path::PathBuf,
+	hook_marker: std::path::PathBuf,
+}
+
+impl Fixture {
+	fn new(location: WorktreeLocation) -> Self {
+		let temp = TempDir::new().expect("temporary directory should create");
+		let origin = temp.path().join("origin.git");
+		let primary = temp.path().join("repo");
+		let checkout = match location {
+			WorktreeLocation::InRepository => primary.join(".worktrees/commit"),
+			WorktreeLocation::ExternalNative => temp.path().join(".codex/worktrees/a1b2/decodex"),
+		};
+		let hooks = temp.path().join("hooks");
+		let hook_marker = temp.path().join("commit-msg-ran");
+
+		fs::create_dir_all(&hooks).expect("hooks directory should create");
+		run_checked(Command::new("git").args([
+			"init",
+			"--bare",
+			"--initial-branch=main",
+			origin.to_str().expect("origin path should be UTF-8"),
+		]));
+		run_checked(Command::new("git").args([
+			"clone",
+			origin.to_str().expect("origin path should be UTF-8"),
+			primary.to_str().expect("primary path should be UTF-8"),
+		]));
+		git_checked(&primary, &["config", "user.name", "Decodex Tests"]);
+		git_checked(&primary, &["config", "user.email", "decodex-tests@example.com"]);
+		git_checked(
+			&primary,
+			&["config", "core.hooksPath", hooks.to_str().expect("hooks path should be UTF-8")],
+		);
+		fs::write(primary.join("README.md"), "base\n").expect("base file should write");
+		git_checked(&primary, &["add", "README.md"]);
+		git_checked(&primary, &["commit", "-m", "base"]);
+		git_checked(&primary, &["push", "-u", "origin", "main"]);
+		configure_signing(temp.path(), &primary);
+		fs::create_dir_all(checkout.parent().expect("checkout should have a parent"))
+			.expect("checkout parent should create");
+		git_checked(
+			&primary,
+			&[
+				"worktree",
+				"add",
+				"-b",
+				"xv/local-commit",
+				checkout.to_str().expect("checkout path should be UTF-8"),
+			],
+		);
+		write_commit_message_hook(&hooks, &hook_marker);
+		fs::write(checkout.join("feature.txt"), "feature\n").expect("feature file should write");
+		git_checked(&checkout, &["add", "feature.txt"]);
+
+		Self { temp, primary, checkout, hook_marker }
+	}
+
+	fn run_commit(&self, cwd: &Path) -> Output {
+		Command::new(env!("CARGO_BIN_EXE_decodex"))
+			.current_dir(cwd)
+			.args(["commit", "Exact local candidate", "--manual-authority"])
+			.output()
+			.expect("Decodex binary should start")
+	}
+}
+
+fn assert_local_commit_succeeds(location: WorktreeLocation) {
+	let fixture = Fixture::new(location);
+	let output = fixture.run_commit(&fixture.checkout);
 
 	assert_success(&output);
-	assert!(hook_marker.is_file(), "commit-msg hook should execute");
-	let commit = git(&checkout, &["rev-parse", "HEAD"]);
-	let subject = git(&checkout, &["show", "-s", "--format=%s", &commit]);
+	assert!(fixture.hook_marker.is_file(), "commit-msg hook should execute");
+	let commit = git(&fixture.checkout, &["rev-parse", "HEAD"]);
+	let subject = git(&fixture.checkout, &["show", "-s", "--format=%s", &commit]);
 
 	assert_eq!(
 		subject,
 		r#"{"schema":"decodex/commit/2","change":"Exact local candidate","authority":"manual","impact":"compatible"}"#
 	);
-	run_checked(Command::new("git").arg("-C").arg(&checkout).args([
+	run_checked(Command::new("git").arg("-C").arg(&fixture.checkout).args([
 		"verify-commit",
 		"--raw",
 		&commit,
@@ -152,6 +221,19 @@ fn assert_success(output: &Output) {
 		"command failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
 		output.status.code(),
 		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}
+
+fn assert_failure_contains(output: &Output, expected: &str) {
+	assert!(
+		!output.status.success(),
+		"command unexpectedly succeeded with stdout `{}`",
+		String::from_utf8_lossy(&output.stdout),
+	);
+	assert!(
+		String::from_utf8_lossy(&output.stderr).contains(expected),
+		"command failure did not contain `{expected}`; stderr was `{}`",
 		String::from_utf8_lossy(&output.stderr),
 	);
 }

--- a/apps/decodex-cli/tests/local_land.rs
+++ b/apps/decodex-cli/tests/local_land.rs
@@ -21,8 +21,29 @@ const PR_URL: &str = "https://github.com/acg-box/decodex/pull/123";
 const PR_BRANCH: &str = "xv/exact-land";
 
 #[test]
-fn local_land_binary_merges_syncs_and_cleans_the_exact_lane_without_ci() {
-	let fixture = Fixture::new();
+fn local_land_keeps_in_repository_worktree_compatibility() {
+	assert_exact_land(WorktreeLocation::InRepository);
+}
+
+#[test]
+fn local_land_accepts_and_cleans_an_external_native_style_registered_worktree() {
+	assert_exact_land(WorktreeLocation::ExternalNative);
+}
+
+#[test]
+fn local_land_rejects_the_primary_checkout_before_mutation() {
+	let fixture = Fixture::new(WorktreeLocation::InRepository);
+	let output = fixture.land_output(&fixture.primary);
+
+	assert_failure_contains(&output, "must be landed from its isolated task worktree");
+	assert_eq!(git(&fixture.primary, &["rev-parse", "HEAD"]), fixture.base);
+	assert_eq!(bare_git(&fixture.origin, &["rev-parse", "refs/heads/main"]), fixture.base);
+	assert!(fixture.checkout.exists(), "task worktree must remain");
+	assert!(!fixture.hook_marker.exists(), "pre-push hook must not run");
+}
+
+fn assert_exact_land(location: WorktreeLocation) {
+	let fixture = Fixture::new(location);
 	let merge = fixture.run_land();
 
 	assert_eq!(merge.len(), 40);
@@ -49,7 +70,7 @@ fn local_land_binary_merges_syncs_and_cleans_the_exact_lane_without_ci() {
 
 #[test]
 fn local_land_recovers_when_remote_main_advanced_after_the_exact_merge() {
-	let fixture = Fixture::new();
+	let fixture = Fixture::new(WorktreeLocation::InRepository);
 	let tree = git(&fixture.checkout, &["rev-parse", &format!("{}^{{tree}}", fixture.head)]);
 	let record = r#"{"schema":"decodex/commit/2","change":"Land Exact integration candidate","authority":"manual","impact":"compatible"}"#;
 	let merge = git(
@@ -95,6 +116,12 @@ fn local_land_recovers_when_remote_main_advanced_after_the_exact_merge() {
 	assert!(fixture.hook_marker.is_file(), "pre-push hook should execute");
 }
 
+#[derive(Clone, Copy)]
+enum WorktreeLocation {
+	InRepository,
+	ExternalNative,
+}
+
 struct Fixture {
 	_temp: TempDir,
 	origin: PathBuf,
@@ -107,11 +134,14 @@ struct Fixture {
 	head: String,
 }
 impl Fixture {
-	fn new() -> Self {
+	fn new(location: WorktreeLocation) -> Self {
 		let temp = TempDir::new().expect("temporary directory should create");
 		let origin = temp.path().join("origin.git");
 		let primary = temp.path().join("repo");
-		let checkout = primary.join(".worktrees/exact-land");
+		let checkout = match location {
+			WorktreeLocation::InRepository => primary.join(".worktrees/exact-land"),
+			WorktreeLocation::ExternalNative => temp.path().join(".codex/worktrees/c3d4/decodex"),
+		};
 		let fake_bin = temp.path().join("bin");
 		let reported_merge = temp.path().join("reported-merge");
 		let hooks = temp.path().join("hooks");
@@ -156,6 +186,8 @@ impl Fixture {
 			&primary,
 			&["remote", "set-url", "origin", "git@github.com:acg-box/decodex.git"],
 		);
+		fs::create_dir_all(checkout.parent().expect("checkout should have a parent"))
+			.expect("checkout parent should create");
 		git_checked(
 			&primary,
 			&[
@@ -197,8 +229,23 @@ impl Fixture {
 
 	fn run_land(&self) -> String {
 		self.reset_hook_marker();
-		let output = Command::new(env!("CARGO_BIN_EXE_decodex"))
-			.current_dir(&self.checkout)
+		let output = self.land_output(&self.checkout);
+
+		assert_success(&output);
+		let stdout = String::from_utf8(output.stdout).expect("Decodex output should be UTF-8");
+		let prefix = format!("land ok: pr={PR_URL} merge_commit=");
+		let suffix = " default_branch=main local_default_branch_synced=true\n";
+
+		stdout
+			.strip_prefix(&prefix)
+			.and_then(|value| value.strip_suffix(suffix))
+			.expect("Decodex should emit the stable landing receipt")
+			.to_owned()
+	}
+
+	fn land_output(&self, cwd: &Path) -> Output {
+		Command::new(env!("CARGO_BIN_EXE_decodex"))
+			.current_dir(cwd)
 			.env("PATH", self.command_path())
 			.args([
 				"land",
@@ -212,18 +259,7 @@ impl Fixture {
 				&self.head,
 			])
 			.output()
-			.expect("Decodex binary should start");
-
-		assert_success(&output);
-		let stdout = String::from_utf8(output.stdout).expect("Decodex output should be UTF-8");
-		let prefix = format!("land ok: pr={PR_URL} merge_commit=");
-		let suffix = " default_branch=main local_default_branch_synced=true\n";
-
-		stdout
-			.strip_prefix(&prefix)
-			.and_then(|value| value.strip_suffix(suffix))
-			.expect("Decodex should emit the stable landing receipt")
-			.to_owned()
+			.expect("Decodex binary should start")
 	}
 
 	fn reset_hook_marker(&self) {
@@ -400,5 +436,18 @@ fn assert_success(output: &Output) {
 		"command failed with stdout `{}` and stderr `{}`",
 		String::from_utf8_lossy(&output.stdout),
 		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+fn assert_failure_contains(output: &Output, expected: &str) {
+	assert!(
+		!output.status.success(),
+		"command unexpectedly succeeded with stdout `{}`",
+		String::from_utf8_lossy(&output.stdout),
+	);
+	assert!(
+		String::from_utf8_lossy(&output.stderr).contains(expected),
+		"command failure did not contain `{expected}`; stderr was `{}`",
+		String::from_utf8_lossy(&output.stderr),
 	);
 }


### PR DESCRIPTION
Accept only canonical non-primary checkouts that Git reports as exact registered worktrees of the same common repository. Preserve primary rejection and all existing signed commit, exact landing, and cleanup safeguards.\n\nValidation: all 1,060 workspace Rust tests; Decodex CLI focused tests, check, strict Clippy, and release build; Node/site audits and checks. The aggregate wrapper also exposes unrelated formatter and Clippy debt already present on main.