### PR TITLE
Enable safe device-login takeover for ambiguous refresh

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -128,9 +128,12 @@ preserved and blocks new use.
 
 The panel also exposes current daemon-owned account controls: enroll the
 currently signed-in shared Codex login, enable or disable, log out, and select
-fixed or balanced routing. An account with a provider-confirmed unauthorized
-profile shows `Refresh login`; this official device-login flow is the app's only
-interactive credential-replacement surface. The native app ABI has no direct
+fixed or balanced routing. An account with a provider-confirmed unauthorized profile, or
+with one targetless provider-refresh ambiguity, shows `Refresh login`; this official
+device-login flow is the app's only interactive credential-replacement surface. For the
+ambiguous case, Swift passes only the exact recovery operation identity. The daemon keeps
+the old ambiguity fenced until the verified replacement credential commits and never
+relabels it as a definite cancellation. The native app ABI has no direct
 credential-refresh operation. The action presents the official device code
 with fixed-size Copy, Open, and Cancel icon controls, then refreshes only that
 account after the daemon completes the exact credential replacement. The app

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -177,6 +177,7 @@ enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 	case accountMismatch = "account_mismatch"
 	case accountChanged = "account_changed"
 	case accountUnavailable = "account_unavailable"
+	case recoveryChanged = "recovery_changed"
 	case credentialStoreUnavailable = "credential_store_unavailable"
 	case serviceUnavailable = "service_unavailable"
 	case outcomeUnknown = "outcome_unknown"
@@ -197,6 +198,8 @@ enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 			return "The account changed. Close this login and try again."
 		case .accountUnavailable:
 			return "This account is not available for login."
+		case .recoveryChanged:
+			return "This login recovery changed. Refresh the account and try again."
 		case .credentialStoreUnavailable:
 			return "The credential store is unavailable."
 		case .serviceUnavailable:
@@ -284,6 +287,7 @@ protocol AccountControlClient: ResetCardClient {
 		operationID: String,
 		accountID: String,
 		expectedRevision: UInt64,
+		recoveryOperationID: String?,
 		idempotencyKey: String,
 		codexBin: String
 	) async throws -> AccountReauthenticationStatus
@@ -306,6 +310,7 @@ extension AccountControlClient {
 		operationID _: String,
 		accountID _: String,
 		expectedRevision _: UInt64,
+		recoveryOperationID _: String?,
 		idempotencyKey _: String,
 		codexBin _: String
 	) async throws -> AccountReauthenticationStatus {
@@ -553,6 +558,7 @@ extension DecodexNativeClient: AccountControlClient {
 		operationID: String,
 		accountID: String,
 		expectedRevision: UInt64,
+		recoveryOperationID: String?,
 		idempotencyKey: String,
 		codexBin: String
 	) async throws -> AccountReauthenticationStatus {
@@ -564,6 +570,8 @@ extension DecodexNativeClient: AccountControlClient {
 			idempotencyKey: idempotencyKey
 		)
 		guard Self.isCanonicalUUID(sessionID),
+			recoveryOperationID.map(Self.isCanonicalUUID) ?? true,
+			recoveryOperationID != operationID,
 			Self.isValidCodexExecutablePath(codexBin)
 		else {
 			throw AccountControlError.invalidInput
@@ -575,6 +583,7 @@ extension DecodexNativeClient: AccountControlClient {
 				expectedRevision: expectedRevision,
 				idempotencyKey: idempotencyKey,
 				operationID: operationID,
+				recoveryOperationID: recoveryOperationID,
 				sessionID: sessionID,
 				codexBin: codexBin
 			),

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -210,7 +210,9 @@ struct AccountRefreshLoginButton: View {
 				state.account.accountID,
 				activity: .loginRefresh
 			),
-			help: "Sign in to this account with the official Codex device login."
+			help: state.loginRefreshRecoveryOperationID == nil
+				? "Sign in to this account with the official Codex device login."
+				: "Sign in again to safely replace an uncertain account update."
 		) {
 			store.beginAccountReauthentication(for: state.account.accountID)
 		}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -22,6 +22,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 	var order: [String]? = nil
 	var idempotencyKey: String? = nil
 	var operationID: String? = nil
+	var recoveryOperationID: String? = nil
 	var sessionID: String? = nil
 	var codexBin: String? = nil
 	var enabled: Bool? = nil
@@ -41,6 +42,7 @@ struct DecodexNativeRequest: Encodable, Sendable {
 		case order
 		case idempotencyKey = "idempotency_key"
 		case operationID = "operation_id"
+		case recoveryOperationID = "recovery_operation_id"
 		case sessionID = "session_id"
 		case codexBin = "codex_bin"
 		case enabled

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -141,6 +141,20 @@ struct ResetCardAccountState: Identifiable, Equatable {
 		}
 		return profileUnavailable?.error == .unauthorized
 			|| profile?.refreshError == .unauthorized
+			|| loginRefreshRecoveryOperationID != nil
+	}
+
+	var loginRefreshRecoveryOperationID: String? {
+		guard account.lifecycleReadiness == .operationUnsettled,
+			let operation = account.unsettledOperation,
+			operation.kind == .refresh,
+			operation.phase == .recoveryRequired,
+			operation.recoveryCode == "provider_refresh_ambiguous"
+				|| operation.recoveryCode == "provider_refresh_outcome_unknown"
+		else {
+			return nil
+		}
+		return operation.operationID
 	}
 }
 
@@ -1554,6 +1568,7 @@ final class ResetCardStore {
 		let operationID = Self.newCanonicalUUID()
 		let idempotencyKey = Self.newCanonicalUUID()
 		let account = state.account
+		let recoveryOperationID = state.loginRefreshRecoveryOperationID
 		let authority = account.authority ?? establishedAuthority
 		accountControlActivities[accountID] = .loginRefresh
 		clearStaleControlError()
@@ -1576,6 +1591,7 @@ final class ResetCardStore {
 				account: account,
 				sessionID: sessionID,
 				operationID: operationID,
+				recoveryOperationID: recoveryOperationID,
 				idempotencyKey: idempotencyKey
 			)
 		}
@@ -2872,6 +2888,7 @@ final class ResetCardStore {
 		account: ResetCardAccountRecord,
 		sessionID: String,
 		operationID: String,
+		recoveryOperationID: String?,
 		idempotencyKey: String
 	) async {
 		do {
@@ -2889,6 +2906,7 @@ final class ResetCardStore {
 				operationID: operationID,
 				accountID: account.accountID,
 				expectedRevision: account.accountRevision,
+				recoveryOperationID: recoveryOperationID,
 				idempotencyKey: idempotencyKey,
 				codexBin: codexBin
 			)

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -383,6 +383,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 	func testAccountReauthenticationUsesExactStartPollAndCancelRequests() async throws {
 		let authority = authority
 		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let recoveryOperationID = "66666666-6666-4666-8666-666666666666"
 		let recorder = NativeRequestRecorder()
 		let client = DecodexNativeClient { request, requestedAuthority in
 			recorder.append(request, authority: requestedAuthority)
@@ -418,6 +419,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 			operationID: operationID,
 			accountID: accountID,
 			expectedRevision: 7,
+			recoveryOperationID: recoveryOperationID,
 			idempotencyKey: idempotencyKey,
 			codexBin: "/Applications/ChatGPT.app/Contents/Resources/codex"
 		)
@@ -447,12 +449,17 @@ final class AccountControlNativeClientTests: XCTestCase {
 			Set(requests[0].keys),
 			[
 				"schema", "operation", "session_id", "operation_id",
-				"account_id", "expected_revision", "idempotency_key", "codex_bin",
+				"account_id", "expected_revision", "recovery_operation_id",
+				"idempotency_key", "codex_bin",
 			]
 		)
 		XCTAssertEqual(requests[0]["session_id"] as? String, sessionID)
 		XCTAssertEqual(requests[0]["account_id"] as? String, accountID)
 		XCTAssertEqual(requests[0]["expected_revision"] as? NSNumber, 7)
+		XCTAssertEqual(
+			requests[0]["recovery_operation_id"] as? String,
+			recoveryOperationID
+		)
 		XCTAssertEqual(
 			requests[0]["codex_bin"] as? String,
 			"/Applications/ChatGPT.app/Contents/Resources/codex"

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -1316,6 +1316,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let request = try XCTUnwrap(recordedRequest)
 		XCTAssertEqual(request.accountID, accountID)
 		XCTAssertEqual(request.expectedRevision, 7)
+		XCTAssertNil(request.recoveryOperationID)
 		XCTAssertEqual(
 			request.codexBin,
 			"/Applications/ChatGPT.app/Contents/Resources/codex"
@@ -1327,6 +1328,59 @@ final class AccountControlStoreTests: XCTestCase {
 		let reads = await client.readCounts()
 		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
 		XCTAssertGreaterThanOrEqual(reads.inventory, 4)
+	}
+
+	func testAmbiguousRefreshUsesLoginTakeoverWithTheExactRecoveryOperation() async throws {
+		let recoveryOperationID = "77777777-7777-4777-8777-777777777777"
+		let account = accountRecord(
+			observedState: .available,
+			lifecycleReadiness: .operationUnsettled,
+			unsettledOperation: AccountUnsettledOperation(
+				operationID: recoveryOperationID,
+				kind: .refresh,
+				phase: .recoveryRequired,
+				recoveryCode: "provider_refresh_ambiguous"
+			)
+		)
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			reauthenticationStates: [.waitingForBrowser, .completed]
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			accountReauthenticationPollInterval: .zero,
+			resolveCodexExecutable: {
+				"/Applications/ChatGPT.app/Contents/Resources/codex"
+			}
+		)
+		await store.refresh()
+
+		XCTAssertTrue(store.accounts.first?.requiresLoginRefresh == true)
+		XCTAssertEqual(
+			store.accounts.first?.loginRefreshRecoveryOperationID,
+			recoveryOperationID
+		)
+		store.beginAccountReauthentication(for: accountID)
+		for _ in 0 ..< 200 {
+			if store.accountReauthentication == nil,
+				store.accounts.first?.account.accountRevision == 8
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let recordedRequest = await client.reauthenticationStartRequest()
+		let request = try XCTUnwrap(recordedRequest)
+		XCTAssertEqual(request.recoveryOperationID, recoveryOperationID)
+		XCTAssertEqual(store.accounts.first?.account.lifecycleReadiness, .ready)
+		XCTAssertNil(store.accounts.first?.account.unsettledOperation)
+		XCTAssertFalse(store.accounts.first?.requiresLoginRefresh ?? true)
 	}
 
 	func testBrowserLoginRemainsActiveUntilExplicitCancel() async throws {
@@ -1419,6 +1473,7 @@ final class AccountControlStoreTests: XCTestCase {
 		enabled: Bool = true,
 		observedState: ResetCardObservedState = .available,
 		lifecycleReadiness: ResetCardLifecycleReadiness = .ready,
+		unsettledOperation: AccountUnsettledOperation? = nil,
 		sevenDayQuota: ResetCardQuotaWindow = .unknown(durationMinutes: 10_080)
 	) -> ResetCardAccountRecord {
 		let accountID = accountID ?? self.accountID
@@ -1437,6 +1492,7 @@ final class AccountControlStoreTests: XCTestCase {
 				provider: .chatGPT,
 				providerAccountID: accountID == self.accountID ? "provider-a" : "provider-b"
 			),
+			unsettledOperation: unsettledOperation,
 			fiveHourQuota: .unknown(durationMinutes: 300),
 			sevenDayQuota: sevenDayQuota
 		)
@@ -1495,6 +1551,7 @@ private struct AccountControlStoreLogoutRequest: Equatable, Sendable {
 private struct AccountControlStoreReauthenticationRequest: Equatable, Sendable {
 	let accountID: String
 	let expectedRevision: UInt64
+	let recoveryOperationID: String?
 	let codexBin: String
 }
 
@@ -2052,6 +2109,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		operationID _: String,
 		accountID: String,
 		expectedRevision: UInt64,
+		recoveryOperationID: String?,
 		idempotencyKey _: String,
 		codexBin: String
 	) async throws -> AccountReauthenticationStatus {
@@ -2062,6 +2120,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		lastReauthenticationStartRequest = AccountControlStoreReauthenticationRequest(
 			accountID: accountID,
 			expectedRevision: expectedRevision,
+			recoveryOperationID: recoveryOperationID,
 			codexBin: codexBin
 		)
 		return reauthenticationStatus(

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -102,16 +102,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_4() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_5() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.4");
+		.expect("production lifecycle constructs at protocol V2.5");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 4);
+	assert_eq!(CURRENT_VERSION.minor, 5);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =

--- a/crates/decodex-app-client-ffi/src/account_reauthentication.rs
+++ b/crates/decodex-app-client-ffi/src/account_reauthentication.rs
@@ -40,6 +40,7 @@ pub(crate) enum Failure {
 	AccountMismatch,
 	AccountChanged,
 	AccountUnavailable,
+	RecoveryChanged,
 	CredentialStoreUnavailable,
 	ServiceUnavailable,
 	OutcomeUnknown,
@@ -101,6 +102,7 @@ pub(crate) struct Start {
 	pub operation_id: EntityId,
 	pub account_id: EntityId,
 	pub expected_revision: EntityRevision,
+	pub recovery_operation_id: Option<EntityId>,
 	pub idempotency_key: IdempotencyKey,
 	pub codex_bin: PathBuf,
 }
@@ -479,6 +481,7 @@ async fn install_credential(
 				CommandPayload::ReauthenticateAccountFromCredentialFile {
 					operation_id: start.operation_id.clone(),
 					account_id: start.account_id.clone(),
+					recovery_operation_id: start.recovery_operation_id.clone(),
 					source_descriptor: source_descriptor.clone(),
 				},
 				Some(start.expected_revision),
@@ -522,11 +525,11 @@ fn map_command_error(error: &CommandError) -> Failure {
 			| AccountCommandRejectionDto::CredentialAbsent
 			| AccountCommandRejectionDto::LifecycleUnready
 			| AccountCommandRejectionDto::OperationUnsettled
-			| AccountCommandRejectionDto::OperationNotFound
-			| AccountCommandRejectionDto::ManualRecoveryRequired
 			| AccountCommandRejectionDto::InvalidRequest
 			| AccountCommandRejectionDto::AccountInUse
 			| AccountCommandRejectionDto::RoutingOrderInvalid => Failure::AccountUnavailable,
+			AccountCommandRejectionDto::OperationNotFound
+			| AccountCommandRejectionDto::ManualRecoveryRequired => Failure::RecoveryChanged,
 			AccountCommandRejectionDto::StaleRoutingControl => Failure::AccountChanged,
 		},
 		CommandError::IdempotencyConflict

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -138,6 +138,7 @@ enum Request {
 		operation_id: String,
 		account_id: String,
 		expected_revision: u64,
+		recovery_operation_id: Option<String>,
 		idempotency_key: String,
 		codex_bin: String,
 	},
@@ -704,6 +705,7 @@ async fn execute_request(
 			operation_id,
 			account_id,
 			expected_revision,
+			recovery_operation_id,
 			idempotency_key,
 			codex_bin,
 			..
@@ -715,6 +717,7 @@ async fn execute_request(
 				operation_id,
 				account_id,
 				expected_revision,
+				recovery_operation_id,
 				idempotency_key,
 				codex_bin,
 			},
@@ -740,6 +743,7 @@ struct AccountReauthenticationInput {
 	operation_id: String,
 	account_id: String,
 	expected_revision: u64,
+	recovery_operation_id: Option<String>,
 	idempotency_key: String,
 	codex_bin: String,
 }
@@ -827,11 +831,18 @@ fn start_account_reauthentication(
 	{
 		return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
 	}
+	let operation_id = entity_id(&input.operation_id)?;
+	let recovery_operation_id =
+		input.recovery_operation_id.map(|operation_id| entity_id(&operation_id)).transpose()?;
+	if recovery_operation_id.as_ref() == Some(&operation_id) {
+		return Err(RequestFailure::Bridge(BridgeFailure::InvalidInput));
+	}
 	let start = account_reauthentication::Start {
 		session_id: input.session_id,
-		operation_id: entity_id(&input.operation_id)?,
+		operation_id,
 		account_id: entity_id(&input.account_id)?,
 		expected_revision: revision(input.expected_revision)?,
+		recovery_operation_id,
 		idempotency_key: parse_idempotency_key(input.idempotency_key)?,
 		codex_bin: PathBuf::from(input.codex_bin),
 	};
@@ -1207,8 +1218,9 @@ mod tests {
 	fn account_reauthentication_requests_are_exact_and_revision_fenced() {
 		let session_id = "028f0f9e-7b6e-4a31-8f4c-1d2e3f405163";
 		let operation_id = "038f0f9e-7b6e-4a31-8f4c-1d2e3f405164";
+		let recovery_operation_id = "048f0f9e-7b6e-4a31-8f4c-1d2e3f405165";
 		let start = serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"start_account_reauthentication","session_id":"{session_id}","operation_id":"{operation_id}","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"{operation_id}","codex_bin":"/Applications/Codex.app/Contents/Resources/codex"}}"#
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"start_account_reauthentication","session_id":"{session_id}","operation_id":"{operation_id}","account_id":"{ACCOUNT_ID}","expected_revision":7,"recovery_operation_id":"{recovery_operation_id}","idempotency_key":"{operation_id}","codex_bin":"/Applications/Codex.app/Contents/Resources/codex"}}"#
 		))
 		.expect("start request must decode");
 		let poll = serde_json::from_str::<Request>(&format!(
@@ -1221,6 +1233,13 @@ mod tests {
 		.expect("cancel request must decode");
 
 		assert_eq!(start.operation(), "start_account_reauthentication");
+		assert!(matches!(
+			start,
+			Request::StartAccountReauthentication {
+				recovery_operation_id: Some(ref actual),
+				..
+			} if actual == recovery_operation_id
+		));
 		assert_eq!(poll.operation(), "poll_account_reauthentication");
 		assert_eq!(cancel.operation(), "cancel_account_reauthentication");
 		assert!(

--- a/crates/decodex-core/src/account.rs
+++ b/crates/decodex-core/src/account.rs
@@ -254,6 +254,12 @@ pub struct AccountOperation {
 	pub expected: Option<CredentialBinding>,
 	/// Exact credential binding after the effect, when known.
 	pub target: Option<CredentialBinding>,
+	/// Stable reason that required manual recovery, when present.
+	pub recovery_code: Option<String>,
+	/// Exact ambiguous refresh that this verified reauthentication can replace.
+	pub recovery_operation_id: Option<AccountOperationId>,
+	/// Exact verified reauthentication that replaced this ambiguity.
+	pub superseded_by_operation_id: Option<AccountOperationId>,
 }
 
 /// Credential-negative unsettled operation state rendered with one account row.

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -846,7 +846,7 @@ impl ResetCardClient {
 	}
 }
 
-/// Read-only V2.4 client for bounded canonical WorkItem board pages.
+/// Read-only V2.5 client for bounded canonical WorkItem board pages.
 pub struct WorkItemBoardClient {
 	transport: ResetCardClient,
 }
@@ -928,7 +928,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.4 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.5 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1162,7 +1162,7 @@ impl AccountClient {
 		.await
 	}
 
-	/// Execute one V2.4 lifecycle command exactly once on one connection.
+	/// Execute one V2.5 lifecycle command exactly once on one connection.
 	pub async fn execute(
 		&self,
 		payload: CommandPayload,
@@ -1798,12 +1798,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_4_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 4 });
+	fn protocol_constants_expose_only_the_exact_v2_5_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 5 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 4, maximum_minor: 4 },
+			SupportedVersions { major: 2, minimum_minor: 5, maximum_minor: 5 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}
@@ -2971,6 +2971,7 @@ max_entry_bytes = 0
 			operation_id: EntityId::new("43234567-89ab-4def-8123-456789abcdef")
 				.expect("canonical operation ID"),
 			account_id: account_id.clone(),
+			recovery_operation_id: None,
 			source_descriptor: crate::WireText::new("/private/tmp/login/auth.json")
 				.expect("bounded source descriptor"),
 		};

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -95,7 +95,7 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 4 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 5 };
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -77,7 +77,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.4 local endpoint authority.
+/// The complete V2.5 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.4 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.5 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -31,7 +31,7 @@ use crate::{
 	},
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.4.
+/// Maximum UTF-8 size of any human-readable text carried by V2.5.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -156,7 +156,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded the V2.4 byte limit.
+/// A string-backed wire scalar exceeded the V2.5 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -172,7 +172,7 @@ impl Display for WireScalarTooLong {
 	}
 }
 
-/// Closed construction failures for the V2.4 WorkItem board contract.
+/// Closed construction failures for the V2.5 WorkItem board contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkItemBoardContractError {
 	/// An identity was not canonical lowercase RFC 9562 UUID-v4 text.
@@ -274,7 +274,7 @@ impl<'de> Deserialize<'de> for WorkItemBoardTitle {
 #[serde(transparent)]
 pub struct WorkItemBoardPageSize(u16);
 impl WorkItemBoardPageSize {
-	/// Construct a page size inside the closed V2.4 protocol bound.
+	/// Construct a page size inside the closed V2.5 protocol bound.
 	pub const fn new(value: u16) -> Result<Self, WorkItemBoardContractError> {
 		if value == 0 || value > MAX_WORK_ITEM_BOARD_PAGE_SIZE {
 			Err(WorkItemBoardContractError::InvalidPageSize)
@@ -550,7 +550,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.4 resume requires this field. Older hello envelopes can omit it
+	/// A V2.5 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -603,7 +603,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.4 welcome.
+	/// This is present in the exact-current V2.5 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1731,7 +1731,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.4 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.5 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -2262,7 +2262,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.4 protocol.
+/// Live queries available through the exact-current V2.5 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2364,7 +2364,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.4 protocol.
+/// Commands available through the exact-current V2.5 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2564,6 +2564,9 @@ pub enum CommandPayload {
 		operation_id: EntityId,
 		/// Canonical existing account identity.
 		account_id: EntityId,
+		/// Exact ambiguous refresh replaced only after this verified login commits.
+		#[serde(skip_serializing_if = "Option::is_none")]
+		recovery_operation_id: Option<EntityId>,
 		/// Owner-private Codex auth path descriptor opened by the daemon.
 		source_descriptor: WireText,
 	},
@@ -2905,7 +2908,7 @@ pub enum ResultPayload {
 	},
 }
 
-/// Typed live-query results available through the exact-current V2.4 protocol.
+/// Typed live-query results available through the exact-current V2.5 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -3842,12 +3845,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.4 wire encoding.
+/// Serialize a message using the only V2.5 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.4 wire encoding.
+/// Parse a client message using the only V2.5 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -3977,20 +3980,15 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 		CommandPayload::ReauthenticateAccountFromCredentialFile {
 			operation_id,
 			account_id,
+			recovery_operation_id,
 			source_descriptor,
-		} => {
-			validate_canonical_operation(operation_id)?;
-			validate_canonical_account(account_id)?;
-			if !positive_expected {
-				return Err("account revision is required");
-			}
-			let source = source_descriptor.as_str();
-			if source.is_empty() || source.len() > 4096 || source.chars().any(char::is_control) {
-				Err("account credential source descriptor is invalid")
-			} else {
-				Ok(())
-			}
-		},
+		} => validate_account_reauthentication_command(
+			operation_id,
+			account_id,
+			recovery_operation_id.as_ref(),
+			source_descriptor,
+			positive_expected,
+		),
 		CommandPayload::UseAccountInCodex { account_id } => {
 			validate_canonical_account(account_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
@@ -4004,24 +4002,55 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 		},
 		CommandPayload::SetBalancedAccountSelection =>
 			positive_expected.then_some(()).ok_or("account routing revision is required"),
-		CommandPayload::SetAccountOrder { order } => {
-			if !positive_expected
-				|| order.len() > 512
-				|| order.iter().any(|account_id| !is_canonical_uuid(account_id.as_str()))
-			{
-				return Err("account routing revision or order is invalid");
-			}
-			let unique = order.iter().map(EntityId::as_str).collect::<HashSet<_>>();
-			if unique.len() != order.len() {
-				return Err("account routing order contains duplicates");
-			}
-			Ok(())
-		},
+		CommandPayload::SetAccountOrder { order } =>
+			validate_account_order_command(order, positive_expected),
 		CommandPayload::RecoverAccountOperation { operation_id, .. } => {
 			validate_canonical_operation(operation_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
 		},
 	}
+}
+
+fn validate_account_reauthentication_command(
+	operation_id: &EntityId,
+	account_id: &EntityId,
+	recovery_operation_id: Option<&EntityId>,
+	source_descriptor: &WireText,
+	positive_expected: bool,
+) -> Result<(), &'static str> {
+	validate_canonical_operation(operation_id)?;
+	validate_canonical_account(account_id)?;
+	if recovery_operation_id.is_some_and(|recovery| {
+		recovery == operation_id || validate_canonical_operation(recovery).is_err()
+	}) {
+		return Err("account recovery operation identity is invalid");
+	}
+	if !positive_expected {
+		return Err("account revision is required");
+	}
+	let source = source_descriptor.as_str();
+	if source.is_empty() || source.len() > 4096 || source.chars().any(char::is_control) {
+		Err("account credential source descriptor is invalid")
+	} else {
+		Ok(())
+	}
+}
+
+fn validate_account_order_command(
+	order: &[EntityId],
+	positive_expected: bool,
+) -> Result<(), &'static str> {
+	if !positive_expected
+		|| order.len() > 512
+		|| order.iter().any(|account_id| !is_canonical_uuid(account_id.as_str()))
+	{
+		return Err("account routing revision or order is invalid");
+	}
+	let unique = order.iter().map(EntityId::as_str).collect::<HashSet<_>>();
+	if unique.len() != order.len() {
+		return Err("account routing order contains duplicates");
+	}
+	Ok(())
 }
 
 fn validate_project_command(command: &CommandEnvelope) -> Result<(), &'static str> {
@@ -5038,7 +5067,7 @@ mod tests {
 			}),
 		);
 		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 1, minor: 5 }));
-		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 5 }));
+		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 4 }));
 		assert!(command.is_supported_in(CURRENT_VERSION));
 		assert!(
 			serde_json::from_value::<CommandPayload>(serde_json::json!({
@@ -5061,6 +5090,10 @@ mod tests {
 		let payload = CommandPayload::ReauthenticateAccountFromCredentialFile {
 			operation_id: operation_id.clone(),
 			account_id: account_id.clone(),
+			recovery_operation_id: Some(
+				EntityId::new("33234567-89ab-4def-8123-456789abcdef")
+					.expect("canonical recovery operation ID"),
+			),
 			source_descriptor: WireText::new("/private/tmp/decodex-login/auth.json")
 				.expect("bounded source descriptor"),
 		};
@@ -5085,9 +5118,22 @@ mod tests {
 			decode_client_message(&serde_json::to_string(&message(payload.clone(), None)).unwrap())
 				.is_err()
 		);
+		let self_recovery = CommandPayload::ReauthenticateAccountFromCredentialFile {
+			operation_id: operation_id.clone(),
+			account_id: account_id.clone(),
+			recovery_operation_id: Some(operation_id.clone()),
+			source_descriptor: WireText::new("/private/tmp/decodex-login/auth.json").unwrap(),
+		};
+		assert!(
+			decode_client_message(
+				&serde_json::to_string(&message(self_recovery, Some(EntityRevision(7)))).unwrap()
+			)
+			.is_err()
+		);
 		let invalid = CommandPayload::ReauthenticateAccountFromCredentialFile {
 			operation_id,
 			account_id,
+			recovery_operation_id: None,
 			source_descriptor: WireText::new("relative/auth.json").unwrap(),
 		};
 		// Absolute-path enforcement belongs to the daemon's no-follow source reader.
@@ -5509,7 +5555,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":4},"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":5},"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -5518,7 +5564,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":4},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":5},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -5560,7 +5606,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":4},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":5},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5803,7 +5849,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 5 };
+		let future = crate::ProtocolVersion { major: 2, minor: 6 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -46,6 +46,7 @@ use crate::{
 const REFRESH_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
 const CHATGPT_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const MAX_ACCOUNT_READ: u16 = 512;
+const MAX_UNSETTLED_ACCOUNT_OPERATION_READ: u16 = 1_024;
 const PROVIDER_REFRESH_OUTCOME_UNKNOWN: &str = "provider_refresh_outcome_unknown";
 const ACCOUNT_ALIAS_DOMAIN: &[u8] = b"decodex/account-alias/v2\0";
 const CODEX_AUTH_PROJECTION_DOMAIN: &[u8] = b"decodex/codex-auth-projection/v1\0";
@@ -396,6 +397,7 @@ struct ReauthenticationCommandInput<'a> {
 	operation_id: AccountOperationId,
 	account_id: &'a AccountId,
 	expected_account_revision: i64,
+	recovery_operation_id: Option<&'a AccountOperationId>,
 	source_descriptor: &'a str,
 	account: &'a AccountRecord,
 }
@@ -1022,6 +1024,7 @@ impl AccountService {
 		operation_id: AccountOperationId,
 		account_id: &AccountId,
 		expected_account_revision: i64,
+		recovery_operation_id: Option<&AccountOperationId>,
 		source_descriptor: &str,
 		build_response: F,
 	) -> Result<Value, AccountLifecycleError>
@@ -1045,6 +1048,7 @@ impl AccountService {
 					&operation_id,
 					account_id,
 					expected_account_revision,
+					recovery_operation_id,
 					&operation,
 					build_response,
 				)
@@ -1054,18 +1058,21 @@ impl AccountService {
 			operation_id,
 			account_id,
 			expected_account_revision,
+			recovery_operation_id,
 			source_descriptor,
 			account: &account,
 		};
 		self.continue_reauthentication_command(lease, input, build_response).await
 	}
 
+	#[allow(clippy::too_many_arguments)] // Replay needs the receipt, operation identity, account fence, recovery identity, and response owner together.
 	async fn complete_reauthentication_replay<F>(
 		&self,
 		lease: AccountCommandReceiptLease,
 		operation_id: &AccountOperationId,
 		account_id: &AccountId,
 		expected_account_revision: i64,
+		recovery_operation_id: Option<&AccountOperationId>,
 		operation: &AccountOperation,
 		build_response: F,
 	) -> Result<Value, AccountLifecycleError>
@@ -1078,6 +1085,7 @@ impl AccountService {
 			operation,
 			account_id,
 			expected_account_revision,
+			recovery_operation_id,
 		) {
 			Ok(disposition) => disposition,
 			Err(error) => {
@@ -1140,10 +1148,16 @@ impl AccountService {
 		operation: &AccountOperation,
 		account_id: &AccountId,
 		expected_account_revision: i64,
+		recovery_operation_id: Option<&AccountOperationId>,
 	) -> Result<ReauthenticationReplayDisposition, AccountLifecycleError> {
 		self.require_operation_identity(operation, account_id, AccountOperationKind::Refresh)?;
 		if operation.expected_account_revision != Some(expected_account_revision) {
 			return Err(AccountLifecycleError::StaleAccount);
+		}
+		if operation.recovery_operation_id.as_ref() != recovery_operation_id
+			|| operation.superseded_by_operation_id.is_some()
+		{
+			return Err(AccountLifecycleError::InvalidOperation);
 		}
 		Ok(classify_reauthentication_replay(
 			operation.phase,
@@ -1168,6 +1182,7 @@ impl AccountService {
 			operation_id,
 			account_id,
 			expected_account_revision,
+			recovery_operation_id,
 			source_descriptor,
 			account,
 		} = input;
@@ -1194,7 +1209,14 @@ impl AccountService {
 			target: Some(target.clone()),
 			provider: imported.provider.clone(),
 		};
-		let phase = match self.store.prepare_account_operation(&preparation).await? {
+		let preparation_outcome = match recovery_operation_id {
+			Some(recovery_operation_id) =>
+				self.store
+					.prepare_account_reauthentication_takeover(&preparation, recovery_operation_id)
+					.await?,
+			None => self.store.prepare_account_operation(&preparation).await?,
+		};
+		let phase = match preparation_outcome {
 			AccountLifecycleMutationOutcome::Applied(mutation)
 			| AccountLifecycleMutationOutcome::Replayed(mutation) => mutation.phase,
 			AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
@@ -2280,9 +2302,24 @@ impl AccountService {
 	pub async fn reconcile_startup(
 		&self,
 	) -> Result<StartupAccountReconciliation, AccountLifecycleError> {
-		let operations = self.store.read_unsettled_account_operations(MAX_ACCOUNT_READ).await?;
+		let operations = self
+			.store
+			.read_unsettled_account_operations(MAX_UNSETTLED_ACCOUNT_OPERATION_READ)
+			.await?;
 		let mut summary = StartupAccountReconciliation::default();
-		for operation in operations {
+		for discovered in operations {
+			let Some(operation) =
+				self.store.read_account_operation(&discovered.operation_id).await?
+			else {
+				continue;
+			};
+			if operation.superseded_by_operation_id.is_some()
+				|| matches!(
+					operation.phase,
+					AccountOperationPhase::Committed | AccountOperationPhase::Cancelled
+				) {
+				continue;
+			}
 			let lock = self.lock_for(&operation.account_id)?;
 			let _guard = lock.lock().await;
 			match self.reconcile_operation(&operation).await? {
@@ -2313,6 +2350,9 @@ impl AccountService {
 			.read_account_operation(operation_id)
 			.await?
 			.ok_or(AccountLifecycleError::InvalidOperation)?;
+		if operation.superseded_by_operation_id.is_some() {
+			return Err(AccountLifecycleError::InvalidOperation);
+		}
 		let lock = self.lock_for(&operation.account_id)?;
 		let _guard = lock.lock().await;
 		let operation = self
@@ -2320,6 +2360,9 @@ impl AccountService {
 			.read_account_operation(operation_id)
 			.await?
 			.ok_or(AccountLifecycleError::InvalidOperation)?;
+		if operation.superseded_by_operation_id.is_some() {
+			return Err(AccountLifecycleError::InvalidOperation);
+		}
 		let replayed = match (operation.phase, action) {
 			(
 				AccountOperationPhase::Committed,
@@ -2387,6 +2430,15 @@ impl AccountService {
 				)
 				.await;
 		};
+		if operation.superseded_by_operation_id.is_some() {
+			return self
+				.complete_recovery_command_error(
+					lease,
+					AccountLifecycleError::InvalidOperation,
+					build_response.take().expect("builder is retained"),
+				)
+				.await;
+		}
 		let terminal_replay = match (operation.phase, action) {
 			(
 				AccountOperationPhase::Committed,
@@ -2450,6 +2502,11 @@ impl AccountService {
 					self.credentials.read_exact(&operation.account_id, expected).is_ok()
 				}),
 				(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) =>
+					operation.expected.as_ref().is_some_and(|expected| {
+						self.credentials.read_exact(&operation.account_id, expected).is_ok()
+					}),
+				(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Refresh)
+					if operation.recovery_operation_id.is_some() =>
 					operation.expected.as_ref().is_some_and(|expected| {
 						self.credentials.read_exact(&operation.account_id, expected).is_ok()
 					}),
@@ -2972,6 +3029,11 @@ impl AccountService {
 				)
 			}),
 			(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) =>
+				operation.expected.as_ref().is_some_and(|expected| {
+					self.credentials.read_exact(&operation.account_id, expected).is_ok()
+				}),
+			(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Refresh)
+				if operation.recovery_operation_id.is_some() =>
 				operation.expected.as_ref().is_some_and(|expected| {
 					self.credentials.read_exact(&operation.account_id, expected).is_ok()
 				}),
@@ -3577,32 +3639,53 @@ impl From<CredentialImportError> for AccountLifecycleError {
 mod tests {
 	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 	use decodex_core::{
-		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationPhase,
-		AccountProvider, AccountQuotaWindow, AccountQuotaWindowObservation, AccountRecord,
-		AccountState, CredentialBinding, CredentialFingerprint, CredentialStoreSchemaVersion,
-		CredentialVersion, ProviderIdentity,
+		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationKind,
+		AccountOperationPhase, AccountProvider, AccountQuotaWindow, AccountQuotaWindowObservation,
+		AccountRecord, AccountState, CredentialBinding, CredentialFingerprint,
+		CredentialStoreSchemaVersion, CredentialVersion, DecodexRoot, ProviderIdentity,
+	};
+	use decodex_database::{
+		AccountCommandKind, AccountCommandReceiptClaim, AccountLifecycleMutationOutcome,
+		AccountOperationPreparation, CommandIdentity, SqliteStore,
 	};
 	use serde_json::json;
 
 	use super::{
-		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, CredentialImportError, CredentialRefreshError,
-		CredentialSecretBundle, ImportedCredential, PROVIDER_REFRESH_OUTCOME_UNKNOWN,
-		PreparedRefreshReconciliation, ReauthenticationReplayDisposition, RefreshResponse,
-		UseInCodexProjectionError, access_token_needs_refresh, account_lock_for,
-		classify_prepared_refresh_reconciliation, classify_reauthentication_replay,
-		codex_auth_projection_digest, credential_refresh_result, matching_shared_refresh,
-		projection_binding, reauthentication_current, reauthentication_target,
-		refreshed_credential_target, require_refreshed_access_token_for_observation,
-		resolve_reauthentication_store_effect, stable_account_alias, use_in_codex_receipt_result,
+		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, AccountService, CredentialImportError,
+		CredentialRefreshError, CredentialRefreshPort, CredentialRefreshResult,
+		CredentialSecretBundle, HostCredentialStore, ImportedCredential,
+		PROVIDER_REFRESH_OUTCOME_UNKNOWN, PreparedRefreshReconciliation,
+		ReauthenticationReplayDisposition, RefreshResponse, UseInCodexProjectionError,
+		access_token_needs_refresh, account_lock_for, classify_prepared_refresh_reconciliation,
+		classify_reauthentication_replay, codex_auth_projection_digest, credential_refresh_result,
+		matching_shared_refresh, projection_binding, reauthentication_current,
+		reauthentication_target, refreshed_credential_target,
+		require_refreshed_access_token_for_observation, resolve_reauthentication_store_effect,
+		stable_account_alias, use_in_codex_receipt_result,
 	};
 	use std::{
 		collections::{HashMap, HashSet},
+		fs,
+		os::unix::fs::PermissionsExt as _,
 		sync::{Arc, Mutex},
 		time::Duration,
 	};
+	use tempfile::tempdir;
 	use tokio::time;
 
+	use crate::host_credentials::SqliteCredentialStore;
+
 	const OBSERVED_AT_MICROS: i64 = 1_000_000;
+
+	struct UnusedCredentialRefresher;
+	impl CredentialRefreshPort for UnusedCredentialRefresher {
+		fn refresh(
+			&self,
+			_current: &CredentialSecretBundle,
+		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+			panic!("verified reauthentication must not call the provider refresh adapter")
+		}
+	}
 
 	#[test]
 	fn observation_refreshes_only_when_the_access_token_cannot_cover_the_process_deadline() {
@@ -3688,6 +3771,188 @@ mod tests {
 			Err(AccountLifecycleError::StaleAccount)
 		));
 		assert_eq!(account.credential.as_ref(), Some(&current));
+	}
+
+	#[tokio::test]
+	#[allow(clippy::too_many_lines)] // One full cross-store takeover regression keeps every safety boundary visible together.
+	async fn verified_device_login_takes_over_targetless_refresh_ambiguity_end_to_end() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(UnusedCredentialRefresher),
+		);
+		let account_id =
+			AccountId::new("21000000-0000-4000-8000-000000000001").expect("account identity");
+		let enrollment_id = AccountOperationId::new("22000000-0000-4000-8000-000000000001")
+			.expect("enrollment identity");
+		let ambiguity_id = AccountOperationId::new("22000000-0000-4000-8000-000000000002")
+			.expect("ambiguity identity");
+		let takeover_id = AccountOperationId::new("22000000-0000-4000-8000-000000000003")
+			.expect("takeover identity");
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, "old-provider-account")
+			.expect("provider identity");
+		let current_bundle = current_bundle();
+		let current = current_bundle
+			.binding_for(
+				&account_id,
+				&enrollment_id,
+				CredentialVersion::new(1).expect("initial version"),
+				&provider,
+			)
+			.expect("initial credential binding");
+		assert!(matches!(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: enrollment_id.clone(),
+					account_id: account_id.clone(),
+					kind: AccountOperationKind::Enroll,
+					display_label: Some("Primary".to_owned()),
+					enabled: Some(true),
+					expected_account_revision: None,
+					expected: None,
+					target: Some(current.clone()),
+					provider: provider.clone(),
+				})
+				.await
+				.expect("prepare enrollment"),
+			AccountLifecycleMutationOutcome::Applied(_)
+		));
+		credentials
+			.create(&account_id, &current, current_bundle)
+			.expect("write initial credential");
+		store
+			.advance_account_operation(
+				&enrollment_id,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::StoreApplied,
+				None,
+			)
+			.await
+			.expect("record initial credential");
+		store
+			.advance_account_operation(
+				&enrollment_id,
+				AccountOperationPhase::StoreApplied,
+				AccountOperationPhase::Committed,
+				None,
+			)
+			.await
+			.expect("commit initial account");
+		store
+			.prepare_account_operation(&AccountOperationPreparation {
+				operation_id: ambiguity_id.clone(),
+				account_id: account_id.clone(),
+				kind: AccountOperationKind::Refresh,
+				display_label: None,
+				enabled: None,
+				expected_account_revision: Some(1),
+				expected: Some(current.clone()),
+				target: None,
+				provider: provider.clone(),
+			})
+			.await
+			.expect("prepare provider refresh");
+		store
+			.advance_account_operation(
+				&ambiguity_id,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::ProviderEffectPending,
+				None,
+			)
+			.await
+			.expect("record possible provider effect");
+		store
+			.advance_account_operation(
+				&ambiguity_id,
+				AccountOperationPhase::ProviderEffectPending,
+				AccountOperationPhase::RecoveryRequired,
+				Some("provider_refresh_ambiguous"),
+			)
+			.await
+			.expect("preserve provider ambiguity");
+
+		let login_directory = tempdir().expect("private login directory");
+		let login_root = fs::canonicalize(login_directory.path()).expect("canonical login root");
+		let auth_path = login_root.join("auth.json");
+		let access_payload = URL_SAFE_NO_PAD
+			.encode(serde_json::to_vec(&json!({"exp": 4_000_000_000_i64})).expect("access claims"));
+		fs::write(
+			&auth_path,
+			serde_json::to_vec(&json!({
+				"auth_mode": "chatgpt",
+				"OPENAI_API_KEY": null,
+				"tokens": {
+					"id_token": identity_token(
+						"old-provider-account",
+						"verified@example.test",
+						"team"
+					),
+					"access_token": format!("header.{access_payload}.signature"),
+					"refresh_token": "verified-refresh",
+					"account_id": "old-provider-account"
+				},
+				"last_refresh": null
+			}))
+			.expect("login document"),
+		)
+		.expect("write login document");
+		fs::set_permissions(&auth_path, fs::Permissions::from_mode(0o600))
+			.expect("private login document");
+		let command = CommandIdentity::new("verified-login-takeover", b"exact takeover request")
+			.expect("command identity");
+		let lease = match store
+			.reserve_account_command(
+				&command,
+				AccountCommandKind::Refresh,
+				account_id.as_str(),
+				Some(1),
+			)
+			.await
+			.expect("reserve takeover command")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Replayed(_) => panic!("new takeover command replayed"),
+		};
+		let response = service
+			.reauthenticate_from_credential_file_command(
+				lease,
+				takeover_id.clone(),
+				&account_id,
+				1,
+				Some(&ambiguity_id),
+				auth_path.to_string_lossy().as_ref(),
+				|result| {
+					Ok(match result {
+						Ok(account) => json!({"outcome": "applied", "revision": account.revision}),
+						Err(_) => json!({"outcome": "rejected"}),
+					})
+				},
+			)
+			.await
+			.expect("complete verified login takeover");
+
+		assert_eq!(response, json!({"outcome": "applied", "revision": 2}));
+		let account = service.inspect(&account_id).await.expect("inspect settled account");
+		assert_eq!(account.account.revision, 2);
+		assert!(account.account.unsettled_operation.is_none());
+		let target = account.account.credential.expect("replacement binding");
+		assert_eq!(target.version.get(), 2);
+		assert_eq!(target.writer_operation_id, takeover_id.clone());
+		credentials.read_exact(&account_id, &target).expect("read exact replacement credential");
+		let ambiguity = store
+			.read_account_operation(&ambiguity_id)
+			.await
+			.expect("read ambiguity")
+			.expect("ambiguity remains recorded");
+		assert_eq!(ambiguity.phase, AccountOperationPhase::RecoveryRequired);
+		assert_eq!(ambiguity.recovery_code.as_deref(), Some("provider_refresh_ambiguous"));
+		assert_eq!(ambiguity.superseded_by_operation_id, Some(takeover_id));
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -640,10 +640,13 @@ impl ServiceApplication {
 			CommandPayload::ReauthenticateAccountFromCredentialFile {
 				operation_id,
 				account_id,
+				recovery_operation_id,
 				source_descriptor,
 			} => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let account_id = account_id_from_wire(account_id)?;
+				let recovery_operation_id =
+					recovery_operation_id.as_ref().map(operation_id_from_wire).transpose()?;
 				let expected = required_expected_revision(command)?;
 				service
 					.reauthenticate_from_credential_file_command(
@@ -651,6 +654,7 @@ impl ServiceApplication {
 						operation_id,
 						&account_id,
 						expected,
+						recovery_operation_id.as_ref(),
 						source_descriptor.as_str(),
 						|result| {
 							encode_account_command_receipt(
@@ -3422,10 +3426,17 @@ fn validate_account_command_envelope(command: &CommandEnvelope) -> Result<(), Co
 		CommandPayload::ReauthenticateAccountFromCredentialFile {
 			operation_id,
 			account_id,
+			recovery_operation_id,
 			source_descriptor,
 		} => {
 			let _ = operation_id_from_wire(operation_id)?;
 			let _ = account_id_from_wire(account_id)?;
+			if recovery_operation_id.as_ref().is_some_and(|recovery| recovery == operation_id) {
+				return Err(account_rejection(AccountCommandRejectionDto::InvalidRequest, None));
+			}
+			if let Some(recovery_operation_id) = recovery_operation_id {
+				let _ = operation_id_from_wire(recovery_operation_id)?;
+			}
 			let _ = required_expected_revision(command)?;
 			let source = source_descriptor.as_str();
 			if source.is_empty() || source.len() > 4096 || source.chars().any(char::is_control) {

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.4 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.5 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Quick Task owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -360,7 +360,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 5 },
+			version: ProtocolVersion { major: 2, minor: 6 },
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
 		}),
@@ -390,7 +390,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 5 },
+			ProtocolVersion { major: 2, minor: 6 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -477,7 +477,7 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 
 	drop(client);
 
-	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 5 }).await;
+	let mut client = connect(&transport, ProtocolVersion { major: 2, minor: 6 }).await;
 	let ServerMessage::Refusal(refusal) = receive(&mut client).await else {
 		panic!("expected minor-version refusal");
 	};
@@ -495,8 +495,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 4);
-	assert_eq!(welcome.supported.maximum_minor, 4);
+	assert_eq!(welcome.supported.minimum_minor, 5);
+	assert_eq!(welcome.supported.maximum_minor, 5);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
@@ -519,7 +519,7 @@ async fn post_negotiation_payload_envelopes_require_exact_current_version() {
 	send(
 		&mut client,
 		ClientMessage::Query(QueryEnvelope {
-			version: ProtocolVersion { major: 2, minor: 5 },
+			version: ProtocolVersion { major: 2, minor: 6 },
 			query_id: QueryId::new("future-query").expect("bounded query ID"),
 			payload: QueryPayload::GetDoctorStatus,
 		}),

--- a/database/migrations/0008_account_reauthentication_takeover.sql
+++ b/database/migrations/0008_account_reauthentication_takeover.sql
@@ -1,0 +1,31 @@
+ALTER TABLE account_operations
+  ADD COLUMN recovery_operation_id TEXT
+    REFERENCES account_operations(operation_id)
+    DEFERRABLE INITIALLY DEFERRED
+    CHECK (recovery_operation_id IS NULL OR recovery_operation_id <> operation_id);
+
+ALTER TABLE account_operations
+  ADD COLUMN superseded_by_operation_id TEXT
+    REFERENCES account_operations(operation_id)
+    DEFERRABLE INITIALLY DEFERRED
+    CHECK (
+      superseded_by_operation_id IS NULL OR
+      (superseded_by_operation_id <> operation_id AND recovery_operation_id IS NULL)
+    );
+
+DROP INDEX one_unsettled_account_operation;
+
+CREATE UNIQUE INDEX one_unsettled_account_operation
+  ON account_operations(account_id)
+  WHERE phase NOT IN ('committed', 'cancelled')
+    AND recovery_operation_id IS NULL
+    AND superseded_by_operation_id IS NULL;
+
+CREATE UNIQUE INDEX one_active_account_reauthentication_takeover
+  ON account_operations(recovery_operation_id)
+  WHERE recovery_operation_id IS NOT NULL
+    AND phase NOT IN ('committed', 'cancelled');
+
+CREATE UNIQUE INDEX one_account_operation_supersession
+  ON account_operations(superseded_by_operation_id)
+  WHERE superseded_by_operation_id IS NOT NULL;

--- a/database/src/account_lifecycle.rs
+++ b/database/src/account_lifecycle.rs
@@ -19,6 +19,7 @@ const ACCOUNT_COMMAND_PROTOCOL: &str = "decodex/account-command/1";
 const CLAIM_LIFETIME_MICROS: i64 = 5 * 60 * 1_000_000;
 const QUOTA_FRESHNESS_MICROS: i64 = 5 * 60 * 1_000_000;
 const MAX_ACCOUNT_COUNT: usize = 512;
+const MAX_UNSETTLED_ACCOUNT_OPERATION_COUNT: usize = MAX_ACCOUNT_COUNT * 2;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccountOperationPreparation {
@@ -228,7 +229,33 @@ impl SqliteStore {
 			let transaction = connection
 				.transaction_with_behavior(TransactionBehavior::Immediate)
 				.map_err(sql_error)?;
-			let outcome = prepare_operation_sync(&transaction, &preparation)?;
+			let outcome = prepare_operation_sync(&transaction, &preparation, None)?;
+			transaction.commit().map_err(sql_error)?;
+			Ok(outcome)
+		})
+		.await
+	}
+
+	/// Prepare a verified credential replacement beside one exact ambiguous refresh.
+	pub async fn prepare_account_reauthentication_takeover(
+		&self,
+		preparation: &AccountOperationPreparation,
+		recovery_operation_id: &AccountOperationId,
+	) -> Result<AccountLifecycleMutationOutcome, StoreError> {
+		validate_preparation(preparation)?;
+		if preparation.operation_id == *recovery_operation_id {
+			return Err(StoreError::InvalidInput(
+				"account reauthentication recovery identity is invalid",
+			));
+		}
+		let preparation = preparation.clone();
+		let recovery_operation_id = recovery_operation_id.clone();
+		self.run(move |connection| {
+			let transaction = connection
+				.transaction_with_behavior(TransactionBehavior::Immediate)
+				.map_err(sql_error)?;
+			let outcome =
+				prepare_operation_sync(&transaction, &preparation, Some(&recovery_operation_id))?;
 			transaction.commit().map_err(sql_error)?;
 			Ok(outcome)
 		})
@@ -336,13 +363,19 @@ impl SqliteStore {
 		&self,
 		limit: u16,
 	) -> Result<Vec<AccountOperation>, StoreError> {
-		validate_limit(limit, "account operation limit must be between 1 and 512")?;
+		validate_bounded_limit(
+			limit,
+			MAX_UNSETTLED_ACCOUNT_OPERATION_COUNT,
+			"account operation limit must be between 1 and 1024",
+		)?;
 		self.run(move |connection| {
 			let mut statement = connection
 				.prepare(
 					"SELECT operation_id FROM account_operations
 					 WHERE phase NOT IN ('committed', 'cancelled')
-					 ORDER BY created_at_micros, operation_id LIMIT ?1",
+					   AND superseded_by_operation_id IS NULL
+					 ORDER BY recovery_operation_id IS NULL, created_at_micros, operation_id
+					 LIMIT ?1",
 				)
 				.map_err(sql_error)?;
 			let rows = statement
@@ -879,6 +912,7 @@ fn finish_command_sync(
 fn prepare_operation_sync(
 	connection: &Connection,
 	preparation: &AccountOperationPreparation,
+	recovery_operation_id: Option<&AccountOperationId>,
 ) -> Result<AccountLifecycleMutationOutcome, StoreError> {
 	if let Some(existing) = read_operation_sync(connection, &preparation.operation_id)? {
 		let descriptor_matches = existing.account_id == preparation.account_id
@@ -887,7 +921,8 @@ fn prepare_operation_sync(
 			&& existing.requested_display_label == preparation.display_label
 			&& existing.requested_enabled == preparation.enabled
 			&& existing.expected == preparation.expected
-			&& existing.target == preparation.target;
+			&& existing.target == preparation.target
+			&& existing.recovery_operation_id.as_ref() == recovery_operation_id;
 		let actual = mutation_for(connection, &existing.account_id, existing.phase)?;
 		return if descriptor_matches {
 			Ok(AccountLifecycleMutationOutcome::Replayed(actual))
@@ -899,10 +934,17 @@ fn prepare_operation_sync(
 		};
 	}
 
-	if let Some((phase, account_id)) = connection
+	if let Some(recovery_operation_id) = recovery_operation_id {
+		if let Some(rejection) =
+			validate_reauthentication_takeover_sync(connection, preparation, recovery_operation_id)?
+		{
+			return Ok(rejection);
+		}
+	} else if let Some((phase, account_id)) = connection
 		.query_row(
 			"SELECT phase, account_id FROM account_operations
-			 WHERE account_id = ?1 AND phase NOT IN ('committed', 'cancelled') LIMIT 1",
+			 WHERE account_id = ?1 AND phase NOT IN ('committed', 'cancelled')
+			   AND superseded_by_operation_id IS NULL LIMIT 1",
 			params![preparation.account_id.as_str()],
 			|row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
 		)
@@ -960,9 +1002,11 @@ fn prepare_operation_sync(
 			   operation_id, account_id, kind, phase, expected_account_revision,
 			   expected_credential_json, target_credential_json, provider,
 			   provider_account_id, requested_display_label, requested_enabled,
-			   recovery_code, created_at_micros, updated_at_micros, completed_at_micros
+			   recovery_code, created_at_micros, updated_at_micros, completed_at_micros,
+			   recovery_operation_id, superseded_by_operation_id
 			 ) VALUES (
-			   ?1, ?2, ?3, 'prepared', ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, ?11, ?11, NULL
+			   ?1, ?2, ?3, 'prepared', ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, ?11, ?11,
+			   NULL, ?12, NULL
 			 )",
 			params![
 				preparation.operation_id.as_str(),
@@ -976,6 +1020,7 @@ fn prepare_operation_sync(
 				preparation.display_label,
 				preparation.enabled,
 				now,
+				recovery_operation_id.map(AccountOperationId::as_str),
 			],
 		)
 		.map_err(sql_error)?;
@@ -983,6 +1028,60 @@ fn prepare_operation_sync(
 		account_revision: account.map_or(0, |value| value.revision),
 		phase: AccountOperationPhase::Prepared,
 	}))
+}
+
+fn validate_reauthentication_takeover_sync(
+	connection: &Connection,
+	preparation: &AccountOperationPreparation,
+	recovery_operation_id: &AccountOperationId,
+) -> Result<Option<AccountLifecycleMutationOutcome>, StoreError> {
+	let Some(recovery) = read_operation_sync(connection, recovery_operation_id)? else {
+		return Ok(Some(AccountLifecycleMutationOutcome::Rejected {
+			rejection: AccountLifecycleRejection::OperationMissing,
+			actual: AccountLifecycleMutation {
+				account_revision: 0,
+				phase: AccountOperationPhase::RecoveryRequired,
+			},
+		}));
+	};
+	let actual = mutation_for(connection, &recovery.account_id, recovery.phase)?;
+	let exact_ambiguity = preparation.kind == AccountOperationKind::Refresh
+		&& preparation.target.is_some()
+		&& recovery.account_id == preparation.account_id
+		&& recovery.kind == AccountOperationKind::Refresh
+		&& recovery.phase == AccountOperationPhase::RecoveryRequired
+		&& recovery.target.is_none()
+		&& recovery.recovery_code.is_some()
+		&& recovery.recovery_operation_id.is_none()
+		&& recovery.superseded_by_operation_id.is_none()
+		&& recovery.expected_account_revision == preparation.expected_account_revision
+		&& recovery.expected == preparation.expected;
+	if !exact_ambiguity {
+		return Ok(Some(AccountLifecycleMutationOutcome::Rejected {
+			rejection: AccountLifecycleRejection::StaleOperation,
+			actual,
+		}));
+	}
+	let active_takeover = connection
+		.query_row(
+			"SELECT phase FROM account_operations
+			 WHERE recovery_operation_id = ?1
+			   AND phase NOT IN ('committed', 'cancelled') LIMIT 1",
+			params![recovery_operation_id.as_str()],
+			|row| row.get::<_, String>(0),
+		)
+		.optional()
+		.map_err(sql_error)?;
+	if let Some(phase) = active_takeover {
+		return Ok(Some(AccountLifecycleMutationOutcome::Rejected {
+			rejection: AccountLifecycleRejection::OperationUnsettled,
+			actual: AccountLifecycleMutation {
+				account_revision: actual.account_revision,
+				phase: parse_operation_phase(&phase)?,
+			},
+		}));
+	}
+	Ok(None)
 }
 
 fn advance_operation_sync(
@@ -1003,7 +1102,10 @@ fn advance_operation_sync(
 	if operation.phase == target {
 		return Ok(AccountLifecycleMutationOutcome::Replayed(actual));
 	}
-	if operation.phase != expected || !allowed_operation_transition(expected, target) {
+	if operation.superseded_by_operation_id.is_some()
+		|| operation.phase != expected
+		|| !allowed_operation_transition(expected, target)
+	{
 		return Ok(AccountLifecycleMutationOutcome::Rejected {
 			rejection: AccountLifecycleRejection::StaleOperation,
 			actual,
@@ -1043,11 +1145,15 @@ fn advance_operation_sync(
 	)?))
 }
 
+#[allow(clippy::too_many_lines)] // Keep every account-operation commit and its takeover linkage in one transaction boundary.
 fn commit_account_operation(
 	connection: &Connection,
 	operation: &AccountOperation,
 ) -> Result<Option<AccountLifecycleRejection>, StoreError> {
 	let now = unix_micros().map_err(StoreError::from)?;
+	if let Some(rejection) = validate_reauthentication_takeover_commit(connection, operation)? {
+		return Ok(Some(rejection));
+	}
 	match operation.kind {
 		AccountOperationKind::Enroll | AccountOperationKind::Import => {
 			let Some(target) = operation.target.as_ref() else {
@@ -1166,7 +1272,53 @@ fn commit_account_operation(
 			bump_routing_revision(connection, now)?;
 		},
 	}
+	record_reauthentication_supersession(connection, operation, now)?;
 	Ok(None)
+}
+
+fn validate_reauthentication_takeover_commit(
+	connection: &Connection,
+	operation: &AccountOperation,
+) -> Result<Option<AccountLifecycleRejection>, StoreError> {
+	let Some(recovery_operation_id) = operation.recovery_operation_id.as_ref() else {
+		return Ok(None);
+	};
+	let Some(recovery) = read_operation_sync(connection, recovery_operation_id)? else {
+		return Ok(Some(AccountLifecycleRejection::OperationMissing));
+	};
+	let exact_ambiguity = operation.kind == AccountOperationKind::Refresh
+		&& recovery.account_id == operation.account_id
+		&& recovery.kind == AccountOperationKind::Refresh
+		&& recovery.phase == AccountOperationPhase::RecoveryRequired
+		&& recovery.target.is_none()
+		&& recovery.recovery_code.is_some()
+		&& recovery.recovery_operation_id.is_none()
+		&& recovery.superseded_by_operation_id.is_none()
+		&& recovery.expected_account_revision == operation.expected_account_revision
+		&& recovery.expected == operation.expected;
+	Ok((!exact_ambiguity).then_some(AccountLifecycleRejection::StaleOperation))
+}
+
+fn record_reauthentication_supersession(
+	connection: &Connection,
+	operation: &AccountOperation,
+	now: i64,
+) -> Result<(), StoreError> {
+	let Some(recovery_operation_id) = operation.recovery_operation_id.as_ref() else {
+		return Ok(());
+	};
+	let changed = connection
+		.execute(
+			"UPDATE account_operations
+			 SET superseded_by_operation_id = ?1, updated_at_micros = ?2
+			 WHERE operation_id = ?3 AND phase = 'recovery_required'
+			   AND target_credential_json IS NULL
+			   AND recovery_operation_id IS NULL
+			   AND superseded_by_operation_id IS NULL",
+			params![operation.operation_id.as_str(), now, recovery_operation_id.as_str()],
+		)
+		.map_err(sql_error)?;
+	if changed == 1 { Ok(()) } else { Err(incompatible("account reauthentication supersession")) }
 }
 
 fn set_operation_target_sync(
@@ -1189,6 +1341,7 @@ fn set_operation_target_sync(
 	}
 	if operation.phase != AccountOperationPhase::ProviderEffectPending
 		|| operation.target.is_some()
+		|| operation.superseded_by_operation_id.is_some()
 		|| target.writer_operation_id != *operation_id
 	{
 		return Ok(AccountLifecycleMutationOutcome::Rejected {
@@ -1219,7 +1372,8 @@ fn read_operation_sync(
 		.query_row(
 			"SELECT account_id, kind, phase, expected_account_revision,
 			        requested_display_label, requested_enabled,
-			        expected_credential_json, target_credential_json
+			        expected_credential_json, target_credential_json, recovery_code,
+			        recovery_operation_id, superseded_by_operation_id
 			 FROM account_operations WHERE operation_id = ?1",
 			params![operation_id.as_str()],
 			|row| {
@@ -1232,25 +1386,51 @@ fn read_operation_sync(
 					row.get::<_, Option<bool>>(5)?,
 					row.get::<_, Option<String>>(6)?,
 					row.get::<_, Option<String>>(7)?,
+					row.get::<_, Option<String>>(8)?,
+					row.get::<_, Option<String>>(9)?,
+					row.get::<_, Option<String>>(10)?,
 				))
 			},
 		)
 		.optional()
 		.map_err(sql_error)?
-		.map(|(account_id, kind, phase, revision, label, enabled, expected, target)| {
-			Ok(AccountOperation {
-				operation_id: operation_id.clone(),
-				account_id: AccountId::new(account_id)
-					.map_err(|_| incompatible("account identity"))?,
-				kind: parse_operation_kind(&kind)?,
-				phase: parse_operation_phase(&phase)?,
-				expected_account_revision: revision,
-				requested_display_label: label,
-				requested_enabled: enabled,
-				expected: parse_binding_json(expected.as_deref())?,
-				target: parse_binding_json(target.as_deref())?,
-			})
-		})
+		.map(
+			|(
+				account_id,
+				kind,
+				phase,
+				revision,
+				label,
+				enabled,
+				expected,
+				target,
+				recovery_code,
+				recovery_operation_id,
+				superseded_by_operation_id,
+			)| {
+				Ok(AccountOperation {
+					operation_id: operation_id.clone(),
+					account_id: AccountId::new(account_id)
+						.map_err(|_| incompatible("account identity"))?,
+					kind: parse_operation_kind(&kind)?,
+					phase: parse_operation_phase(&phase)?,
+					expected_account_revision: revision,
+					requested_display_label: label,
+					requested_enabled: enabled,
+					expected: parse_binding_json(expected.as_deref())?,
+					target: parse_binding_json(target.as_deref())?,
+					recovery_code,
+					recovery_operation_id: recovery_operation_id
+						.map(AccountOperationId::new)
+						.transpose()
+						.map_err(|_| incompatible("account recovery operation identity"))?,
+					superseded_by_operation_id: superseded_by_operation_id
+						.map(AccountOperationId::new)
+						.transpose()
+						.map_err(|_| incompatible("account superseding operation identity"))?,
+				})
+			},
+		)
 		.transpose()
 }
 
@@ -1431,7 +1611,10 @@ fn unsettled_operation_sync(
 	connection
 		.query_row(
 			"SELECT operation_id, kind, phase, recovery_code FROM account_operations
-			 WHERE account_id = ?1 AND phase NOT IN ('committed', 'cancelled') LIMIT 1",
+			 WHERE account_id = ?1 AND phase NOT IN ('committed', 'cancelled')
+			   AND superseded_by_operation_id IS NULL
+			 ORDER BY recovery_operation_id IS NULL, created_at_micros, operation_id
+			 LIMIT 1",
 			params![account_id.as_str()],
 			|row| {
 				Ok((
@@ -1864,7 +2047,15 @@ fn validate_preparation(preparation: &AccountOperationPreparation) -> Result<(),
 }
 
 fn validate_limit(limit: u16, reason: &'static str) -> Result<(), StoreError> {
-	if limit == 0 || usize::from(limit) > MAX_ACCOUNT_COUNT {
+	validate_bounded_limit(limit, MAX_ACCOUNT_COUNT, reason)
+}
+
+fn validate_bounded_limit(
+	limit: u16,
+	maximum: usize,
+	reason: &'static str,
+) -> Result<(), StoreError> {
+	if limit == 0 || usize::from(limit) > maximum {
 		Err(StoreError::InvalidInput(reason))
 	} else {
 		Ok(())

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -303,6 +303,7 @@ mod tests {
 	const ACCOUNT: &str = "10000000-0000-4000-8000-000000000001";
 	const OPERATION_ONE: &str = "20000000-0000-4000-8000-000000000001";
 	const OPERATION_TWO: &str = "20000000-0000-4000-8000-000000000002";
+	const OPERATION_THREE: &str = "20000000-0000-4000-8000-000000000003";
 	const DIGEST_ONE: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 	const DIGEST_TWO: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
@@ -433,6 +434,84 @@ mod tests {
 		assert_eq!(revision, 2);
 		assert_eq!(instructions, "Follow the user request for this task.");
 		assert!(table_sql.contains("BETWEEN 1 AND 65536"));
+	}
+
+	#[tokio::test]
+	async fn upgrades_v7_refresh_ambiguity_without_settling_or_rewriting_it() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("decodex.sqlite3");
+		let connection = Connection::open(&path).expect("open V7 fixture");
+		migrations::configure(&connection).expect("configure V7 fixture");
+		let sources = [
+			("local_product", include_str!("../migrations/0001_local_product.sql")),
+			(
+				"nonempty_task_instructions",
+				include_str!("../migrations/0002_nonempty_task_instructions.sql"),
+			),
+			(
+				"quick_task_execution_controls",
+				include_str!("../migrations/0003_quick_task_execution_controls.sql"),
+			),
+			("context_pack_fallback", include_str!("../migrations/0004_context_pack_fallback.sql")),
+			(
+				"adaptive_factory_spine",
+				include_str!("../migrations/0005_adaptive_factory_spine.sql"),
+			),
+			(
+				"repeatable_program_loop",
+				include_str!("../migrations/0006_repeatable_program_loop.sql"),
+			),
+			(
+				"builtin_domain_pack_binding",
+				include_str!("../migrations/0007_builtin_domain_pack_binding.sql"),
+			),
+		];
+		let digests = migrations::expected_migration_digests();
+		for (index, (name, source)) in sources.into_iter().enumerate() {
+			connection.execute_batch(source).expect("apply V7 migration fixture");
+			connection
+				.execute(
+					"INSERT INTO schema_migrations (version, name, sha256, applied_at_micros)
+					 VALUES (?1, ?2, ?3, ?4)",
+					rusqlite::params![(index + 1) as i64, name, digests[index], (index + 1) as i64],
+				)
+				.expect("record V7 migration fixture");
+		}
+		connection
+			.pragma_update(None, "application_id", migrations::APPLICATION_ID)
+			.expect("set application identity");
+		connection.pragma_update(None, "user_version", 7).expect("set V7 version");
+		connection
+			.execute(
+				"INSERT INTO account_identities (account_id, created_at_micros) VALUES (?1, 1)",
+				rusqlite::params![ACCOUNT],
+			)
+			.expect("seed account identity");
+		connection
+			.execute(
+				"INSERT INTO account_operations (
+				   operation_id, account_id, kind, phase, expected_account_revision,
+				   provider, provider_account_id, recovery_code, created_at_micros,
+				   updated_at_micros
+				 ) VALUES (?1, ?2, 'refresh', 'recovery_required', 1, 'chatgpt',
+				           'provider-account', 'provider_refresh_ambiguous', 1, 1)",
+				rusqlite::params![OPERATION_TWO, ACCOUNT],
+			)
+			.expect("seed refresh ambiguity");
+		drop(connection);
+
+		let store = SqliteStore::open_test(&path).expect("upgrade V7 fixture");
+		let ambiguity = store
+			.read_account_operation(
+				&AccountOperationId::new(OPERATION_TWO).expect("operation identity"),
+			)
+			.await
+			.expect("read upgraded ambiguity")
+			.expect("ambiguity remains present");
+		assert_eq!(ambiguity.phase, AccountOperationPhase::RecoveryRequired);
+		assert_eq!(ambiguity.recovery_code.as_deref(), Some("provider_refresh_ambiguous"));
+		assert!(ambiguity.recovery_operation_id.is_none());
+		assert!(ambiguity.superseded_by_operation_id.is_none());
 	}
 
 	#[test]
@@ -709,6 +788,197 @@ mod tests {
 				.await,
 			Err(StoreError::InvalidInput(_))
 		));
+	}
+
+	#[tokio::test]
+	#[allow(clippy::too_many_lines)] // One complete persisted takeover regression is easier to audit than split fixture phases.
+	async fn verified_reauthentication_can_replace_a_targetless_ambiguous_refresh() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("decodex.sqlite3");
+		let store = SqliteStore::open_test(&path).expect("initialize store");
+		let (account_id, enrollment_id, provider, current) = account_fixture();
+
+		store
+			.prepare_account_operation(&AccountOperationPreparation {
+				operation_id: enrollment_id.clone(),
+				account_id: account_id.clone(),
+				kind: AccountOperationKind::Enroll,
+				display_label: Some("Primary".to_owned()),
+				enabled: Some(true),
+				expected_account_revision: None,
+				expected: None,
+				target: Some(current.clone()),
+				provider: provider.clone(),
+			})
+			.await
+			.expect("prepare enrollment");
+		store
+			.create_credential(CredentialRecord {
+				key: fixture_key(1, DIGEST_ONE, OPERATION_ONE),
+				payload: Zeroizing::new(b"opaque-current-bundle".to_vec()),
+			})
+			.expect("write current credential");
+		store
+			.advance_account_operation(
+				&enrollment_id,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::StoreApplied,
+				None,
+			)
+			.await
+			.expect("record enrollment store effect");
+		store
+			.advance_account_operation(
+				&enrollment_id,
+				AccountOperationPhase::StoreApplied,
+				AccountOperationPhase::Committed,
+				None,
+			)
+			.await
+			.expect("commit enrollment");
+
+		let ambiguous_id = AccountOperationId::new(OPERATION_TWO).expect("ambiguous operation");
+		store
+			.prepare_account_operation(&AccountOperationPreparation {
+				operation_id: ambiguous_id.clone(),
+				account_id: account_id.clone(),
+				kind: AccountOperationKind::Refresh,
+				display_label: None,
+				enabled: None,
+				expected_account_revision: Some(1),
+				expected: Some(current.clone()),
+				target: None,
+				provider: provider.clone(),
+			})
+			.await
+			.expect("prepare provider refresh");
+		store
+			.advance_account_operation(
+				&ambiguous_id,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::ProviderEffectPending,
+				None,
+			)
+			.await
+			.expect("record possible provider effect");
+		store
+			.advance_account_operation(
+				&ambiguous_id,
+				AccountOperationPhase::ProviderEffectPending,
+				AccountOperationPhase::RecoveryRequired,
+				Some("provider_refresh_ambiguous"),
+			)
+			.await
+			.expect("preserve ambiguous provider effect");
+
+		let reauthentication_id =
+			AccountOperationId::new(OPERATION_THREE).expect("reauthentication operation");
+		let target = CredentialBinding {
+			schema_version: CredentialStoreSchemaVersion::V1,
+			version: CredentialVersion::new(2).expect("successor credential version"),
+			fingerprint: CredentialFingerprint::new(DIGEST_TWO).expect("target fingerprint"),
+			provider: provider.clone(),
+			writer_operation_id: reauthentication_id.clone(),
+		};
+		let prepared = store
+			.prepare_account_reauthentication_takeover(
+				&AccountOperationPreparation {
+					operation_id: reauthentication_id.clone(),
+					account_id,
+					kind: AccountOperationKind::Refresh,
+					display_label: None,
+					enabled: None,
+					expected_account_revision: Some(1),
+					expected: Some(current),
+					target: Some(target.clone()),
+					provider,
+				},
+				&ambiguous_id,
+			)
+			.await
+			.expect("prepare verified reauthentication");
+
+		assert!(matches!(
+			prepared,
+			AccountLifecycleMutationOutcome::Applied(ref mutation)
+				if mutation.phase == AccountOperationPhase::Prepared
+		));
+		let ambiguity_before_effect = store
+			.read_account_operation(&ambiguous_id)
+			.await
+			.expect("read pre-effect ambiguity")
+			.expect("pre-effect ambiguity remains durable");
+		assert!(ambiguity_before_effect.superseded_by_operation_id.is_none());
+		assert!(
+			store
+				.read_account_registry(None, 512)
+				.await
+				.expect("read pre-effect account")
+				.pop()
+				.expect("pre-effect account remains present")
+				.unsettled_operation
+				.is_some()
+		);
+		store
+			.rotate_credential(
+				&fixture_key(1, DIGEST_ONE, OPERATION_ONE),
+				CredentialRecord {
+					key: fixture_key(2, DIGEST_TWO, OPERATION_THREE),
+					payload: Zeroizing::new(b"opaque-verified-bundle".to_vec()),
+				},
+			)
+			.expect("replace exact current credential");
+		store
+			.advance_account_operation(
+				&reauthentication_id,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::StoreApplied,
+				None,
+			)
+			.await
+			.expect("record verified credential effect");
+		store
+			.advance_account_operation(
+				&reauthentication_id,
+				AccountOperationPhase::StoreApplied,
+				AccountOperationPhase::Committed,
+				None,
+			)
+			.await
+			.expect("commit verified reauthentication");
+
+		let ambiguity = store
+			.read_account_operation(&ambiguous_id)
+			.await
+			.expect("read ambiguity")
+			.expect("ambiguity remains durable");
+		assert_eq!(ambiguity.phase, AccountOperationPhase::RecoveryRequired);
+		assert_eq!(ambiguity.recovery_code.as_deref(), Some("provider_refresh_ambiguous"));
+		assert_eq!(ambiguity.target, None);
+		assert_eq!(ambiguity.superseded_by_operation_id, Some(reauthentication_id.clone()));
+		let takeover = store
+			.read_account_operation(&reauthentication_id)
+			.await
+			.expect("read takeover")
+			.expect("takeover remains durable");
+		assert_eq!(takeover.recovery_operation_id, Some(ambiguous_id));
+		assert_eq!(takeover.target, Some(target.clone()));
+		let account = store
+			.read_account_registry(None, 512)
+			.await
+			.expect("read settled account")
+			.pop()
+			.expect("account remains present");
+		assert_eq!(account.revision, 2);
+		assert_eq!(account.credential, Some(target));
+		assert!(account.unsettled_operation.is_none());
+		assert!(
+			store
+				.read_unsettled_account_operations(512)
+				.await
+				.expect("read unsettled operations")
+				.is_empty()
+		);
 	}
 
 	#[test]

--- a/database/src/migrations.rs
+++ b/database/src/migrations.rs
@@ -6,7 +6,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{DatabaseError, error::sqlite_error};
 
 pub(crate) const APPLICATION_ID: i64 = 0x4443_5831;
-const CURRENT_SCHEMA_VERSION: i64 = 7;
+const CURRENT_SCHEMA_VERSION: i64 = 8;
 
 struct Migration {
 	version: i64,
@@ -49,6 +49,11 @@ const MIGRATIONS: &[Migration] = &[
 		version: 7,
 		name: "builtin_domain_pack_binding",
 		sql: include_str!("../migrations/0007_builtin_domain_pack_binding.sql"),
+	},
+	Migration {
+		version: 8,
+		name: "account_reauthentication_takeover",
+		sql: include_str!("../migrations/0008_account_reauthentication_takeover.sql"),
 	},
 ];
 

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -486,6 +486,13 @@ and does not own provider observation. After successful login replacement, bound
 readback waits for the daemon's new revision-scoped observation instead of accepting an
 old unauthorized value.
 
+The same `Refresh login` action is available for one targetless ambiguous refresh. Swift
+passes only the exact recovery operation identity through the existing typed Rust bridge.
+The database keeps the old ambiguity admission-blocking while the new target-backed login
+operation performs its existing compare-and-swap. Only the new operation's atomic account
+commit links and supersedes the old fence. A pre-commit failure leaves the original
+`RecoveryRequired` fact unchanged and does not claim cancellation.
+
 Candidate-5 changes must preserve this current-main observation/cache and UI/backend
 behavior exactly.
 

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -175,8 +175,8 @@ the pre-existing malformed-cycle tests pass together. After this correction, the
 complete GPUI package passed 120 tests with two live tests ignored.
 
 The client does not activate the deferred general WorkItem and Project query surface.
-Protocol V2.4 is exact-current. The Adaptive Program controller uses only its bounded
-V2.4 Program and built-in Domain Pack commands and queries. The unrelated WorkItem board
+Protocol V2.5 is exact-current. The Adaptive Program controller uses only its bounded
+Program and built-in Domain Pack commands and queries. The unrelated WorkItem board
 controller stays dormant. This keeps deferred Factory surfaces from affecting
 Conversation history or the Workbench connection.
 
@@ -260,16 +260,19 @@ remain outside this lifecycle-refresh milestone because
 or tool effects. Only one positively client-ID-correlated Decodex Turn may repair its own
 terminal state and assistant suffix.
 
-Protocol V2.4 carries the controls, archive event, bounded Program aggregate, and
-built-in Domain Pack projection. SQLite
+Protocol V2.5 carries the controls, archive event, bounded Program aggregate, built-in
+Domain Pack projection, and the optional exact recovery-operation identity for official
+device-login takeover. It carries no credential value. SQLite
 schema version 3 adds the original Quick Task execution settings. Schema version 4 adds
 the migration-owned `context_packs` table. Schema version 5 adds the Program, Signal,
 Claim, Proposal, Objective, WorkItem binding, Evidence, Review, and semantic identity
 tables. Schema version 6 adds exact predecessor Review lineage for continued Signals,
 root and successor uniqueness, and same-Program lineage guards. Schema version 7 adds
-one immutable Program-to-Pack binding table. It retains the exact 40-table inventory.
-The schema-7 local database gate passed with WAL, `quick_check`, foreign-key
-verification, all seven exact migration digests, and the 40-table inventory. The exact
+one immutable Program-to-Pack binding table. Schema version 8 adds two account-operation
+takeover links and replacement indexes. It does not add another table or rewrite an
+ambiguity as cancellation. It retains the exact 40-table inventory. The schema-8 local
+database gate passed with WAL, `quick_check`, foreign-key verification, all eight exact
+migration digests, and the 40-table inventory. The exact
 two-domain result is in the
 [Built-in Domain Pack Pressure Test V1 evidence](builtin-domain-pack-pressure-test-v1.md).
 

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -29,6 +29,14 @@ key check.
 Normal `decodexd serve` opens and verifies the same database. It does not start or contact
 a database server.
 
+Schema version 8 adds two nullable self-references to the existing account-operation
+journal. They bind one verified reauthentication to one targetless refresh ambiguity and
+record the successful supersession without changing the old operation's recovery phase or
+reason. The migration is additive, preserves existing rows, and replaces the unsettled
+operation indexes atomically. A binary rollback across this schema boundary must retain a
+matching pre-upgrade private database backup; an older daemon does not accept a newer
+migration ledger.
+
 ## Fresh installation
 
 Build one signed, team-consistent local-service set before installation:

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -271,6 +271,16 @@ the private source exists. Prepared-operation startup and command replay compare
 expected and target bindings; only an exact expected binding can prove that cancellation
 is safe, and ambiguous store state becomes `RecoveryRequired`.
 
+A targetless `Refresh` in `RecoveryRequired` can be replaced only by another successful
+official device login that names that exact recovery operation. The new target-backed
+`Refresh` must retain the same account revision, expected credential binding, and provider
+identity. It can coexist with only that one ambiguity while it performs the ordinary
+HostCredentialStore compare-and-swap. The old operation remains `RecoveryRequired`, keeps
+its recovery code, and continues to fence admission until the new credential reaches
+`StoreApplied` and the registry commit atomically records which new operation superseded
+it. Cancellation or failure before that commit leaves the old ambiguity and fence intact.
+This takeover is not evidence that the earlier provider effect did or did not occur.
+
 ## ProcessGeneration binding
 
 The owning [ProcessGeneration authority](process-generation-authority.md) must extend

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -166,7 +166,7 @@ bounded inline value or a digest and length.
 
 ## Repeatable Program Loop V1
 
-The current protocol accepts exact V2.4 clients. It adds one bounded, manually repeated
+The current protocol accepts exact V2.5 clients. It retains the bounded, manually repeated
 Program aggregate above the existing Quick Task execution path. The initial command
 creates one Program charter, one sourced Signal, one Claim, one non-executable Proposal,
 one finite Objective, and one ready WorkItem in one SQLite transaction.

--- a/scripts/vnext/local_database_gate.py
+++ b/scripts/vnext/local_database_gate.py
@@ -48,6 +48,11 @@ MIGRATIONS = (
         "builtin_domain_pack_binding",
         ROOT / "database/migrations/0007_builtin_domain_pack_binding.sql",
     ),
+    (
+        8,
+        "account_reauthentication_takeover",
+        ROOT / "database/migrations/0008_account_reauthentication_takeover.sql",
+    ),
 )
 DATABASE_RELATIVE_PATH = Path("server/decodex.sqlite3")
 APPLICATION_ID = 0x4443_5831


### PR DESCRIPTION
Summary
- preserve targetless provider-refresh ambiguity while verified device login takes over the credential binding
- keep revision, idempotency, CAS, operation fencing, typed protocol, FFI, and Swift credential boundaries intact
- expose Refresh login for the exact recovery state and advance protocol to V2.5 / schema to 8

Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make test
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo make check-rust
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-app

Known baseline
- aggregate pinned-format and lint tasks still fail on existing untouched-file drift; touched implementation has no new formatter or lint diagnostic