### PR TITLE
Restore account login and align App artifact cohort

### DIFF
--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -182,6 +182,7 @@ enum AccountLoginMethod: String, Encodable, Equatable, Sendable {
 enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 	case loginFailed = "login_failed"
 	case loginTimedOut = "login_timed_out"
+	case deviceAuthorizationRejected = "device_authorization_rejected"
 	case accountMismatch = "account_mismatch"
 	case accountChanged = "account_changed"
 	case accountUnavailable = "account_unavailable"
@@ -199,6 +200,8 @@ enum AccountReauthenticationFailure: String, Decodable, Equatable, Sendable {
 			return "Codex could not complete the login."
 		case .loginTimedOut:
 			return "The login timed out. Try again."
+		case .deviceAuthorizationRejected:
+			return "Device-code approval failed. Check ChatGPT Security, then try again."
 		case .accountMismatch:
 			return "This login belongs to a different account."
 		case .accountChanged:
@@ -236,6 +239,23 @@ struct AccountReauthenticationStatus: Equatable, Sendable {
 	let prompt: AccountReauthenticationPrompt?
 	let authorizationURL: URL?
 	let failure: AccountReauthenticationFailure?
+	let resolvedAccountID: String?
+
+	init(
+		sessionID: String,
+		state: AccountReauthenticationState,
+		prompt: AccountReauthenticationPrompt?,
+		authorizationURL: URL?,
+		failure: AccountReauthenticationFailure?,
+		resolvedAccountID: String? = nil
+	) {
+		self.sessionID = sessionID
+		self.state = state
+		self.prompt = prompt
+		self.authorizationURL = authorizationURL
+		self.failure = failure
+		self.resolvedAccountID = resolvedAccountID
+	}
 }
 
 protocol AccountControlClient: ResetCardClient {
@@ -396,8 +416,8 @@ extension DecodexNativeClient: AccountControlClient {
 				enabled: enabled
 			),
 			authority: authority,
-			expected: .accountChanged(
-				accountID: accountID,
+			expected: .accountEnrollment(
+				requestedAccountID: accountID,
 				enabled: enabled
 			)
 		)
@@ -792,6 +812,7 @@ private struct AccountReauthenticationWire: Decodable {
 			in: decoder,
 			allowed: [
 				"session_id", "state", "prompt", "authorization_url", "failure",
+				"resolved_account_id",
 			]
 		)
 		let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -813,13 +834,19 @@ private struct AccountReauthenticationWire: Decodable {
 			AccountReauthenticationFailure.self,
 			forKey: .failure
 		)
+		let resolvedAccountID = try container.decodeIfPresent(
+			String.self,
+			forKey: .resolvedAccountID
+		)
 		guard DecodexNativeClient.isCanonicalUUID(sessionID),
 			authorizationURLText == nil || authorizationURL != nil,
+			resolvedAccountID.map(DecodexNativeClient.isCanonicalUUID) ?? true,
 			Self.hasValidShape(
 				state: state,
 				prompt: prompt,
 				authorizationURL: authorizationURL,
-				failure: failure
+				failure: failure,
+				resolvedAccountID: resolvedAccountID
 			)
 		else {
 			throw AccountControlError.invalidResponse
@@ -829,7 +856,8 @@ private struct AccountReauthenticationWire: Decodable {
 			state: state,
 			prompt: prompt,
 			authorizationURL: authorizationURL,
-			failure: failure
+			failure: failure,
+			resolvedAccountID: resolvedAccountID
 		)
 	}
 
@@ -837,17 +865,24 @@ private struct AccountReauthenticationWire: Decodable {
 		state: AccountReauthenticationState,
 		prompt: AccountReauthenticationPrompt?,
 		authorizationURL: URL?,
-		failure: AccountReauthenticationFailure?
+		failure: AccountReauthenticationFailure?,
+		resolvedAccountID: String?
 	) -> Bool {
 		switch state {
-		case .requestingCode, .openingBrowser, .installing, .completed, .cancelled:
+		case .completed:
 			return prompt == nil && authorizationURL == nil && failure == nil
+				&& resolvedAccountID != nil
+		case .requestingCode, .openingBrowser, .installing, .cancelled:
+			return prompt == nil && authorizationURL == nil && failure == nil
+				&& resolvedAccountID == nil
 		case .waitingForBrowser:
 			return failure == nil
 				&& (prompt != nil) != (authorizationURL != nil)
-				&& authorizationURL.map(Self.isValidAuthorizationURL) ?? true
+				&& (authorizationURL.map(Self.isValidAuthorizationURL) ?? true)
+				&& resolvedAccountID == nil
 		case .failed:
 			return prompt == nil && authorizationURL == nil && failure != nil
+				&& resolvedAccountID == nil
 		}
 	}
 
@@ -919,10 +954,12 @@ private struct AccountReauthenticationWire: Decodable {
 		case prompt
 		case authorizationURL = "authorization_url"
 		case failure
+		case resolvedAccountID = "resolved_account_id"
 	}
 }
 private enum AccountControlExpectedResult {
 	case accountChanged(accountID: String, enabled: Bool?)
+	case accountEnrollment(requestedAccountID: String, enabled: Bool)
 	case accountLoggedOut(accountID: String)
 	case routing(mode: AccountRoutingMode)
 	case routingOrder([String])
@@ -1104,6 +1141,7 @@ private enum AccountControlWireResponse: Decodable {
 
 private enum AccountControlResultPayloadWire: Decodable {
 	case accountChanged(ResetCardAccountWire)
+	case accountRestored(requestedAccountID: String, account: ResetCardAccountWire)
 	case accountLoggedOut(accountID: String, tombstoneRevision: UInt64)
 	case routingChanged(AccountRoutingWire)
 	case codexAuthProjected(accountID: String, accountRevision: UInt64, projectionDigest: String)
@@ -1115,6 +1153,16 @@ private enum AccountControlResultPayloadWire: Decodable {
 			try requireExactFields(in: decoder, expected: ["name", "data"])
 			let data = try container.decode(AccountChangedData.self, forKey: .data)
 			self = .accountChanged(data.account)
+		case "account_restored":
+			try requireExactFields(in: decoder, expected: ["name", "data"])
+			let data = try container.decode(AccountRestoredData.self, forKey: .data)
+			guard DecodexNativeClient.isCanonicalAccountID(data.requestedAccountID) else {
+				throw AccountControlError.invalidResponse
+			}
+			self = .accountRestored(
+				requestedAccountID: data.requestedAccountID,
+				account: data.account
+			)
 		case "account_logged_out":
 			try requireExactFields(in: decoder, expected: ["name", "data"])
 			let data = try container.decode(AccountLoggedOutData.self, forKey: .data)
@@ -1183,6 +1231,31 @@ private enum AccountControlResultPayloadWire: Decodable {
 				)
 			)
 		case (
+			.accountChanged(let wire),
+			.accountEnrollment(let requestedAccountID, let expectedEnabled)
+		):
+			let decoded = try wire.record()
+			guard decoded.accountID == requestedAccountID,
+				decoded.accountRevision == entityRevision,
+				decoded.enabled == expectedEnabled
+			else {
+				throw AccountControlError.invalidResponse
+			}
+			return .accountChanged(decoded.withAuthority(authority))
+		case (
+			.accountRestored(let requestedAccountID, let wire),
+			.accountEnrollment(let expectedRequestedID, let expectedEnabled)
+		):
+			let decoded = try wire.record()
+			guard requestedAccountID == expectedRequestedID,
+				decoded.accountID != requestedAccountID,
+				decoded.accountRevision == entityRevision,
+				decoded.enabled == expectedEnabled
+			else {
+				throw AccountControlError.invalidResponse
+			}
+			return .accountChanged(decoded.withAuthority(authority))
+		case (
 			.accountLoggedOut(let accountID, let tombstoneRevision),
 			.accountLoggedOut(let expectedID)
 		):
@@ -1235,6 +1308,26 @@ private enum AccountControlResultPayloadWire: Decodable {
 		}
 
 		private enum CodingKeys: String, CodingKey {
+			case account
+		}
+	}
+
+	private struct AccountRestoredData: Decodable {
+		let requestedAccountID: String
+		let account: ResetCardAccountWire
+
+		init(from decoder: Decoder) throws {
+			try requireExactFields(
+				in: decoder,
+				expected: ["requested_account_id", "account"]
+			)
+			let container = try decoder.container(keyedBy: CodingKeys.self)
+			requestedAccountID = try container.decode(String.self, forKey: .requestedAccountID)
+			account = try container.decode(ResetCardAccountWire.self, forKey: .account)
+		}
+
+		private enum CodingKeys: String, CodingKey {
+			case requestedAccountID = "requested_account_id"
 			case account
 		}
 	}
@@ -1302,6 +1395,24 @@ private enum AccountControlResultPayloadWire: Decodable {
 	private enum CodingKeys: String, CodingKey {
 		case name
 		case data
+	}
+}
+
+private extension ResetCardAccountRecord {
+	func withAuthority(_ authority: ResetCardAuthority?) -> ResetCardAccountRecord {
+		ResetCardAccountRecord(
+			authority: authority,
+			accountID: accountID,
+			alias: alias,
+			accountRevision: accountRevision,
+			enabled: enabled,
+			observedState: observedState,
+			lifecycleReadiness: lifecycleReadiness,
+			credentialBinding: credentialBinding,
+			unsettledOperation: unsettledOperation,
+			fiveHourQuota: fiveHourQuota,
+			sevenDayQuota: sevenDayQuota
+		)
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeClient.swift
@@ -4,8 +4,6 @@ import Foundation
 let decodexNativeClientSchema = "decodex/app-native-client/1"
 
 private let decodexNativeClientConfigSchema = "decodex/app-native-client-config/1"
-private let decodexNativeClientABIVersion: UInt32 = 1
-private let decodexNativeArtifactCohort: UInt32 = 1
 private let decodexNativeClientResponseLimit = 8 * 1024 * 1024
 
 struct DecodexNativeRequest: Encodable, Sendable {
@@ -448,8 +446,6 @@ private struct DecodexNativeConfig: Encodable {
 }
 
 private final class DecodexNativeLibrary: @unchecked Sendable {
-	typealias ABIVersion = @convention(c) () -> UInt32
-	typealias ArtifactCohort = @convention(c) () -> UInt32
 	typealias Create = @convention(c) (
 		UnsafePointer<UInt8>?,
 		Int,
@@ -483,26 +479,15 @@ private final class DecodexNativeLibrary: @unchecked Sendable {
 			"libdecodex_app_client_ffi.dylib",
 			isDirectory: false
 		)
-		guard let image = dlopen(libraryURL.path, RTLD_NOW | RTLD_LOCAL) else {
+		let image: UnsafeMutableRawPointer
+		do {
+			image = try DecodexNativeCompatibility.openLibrary(at: libraryURL)
+		} catch {
 			throw ResetCardClientError.nativeClientUnavailable
 		}
 		self.image = image
 
 		do {
-			let abi: ABIVersion = try Self.symbol(
-				image,
-				named: "decodex_app_native_client_abi_version"
-			)
-			guard abi() == decodexNativeClientABIVersion else {
-				throw ResetCardClientError.nativeClientUnavailable
-			}
-			let artifactCohort: ArtifactCohort = try Self.symbol(
-				image,
-				named: "decodex_app_native_client_artifact_cohort"
-			)
-			guard artifactCohort() == decodexNativeArtifactCohort else {
-				throw ResetCardClientError.nativeClientUnavailable
-			}
 			create = try Self.symbol(
 				image,
 				named: "decodex_app_native_client_create"

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift
@@ -1,0 +1,50 @@
+import Darwin
+import Foundation
+
+let decodexNativeClientABIVersion: UInt32 = 1
+let decodexNativeArtifactCohort: UInt32 = 2
+
+enum DecodexNativeCompatibility {
+	private typealias Version = @convention(c) () -> UInt32
+
+	private enum LoadError: Error {
+		case unavailable
+	}
+
+	static func openLibrary(at libraryURL: URL) throws -> UnsafeMutableRawPointer {
+		guard let image = dlopen(libraryURL.path, RTLD_NOW | RTLD_LOCAL) else {
+			throw LoadError.unavailable
+		}
+
+		do {
+			let abiVersion: Version = try symbol(
+				image,
+				named: "decodex_app_native_client_abi_version"
+			)
+			guard abiVersion() == decodexNativeClientABIVersion else {
+				throw LoadError.unavailable
+			}
+			let artifactCohort: Version = try symbol(
+				image,
+				named: "decodex_app_native_client_artifact_cohort"
+			)
+			guard artifactCohort() == decodexNativeArtifactCohort else {
+				throw LoadError.unavailable
+			}
+			return image
+		} catch {
+			dlclose(image)
+			throw error
+		}
+	}
+
+	private static func symbol<T>(
+		_ image: UnsafeMutableRawPointer,
+		named name: String
+	) throws -> T {
+		guard let value = dlsym(image, name) else {
+			throw LoadError.unavailable
+		}
+		return unsafeBitCast(value, to: T.self)
+	}
+}

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -1743,8 +1743,20 @@ final class ResetCardStore {
 			case .completed:
 				accountReauthenticationTask?.cancel()
 				accountReauthenticationTask = nil
+				guard let resolvedAccountID = status.resolvedAccountID,
+					presentation.mode == .enrollment
+						|| resolvedAccountID == presentation.accountID
+				else {
+					await failAccountReauthentication(
+						accountID: presentation.accountID,
+						sessionID: presentation.sessionID,
+						message: AccountControlError.invalidResponse.localizedDescription
+					)
+					return
+				}
 				await completeAccountReauthentication(
-					accountID: presentation.accountID,
+					requestedAccountID: presentation.accountID,
+					resolvedAccountID: resolvedAccountID,
 					sessionID: presentation.sessionID
 				)
 			case .failed:
@@ -3145,8 +3157,19 @@ final class ResetCardStore {
 			)
 			return false
 		case .completed:
+			guard let resolvedAccountID = status.resolvedAccountID,
+				presentation.mode == .enrollment || resolvedAccountID == accountID
+			else {
+				await failAccountReauthentication(
+					accountID: accountID,
+					sessionID: sessionID,
+					message: AccountControlError.invalidResponse.localizedDescription
+				)
+				return true
+			}
 			await completeAccountReauthentication(
-				accountID: accountID,
+				requestedAccountID: accountID,
+				resolvedAccountID: resolvedAccountID,
 				sessionID: sessionID
 			)
 			return true
@@ -3180,16 +3203,22 @@ final class ResetCardStore {
 			return loginMethod == .deviceCode
 				&& status.prompt == nil
 				&& status.authorizationURL == nil
+				&& status.resolvedAccountID == nil
 		case .openingBrowser:
 			return loginMethod == .browserRedirect
 				&& status.prompt == nil
 				&& status.authorizationURL == nil
+				&& status.resolvedAccountID == nil
 		case .waitingForBrowser:
-			return loginMethod == .deviceCode
+			return status.resolvedAccountID == nil && (loginMethod == .deviceCode
 				? status.prompt != nil && status.authorizationURL == nil
-				: status.prompt == nil && status.authorizationURL != nil
-		case .installing, .completed, .failed, .cancelled:
+				: status.prompt == nil && status.authorizationURL != nil)
+		case .completed:
 			return status.prompt == nil && status.authorizationURL == nil
+				&& status.resolvedAccountID != nil
+		case .installing, .failed, .cancelled:
+			return status.prompt == nil && status.authorizationURL == nil
+				&& status.resolvedAccountID == nil
 		}
 	}
 
@@ -3218,7 +3247,8 @@ final class ResetCardStore {
 	}
 
 	private func completeAccountReauthentication(
-		accountID: String,
+		requestedAccountID: String,
+		resolvedAccountID: String,
 		sessionID: String
 	) async {
 		guard let presentation = accountReauthentication,
@@ -3226,7 +3256,7 @@ final class ResetCardStore {
 		else {
 			return
 		}
-		accountControlActivities.removeValue(forKey: accountID)
+		accountControlActivities.removeValue(forKey: requestedAccountID)
 		if presentation.mode == .enrollment {
 			isEnrollingAccount = false
 		}
@@ -3238,7 +3268,7 @@ final class ResetCardStore {
 		case .enrollment:
 			message = ResetCardStoreMessage(tone: .success, text: "Account added.")
 			await refreshEnrolledAccountAuthority(
-				accountID,
+				resolvedAccountID,
 				retryDelays: accountObservationRetryDelays
 			)
 		case .reauthentication:
@@ -3247,7 +3277,7 @@ final class ResetCardStore {
 				text: "Account login refreshed."
 			)
 			await refreshReauthenticatedAccountAuthority(
-				accountID,
+				resolvedAccountID,
 				retryDelays: accountObservationRetryDelays
 			)
 		}

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -387,6 +387,44 @@ final class AccountControlNativeClientTests: XCTestCase {
 		XCTAssertEqual(request.authority, authority)
 	}
 
+	func testSharedEnrollmentAcceptsOnlyTheResolvedTombstonedAccountResult() async throws {
+		let authority = authority
+		let requestedAccountID = accountID
+		let restoredAccountID = secondAccountID
+		let recorder = NativeRequestRecorder()
+		let client = DecodexNativeClient { request, requestedAuthority in
+			recorder.append(request, authority: requestedAuthority)
+			return nativeSuccess(
+				operation: "enroll_account",
+				authority: authority,
+				data: """
+				{"outcome":"applied","data":{"entity_revision":3,
+				  "result":{"name":"account_restored","data":{
+				    "requested_account_id":"\(requestedAccountID)","account":
+				    \(controlAccountJSON(accountID: restoredAccountID, alias: "Iris", revision: 3, enabled: true))
+				  }}}}
+				"""
+			)
+		}
+
+		let result = try await client.enrollFromSharedCodex(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			enabled: true,
+			idempotencyKey: idempotencyKey
+		)
+		guard case .accountChanged(let restored) = result else {
+			return XCTFail("Restoration must return the authoritative account")
+		}
+		XCTAssertEqual(restored.accountID, secondAccountID)
+		XCTAssertEqual(restored.accountRevision, 3)
+		let request = try XCTUnwrap(recorder.requests.first)
+		let object = try nativeJSONObject(request.data)
+		XCTAssertEqual(object["account_id"] as? String, accountID)
+		XCTAssertEqual(request.authority, authority)
+	}
+
 	func testAccountEnrollmentUsesExactNativeStartRequest() async throws {
 		let authority = authority
 		let sessionID = "55555555-5555-4555-8555-555555555555"
@@ -594,6 +632,57 @@ final class AccountControlNativeClientTests: XCTestCase {
 		XCTAssertEqual(status.failure, .accountMismatch)
 	}
 
+	func testDeviceAuthorizationRejectionIsActionableAndClosed() async throws {
+		let authority = authority
+		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "poll_account_reauthentication",
+				authority: authority,
+				data: """
+					{"session_id":"\(sessionID)","state":"failed",
+					 "failure":"device_authorization_rejected"}
+					"""
+			)
+		}
+
+		let status = try await client.pollAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID
+		)
+
+		XCTAssertEqual(status.state, .failed)
+		XCTAssertEqual(status.failure, .deviceAuthorizationRejected)
+		XCTAssertEqual(
+			status.failure?.presentation,
+			"Device-code approval failed. Check ChatGPT Security, then try again."
+		)
+	}
+
+	func testCompletedLoginCarriesTheDaemonResolvedAccountIdentity() async throws {
+		let authority = authority
+		let sessionID = "55555555-5555-4555-8555-555555555555"
+		let restoredAccountID = "66666666-6666-4666-8666-666666666666"
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "poll_account_reauthentication",
+				authority: authority,
+				data: """
+					{"session_id":"\(sessionID)","state":"completed",
+					 "resolved_account_id":"\(restoredAccountID)"}
+					"""
+			)
+		}
+
+		let status = try await client.pollAccountReauthentication(
+			authority: authority,
+			sessionID: sessionID
+		)
+
+		XCTAssertEqual(status.state, .completed)
+		XCTAssertEqual(status.resolvedAccountID, restoredAccountID)
+	}
+
 	func testAccountEnrollmentDecodesDuplicateProviderFailure() async throws {
 		let authority = authority
 		let sessionID = "55555555-5555-4555-8555-555555555555"
@@ -625,6 +714,9 @@ final class AccountControlNativeClientTests: XCTestCase {
 		let authority = authority
 		let sessionID = "55555555-5555-4555-8555-555555555555"
 		let malformed = [
+			"""
+			{"session_id":"\(sessionID)","state":"completed"}
+			""",
 			"""
 			{"session_id":"\(sessionID)","state":"waiting_for_browser"}
 			""",

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -783,6 +783,52 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.message?.text, "Account added.")
 	}
 
+	func testBrowserEnrollmentRefreshesTheRestoredAccountIdentityAfterLogout() async throws {
+		let restoredAccountID = "22222222-2222-4222-8222-222222222222"
+		let client = AccountControlStoreClient(
+			account: accountRecord(),
+			authority: authority,
+			reauthenticationStates: [.completed],
+			restoredEnrollmentAccountID: restoredAccountID
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: [],
+			accountReauthenticationPollInterval: .zero,
+			accountObservationRetryDelays: [],
+			openLoginURL: { _ in }
+		)
+
+		await store.refresh()
+		store.beginAccountEnrollment()
+		store.selectAccountLoginMethod(.browserRedirect)
+		for _ in 0 ..< 200 {
+			if store.accountReauthentication == nil,
+				store.accounts.contains(where: { $0.account.accountID == restoredAccountID })
+			{
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+
+		let enrollmentRequest = await client.enrollmentLoginStartRequest()
+		let requestedAccountID = try XCTUnwrap(enrollmentRequest?.accountID)
+		XCTAssertNotEqual(requestedAccountID, restoredAccountID)
+		XCTAssertTrue(store.accounts.contains(where: {
+			$0.account.accountID == restoredAccountID
+				&& $0.account.accountRevision == 3
+				&& $0.account.credentialBinding?.version == 2
+		}))
+		XCTAssertFalse(store.accounts.contains(where: {
+			$0.account.accountID == requestedAccountID
+		}))
+		XCTAssertEqual(store.message?.tone, .success)
+		XCTAssertEqual(store.message?.text, "Account added.")
+	}
+
 	func testEnrollmentPickerClosesBeforeStartingNativeLogin() async {
 		let client = AccountControlStoreClient(
 			account: accountRecord(),
@@ -1771,6 +1817,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private var reauthenticationCompleted = false
 	private var reauthenticationObservationDelayReads: Int
 	private let cancelReauthenticationWithOutcomeUnknown: Bool
+	private let restoredEnrollmentAccountID: String?
 
 	init(
 		account: ResetCardAccountRecord,
@@ -1794,7 +1841,8 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		reauthenticationStates: [AccountReauthenticationState] = [],
 		accountLoginFailure: AccountReauthenticationFailure? = nil,
 		reauthenticationObservationDelayReads: Int = 0,
-		cancelReauthenticationWithOutcomeUnknown: Bool = false
+		cancelReauthenticationWithOutcomeUnknown: Bool = false,
+		restoredEnrollmentAccountID: String? = nil
 	) {
 		self.account = account
 		self.secondaryAccount = secondaryAccount
@@ -1824,6 +1872,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		self.reauthenticationObservationDelayReads = reauthenticationObservationDelayReads
 		self.cancelReauthenticationWithOutcomeUnknown =
 			cancelReauthenticationWithOutcomeUnknown
+		self.restoredEnrollmentAccountID = restoredEnrollmentAccountID
 	}
 
 	func accountSnapshot(
@@ -2386,6 +2435,18 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		sessionID: String,
 		failure: AccountReauthenticationFailure? = nil
 	) -> AccountReauthenticationStatus {
+		let resolvedAccountID: String? = if state == .completed {
+			switch activeLogin {
+			case .enrollment(let accountID, _, _):
+				restoredEnrollmentAccountID ?? accountID
+			case .reauthentication:
+				account.accountID
+			case .none:
+				nil
+			}
+		} else {
+			nil
+		}
 		return AccountReauthenticationStatus(
 			sessionID: sessionID,
 			state: state,
@@ -2399,24 +2460,26 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 				&& activeLogin?.loginMethod == .browserRedirect
 				? URL(string: "https://auth.openai.com/oauth/authorize?fixture=true")
 				: nil,
-			failure: failure ?? (state == .failed ? accountLoginFailure : nil)
+			failure: failure ?? (state == .failed ? accountLoginFailure : nil),
+			resolvedAccountID: resolvedAccountID
 		)
 	}
 
 	private func markAccountLoginCompleted() {
 		switch activeLogin {
-		case .enrollment(let accountID, let enabled, _):
+		case .enrollment(let requestedAccountID, let enabled, _):
+			let accountID = restoredEnrollmentAccountID ?? requestedAccountID
 			secondaryAccount = ResetCardAccountRecord(
 				authority: account.authority,
 				accountID: accountID,
 				alias: "Account added",
-				accountRevision: 1,
+				accountRevision: restoredEnrollmentAccountID == nil ? 1 : 3,
 				enabled: enabled,
 				observedState: .available,
 				lifecycleReadiness: .ready,
 				credentialBinding: AccountCredentialBinding(
 					schemaVersion: 1,
-					version: 1,
+					version: restoredEnrollmentAccountID == nil ? 1 : 2,
 					fingerprintSHA256: String(repeating: "c", count: 64),
 					provider: .chatGPT,
 					providerAccountID: "provider-added"

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -702,6 +702,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 			),
 			encoding: .utf8
 		)
+		let compatibility = try String(
+			contentsOf: appURL.appendingPathComponent(
+				"Sources/DecodexApp/DecodexNativeCompatibility.swift"
+			),
+			encoding: .utf8
+		)
 
 		XCTAssertTrue(
 			script.contains(#"NATIVE_CLIENT_NAME="libdecodex_app_client_ffi.dylib""#)
@@ -716,8 +722,24 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(script.contains("rust-lld"))
 		XCTAssertTrue(script.contains("linker-flavor=ld64.lld"))
 		XCTAssertTrue(script.contains("NATIVE_CLIENT_MIN_SYSTEM_VERSION=\"11.0\""))
-		XCTAssertTrue(stageTest.contains("dlopen"))
-		XCTAssertTrue(stageTest.contains("decodex_app_native_client_abi_version"))
+		XCTAssertTrue(
+			compatibility.contains("decodexNativeClientABIVersion: UInt32 = 1")
+		)
+		XCTAssertTrue(
+			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 2")
+		)
+		XCTAssertTrue(
+			compatibility.contains("static func openLibrary(at libraryURL: URL)")
+		)
+		XCTAssertTrue(
+			stageTest.contains(#"compatibility_source="$worktree_root/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift""#)
+		)
+		XCTAssertTrue(
+			stageTest.contains(#"xcrun swiftc "$compatibility_source" "$loader_dir/main.swift""#)
+		)
+		XCTAssertTrue(
+			stageTest.contains("DecodexNativeCompatibility.openLibrary")
+		)
 		XCTAssertTrue(
 			script.contains(#"cp "$NATIVE_CLIENT_BINARY" "$APP_NATIVE_CLIENT""#)
 		)
@@ -879,11 +901,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(store.contains(".resolvingCodex"))
 		XCTAssertTrue(native.contains(#"case loginMethod = "login_method""#))
 		XCTAssertTrue(native.contains("library.destroy(handle)"))
-		XCTAssertTrue(native.contains("decodexNativeArtifactCohort: UInt32 = 1"))
-		XCTAssertTrue(native.contains("decodex_app_native_client_artifact_cohort"))
 		XCTAssertTrue(
-			native.contains("artifactCohort() == decodexNativeArtifactCohort")
+			native.contains("DecodexNativeCompatibility.openLibrary(at: libraryURL)")
 		)
+		XCTAssertFalse(native.contains("decodexNativeArtifactCohort"))
 	}
 
 	func testAccountDataUsesDaemonObservationSignalsWithoutAUiRefreshClock() throws {

--- a/crates/decodex-app-client-ffi/THIRD_PARTY_NOTICES.md
+++ b/crates/decodex-app-client-ffi/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,8 @@ Apache-2.0-licensed OpenAI Codex repository:
 
 Decodex keeps the protocol constants and bounded behavior needed for browser and device-code
 login. It replaces Codex terminal/process integration with a closed in-process adapter, adds
-strict size and lifecycle bounds, uses the daemon-compatible four-field auth document, and does
+strict size and lifecycle bounds, distinguishes bounded structured pending device polls from
+terminal authorization rejection, uses the daemon-compatible four-field auth document, and does
 not copy the general Codex login framework.
 
 The upstream Apache License 2.0 text is retained at

--- a/crates/decodex-app-client-ffi/src/account_reauthentication.rs
+++ b/crates/decodex-app-client-ffi/src/account_reauthentication.rs
@@ -28,6 +28,7 @@ const INSTALL_REPLAY_DELAY: Duration = Duration::from_millis(100);
 pub(crate) enum Failure {
 	LoginFailed,
 	LoginTimedOut,
+	DeviceAuthorizationRejected,
 	AccountMismatch,
 	AccountChanged,
 	AccountUnavailable,
@@ -75,6 +76,8 @@ pub(crate) struct Status {
 	authorization_url: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	failure: Option<Failure>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	resolved_account_id: Option<String>,
 }
 
 impl Status {
@@ -85,6 +88,7 @@ impl Status {
 			prompt: None,
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
@@ -95,6 +99,7 @@ impl Status {
 			prompt: None,
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
@@ -105,6 +110,7 @@ impl Status {
 			prompt: None,
 			authorization_url: Some(authorization_url),
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
@@ -115,6 +121,7 @@ impl Status {
 			prompt: Some(prompt),
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
@@ -125,16 +132,18 @@ impl Status {
 			prompt: None,
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
-	fn completed(session_id: String) -> Self {
+	fn completed(session_id: String, resolved_account_id: EntityId) -> Self {
 		Self {
 			session_id,
 			state: State::Completed,
 			prompt: None,
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: Some(resolved_account_id.as_str().to_owned()),
 		}
 	}
 
@@ -145,6 +154,7 @@ impl Status {
 			prompt: None,
 			authorization_url: None,
 			failure: Some(failure),
+			resolved_account_id: None,
 		}
 	}
 
@@ -155,6 +165,7 @@ impl Status {
 			prompt: None,
 			authorization_url: None,
 			failure: None,
+			resolved_account_id: None,
 		}
 	}
 
@@ -414,7 +425,7 @@ fn run_login_in_home(
 	shared.set_status(Status::installing(session_id.clone()));
 	let outcome = runtime.block_on(install_credential(profile, start, auth_path));
 	match outcome {
-		Ok(()) => Status::completed(session_id),
+		Ok(resolved_account_id) => Status::completed(session_id, resolved_account_id),
 		Err(failure) => Status::failed(session_id, failure),
 	}
 }
@@ -423,6 +434,8 @@ fn map_adapter_error(error: source_login_adapter::Error) -> Failure {
 	match error {
 		source_login_adapter::Error::Cancelled => Failure::LoginFailed,
 		source_login_adapter::Error::TimedOut => Failure::LoginTimedOut,
+		source_login_adapter::Error::DeviceAuthorizationRejected =>
+			Failure::DeviceAuthorizationRejected,
 		source_login_adapter::Error::Unavailable
 		| source_login_adapter::Error::Rejected
 		| source_login_adapter::Error::InvalidResponse => Failure::LoginFailed,
@@ -434,7 +447,7 @@ async fn install_credential(
 	profile: ClientProfile,
 	start: Start,
 	auth_path: PathBuf,
-) -> Result<(), Failure> {
+) -> Result<EntityId, Failure> {
 	let source_descriptor = WireText::new(auth_path.to_string_lossy().into_owned())
 		.map_err(|_| Failure::LoginFailed)?;
 	let (payload, expected_revision) = install_command(&start, source_descriptor);
@@ -447,7 +460,12 @@ async fn install_credential(
 			AccountCommandResponse::Applied { result, .. } => match result.as_ref() {
 				ResultPayload::AccountChanged { account }
 					if account.account_id == start.account_id =>
-					return Ok(()),
+					return Ok(account.account_id.clone()),
+				ResultPayload::AccountRestored { requested_account_id, account }
+					if matches!(&start.install_mode, InstallMode::Enroll { .. })
+						&& requested_account_id == &start.account_id
+						&& account.account_id != start.account_id =>
+					return Ok(account.account_id.clone()),
 				_ => return Err(Failure::ServiceUnavailable),
 			},
 			AccountCommandResponse::Rejected { error } => return Err(map_command_error(&error)),
@@ -649,6 +667,18 @@ mod tests {
 	}
 
 	#[test]
+	fn completed_status_names_the_daemon_resolved_account() {
+		let session_id = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
+		let account_id = entity_id("038f0f9e-7b6e-4a31-8f4c-1d2e3f405164");
+		let status = Status::completed(session_id.to_owned(), account_id.clone());
+		let value = serde_json::to_value(status).expect("completed status");
+
+		assert_eq!(value["state"], "completed");
+		assert_eq!(value["resolved_account_id"], account_id.as_str());
+		assert_eq!(value.as_object().expect("status object").len(), 3);
+	}
+
+	#[test]
 	fn structured_login_events_publish_closed_browser_and_device_status() {
 		let session_id = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162".to_owned();
 		let browser = Status::browser_authorization(
@@ -794,7 +824,10 @@ mod tests {
 		let status = finalize_login_status(
 			&mut home,
 			session_id.to_owned(),
-			Status::completed(session_id.to_owned()),
+			Status::completed(
+				session_id.to_owned(),
+				entity_id("038f0f9e-7b6e-4a31-8f4c-1d2e3f405164"),
+			),
 		);
 
 		assert_eq!(status.state, State::Failed);
@@ -862,7 +895,10 @@ mod tests {
 		let worker_session_id = session_id.clone();
 		let worker = thread::spawn(move || {
 			thread::sleep(Duration::from_millis(5));
-			worker_shared.set_status(Status::completed(worker_session_id));
+			worker_shared.set_status(Status::completed(
+				worker_session_id,
+				entity_id("038f0f9e-7b6e-4a31-8f4c-1d2e3f405164"),
+			));
 		});
 		*manager.lock_session() = Some(Session {
 			session_id: session_id.clone(),

--- a/crates/decodex-app-client-ffi/src/source_login_adapter.rs
+++ b/crates/decodex-app-client-ffi/src/source_login_adapter.rs
@@ -12,8 +12,9 @@
 //
 // Decodex modifications: one closed error surface; strict request/response
 // bounds; loopback-only callback binding; typed cancellation; no logging;
-// no browser launcher, terminal, executable, or child process; and an exact
-// four-field auth document accepted by the daemon-owned import authority.
+// terminal device-poll classification; no browser launcher, terminal,
+// executable, or child process; and an exact four-field auth document accepted
+// by the daemon-owned import authority.
 
 use std::{
 	collections::HashMap,
@@ -66,6 +67,7 @@ pub(crate) enum Error {
 	TimedOut,
 	Unavailable,
 	Rejected,
+	DeviceAuthorizationRejected,
 	InvalidResponse,
 	Persistence,
 }
@@ -299,6 +301,11 @@ async fn run_device(
 					.await;
 			},
 			403 | 404 => {
+				let failure: DevicePollFailure =
+					read_bounded_json(response, cancellation, deadline).await?;
+				if !failure.is_pending() {
+					return Err(Error::DeviceAuthorizationRejected);
+				}
 				sleep_cancellable(cancellation, deadline, grant.interval).await?;
 			},
 			_ => return Err(Error::Rejected),
@@ -360,7 +367,11 @@ fn handle_callback_request(
 	);
 	match result {
 		Ok(()) => {
-			respond_text(&mut stream, 200, "Sign-in completed. You can close this window.")?;
+			respond_text(
+				&mut stream,
+				200,
+				"Browser sign-in completed. Return to Decodex to finish.",
+			)?;
 			Ok(CallbackOutcome::Completed)
 		},
 		Err(error) => {
@@ -789,6 +800,27 @@ struct DevicePollRequest<'a> {
 }
 
 #[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
+struct DevicePollFailure {
+	error: DevicePollError,
+}
+
+impl DevicePollFailure {
+	fn is_pending(&self) -> bool {
+		matches!(
+			self.error.code.as_str(),
+			"authorization_pending"
+				| "deviceauth_authorization_pending"
+				| "deviceauth_authorization_unknown"
+		)
+	}
+}
+
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
+struct DevicePollError {
+	code: String,
+}
+
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
 struct DeviceCodeSuccess {
 	authorization_code: String,
 	code_challenge: String,
@@ -1150,7 +1182,22 @@ mod tests {
 						value.get("device_auth_id").and_then(serde_json::Value::as_str).is_some()
 					);
 					assert!(value.get("user_code").and_then(serde_json::Value::as_str).is_some());
-					if pending { (403, "{}".to_owned()) } else { (200, fixture_device_success()) }
+					if pending {
+						(
+							403,
+							serde_json::json!({
+								"error": {
+									"code": "deviceauth_authorization_pending",
+									"message": "fixture pending",
+									"param": null,
+									"type": "authorization_error",
+								},
+							})
+							.to_string(),
+						)
+					} else {
+						(200, fixture_device_success())
+					}
 				},
 				"/oauth/token" => {
 					let fields =
@@ -1158,6 +1205,36 @@ mod tests {
 					assert_eq!(fields.len(), 5);
 					(200, fixture_token_response())
 				},
+				_ => (404, "{}".to_owned()),
+			}
+		})
+	}
+
+	fn terminal_device_rejection_issuer() -> MockIssuer {
+		MockIssuer::start(|request| {
+			assert_eq!(request.method, "POST");
+			match request.target.as_str() {
+				"/api/accounts/deviceauth/usercode" => (
+					200,
+					serde_json::json!({
+						"device_auth_id": "fixture-device",
+						"user_code": "FIXT-URE1",
+						"interval": "1",
+					})
+					.to_string(),
+				),
+				"/api/accounts/deviceauth/token" => (
+					403,
+					serde_json::json!({
+						"error": {
+							"code": "deviceauth_authorization_denied",
+							"message": "fixture terminal denial",
+							"param": null,
+							"type": "authorization_error",
+						},
+					})
+					.to_string(),
+				),
 				_ => (404, "{}".to_owned()),
 			}
 		})
@@ -1217,8 +1294,9 @@ mod tests {
 		let metadata = fs::symlink_metadata(&path).expect("auth metadata");
 		let value: serde_json::Value =
 			serde_json::from_slice(&fs::read(path).expect("auth bytes")).expect("auth JSON");
-		let keys =
+		let mut keys =
 			value.as_object().expect("auth object").keys().map(String::as_str).collect::<Vec<_>>();
+		keys.sort_unstable();
 		assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
 		assert_eq!(keys, ["OPENAI_API_KEY", "auth_mode", "last_refresh", "tokens"]);
 		assert!(value["OPENAI_API_KEY"].is_null());
@@ -1282,6 +1360,10 @@ mod tests {
 			.send()
 			.expect("callback response");
 		assert_eq!(response.status().as_u16(), 200);
+		assert_eq!(
+			response.text().expect("callback response body"),
+			"Browser sign-in completed. Return to Decodex to finish."
+		);
 		let result = worker.join().expect("browser adapter worker");
 
 		assert!(result.is_ok());
@@ -1311,6 +1393,26 @@ mod tests {
 		assert_eq!(events.len(), 1);
 		assert!(matches!(events.first(), Some(LoginEvent::DeviceAuthorization { .. })));
 		assert!(home_path.join("auth.json").is_file());
+	}
+
+	#[test]
+	fn terminal_device_poll_rejection_does_not_wait_for_the_login_timeout() {
+		let issuer = terminal_device_rejection_issuer();
+		let config = Config::test(issuer.issuer.clone(), 0, Duration::from_millis(80))
+			.expect("device config");
+		let (_home, home_path) = canonical_temp_home();
+		let runtime = runtime();
+		let result = run(
+			&config,
+			LoginMethod::DeviceCode,
+			&home_path,
+			runtime.handle(),
+			&Cancellation::default(),
+			|_| {},
+		);
+
+		assert!(matches!(result, Err(Error::DeviceAuthorizationRejected)));
+		assert!(!home_path.join("auth.json").exists());
 	}
 
 	#[test]

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -1343,6 +1343,15 @@ fn account_result_matches(
 			ResultPayload::AccountChanged { account },
 		) => account_id == &account.account_id && entity_revision == account.account_revision,
 		(
+			CommandPayload::EnrollAccountFromSharedCodex { account_id, .. }
+			| CommandPayload::EnrollAccountFromCredentialFile { account_id, .. }
+			| CommandPayload::ImportAccountCredentialFile { account_id, .. },
+			ResultPayload::AccountRestored { requested_account_id, account },
+		) =>
+			account_id == requested_account_id
+				&& account.account_id != *requested_account_id
+				&& entity_revision == account.account_revision,
+		(
 			CommandPayload::LogoutAccount { account_id, .. },
 			ResultPayload::AccountLoggedOut { account_id: result_id, tombstone_revision },
 		) => account_id == result_id && *tombstone_revision == entity_revision,
@@ -3054,7 +3063,7 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn device_login_enrollment_result_requires_exact_new_account_and_revision() {
+	fn device_login_enrollment_result_requires_exact_requested_or_restored_account_and_revision() {
 		let account_id =
 			EntityId::new("44234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let command = crate::CommandPayload::EnrollAccountFromCredentialFile {
@@ -3089,12 +3098,37 @@ max_entry_bytes = 0
 			account: Box::new(crate::AccountDto {
 				account_id: EntityId::new("46234567-89ab-4def-8123-456789abcdef")
 					.expect("canonical account ID"),
+				..account.clone()
+			}),
+		};
+		let restored_account_id =
+			EntityId::new("47234567-89ab-4def-8123-456789abcdef").expect("restored account ID");
+		let restored = ResultPayload::AccountRestored {
+			requested_account_id: account_id.clone(),
+			account: Box::new(crate::AccountDto {
+				account_id: restored_account_id,
+				account_revision: EntityRevision(3),
 				..account
 			}),
+		};
+		let wrong_request = ResultPayload::AccountRestored {
+			requested_account_id: EntityId::new("48234567-89ab-4def-8123-456789abcdef")
+				.expect("wrong requested account ID"),
+			account: match &restored {
+				ResultPayload::AccountRestored { account, .. } => account.clone(),
+				_ => unreachable!(),
+			},
 		};
 
 		assert!(super::account_result_matches(&command, EntityRevision(1), &exact));
 		assert!(!super::account_result_matches(&command, EntityRevision(1), &other_account));
+		assert!(super::account_result_matches(&command, EntityRevision(3), &restored));
+		assert!(!super::account_result_matches(
+			&command,
+			EntityRevision(3),
+			&wrong_request
+		));
+		assert!(!super::account_result_matches(&command, EntityRevision(2), &restored));
 	}
 
 	#[tokio::test]

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -97,7 +97,7 @@ use decodex_core::FoundationStatus;
 /// The only protocol generation and revision accepted by this build.
 pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 5 };
 /// Build/protocol cohort that must agree across the daemon and every local consumer.
-pub const CURRENT_ARTIFACT_COHORT: u32 = 1;
+pub const CURRENT_ARTIFACT_COHORT: u32 = 2;
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -2895,6 +2895,13 @@ pub enum ResultPayload {
 		/// Complete credential-negative account projection.
 		account: Box<AccountDto>,
 	},
+	/// A new enrollment request restored the one tombstoned account with the same provider binding.
+	AccountRestored {
+		/// New account identity proposed by the client before the provider binding was known.
+		requested_account_id: EntityId,
+		/// Restored canonical account projection and original stable identity.
+		account: Box<AccountDto>,
+	},
 	/// One account logout completed with an exact tombstone revision.
 	AccountLoggedOut {
 		/// Canonical logged-out account identity.
@@ -5670,7 +5677,7 @@ mod tests {
 			serde_json::to_string(&message).unwrap(),
 			concat!(
 				r#"{"type":"hello","body":{"version":{"major":2,"minor":5},"#,
-				r#""artifact_cohort":1,"#,
+				r#""artifact_cohort":2,"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -18,9 +18,9 @@ use decodex_core::{
 	ProcessGenerationAccountBinding, ProcessGenerationId, ProcessGenerationState, ProviderIdentity,
 };
 use decodex_database::{
-	AccountAdministrationOutcome, AccountCommandReceiptLease, AccountLifecycleMutationOutcome,
-	AccountOperationPreparation, AccountStoreObservation, CodexAccountCapabilityAttestation,
-	RoutingControlOutcome, SqliteStore, StoreError,
+	AccountAdministrationOutcome, AccountCommandReceiptLease, AccountEnrollmentResolution,
+	AccountLifecycleMutationOutcome, AccountOperationPreparation, AccountStoreObservation,
+	CodexAccountCapabilityAttestation, RoutingControlOutcome, SqliteStore, StoreError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -48,6 +48,7 @@ const CHATGPT_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const MAX_ACCOUNT_READ: u16 = 512;
 const MAX_UNSETTLED_ACCOUNT_OPERATION_READ: u16 = 1_024;
 const PROVIDER_REFRESH_OUTCOME_UNKNOWN: &str = "provider_refresh_outcome_unknown";
+const TOMBSTONE_ENROLLMENT_COLLISION: &str = "tombstone_enrollment_collision";
 const ACCOUNT_ALIAS_DOMAIN: &[u8] = b"decodex/account-alias/v2\0";
 const CODEX_AUTH_PROJECTION_DOMAIN: &[u8] = b"decodex/codex-auth-projection/v1\0";
 const ACCOUNT_ALIAS_WORDS: [&str; 44] = [
@@ -733,7 +734,7 @@ impl AccountService {
 		.await
 	}
 
-	#[allow(clippy::too_many_arguments)]
+	#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Keep provider resolution, credential effect, and journal completion in one auditable sequence.
 	async fn install_credentials_command<F>(
 		&self,
 		lease: AccountCommandReceiptLease,
@@ -751,21 +752,55 @@ impl AccountService {
 			+ Send
 			+ 'static,
 	{
-		let lock = self.lock_for(&account_id)?;
+		let resolution = self.store.resolve_account_enrollment(&account_id, &provider).await?;
+		let (resolved_account_id, expected_account_revision, previous_credential) =
+			match &resolution {
+				AccountEnrollmentResolution::Fresh { account_id } =>
+					(account_id.clone(), None, None),
+				AccountEnrollmentResolution::Restore {
+					account_id,
+					account_revision,
+					previous_credential,
+				} => (
+					account_id.clone(),
+					Some(*account_revision),
+					Some(previous_credential.clone()),
+				),
+				AccountEnrollmentResolution::AlreadyEnrolled { .. } =>
+					(account_id.clone(), None, None),
+			};
+		let lock = self.lock_for(&resolved_account_id)?;
 		let _guard = lock.lock().await;
+		if self.store.resolve_account_enrollment(&account_id, &provider).await? != resolution {
+			return self
+				.complete_account_command_error(
+					lease,
+					AccountLifecycleError::StaleAccount,
+					build_response,
+				)
+				.await;
+		}
+		let target_version = match previous_credential.as_ref() {
+			Some(previous) => previous
+				.version
+				.successor()
+				.map_err(|_| AccountLifecycleError::InvalidOperation)?,
+			None =>
+				CredentialVersion::new(1).map_err(|_| AccountLifecycleError::InvalidOperation)?,
+		};
 		let target = bundle.binding_for(
-			&account_id,
+			&resolved_account_id,
 			&operation_id,
-			CredentialVersion::new(1).map_err(|_| AccountLifecycleError::InvalidOperation)?,
+			target_version,
 			&provider,
 		)?;
 		let preparation = AccountOperationPreparation {
 			operation_id: operation_id.clone(),
-			account_id,
+			account_id: resolved_account_id,
 			kind,
 			display_label: Some(alias),
 			enabled: Some(enabled),
-			expected_account_revision: None,
+			expected_account_revision,
 			expected: None,
 			target: Some(target.clone()),
 			provider,
@@ -784,7 +819,16 @@ impl AccountService {
 			},
 		};
 		if phase == AccountOperationPhase::Prepared {
-			if let Err(error) = self.credentials.create(&preparation.account_id, &target, bundle)
+			let store_result = match previous_credential.as_ref() {
+				Some(previous) => self.credentials.restore_absent(
+					&preparation.account_id,
+					previous,
+					&target,
+					bundle,
+				),
+				None => self.credentials.create(&preparation.account_id, &target, bundle),
+			};
+			if let Err(error) = store_result
 				&& (error != CredentialStoreError::AlreadyExists
 					|| self.credentials.read_exact(&preparation.account_id, &target).is_err())
 			{
@@ -800,7 +844,11 @@ impl AccountService {
 						&operation_id,
 						AccountOperationPhase::Prepared,
 						terminal,
-						ambiguous.then_some("credential_create_failed"),
+						ambiguous.then_some(if previous_credential.is_some() {
+							"credential_restore_failed"
+						} else {
+							"credential_create_failed"
+						}),
 						error.into(),
 						build_response,
 					)
@@ -3114,6 +3162,11 @@ impl AccountService {
 		&self,
 		operation: &AccountOperation,
 	) -> Result<Option<ReconciliationDisposition>, AccountLifecycleError> {
+		if let Some(disposition) =
+			self.reconcile_legacy_tombstone_enrollment_collision(operation).await?
+		{
+			return Ok(Some(disposition));
+		}
 		match operation.phase {
 			AccountOperationPhase::Committed => Ok(Some(ReconciliationDisposition::Committed)),
 			AccountOperationPhase::Cancelled => Ok(Some(ReconciliationDisposition::Cancelled)),
@@ -3125,6 +3178,74 @@ impl AccountService {
 			AccountOperationPhase::Prepared | AccountOperationPhase::ProviderEffectPending =>
 				Ok(None),
 		}
+	}
+
+	async fn reconcile_legacy_tombstone_enrollment_collision(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<Option<ReconciliationDisposition>, AccountLifecycleError> {
+		if !self.store.is_legacy_tombstone_enrollment_collision(operation).await? {
+			return Ok(None);
+		}
+		let target = operation.target.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
+		match self.credentials.read_exact(&operation.account_id, target) {
+			Ok(_) => {
+				if self.credentials.delete(&operation.account_id, target).is_err() {
+					if operation.phase == AccountOperationPhase::StoreApplied {
+						accepted_phase(
+							self.store
+								.advance_account_operation(
+									&operation.operation_id,
+									AccountOperationPhase::StoreApplied,
+									AccountOperationPhase::RecoveryRequired,
+									Some(TOMBSTONE_ENROLLMENT_COLLISION),
+								)
+								.await?,
+						)?;
+					}
+					return Ok(Some(ReconciliationDisposition::Manual));
+				}
+			},
+			Err(CredentialStoreError::NotFound) => {},
+			Err(_) => {
+				if operation.phase == AccountOperationPhase::StoreApplied {
+					accepted_phase(
+						self.store
+							.advance_account_operation(
+								&operation.operation_id,
+								AccountOperationPhase::StoreApplied,
+								AccountOperationPhase::RecoveryRequired,
+								Some(TOMBSTONE_ENROLLMENT_COLLISION),
+							)
+							.await?,
+					)?;
+				}
+				return Ok(Some(ReconciliationDisposition::Manual));
+			},
+		}
+		if operation.phase == AccountOperationPhase::StoreApplied {
+			accepted_phase(
+				self.store
+					.advance_account_operation(
+						&operation.operation_id,
+						AccountOperationPhase::StoreApplied,
+						AccountOperationPhase::RecoveryRequired,
+						Some(TOMBSTONE_ENROLLMENT_COLLISION),
+					)
+					.await?,
+			)?;
+		}
+		accepted_phase(
+			self.store
+				.advance_account_operation(
+					&operation.operation_id,
+					AccountOperationPhase::RecoveryRequired,
+					AccountOperationPhase::Cancelled,
+					None,
+				)
+				.await?,
+		)?;
+		Ok(Some(ReconciliationDisposition::Cancelled))
 	}
 
 	async fn reconcile_import_operation(
@@ -3906,8 +4027,11 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[allow(clippy::too_many_lines)] // The existing-provider setup and exact durable rejection remain one end-to-end boundary.
 	async fn duplicate_provider_enrollment_is_cancelled_and_replays_its_typed_receipt() {
 		let directory = tempdir().expect("temporary product root");
+		fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700))
+			.expect("private product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
@@ -4050,6 +4174,263 @@ mod tests {
 			.read_exact(&existing_account, &existing_binding)
 			.expect("existing credential remains authoritative");
 		assert_eq!(service.list().await.expect("list accounts").len(), 1);
+	}
+
+	#[tokio::test]
+	#[allow(clippy::too_many_lines)] // One regression proves legacy cleanup, restoration, replay, routing, and reopen together.
+	async fn logged_out_provider_enrollment_restores_the_original_account_and_receipt() {
+		let directory = tempdir().expect("temporary product root");
+		fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700))
+			.expect("private product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(UnusedCredentialRefresher),
+		);
+		let provider =
+			ProviderIdentity::new(AccountProvider::Chatgpt, "restored-provider-account")
+				.expect("provider identity");
+		let original_account =
+			AccountId::new("21000000-0000-4000-8000-000000000020").expect("original account");
+		let enrollment_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000020")
+				.expect("enrollment operation");
+		let enrollment_command =
+			CommandIdentity::new("restore-provider-enroll", b"initial enrollment")
+				.expect("enrollment command");
+		let enrollment_lease = match store
+			.reserve_account_command(
+				&enrollment_command,
+				AccountCommandKind::Enroll,
+				original_account.as_str(),
+				None,
+			)
+			.await
+			.expect("reserve initial enrollment")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Replayed(_) => panic!("initial enrollment replayed"),
+		};
+		let (_initial_source, initial_descriptor) = owner_private_shared_codex_auth(
+			provider.account_id(),
+			"initial@example.test",
+		);
+		let initial = service
+			.enroll_from_credential_file_command(
+				enrollment_lease,
+				enrollment_operation,
+				original_account.clone(),
+				true,
+				&initial_descriptor,
+				|result| {
+					Ok(match result {
+						Ok(account) => json!({
+							"outcome": "succeeded",
+							"account_id": account.account_id.as_str(),
+							"account_revision": account.revision,
+						}),
+						Err(_) => json!({"outcome": "unexpected"}),
+					})
+				},
+			)
+			.await
+			.expect("complete initial enrollment");
+		assert_eq!(
+			initial,
+			json!({
+				"outcome": "succeeded",
+				"account_id": original_account.as_str(),
+				"account_revision": 1,
+			})
+		);
+
+		let logout_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000021")
+				.expect("logout operation");
+		let tombstone = service
+			.logout(logout_operation, &original_account, 1)
+			.await
+			.expect("logout original account");
+		assert!(tombstone.tombstoned);
+		assert_eq!(tombstone.revision, 2);
+		assert!(service.list().await.expect("list after logout").is_empty());
+
+		let legacy_account =
+			AccountId::new("21000000-0000-4000-8000-000000000022").expect("legacy account");
+		let legacy_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000022")
+				.expect("legacy operation");
+		let legacy_bundle = shared_bundle(provider.account_id(), "legacy-access", 3_000_000);
+		let legacy_target = legacy_bundle
+			.binding_for(
+				&legacy_account,
+				&legacy_operation,
+				CredentialVersion::new(1).expect("legacy version"),
+				&provider,
+			)
+			.expect("legacy target");
+		assert!(matches!(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: legacy_operation.clone(),
+					account_id: legacy_account.clone(),
+					kind: AccountOperationKind::Enroll,
+					display_label: Some(stable_account_alias(&provider)),
+					enabled: Some(true),
+					expected_account_revision: None,
+					expected: None,
+					target: Some(legacy_target.clone()),
+					provider: provider.clone(),
+				})
+				.await
+				.expect("prepare legacy collision"),
+			AccountLifecycleMutationOutcome::Applied(_)
+		));
+		credentials
+			.create(&legacy_account, &legacy_target, legacy_bundle)
+			.expect("write legacy credential");
+		store
+			.advance_account_operation(
+				&legacy_operation,
+				AccountOperationPhase::Prepared,
+				AccountOperationPhase::StoreApplied,
+				None,
+			)
+			.await
+			.expect("record legacy store effect");
+		let startup = service.reconcile_startup().await.expect("reconcile legacy collision");
+		assert_eq!(startup.cancelled, 1);
+		assert_eq!(startup.committed, 0);
+		assert!(startup.manual_recovery.is_empty());
+		assert!(matches!(
+			credentials.read_exact(&legacy_account, &legacy_target),
+			Err(CredentialStoreError::NotFound)
+		));
+		let legacy = store
+			.read_account_operation(&legacy_operation)
+			.await
+			.expect("read legacy collision")
+			.expect("legacy collision is retained");
+		assert_eq!(legacy.phase, AccountOperationPhase::Cancelled);
+
+		let requested_account =
+			AccountId::new("21000000-0000-4000-8000-000000000023").expect("requested account");
+		let restore_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000023")
+				.expect("restore operation");
+		let restore_command =
+			CommandIdentity::new("restore-provider-reenroll", b"restore enrollment")
+				.expect("restore command");
+		let restore_lease = match store
+			.reserve_account_command(
+				&restore_command,
+				AccountCommandKind::Enroll,
+				requested_account.as_str(),
+				None,
+			)
+			.await
+			.expect("reserve restore enrollment")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Replayed(_) => panic!("restore enrollment replayed"),
+		};
+		let (_restore_source, restore_descriptor) = owner_private_shared_codex_auth(
+			provider.account_id(),
+			"restored@example.test",
+		);
+		let restored = service
+			.enroll_from_credential_file_command(
+				restore_lease,
+				restore_operation.clone(),
+				requested_account.clone(),
+				true,
+				&restore_descriptor,
+				|result| {
+					Ok(match result {
+						Ok(account) => json!({
+							"outcome": "succeeded",
+							"account_id": account.account_id.as_str(),
+							"account_revision": account.revision,
+						}),
+						Err(_) => json!({"outcome": "unexpected"}),
+					})
+				},
+			)
+			.await;
+		if restored.is_err() {
+			let operation = store
+				.read_account_operation(&restore_operation)
+				.await
+				.expect("read failed restore operation")
+				.expect("failed restore operation is journaled");
+			assert_eq!(operation.phase, AccountOperationPhase::StoreApplied);
+			let target = operation.target.expect("failed restore retains its target binding");
+			credentials
+				.read_exact(&requested_account, &target)
+				.expect("failed restore wrote the requested account credential");
+			assert!(service.list().await.expect("list after failed restore").is_empty());
+		}
+		let restored = restored.expect("restore logged-out provider");
+
+		assert_eq!(
+			restored,
+			json!({
+				"outcome": "succeeded",
+				"account_id": original_account.as_str(),
+				"account_revision": 3,
+			})
+		);
+		let accounts = service.list().await.expect("list restored account");
+		assert_eq!(accounts.len(), 1);
+		assert_eq!(accounts[0].account.account_id, original_account);
+		let binding = accounts[0]
+			.account
+			.credential
+			.as_ref()
+			.expect("restored credential binding");
+		assert_eq!(binding.version.get(), 2);
+		assert_eq!(binding.writer_operation_id, restore_operation);
+		credentials
+			.read_exact(&accounts[0].account.account_id, binding)
+			.expect("restored credential is authoritative");
+		let restored_account_id = accounts[0].account.account_id.clone();
+		let restored_binding = binding.clone();
+		assert!(matches!(
+			store
+				.reserve_account_command(
+					&restore_command,
+					AccountCommandKind::Enroll,
+					requested_account.as_str(),
+					None,
+				)
+				.await
+				.expect("replay restore enrollment"),
+			AccountCommandReceiptClaim::Replayed(replayed) if replayed == restored
+		));
+
+		drop(accounts);
+		drop(service);
+		drop(credentials);
+		drop(store);
+		let reopened = SqliteStore::open(&root.paths()).expect("reopen product store");
+		let reopened_credentials = SqliteCredentialStore::new(reopened.clone());
+		reopened_credentials
+			.read_exact(&restored_account_id, &restored_binding)
+			.expect("restored credential survives reopen");
+		let reopened_service = AccountService::new(
+			reopened,
+			Arc::new(reopened_credentials),
+			Arc::new(UnusedCredentialRefresher),
+		);
+		let reopened_accounts = reopened_service.list().await.expect("list restored after reopen");
+		assert_eq!(reopened_accounts.len(), 1);
+		assert_eq!(reopened_accounts[0].account.account_id, restored_account_id);
+		assert_eq!(reopened_accounts[0].account.credential.as_ref(), Some(&restored_binding));
 	}
 
 	#[tokio::test]

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -568,16 +568,22 @@ impl ServiceApplication {
 			CommandPayload::EnrollAccountFromSharedCodex { operation_id, account_id, enabled } => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let account_id = account_id_from_wire(account_id)?;
+				let requested_account_id = account_id.clone();
 				service
 					.enroll_from_shared_codex_command(
 						lease,
 						operation_id,
 						account_id,
 						*enabled,
-						|result| {
+						move |result| {
 							encode_account_command_receipt(
 								&result.map_err(account_lifecycle_command_error).and_then(
-									|account| account_changed_publication(account.clone()),
+									|account| {
+										account_enrollment_publication(
+											&requested_account_id,
+											account.clone(),
+										)
+									},
 								),
 							)
 						},
@@ -592,6 +598,7 @@ impl ServiceApplication {
 			} => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let account_id = account_id_from_wire(account_id)?;
+				let requested_account_id = account_id.clone();
 				service
 					.enroll_from_credential_file_command(
 						lease,
@@ -599,10 +606,15 @@ impl ServiceApplication {
 						account_id,
 						*enabled,
 						source_descriptor.as_str(),
-						|result| {
+						move |result| {
 							encode_account_command_receipt(
 								&result.map_err(account_lifecycle_command_error).and_then(
-									|account| account_changed_publication(account.clone()),
+									|account| {
+										account_enrollment_publication(
+											&requested_account_id,
+											account.clone(),
+										)
+									},
 								),
 							)
 						},
@@ -617,6 +629,7 @@ impl ServiceApplication {
 			} => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let account_id = account_id_from_wire(account_id)?;
+				let requested_account_id = account_id.clone();
 				service
 					.import_credential_file_command(
 						lease,
@@ -624,10 +637,15 @@ impl ServiceApplication {
 						account_id,
 						*enabled,
 						source_descriptor.as_str(),
-						|result| {
+						move |result| {
 							encode_account_command_receipt(
 								&result.map_err(account_lifecycle_command_error).and_then(
-									|account| account_changed_publication(account.clone()),
+									|account| {
+										account_enrollment_publication(
+											&requested_account_id,
+											account.clone(),
+										)
+									},
 								),
 							)
 						},
@@ -3543,6 +3561,29 @@ fn account_changed_publication(
 		entity_id: account.account_id.clone(),
 		entity_revision: account.account_revision,
 		result: ResultPayload::AccountChanged { account: Box::new(account.clone()) },
+		event: EventPayload::AccountChanged { account: Box::new(account) },
+	})
+}
+
+fn account_enrollment_publication(
+	requested_account_id: &AccountId,
+	account: AccountRecord,
+) -> Result<ApplicationPublication, CommandError> {
+	if &account.account_id == requested_account_id {
+		return account_changed_publication(account);
+	}
+	let requested_account_id = EntityId::new(requested_account_id.as_str().to_owned())
+		.map_err(|_| application_unavailable("account enrollment result is incompatible"))?;
+	let account = account_dto(account)
+		.map_err(|_| application_unavailable("account enrollment result is incompatible"))?;
+	Ok(ApplicationPublication {
+		channel: Channel::AccountsHealth,
+		entity_id: account.account_id.clone(),
+		entity_revision: account.account_revision,
+		result: ResultPayload::AccountRestored {
+			requested_account_id,
+			account: Box::new(account.clone()),
+		},
 		event: EventPayload::AccountChanged { account: Box::new(account) },
 	})
 }

--- a/crates/decodex-runtime/src/host_credentials.rs
+++ b/crates/decodex-runtime/src/host_credentials.rs
@@ -175,6 +175,15 @@ pub trait HostCredentialStore: Send + Sync {
 		bundle: CredentialSecretBundle,
 	) -> Result<(), CredentialStoreError>;
 
+	/// Recreate an absent bundle only at the immediate successor of the last deleted binding.
+	fn restore_absent(
+		&self,
+		account_id: &AccountId,
+		previous: &CredentialBinding,
+		target: &CredentialBinding,
+		bundle: CredentialSecretBundle,
+	) -> Result<(), CredentialStoreError>;
+
 	/// Read only when schema, version, fingerprint, and provider all agree.
 	fn read_exact(
 		&self,

--- a/crates/decodex-runtime/src/host_credentials/sqlite_store.rs
+++ b/crates/decodex-runtime/src/host_credentials/sqlite_store.rs
@@ -72,6 +72,41 @@ impl HostCredentialStore for SqliteCredentialStore {
 			.map_err(map_create_error)
 	}
 
+	fn restore_absent(
+		&self,
+		account_id: &AccountId,
+		previous: &CredentialBinding,
+		target: &CredentialBinding,
+		bundle: CredentialSecretBundle,
+	) -> Result<(), CredentialStoreError> {
+		let next =
+			previous.version.successor().map_err(|_| CredentialStoreError::VersionConflict)?;
+		if target.version != next || target.provider != previous.provider {
+			return Err(CredentialStoreError::VersionConflict);
+		}
+		match self.store.read_credential(account_id.as_str()) {
+			Err(DatabaseError::NotFound) => {},
+			Ok(_) => return Err(CredentialStoreError::AlreadyExists),
+			Err(error) => return Err(map_read_error(error)),
+		}
+		let persisted = PersistedCredentialV1::new(
+			account_id,
+			&target.writer_operation_id,
+			next,
+			&target.provider,
+			bundle,
+		);
+		let bytes = encode(&persisted)?;
+		let binding = persisted.binding(fingerprint(&bytes)?)?;
+		enforce_exact(&binding, target)?;
+		self.store
+			.create_credential(CredentialRecord {
+				key: credential_key(target, account_id),
+				payload: bytes,
+			})
+			.map_err(map_create_error)
+	}
+
 	fn read_exact(
 		&self,
 		account_id: &AccountId,

--- a/database/src/account_lifecycle.rs
+++ b/database/src/account_lifecycle.rs
@@ -60,6 +60,17 @@ pub enum AccountLifecycleMutationOutcome {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AccountEnrollmentResolution {
+	Fresh { account_id: AccountId },
+	Restore {
+		account_id: AccountId,
+		account_revision: i64,
+		previous_credential: CredentialBinding,
+	},
+	AlreadyEnrolled { account_id: AccountId, account_revision: i64 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AccountAdministrationOutcome {
 	Updated { revision: i64 },
 	Rejected { rejection: AccountLifecycleRejection, revision: i64 },
@@ -163,6 +174,19 @@ impl SqliteStore {
 			let routing = read_routing_control_sync(connection)?;
 			validate_registry_snapshot(&accounts, &routing)?;
 			Ok((accounts, routing))
+		})
+		.await
+	}
+
+	pub async fn resolve_account_enrollment(
+		&self,
+		requested_account_id: &AccountId,
+		provider: &ProviderIdentity,
+	) -> Result<AccountEnrollmentResolution, StoreError> {
+		let requested_account_id = requested_account_id.clone();
+		let provider = provider.clone();
+		self.run(move |connection| {
+			resolve_account_enrollment_sync(connection, &requested_account_id, &provider)
 		})
 		.await
 	}
@@ -400,6 +424,17 @@ impl SqliteStore {
 	) -> Result<Option<AccountOperation>, StoreError> {
 		let operation_id = operation_id.clone();
 		self.run(move |connection| read_operation_sync(connection, &operation_id)).await
+	}
+
+	pub async fn is_legacy_tombstone_enrollment_collision(
+		&self,
+		operation: &AccountOperation,
+	) -> Result<bool, StoreError> {
+		let operation = operation.clone();
+		self.run(move |connection| {
+			is_legacy_tombstone_enrollment_collision_sync(connection, &operation)
+		})
+		.await
 	}
 
 	pub async fn set_account_enabled(
@@ -961,9 +996,8 @@ fn prepare_operation_sync(
 
 	let account = account_base_sync(connection, &preparation.account_id)?;
 	let rejection = match preparation.kind {
-		AccountOperationKind::Enroll | AccountOperationKind::Import if account.is_some() =>
-			Some(AccountLifecycleRejection::IdentityConflict),
-		AccountOperationKind::Enroll | AccountOperationKind::Import => None,
+		AccountOperationKind::Enroll | AccountOperationKind::Import =>
+			enrollment_rejection_sync(connection, preparation, account.as_ref())?,
 		AccountOperationKind::Refresh | AccountOperationKind::Logout => match account {
 			None => Some(AccountLifecycleRejection::AccountMissing),
 			Some(ref account) if account.tombstoned =>
@@ -1028,6 +1062,45 @@ fn prepare_operation_sync(
 		account_revision: account.map_or(0, |value| value.revision),
 		phase: AccountOperationPhase::Prepared,
 	}))
+}
+
+fn enrollment_rejection_sync(
+	connection: &Connection,
+	preparation: &AccountOperationPreparation,
+	account: Option<&AccountBase>,
+) -> Result<Option<AccountLifecycleRejection>, StoreError> {
+	let Some(account) = account else {
+		return Ok(preparation
+			.expected_account_revision
+			.is_some()
+			.then_some(AccountLifecycleRejection::StaleAccount));
+	};
+	if !account.tombstoned {
+		return Ok(Some(AccountLifecycleRejection::IdentityConflict));
+	}
+	if preparation.expected_account_revision != Some(account.revision)
+		|| provider_text(preparation.provider.provider()) != account.provider
+		|| preparation.provider.account_id() != account.provider_account_id
+		|| credential_binding_sync(connection, &preparation.account_id)?.is_some()
+	{
+		return Ok(Some(AccountLifecycleRejection::StaleAccount));
+	}
+	let previous = tombstone_predecessor_credential_sync(
+		connection,
+		&preparation.account_id,
+		account.revision,
+		&preparation.provider,
+	)?;
+	let successor = previous
+		.version
+		.successor()
+		.map_err(|_| StoreError::InvalidInput("credential version is exhausted"))?;
+	let target = preparation
+		.target
+		.as_ref()
+		.ok_or(StoreError::InvalidInput("account operation target is absent"))?;
+	Ok((target.version != successor || target.provider != previous.provider)
+		.then_some(AccountLifecycleRejection::StaleAccount))
 }
 
 fn validate_reauthentication_takeover_sync(
@@ -1170,23 +1243,71 @@ fn commit_account_operation(
 			let enabled = operation
 				.requested_enabled
 				.ok_or(StoreError::InvalidInput("account enablement is absent"))?;
-			connection
-				.execute(
-					"INSERT INTO accounts (
-					   account_id, display_label, enabled, state, revision, provider,
-					   provider_account_id, credential_store_observation,
-					   created_at_micros, updated_at_micros, tombstoned_at_micros
-					 ) VALUES (?1, ?2, ?3, 'available', 1, ?4, ?5, 'exact', ?6, ?6, NULL)",
-					params![
-						operation.account_id.as_str(),
-						label,
-						enabled,
-						provider_text(target.provider.provider()),
-						target.provider.account_id(),
-						now,
-					],
-				)
-				.map_err(sql_error)?;
+			match account_base_sync(connection, &operation.account_id)? {
+				None => {
+					if operation.expected_account_revision.is_some() || target.version.get() != 1 {
+						return Ok(Some(AccountLifecycleRejection::StaleAccount));
+					}
+					connection
+						.execute(
+							"INSERT INTO accounts (
+							   account_id, display_label, enabled, state, revision, provider,
+							   provider_account_id, credential_store_observation,
+							   created_at_micros, updated_at_micros, tombstoned_at_micros
+							 ) VALUES (?1, ?2, ?3, 'available', 1, ?4, ?5, 'exact', ?6, ?6, NULL)",
+							params![
+								operation.account_id.as_str(),
+								label,
+								enabled,
+								provider_text(target.provider.provider()),
+								target.provider.account_id(),
+								now,
+							],
+						)
+						.map_err(sql_error)?;
+				},
+				Some(account) if account.tombstoned => {
+					if operation.expected_account_revision != Some(account.revision)
+						|| provider_text(target.provider.provider()) != account.provider
+						|| target.provider.account_id() != account.provider_account_id
+					{
+						return Ok(Some(AccountLifecycleRejection::StaleAccount));
+					}
+					let previous = tombstone_predecessor_credential_sync(
+						connection,
+						&operation.account_id,
+						account.revision,
+						&target.provider,
+					)?;
+					if previous.version.successor().ok() != Some(target.version) {
+						return Ok(Some(AccountLifecycleRejection::StaleAccount));
+					}
+					let changed = connection
+						.execute(
+							"UPDATE accounts
+							 SET display_label = ?1, enabled = ?2, state = 'available',
+							     revision = revision + 1, provider = ?3, provider_account_id = ?4,
+							     credential_store_observation = 'exact', updated_at_micros = ?5,
+							     tombstoned_at_micros = NULL
+							 WHERE account_id = ?6 AND revision = ?7
+							   AND tombstoned_at_micros IS NOT NULL",
+							params![
+								label,
+								enabled,
+								provider_text(target.provider.provider()),
+								target.provider.account_id(),
+								now,
+								operation.account_id.as_str(),
+								account.revision,
+							],
+						)
+						.map_err(sql_error)?;
+					if changed != 1 {
+						return Ok(Some(AccountLifecycleRejection::StaleAccount));
+					}
+				},
+				Some(_) => return Ok(Some(AccountLifecycleRejection::IdentityConflict)),
+			}
 			let position: i64 = connection
 				.query_row("SELECT COUNT(*) FROM account_routing_order", [], |row| row.get(0))
 				.map_err(sql_error)?;
@@ -1573,6 +1694,160 @@ fn account_base_sync(
 		)
 		.optional()
 		.map_err(sql_error)
+}
+
+fn resolve_account_enrollment_sync(
+	connection: &Connection,
+	requested_account_id: &AccountId,
+	provider: &ProviderIdentity,
+) -> Result<AccountEnrollmentResolution, StoreError> {
+	let existing = connection
+		.query_row(
+			"SELECT account_id FROM accounts
+			 WHERE provider = ?1 AND provider_account_id = ?2",
+			params![provider_text(provider.provider()), provider.account_id()],
+			|row| row.get::<_, String>(0),
+		)
+		.optional()
+		.map_err(sql_error)?;
+	let Some(existing) = existing else {
+		return Ok(AccountEnrollmentResolution::Fresh {
+			account_id: requested_account_id.clone(),
+		});
+	};
+	let account_id =
+		AccountId::new(existing).map_err(|_| incompatible("account identity"))?;
+	let account = account_base_sync(connection, &account_id)?
+		.ok_or_else(|| incompatible("account enrollment resolution"))?;
+	if !account.tombstoned {
+		return Ok(AccountEnrollmentResolution::AlreadyEnrolled {
+			account_id,
+			account_revision: account.revision,
+		});
+	}
+	if let Some(current) = credential_binding_sync(connection, &account_id)? {
+		let unsettled = unsettled_operation_sync(connection, &account_id)?
+			.ok_or_else(|| incompatible("tombstoned account credential state"))?;
+		let operation = read_operation_sync(connection, &unsettled.operation_id)?
+			.ok_or_else(|| incompatible("tombstoned account operation state"))?;
+		if !matches!(operation.kind, AccountOperationKind::Enroll | AccountOperationKind::Import)
+			|| operation.target.as_ref() != Some(&current)
+			|| operation.expected_account_revision != Some(account.revision)
+		{
+			return Err(incompatible("tombstoned account enrollment state"));
+		}
+	}
+	let previous_credential = tombstone_predecessor_credential_sync(
+		connection,
+		&account_id,
+		account.revision,
+		provider,
+	)?;
+	Ok(AccountEnrollmentResolution::Restore {
+		account_id,
+		account_revision: account.revision,
+		previous_credential,
+	})
+}
+
+fn is_legacy_tombstone_enrollment_collision_sync(
+	connection: &Connection,
+	operation: &AccountOperation,
+) -> Result<bool, StoreError> {
+	const RECOVERY_CODE: &str = "tombstone_enrollment_collision";
+	if !matches!(operation.kind, AccountOperationKind::Enroll | AccountOperationKind::Import)
+		|| !matches!(
+			operation.phase,
+			AccountOperationPhase::StoreApplied | AccountOperationPhase::RecoveryRequired
+		)
+		|| (operation.phase == AccountOperationPhase::RecoveryRequired
+			&& operation.recovery_code.as_deref() != Some(RECOVERY_CODE))
+		|| operation.expected_account_revision.is_some()
+		|| operation.expected.is_some()
+		|| operation.requested_display_label.is_none()
+		|| operation.requested_enabled.is_none()
+	{
+		return Ok(false);
+	}
+	let Some(target) = operation.target.as_ref() else { return Ok(false) };
+	if target.version.get() != 1
+		|| account_base_sync(connection, &operation.account_id)?.is_some()
+	{
+		return Ok(false);
+	}
+	if credential_binding_sync(connection, &operation.account_id)?
+		.as_ref()
+		.is_some_and(|binding| binding != target)
+	{
+		return Ok(false);
+	}
+	let tombstone = connection
+		.query_row(
+			"SELECT account_id, revision FROM accounts
+			 WHERE provider = ?1 AND provider_account_id = ?2
+			   AND tombstoned_at_micros IS NOT NULL",
+			params![
+				provider_text(target.provider.provider()),
+				target.provider.account_id(),
+			],
+			|row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+		)
+		.optional()
+		.map_err(sql_error)?;
+	let Some((tombstone_id, tombstone_revision)) = tombstone else { return Ok(false) };
+	let tombstone_id =
+		AccountId::new(tombstone_id).map_err(|_| incompatible("account identity"))?;
+	let _ = tombstone_predecessor_credential_sync(
+		connection,
+		&tombstone_id,
+		tombstone_revision,
+		&target.provider,
+	)?;
+	let referenced: bool = connection
+		.query_row(
+			"SELECT EXISTS (
+			   SELECT 1 FROM account_routing_order WHERE account_id = ?1
+			   UNION ALL SELECT 1 FROM account_quota_facts WHERE account_id = ?1
+			   UNION ALL SELECT 1 FROM account_profile_snapshots WHERE account_id = ?1
+			   UNION ALL SELECT 1 FROM account_routing_control WHERE fixed_account_id = ?1
+			 )",
+			params![operation.account_id.as_str()],
+			|row| row.get(0),
+		)
+		.map_err(sql_error)?;
+	Ok(!referenced)
+}
+
+fn tombstone_predecessor_credential_sync(
+	connection: &Connection,
+	account_id: &AccountId,
+	account_revision: i64,
+	provider: &ProviderIdentity,
+) -> Result<CredentialBinding, StoreError> {
+	let predecessor = connection
+		.query_row(
+			"SELECT expected_credential_json, expected_account_revision
+			 FROM account_operations
+			 WHERE account_id = ?1 AND kind = 'logout' AND phase = 'committed'
+			 ORDER BY expected_account_revision DESC, completed_at_micros DESC,
+			          operation_id DESC LIMIT 1",
+			params![account_id.as_str()],
+			|row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<i64>>(1)?)),
+		)
+		.optional()
+		.map_err(sql_error)?
+		.ok_or_else(|| incompatible("tombstoned account logout history"))?;
+	let (binding, predecessor_revision) = predecessor;
+	let binding = parse_binding_json(binding.as_deref())?
+		.ok_or_else(|| incompatible("tombstoned account credential history"))?;
+	let predecessor_revision = predecessor_revision
+		.ok_or_else(|| incompatible("tombstoned account revision history"))?;
+	if predecessor_revision.checked_add(1) != Some(account_revision)
+		|| binding.provider != *provider
+	{
+		return Err(incompatible("tombstoned account binding history"));
+	}
+	Ok(binding)
 }
 
 fn credential_binding_sync(
@@ -2012,13 +2287,19 @@ fn validate_preparation(preparation: &AccountOperationPreparation) -> Result<(),
 	let new =
 		matches!(preparation.kind, AccountOperationKind::Enroll | AccountOperationKind::Import);
 	if new
-		!= (preparation.display_label.is_some()
-			&& preparation.enabled.is_some()
-			&& preparation.expected_account_revision.is_none()
-			&& preparation.expected.is_none()
-			&& preparation.target.is_some())
+		&& (preparation.display_label.is_none()
+			|| preparation.enabled.is_none()
+			|| preparation.expected.is_some()
+			|| preparation.target.is_none())
 	{
 		return Err(StoreError::InvalidInput("account operation shape is invalid"));
+	}
+	if new {
+		let target = preparation.target.as_ref().expect("new operation target is present");
+		let fresh = preparation.expected_account_revision.is_none();
+		if fresh != (target.version.get() == 1) {
+			return Err(StoreError::InvalidInput("account operation version is invalid"));
+		}
 	}
 	if !new
 		&& (preparation.display_label.is_some()

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -21,9 +21,9 @@ mod transfers;
 pub use self::{
 	account_lifecycle::{
 		AccountAdministrationOutcome, AccountCommandKind, AccountCommandReceiptClaim,
-		AccountCommandReceiptLease, AccountLifecycleMutation, AccountLifecycleMutationOutcome,
-		AccountLifecycleRejection, AccountOperationPreparation, AccountStoreObservation,
-		CodexAccountCapabilityAttestation, RoutingControlOutcome,
+		AccountCommandReceiptLease, AccountEnrollmentResolution, AccountLifecycleMutation,
+		AccountLifecycleMutationOutcome, AccountLifecycleRejection, AccountOperationPreparation,
+		AccountStoreObservation, CodexAccountCapabilityAttestation, RoutingControlOutcome,
 	},
 	account_profiles::{
 		AccountProfileDailyUsage, AccountProfileObservation, AccountProfileObservationOutcome,

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -6,10 +6,10 @@ tags: [local-product, sqlite, evidence, quick-task]
 openwiki:
   roles: [testing, architecture, workflow]
   change_kinds: [lifecycle, public-api, validation]
-  source_paths: [crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/account_launch/process.rs, crates/decodex-codex/src/quick_task.rs, database/src/conversations.rs, database/src/continuations.rs, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/quick_tasks.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
+  source_paths: [crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-app-client-ffi/src/account_reauthentication.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/account_launch/process.rs, crates/decodex-codex/src/quick_task.rs, database/src/account_lifecycle.rs, database/src/conversations.rs, database/src/continuations.rs, database/src/program_cycles.rs, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/quick_tasks.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
   symbols: [control_thread, ExactSubmittedTurnReadback, recover_unknown_quick_task_turn, plan_continuation, QuickTaskExecutionSettings, TranscriptRow]
-  test_paths: [database/tests/quick_task_restart.rs, database/src/conversations.rs, crates/decodex-runtime/src/account_launch/process.rs, apps/decodex-gpui/src/quick_tasks.rs, apps/decodex-gpui/src/shell.rs]
-  invariants: [Lossy external thread turns are not imported during lifecycle refresh.; Stable client Turn identity permits positive correlation but never replay.; Inconclusive recovery requires positive exact process death.; A successor Context Pack excludes its own Turn.; Durable positive evidence survives an interrupted local terminalization.; Archive commits only after positive post-readback.; RestoreProcessReadiness is pre-effect.]
+  test_paths: [database/tests/quick_task_restart.rs, database/src/conversations.rs, crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/account_launch/process.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, apps/decodex-gpui/src/quick_tasks.rs, apps/decodex-gpui/src/shell.rs]
+  invariants: [Lossy external thread turns are not imported during lifecycle refresh.; Stable client Turn identity permits positive correlation but never replay.; Inconclusive recovery requires positive exact process death.; A successor Context Pack excludes its own Turn.; Durable positive evidence survives an interrupted local terminalization.; Archive commits only after positive post-readback.; RestoreProcessReadiness is pre-effect.; A provider binding can have only one active Account and re-enrollment restores its tombstoned UUID.; A structured terminal device denial cannot remain pending.]
   validation_commands: [cargo test -p decodex-core -p decodex-codex -p decodex-database -p decodex-runtime -p decodex-gpui --all-targets, cargo clippy -p decodex-core -p decodex-codex -p decodex-database -p decodex-runtime -p decodex-gpui --all-targets -- -D warnings, python3 scripts/vnext/local_database_gate.py, python3 -m unittest tests/scripts/test_vnext_architecture.py]
 ---
 
@@ -17,7 +17,7 @@ openwiki:
 
 Status: accepted implementation and signed live-cutover evidence.
 
-Date: 2026-08-15.
+Date: 2026-08-18.
 
 This page contains no credential value, email address, provider-account identifier, or
 credential fingerprint.
@@ -373,6 +373,26 @@ the structured device prompt without printing the code, cancelled both sessions,
 login process or private-home residue. This is live acceptance through the exact user-action
 boundary; a real provider login and successful source-level credential installation remain
 unverified until a user explicitly completes either official sign-in method.
+
+The 2026-08-18 repair started with two independent red tests. A structured terminal device poll
+response at HTTP 403 was incorrectly treated as pending until timeout. A successful browser
+provider handoff after logout wrote a version-one credential under the provisional UUID, left the
+enrollment journal at `StoreApplied`, then failed the unique provider Account insert while the
+visible list remained empty. The repaired tests prove immediate typed device rejection and the
+complete logout-to-restoration path: original Account UUID, Account revision increment, immediate
+successor credential version, routing re-entry, exact command replay, and SQLite reopen.
+
+The same runtime test constructs the exact pre-repair `StoreApplied` collision. Startup proves
+that the provisional identity has no Account, routing, quota, profile, or fixed-selection
+reference, deletes only its exact orphan credential, and durably cancels the old operation. A new
+login then restores the tombstoned UUID. Protocol tests bind `AccountRestored` to both the
+provisional request UUID and restored projection. FFI and Swift tests bind terminal completion to
+the daemon-resolved UUID. The full workspace gate passed 1,093 Rust tests with nine intentional
+skips, both live CLI diagnostics, the local database and architecture gates, and all 223 Swift
+tests. The full workspace type-check and strict Clippy for every changed package also passed.
+Repository-wide formatting and enhanced lint remain blocked by pre-existing unrelated baseline
+findings. Signed installation and two real provider completions remain pending and must be
+appended before this repair is called live-accepted.
 
 ## Earlier repository gates
 

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -394,6 +394,14 @@ Repository-wide formatting and enhanced lint remain blocked by pre-existing unre
 findings. Signed installation and two real provider completions remain pending and must be
 appended before this repair is called live-accepted.
 
+The first cohort-2 installation exposed a separate App packaging regression before account
+readback. The daemon, CLI, and embedded native library reported cohort 2, but the Swift App loader
+still required cohort 1. The validly signed App therefore rejected its own native library and
+reported that the native client was unavailable. A red Swift architecture test now requires one
+shared native-compatibility source. Both the App loader and the staging verifier use that source
+for ABI 1 and cohort 2. The signed staging gate compiles the shared check and loads the actual
+staged dylib, so an App/FFI cohort mismatch now fails before installation.
+
 ## Earlier repository gates
 
 One complete `cargo make check` run finished successfully on the pre-Silent-Recovery source. It included:

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -41,7 +41,10 @@ The account-login restoration repair adds no schema migration. Artifact cohort 2
 strict local result/FFI shape. On startup, the daemon can compensate only the exact pre-repair
 `StoreApplied` enrollment collision described by the account-lifecycle contract; it deletes the
 proved orphan credential and cancels that operation. Installation therefore upgrades the signed
-daemon, CLI, and App FFI as one cohort while retaining the pre-install database rollback copy.
+daemon, CLI, App executable, and App FFI as one cohort while retaining the pre-install database
+rollback copy. The App and the staging verifier use one Swift compatibility source for the native
+ABI and artifact cohort. The staging gate must load the actual signed staged dylib through that
+shared check before installation.
 
 ## Fresh installation
 

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -37,6 +37,12 @@ operation indexes atomically. A binary rollback across this schema boundary must
 matching pre-upgrade private database backup; an older daemon does not accept a newer
 migration ledger.
 
+The account-login restoration repair adds no schema migration. Artifact cohort 2 changes the
+strict local result/FFI shape. On startup, the daemon can compensate only the exact pre-repair
+`StoreApplied` enrollment collision described by the account-lifecycle contract; it deletes the
+proved orphan credential and cancels that operation. Installation therefore upgrades the signed
+daemon, CLI, and App FFI as one cohort while retaining the pre-install database rollback copy.
+
 ## Fresh installation
 
 Build one signed, team-consistent local-service set before installation:

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -235,6 +235,22 @@ one exact store version through the same journal. Metadata deletion is allowed o
 after logout and creates a tombstone. Historical UUIDs, receipts, and execution
 references remain.
 
+A later enrollment with the same exact provider binding restores that tombstoned Account
+UUID. It does not create a second provider owner or reuse the client's provisional new UUID.
+The daemon resolves the provider only after it reads the owner-private login file, fences the
+current tombstone revision, restores the immediate successor credential version, clears the
+tombstone, increments the Account revision, and appends the original UUID to routing order.
+The typed result carries both the provisional request UUID and the resolved Account projection so
+strict clients refresh the restored row. An active non-tombstoned provider owner still produces
+the durable `provider_already_enrolled` rejection.
+
+Startup recognizes only the exact pre-repair collision shape: a `StoreApplied` version-one
+enrollment has no Account row, its exact credential provider belongs to one retained tombstone,
+and the provisional identity has no routing, quota, profile, or fixed-selection reference. The
+daemon deletes that exact orphan credential and journals the old enrollment as cancelled before
+it accepts a fresh restoration login. Any mismatch remains manual recovery; this is not a general
+credential cleanup or fallback.
+
 ## Runtime-negotiated account capability
 
 `AccountLifecycle` readiness is positive runtime evidence, not a release allowlist or a
@@ -268,6 +284,10 @@ existing-account `Refresh`, and applies only the immediate next HostCredentialSt
 compare-and-swap. The temporary home is removed on success, failure, cancellation, timeout, or
 bridge destruction. Ambient `Use in Codex` remains a separate explicit projection command;
 neither action implies the other.
+Device polling reads one bounded structured error response. Only the closed pending-code set can
+continue polling; another structured 403 or 404 is a terminal typed device-authorization
+rejection, not permission to wait until the session timeout. The native failure tells the user to
+check ChatGPT Security and retry without exposing provider text.
 An acceptance-unknown install replays only the same operation and idempotency key while
 the private source exists. Prepared-operation startup and command replay compare both the
 expected and target bindings; only an exact expected binding can prove that cancellation

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -6,10 +6,10 @@ tags: [local-product, sqlite, quick-task, adaptive-factory, domain-pack, app-ser
 openwiki:
   roles: [architecture, domain, workflow]
   change_kinds: [lifecycle, public-api, runtime]
-  source_paths: [crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
+  source_paths: [crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-app-client-ffi/src/account_reauthentication.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
   symbols: [QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
-  test_paths: [database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
-  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
+  test_paths: [crates/decodex-app-client-ffi/src/source_login_adapter.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
+  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
   validation_commands: [cargo test --workspace --all-targets]
 ---
 
@@ -370,13 +370,34 @@ terminal reader, or prompt parser.
 
 For browser login, the adapter binds one loopback callback on the official allowed port,
 builds the PKCE/state authorize URL, and returns that URL through the typed credential-negative
-status. Swift opens it once. For device login, the adapter requests and polls the official
+status. Swift opens it once. The loopback success page reports only that browser sign-in finished
+and sends the user back to Decodex for daemon installation; it does not claim that the account was
+added. For device login, the adapter requests and polls the official
 structured endpoints and returns only the verification URL and one-time code. The compact code
 card is one native button; one activation copies the code and opens the verification URL. Both
 methods use the same Manager, owner-private temporary home, bounded HTTP client, token exchange,
 mode-0600 `auth.json` persistence, timeout, cancellation, daemon install command, and cleanup
 path. The normal shared `~/.codex/auth.json` is unchanged. Swift never receives a credential
 value or auth-file path.
+
+The device poll consumes a bounded nested provider error and continues only for the closed
+pending-code set. A different structured 403 or 404 terminates as
+`device_authorization_rejected`; the app presents one concise ChatGPT Security action instead of
+waiting for the 15-minute timeout. Provider bodies and messages remain private.
+
+Enrollment resolves the imported provider binding inside `decodexd`. If that binding belongs to
+one tombstoned Account, the operation restores the original Account UUID at the exact tombstone
+revision and the immediate successor credential version, then appends that UUID to routing order.
+The provisional client UUID is retained only in the strict `AccountRestored` command result.
+FFI completion returns the daemon-resolved UUID, and Swift refreshes that row before reporting
+success. A live provider owner remains `provider_already_enrolled`. Artifact cohort 2 fences the
+new result and FFI completion shape from older local clients.
+
+Startup also compensates the one exact pre-repair collision in which a version-one enrollment
+credential reached `StoreApplied` under a provisional UUID but the provider's retained tombstone
+prevented the Account insert. Only after proving the orphan target and the absence of account,
+routing, quota, profile, and fixed-selection references does the daemon delete that exact
+credential and cancel the old enrollment. Every other ambiguity remains recovery-required.
 
 The adapter records its exact upstream files and functions in its source and third-party notice.
 Any upstream pin change requires a source diff of those named functions, dependency and advisory

--- a/scripts/macos/test_decodex_app_stage.sh
+++ b/scripts/macos/test_decodex_app_stage.sh
@@ -9,8 +9,10 @@ fi
 ./apps/decodex-app/script/build_and_run.sh stage
 
 common_root="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
+worktree_root="$(git rev-parse --show-toplevel)"
 stage_dir="${DECODEX_APP_STAGE_DIR:-$common_root/target/decodex-app}"
 app_path="$stage_dir/Decodex.app"
+compatibility_source="$worktree_root/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift"
 
 test -d "$app_path"
 test -x "$app_path/Contents/MacOS/DecodexApp"
@@ -28,21 +30,21 @@ loader_dir="$(mktemp -d "${TMPDIR:-/tmp}/decodex-native-loader.XXXXXX")"
 trap 'rm -rf "$loader_dir"' EXIT
 cat >"$loader_dir/main.swift" <<'SWIFT'
 import Darwin
+import Foundation
 
-guard CommandLine.arguments.count == 2,
-      let handle = dlopen(CommandLine.arguments[1], RTLD_NOW | RTLD_LOCAL),
-      let symbol = dlsym(handle, "decodex_app_native_client_abi_version")
-else {
+guard CommandLine.arguments.count == 2 else {
     exit(1)
 }
-defer { dlclose(handle) }
-typealias ABIVersion = @convention(c) () -> UInt32
-let abiVersion = unsafeBitCast(symbol, to: ABIVersion.self)
-guard abiVersion() == 1 else {
+do {
+    let handle = try DecodexNativeCompatibility.openLibrary(
+        at: URL(fileURLWithPath: CommandLine.arguments[1])
+    )
+    dlclose(handle)
+} catch {
     exit(1)
 }
 SWIFT
-xcrun swiftc "$loader_dir/main.swift" -o "$loader_dir/native-loader"
+xcrun swiftc "$compatibility_source" "$loader_dir/main.swift" -o "$loader_dir/native-loader"
 "$loader_dir/native-loader" "$native_client"
 for symbol in \
   _decodex_app_native_client_abi_version \


### PR DESCRIPTION
## Summary\n\n- Reject terminal device-code authorization failures instead of polling until timeout.\n- Restore the sole tombstoned account when the same provider identity enrolls again after logout.\n- Return the daemon-resolved account identity to the native App.\n- Share one Swift ABI and artifact-cohort check between the App and the signed staging verifier.\n- Load the actual staged dylib through that shared compatibility check.\n\n## Verification\n\n- 1,093 Rust tests passed with nine intentional skips on the login repair commit.\n- All 223 Swift tests passed on the final branch head.\n- All 10 vNext architecture tests passed.\n- The signed App staging gate loaded the actual cohort-2 native library.\n- The installed App passed strict code-signature verification and returned a value-free six-account, six-route native readback.\n\n## Remaining live acceptance\n\nBrowser and device-code provider completions require the user's account selection or code entry. The installed App is ready for those two handoffs.