### PR TITLE
Restore Codex auth refresh before routing

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -136,17 +136,22 @@ with one targetless provider-refresh ambiguity, shows `Refresh login`; this offi
 device-login flow is the app's only interactive credential-replacement surface. For the
 ambiguous case, Swift passes only the exact recovery operation identity. The daemon keeps
 the old ambiguity fenced until the verified replacement credential commits and never
-relabels it as a definite cancellation. The native app ABI has no direct
-credential-refresh operation. The action uses the same login-method selector. Manual
+relabels it as a definite cancellation. The native app exposes the existing
+revision-fenced credential refresh only as one step of Route; it is not a standalone
+interactive action. Refresh login uses the same login-method selector. Manual
 device-code login presents fixed-size Copy, Open, and Cancel controls. Automatic browser
 login opens the official redirect flow. The app then refreshes only that account after
 the daemon completes the exact credential replacement. The app
 then performs bounded short-interval daemon readback until the new background
 observation replaces any old unauthorized value. Each
-account row has one `Route` control. It first projects that exact daemon-owned login to shared
-`~/.codex/auth.json` for future Codex launches, then selects the same account as
-the fixed Decodex route. The underlying typed commands remain independently
-fenced, and retrying the control completes whichever step is not current. The
+account row has one `Route` control. Route first asks Account Service to reconcile a valid
+newer shared Codex login for the exact same provider identity or run its journaled provider
+refresh. It then carries the committed account and credential revisions into the exact
+`~/.codex/auth.json` projection for future Codex launches. Only after projection succeeds does
+it select the same account as the fixed Decodex route. A rejected refresh without a newer exact
+shared login does not write shared auth or change fixed routing. The underlying typed commands
+remain independently fenced. Route retains an uncertain refresh receipt and a prepared account
+revision so a retry resumes at the first incomplete step. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
 The overflow menu contains only `Refresh all`, the material selector, and Quit.

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -319,6 +319,14 @@ protocol AccountControlClient: ResetCardClient {
 		idempotencyKey: String
 	) async throws -> AccountControlResult
 
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult
+
 	func startAccountReauthentication(
 		authority: ResetCardAuthority?,
 		sessionID: String,
@@ -352,6 +360,16 @@ protocol AccountControlClient: ResetCardClient {
 }
 
 extension AccountControlClient {
+	func refreshAccountCredentials(
+		authority _: ResetCardAuthority?,
+		operationID _: String,
+		accountID _: String,
+		expectedRevision _: UInt64,
+		idempotencyKey _: String
+	) async throws -> AccountControlResult {
+		throw AccountControlError.applicationUnavailable
+	}
+
 	func startAccountEnrollment(
 		authority _: ResetCardAuthority?,
 		sessionID _: String,
@@ -609,6 +627,36 @@ extension DecodexNativeClient: AccountControlClient {
 			),
 			authority: authority,
 			expected: .routingOrder(order)
+		)
+	}
+
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		try Self.validateAccountControlInput(
+			authority: authority,
+			accountID: accountID,
+			operationID: operationID,
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
+		)
+		return try await executeAccountControl(
+			request: DecodexNativeRequest(
+				operation: "refresh_account",
+				accountID: accountID,
+				expectedRevision: expectedRevision,
+				idempotencyKey: idempotencyKey,
+				operationID: operationID
+			),
+			authority: authority,
+			expected: .accountChanged(
+				accountID: accountID,
+				enabled: nil
+			)
 		)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -267,6 +267,15 @@ enum AccountControlActivity: Equatable {
 	case route
 }
 
+private struct PendingAccountRoutePreparation {
+	let expectedAccountRevision: UInt64
+	let expectedCredentialBinding: AccountCredentialBinding
+	let refreshOperationID: String
+	let refreshIdempotencyKey: String
+	let projectionIdempotencyKey: String
+	var refreshedAccountRevision: UInt64?
+}
+
 private enum AccountLoginStart {
 	case enrollment(enabled: Bool)
 	case reauthentication(
@@ -392,6 +401,9 @@ final class ResetCardStore {
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingAccountLoginStart: PendingAccountLoginStart?
+	@ObservationIgnored private var pendingAccountRoutePreparations = [
+		String: PendingAccountRoutePreparation
+	]()
 	@ObservationIgnored private var postUseReconciliationTasks = [
 		String: Task<Void, Never>
 	]()
@@ -1431,28 +1443,151 @@ final class ResetCardStore {
 			allowsDuringRefresh: true,
 			successMessage: nil,
 			operation: {
+				var routedAccount = account
 				if needsCodexProjection {
-					let projectionResult = try await accountControlClient.useAccountInCodex(
-						authority: account.authority ?? establishedAuthority,
-						accountID: accountID,
-						expectedRevision: account.accountRevision,
-						idempotencyKey: Self.newCanonicalUUID()
-					)
-					if needsFixedRouting == false {
-						return projectionResult
+					var preparation = pendingAccountRoutePreparations[accountID]
+					if let refreshedRevision = preparation?.refreshedAccountRevision,
+						refreshedRevision != account.accountRevision
+					{
+						pendingAccountRoutePreparations.removeValue(forKey: accountID)
+						preparation = nil
 					}
-					_ = applyAccountControlResult(projectionResult)
+					if preparation == nil {
+						guard let credentialBinding = account.credentialBinding else {
+							throw AccountControlError.invalidResponse
+						}
+						preparation = PendingAccountRoutePreparation(
+							expectedAccountRevision: account.accountRevision,
+							expectedCredentialBinding: credentialBinding,
+							refreshOperationID: Self.newCanonicalUUID(),
+							refreshIdempotencyKey: Self.newCanonicalUUID(),
+							projectionIdempotencyKey: Self.newCanonicalUUID(),
+							refreshedAccountRevision: nil
+						)
+						pendingAccountRoutePreparations[accountID] = preparation
+					}
+					guard var preparation else {
+						throw AccountControlError.invalidResponse
+					}
+
+					if preparation.refreshedAccountRevision == nil {
+						do {
+							let refreshResult = try await accountControlClient
+								.refreshAccountCredentials(
+									authority: account.authority ?? establishedAuthority,
+									operationID: preparation.refreshOperationID,
+									accountID: accountID,
+									expectedRevision: preparation.expectedAccountRevision,
+									idempotencyKey: preparation.refreshIdempotencyKey
+								)
+							let currentRouteRevision = accountRecord(accountID)?.accountRevision
+								?? account.accountRevision
+							guard refreshedAccountRevisionIsCurrent(
+								refreshResult,
+								currentAccountRevision: currentRouteRevision
+							) else {
+								throw AccountControlError.expectedRevisionMismatch(
+									expected: preparation.expectedAccountRevision,
+									actual: currentRouteRevision
+								)
+							}
+							guard case .accountChanged(let refreshedAccount) = refreshResult,
+								Self.isImmediateRouteRefresh(
+									accountID: accountID,
+									expectedAccountRevision: preparation
+										.expectedAccountRevision,
+									expectedCredentialBinding: preparation
+										.expectedCredentialBinding,
+									to: refreshedAccount
+								)
+							else {
+								throw AccountControlError.invalidResponse
+							}
+							_ = applyAccountControlResult(refreshResult)
+							preparation.refreshedAccountRevision = refreshedAccount
+								.accountRevision
+							pendingAccountRoutePreparations[accountID] = preparation
+							routedAccount = refreshedAccount
+						} catch {
+							if Self.routeRefreshCanReuseReceipt(after: error) == false {
+								pendingAccountRoutePreparations.removeValue(forKey: accountID)
+							}
+							throw error
+						}
+					} else {
+						routedAccount = account
+					}
+
+					let result = try await accountControlClient.useAccountInCodex(
+						authority: routedAccount.authority ?? establishedAuthority,
+						accountID: accountID,
+						expectedRevision: routedAccount.accountRevision,
+						idempotencyKey: preparation.projectionIdempotencyKey
+					)
+					_ = applyAccountControlResult(result)
+					pendingAccountRoutePreparations.removeValue(forKey: accountID)
+					if needsFixedRouting == false {
+						return result
+					}
+				} else {
+					pendingAccountRoutePreparations.removeValue(forKey: accountID)
 				}
 
 				return try await accountControlClient.setFixedSelection(
-					authority: account.authority ?? establishedAuthority,
+					authority: routedAccount.authority ?? establishedAuthority,
 					accountID: accountID,
-					expectedAccountRevision: account.accountRevision,
+					expectedAccountRevision: routedAccount.accountRevision,
 					expectedRoutingRevision: routing.revision,
 					idempotencyKey: Self.newCanonicalUUID()
 				)
 			}
 		)
+	}
+
+	private func refreshedAccountRevisionIsCurrent(
+		_ result: AccountControlResult,
+		currentAccountRevision: UInt64
+	) -> Bool {
+		guard case .accountChanged(let refreshedAccount) = result else {
+			return false
+		}
+		return refreshedAccount.accountRevision >= currentAccountRevision
+	}
+
+	nonisolated private static func isImmediateRouteRefresh(
+		accountID: String,
+		expectedAccountRevision: UInt64,
+		expectedCredentialBinding: AccountCredentialBinding,
+		to refreshed: ResetCardAccountRecord
+	) -> Bool {
+		let (refreshedAccountRevision, accountRevisionOverflow) = expectedAccountRevision
+			.addingReportingOverflow(1)
+		guard accountRevisionOverflow == false,
+			refreshed.accountID == accountID,
+			refreshed.accountRevision == refreshedAccountRevision,
+			let refreshedBinding = refreshed.credentialBinding
+		else {
+			return false
+		}
+		let (expectedCredentialVersion, credentialVersionOverflow) = expectedCredentialBinding.version
+			.addingReportingOverflow(1)
+		return credentialVersionOverflow == false
+			&& refreshedBinding.version == expectedCredentialVersion
+			&& refreshedBinding.provider == expectedCredentialBinding.provider
+			&& refreshedBinding.providerAccountID == expectedCredentialBinding.providerAccountID
+	}
+
+	nonisolated private static func routeRefreshCanReuseReceipt(after error: Error) -> Bool {
+		guard let error = error as? AccountControlError else {
+			return true
+		}
+		switch error {
+		case .invalidInput, .invalidResponse, .expectedRevisionMismatch, .idempotencyConflict,
+			.idempotencyCapacityExceeded, .rejected:
+			return false
+		case .client, .applicationUnavailable, .acceptanceUnknown, .potentiallyDispatched:
+			return true
+		}
 	}
 
 	func selectBalancedAccounts() async {
@@ -3509,6 +3644,7 @@ final class ResetCardStore {
 			_ = reorderAccountStates(to: routing.order)
 			return .none
 		case .accountLoggedOut(let accountID, _):
+			pendingAccountRoutePreparations.removeValue(forKey: accountID)
 			if case .current(let projectedID, _, _) = codexAuthProjection,
 				projectedID == accountID
 			{

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -175,6 +175,13 @@ final class AccountControlNativeClientTests: XCTestCase {
 			expectedRoutingRevision: 9,
 			idempotencyKey: idempotencyKey
 		)
+		_ = try await client.refreshAccountCredentials(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			expectedRevision: 7,
+			idempotencyKey: idempotencyKey
+		)
 		let requests = try recorder.requests.map { try nativeJSONObject($0.data) }
 		XCTAssertEqual(
 			requests.compactMap { $0["operation"] as? String },
@@ -182,7 +189,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 				"enroll_account", "get_codex_auth_projection", "use_account_in_codex",
 				"disable_account",
 				"logout_account", "set_fixed_selection",
-				"set_balanced_selection", "set_account_order",
+				"set_balanced_selection", "set_account_order", "refresh_account",
 			]
 		)
 		XCTAssertEqual(
@@ -209,7 +216,13 @@ final class AccountControlNativeClientTests: XCTestCase {
 		XCTAssertEqual(Set(requests[7].keys), [
 			"schema", "operation", "order", "expected_routing_revision", "idempotency_key",
 		])
-		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 8))
+		XCTAssertEqual(Set(requests[8].keys), [
+			"schema", "operation", "operation_id", "account_id", "expected_revision",
+			"idempotency_key",
+		])
+		XCTAssertEqual(requests[8]["operation_id"] as? String, operationID)
+		XCTAssertEqual(requests[8]["expected_revision"] as? NSNumber, 7)
+		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 9))
 	}
 
 	func testAccountOrderRejectsAContradictoryAppliedOrder() async throws {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -1093,13 +1093,11 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .balanced)
 		XCTAssertNil(store.message)
 		let useRequest = await client.useRequest()
-		XCTAssertEqual(
-			useRequest,
-			AccountControlStoreUseRequest(
-				authority: nil,
-				accountID: accountID,
-				expectedRevision: 7
-			)
+		XCTAssertEqual(useRequest?.authority, nil)
+		XCTAssertEqual(useRequest?.accountID, accountID)
+		XCTAssertEqual(useRequest?.expectedRevision, 7)
+		XCTAssertTrue(
+			useRequest.map { DecodexNativeClient.isCanonicalUUID($0.idempotencyKey) } ?? false
 		)
 
 		await client.releaseInventory()
@@ -1227,7 +1225,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNotNil(store.message)
 	}
 
-	func testRouteAccountProjectsThenSelectsFixedRouting() async throws {
+	func testRouteAccountRefreshesThenProjectsAndSelectsFixedRoutingWithAdvancedBinding() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
@@ -1246,14 +1244,50 @@ final class AccountControlStoreTests: XCTestCase {
 
 		let controlSequence = await client.controlSequence()
 		let controlCounts = await client.controlCounts()
+		let recordedUseRequest = await client.useRequest()
+		let recordedFixedRequest = await client.fixedRequest()
+		let useRequest = try XCTUnwrap(recordedUseRequest)
+		let fixedRequest = try XCTUnwrap(recordedFixedRequest)
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
+		XCTAssertEqual(store.accounts.first?.account.credentialBinding?.version, 4)
+		XCTAssertEqual(useRequest.expectedRevision, 8)
+		XCTAssertEqual(fixedRequest.expectedAccountRevision, 8)
 		XCTAssertEqual(
 			controlSequence,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
-		XCTAssertEqual(controlCounts, .init(fixed: 1, projection: 1))
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 1))
 		XCTAssertNil(store.message)
+	}
+
+	func testRouteAccountDoesNotProjectOrChangeRoutingWhenRefreshFails() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			refreshAccountError: .rejected(.lifecycleUnready, actualRevision: nil)
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.routeAccount(accountID)
+
+		let controlSequence = await client.controlSequence()
+		let controlCounts = await client.controlCounts()
+		XCTAssertEqual(controlSequence, [.credentialRefresh])
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 0))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
+		XCTAssertFalse(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .balanced)
+		XCTAssertNotNil(store.message)
 	}
 
 	func testRouteAccountDoesNotChangeRoutingWhenProjectionFails() async throws {
@@ -1278,9 +1312,47 @@ final class AccountControlStoreTests: XCTestCase {
 		let controlCounts = await client.controlCounts()
 		XCTAssertFalse(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .balanced)
-		XCTAssertEqual(controlSequence, [.codexProjection])
-		XCTAssertEqual(controlCounts, .init(fixed: 0, projection: 1))
+		XCTAssertEqual(controlSequence, [.credentialRefresh, .codexProjection])
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 1))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
 		XCTAssertNotNil(store.message)
+	}
+
+	func testRouteAccountRetriesProjectionWithTheSameReceiptWithoutRefreshingAgain() async throws {
+		let account = accountRecord()
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			useAccountError: .applicationUnavailable
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.routeAccount(accountID)
+		let recordedFirstUseRequest = await client.useRequest()
+		let firstUseRequest = try XCTUnwrap(recordedFirstUseRequest)
+		await client.setUseAccountError(nil)
+		await store.routeAccount(accountID)
+		let recordedSecondUseRequest = await client.useRequest()
+		let secondUseRequest = try XCTUnwrap(recordedSecondUseRequest)
+		let controlSequence = await client.controlSequence()
+		let controlCounts = await client.controlCounts()
+
+		XCTAssertEqual(firstUseRequest.idempotencyKey, secondUseRequest.idempotencyKey)
+		XCTAssertEqual(
+			controlSequence,
+			[.credentialRefresh, .codexProjection, .codexProjection, .fixedRouting]
+		)
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 2))
+		XCTAssertTrue(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		XCTAssertNil(store.message)
 	}
 
 	func testRouteAccountRetriesOnlyRoutingAfterPartialSuccess() async throws {
@@ -1306,7 +1378,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .balanced)
 		XCTAssertEqual(
 			firstControlSequence,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
 		XCTAssertNotNil(store.message)
 
@@ -1319,9 +1391,9 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		XCTAssertEqual(
 			finalControlSequence,
-			[.codexProjection, .fixedRouting, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting, .fixedRouting]
 		)
-		XCTAssertEqual(finalControlCounts, .init(fixed: 2, projection: 1))
+		XCTAssertEqual(finalControlCounts, .init(refresh: 1, fixed: 2, projection: 1))
 		XCTAssertNil(store.message)
 	}
 
@@ -1355,7 +1427,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let controlSequence = await client.controlSequence()
 		let controlCounts = await client.controlCounts()
 		XCTAssertEqual(controlSequence, [])
-		XCTAssertEqual(controlCounts, .init(fixed: 0, projection: 0))
+		XCTAssertEqual(controlCounts, .init(refresh: 0, fixed: 0, projection: 0))
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 	}
@@ -1435,7 +1507,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let useRequest = await client.useRequest()
 		XCTAssertEqual(
 			operationsWhileFirstRouteIsPending,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
 		XCTAssertEqual(useRequest?.accountID, accountID)
 
@@ -1709,6 +1781,15 @@ private struct AccountControlStoreUseRequest: Equatable, Sendable {
 	let authority: ResetCardAuthority?
 	let accountID: String
 	let expectedRevision: UInt64
+	let idempotencyKey: String
+}
+
+private struct AccountControlStoreRefreshRequest: Equatable, Sendable {
+	let authority: ResetCardAuthority?
+	let operationID: String
+	let accountID: String
+	let expectedRevision: UInt64
+	let idempotencyKey: String
 }
 
 private struct AccountControlStoreEnabledRequest: Equatable, Sendable {
@@ -1757,11 +1838,13 @@ private struct AccountControlStoreOrderRequest: Equatable, Sendable {
 }
 
 private enum AccountControlStoreOperation: Equatable, Sendable {
+	case credentialRefresh
 	case codexProjection
 	case fixedRouting
 }
 
 private struct AccountControlStoreCounts: Equatable, Sendable {
+	let refresh: Int
 	let fixed: Int
 	let projection: Int
 }
@@ -1785,14 +1868,17 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private var routing: AccountRoutingControl
 	private var fixedSelectionError: AccountControlError?
 	private let accountOrderError: AccountControlError?
-	private let useAccountError: AccountControlError?
+	private var refreshAccountError: AccountControlError?
+	private var useAccountError: AccountControlError?
 	private var lastFixedRequest: AccountControlStoreFixedRequest?
 	private var lastUseRequest: AccountControlStoreUseRequest?
+	private var lastRefreshRequest: AccountControlStoreRefreshRequest?
 	private var lastEnabledRequest: AccountControlStoreEnabledRequest?
 	private var lastLogoutRequest: AccountControlStoreLogoutRequest?
 	private var lastOrderRequest: AccountControlStoreOrderRequest?
 	private var controlOperations = [AccountControlStoreOperation]()
 	private var fixedRequestCount = 0
+	private var refreshRequestCount = 0
 	private var projectionRequestCount = 0
 	private var projection: CodexAuthProjection
 	private var projectionError: AccountControlError?
@@ -1836,6 +1922,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
 		accountOrderError: AccountControlError? = nil,
+		refreshAccountError: AccountControlError? = nil,
 		useAccountError: AccountControlError? = nil,
 		projection: CodexAuthProjection = .unmanaged,
 		reauthenticationStates: [AccountReauthenticationState] = [],
@@ -1866,6 +1953,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 			)
 		self.fixedSelectionError = fixedSelectionError
 		self.accountOrderError = accountOrderError
+		self.refreshAccountError = refreshAccountError
 		self.useAccountError = useAccountError
 		self.reauthenticationStates = reauthenticationStates
 		self.accountLoginFailure = accountLoginFailure
@@ -2014,6 +2102,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 
 	func controlCounts() -> AccountControlStoreCounts {
 		AccountControlStoreCounts(
+			refresh: refreshRequestCount,
 			fixed: fixedRequestCount,
 			projection: projectionRequestCount
 		)
@@ -2178,7 +2267,8 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		lastUseRequest = AccountControlStoreUseRequest(
 			authority: authority,
 			accountID: accountID,
-			expectedRevision: expectedRevision
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
 		)
 		projectionRequestCount += 1
 		controlOperations.append(.codexProjection)
@@ -2200,6 +2290,83 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 
 	func useRequest() -> AccountControlStoreUseRequest? {
 		lastUseRequest
+	}
+
+	func setUseAccountError(_ error: AccountControlError?) {
+		useAccountError = error
+	}
+
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		guard DecodexNativeClient.isCanonicalUUID(operationID),
+			DecodexNativeClient.isCanonicalUUID(idempotencyKey)
+		else {
+			throw AccountControlError.invalidInput
+		}
+		lastRefreshRequest = AccountControlStoreRefreshRequest(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
+		)
+		refreshRequestCount += 1
+		controlOperations.append(.credentialRefresh)
+		if let refreshAccountError {
+			throw refreshAccountError
+		}
+
+		let current: ResetCardAccountRecord
+		if account.accountID == accountID {
+			current = account
+		} else if let secondaryAccount, secondaryAccount.accountID == accountID {
+			current = secondaryAccount
+		} else {
+			throw AccountControlError.invalidInput
+		}
+		guard current.accountRevision == expectedRevision,
+			let binding = current.credentialBinding
+		else {
+			throw AccountControlError.invalidInput
+		}
+		let refreshed = ResetCardAccountRecord(
+			authority: current.authority,
+			accountID: current.accountID,
+			alias: current.alias,
+			accountRevision: current.accountRevision + 1,
+			enabled: current.enabled,
+			observedState: current.observedState,
+			lifecycleReadiness: current.lifecycleReadiness,
+			credentialBinding: AccountCredentialBinding(
+				schemaVersion: binding.schemaVersion,
+				version: binding.version + 1,
+				fingerprintSHA256: String(repeating: "d", count: 64),
+				provider: binding.provider,
+				providerAccountID: binding.providerAccountID
+			),
+			unsettledOperation: current.unsettledOperation,
+			fiveHourQuota: current.fiveHourQuota,
+			sevenDayQuota: current.sevenDayQuota
+		)
+		if account.accountID == accountID {
+			account = refreshed
+		} else {
+			secondaryAccount = refreshed
+		}
+		return .accountChanged(refreshed)
+	}
+
+	func refreshRequest() -> AccountControlStoreRefreshRequest? {
+		lastRefreshRequest
+	}
+
+	func setRefreshAccountError(_ error: AccountControlError?) {
+		refreshAccountError = error
 	}
 
 	func setAccountEnabled(

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -157,6 +157,13 @@ enum Request {
 		expected_routing_revision: u64,
 		idempotency_key: String,
 	},
+	RefreshAccount {
+		schema: String,
+		operation_id: String,
+		account_id: String,
+		expected_revision: u64,
+		idempotency_key: String,
+	},
 	StartAccountEnrollment {
 		schema: String,
 		session_id: String,
@@ -216,6 +223,7 @@ impl Request {
 			Self::SetFixedSelection { .. } => "set_fixed_selection",
 			Self::SetBalancedSelection { .. } => "set_balanced_selection",
 			Self::SetAccountOrder { .. } => "set_account_order",
+			Self::RefreshAccount { .. } => "refresh_account",
 			Self::StartAccountEnrollment { .. } => "start_account_enrollment",
 			Self::StartAccountReauthentication { .. } => "start_account_reauthentication",
 			Self::PollAccountReauthentication { .. } => "poll_account_reauthentication",
@@ -242,6 +250,7 @@ impl Request {
 			| Self::SetFixedSelection { schema, .. }
 			| Self::SetBalancedSelection { schema, .. }
 			| Self::SetAccountOrder { schema, .. }
+			| Self::RefreshAccount { schema, .. }
 			| Self::StartAccountEnrollment { schema, .. }
 			| Self::StartAccountReauthentication { schema, .. }
 			| Self::PollAccountReauthentication { schema, .. }
@@ -745,6 +754,15 @@ async fn execute_request(
 			set_balanced_selection(profile, expected_routing_revision, idempotency_key).await,
 		Request::SetAccountOrder { order, expected_routing_revision, idempotency_key, .. } =>
 			set_account_order(profile, order, expected_routing_revision, idempotency_key).await,
+		Request::RefreshAccount {
+			operation_id,
+			account_id,
+			expected_revision,
+			idempotency_key,
+			..
+		} =>
+			refresh_account(profile, operation_id, account_id, expected_revision, idempotency_key)
+				.await,
 		Request::StartAccountEnrollment {
 			session_id,
 			operation_id,
@@ -892,6 +910,21 @@ async fn logout_account(
 	idempotency_key: String,
 ) -> Result<Value, RequestFailure> {
 	let payload = CommandPayload::LogoutAccount {
+		operation_id: entity_id(&operation_id)?,
+		account_id: entity_id(&account_id)?,
+	};
+	execute_account_command(profile, payload, Some(revision(expected_revision)?), idempotency_key)
+		.await
+}
+
+async fn refresh_account(
+	profile: ClientProfile,
+	operation_id: String,
+	account_id: String,
+	expected_revision: u64,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let payload = CommandPayload::RefreshAccount {
 		operation_id: entity_id(&operation_id)?,
 		account_id: entity_id(&account_id)?,
 	};
@@ -1286,8 +1319,22 @@ mod tests {
 			))
 			.is_err()
 		);
-		assert!(serde_json::from_str::<Request>(&format!(
+	}
+
+	#[test]
+	fn refresh_request_is_operation_and_account_revision_fenced() {
+		let request = serde_json::from_str::<Request>(&format!(
 			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
+		))
+		.expect("refresh request must decode");
+
+		assert_eq!(request.operation(), "refresh_account");
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
+		))
+		.is_err());
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","idempotency_key":"refresh-test"}}"#
 		))
 		.is_err());
 	}

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -102,6 +102,9 @@ pub(crate) struct CredentialRefreshResult {
 	bundle: CredentialSecretBundle,
 }
 
+type SharedAuthReprojector =
+	fn(&CredentialBinding, &CredentialSecretBundle) -> Result<(), AccountLifecycleError>;
+
 /// Credential-negative readback of the normal shared Codex auth projection.
 pub(crate) enum CodexAuthProjectionInspection {
 	Current { account_id: AccountId, account_revision: i64, projection_digest: String },
@@ -408,6 +411,7 @@ pub struct AccountService {
 	store: SqliteStore,
 	credentials: Arc<dyn HostCredentialStore>,
 	refresher: Arc<dyn CredentialRefreshPort>,
+	shared_auth_reprojector: SharedAuthReprojector,
 	account_locks: Mutex<HashMap<AccountId, Arc<AsyncMutex<()>>>>,
 	callback_ready: AtomicBool,
 	callback_profile_sha256: Mutex<Option<String>>,
@@ -423,10 +427,17 @@ impl AccountService {
 			store,
 			credentials,
 			refresher,
+			shared_auth_reprojector: reproject_shared_codex_auth_if_current,
 			account_locks: Mutex::new(HashMap::new()),
 			callback_ready: AtomicBool::new(false),
 			callback_profile_sha256: Mutex::new(None),
 		}
+	}
+
+	#[cfg(test)]
+	fn with_shared_auth_reprojector(mut self, reprojector: SharedAuthReprojector) -> Self {
+		self.shared_auth_reprojector = reprojector;
+		self
 	}
 
 	fn set_callback_capability(&self, profile_sha256: String, ready: bool) {
@@ -925,6 +936,30 @@ impl AccountService {
 		.await
 	}
 
+	async fn refresh_or_reconcile_shared(
+		&self,
+		current: &CredentialBinding,
+		stored: StoredCredential,
+	) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+		if let Some(shared) = matching_shared_refresh_now(current, stored.bundle()) {
+			return Ok(shared);
+		}
+
+		let refresher = Arc::clone(&self.refresher);
+		let (result, stored) = tokio::task::spawn_blocking(move || {
+			let result = refresher.refresh(stored.bundle());
+			(result, stored)
+		})
+		.await
+		.map_err(|_| CredentialRefreshError::Ambiguous)?;
+
+		match result {
+			Err(CredentialRefreshError::Rejected) =>
+				recover_rejected_refresh_from_shared_now(current, stored.bundle()),
+			result => result,
+		}
+	}
+
 	#[allow(clippy::too_many_lines)] // Keep the generation-bound refresh state machine auditable as one sequence.
 	async fn refresh_while_locked(
 		&self,
@@ -1019,21 +1054,7 @@ impl AccountService {
 					.await?,
 			)?;
 		}
-		let refresher = Arc::clone(&self.refresher);
-		let refreshed =
-			match tokio::task::spawn_blocking(move || refresher.refresh(stored.bundle())).await {
-				Ok(refreshed) => refreshed,
-				Err(_) => {
-					self.recover_or_cancel(
-						&operation_id,
-						AccountOperationPhase::ProviderEffectPending,
-						"provider_refresh_ambiguous",
-						true,
-					)
-					.await?;
-					return Err(AccountLifecycleError::Refresh(CredentialRefreshError::Ambiguous));
-				},
-			};
+		let refreshed = self.refresh_or_reconcile_shared(current, stored).await;
 		let refreshed = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(CredentialRefreshError::Rejected) => {
@@ -1073,7 +1094,6 @@ impl AccountService {
 				Err(error) => return Err(error),
 			};
 		accepted_phase(self.store.set_account_operation_target(&operation_id, &target).await?)?;
-		let projection_bundle = refreshed.bundle.clone();
 		if let Err(error) =
 			self.credentials.compare_and_swap_rotate(account_id, current, &target, refreshed.bundle)
 		{
@@ -1096,12 +1116,12 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		self.commit_store_applied(&operation_id).await?;
-		if let Some((generation_id, process_binding)) = callback_generation {
-			self.require_active_callback_generation(account_id, generation_id, process_binding)
-				.await?;
-		}
-		Ok(projection(&target, &projection_bundle))
+		self.commit_and_project_refresh_result(
+			&operation_id,
+			account_id,
+			callback_generation,
+		)
+		.await
 	}
 
 	/// Replace one exact account credential from a private Codex auth file.
@@ -1447,6 +1467,8 @@ impl AccountService {
 			}
 			match operation.phase {
 				AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied => {
+					self.commit_and_project_refresh_result(&operation_id, account_id, None)
+						.await?;
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -1539,6 +1561,8 @@ impl AccountService {
 							)
 							.await?,
 					)?;
+					self.commit_and_project_refresh_result(&operation_id, account_id, None)
+						.await?;
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -1572,18 +1596,6 @@ impl AccountService {
 					.await;
 			},
 		};
-		let now_unix_micros = SystemTime::now()
-			.duration_since(UNIX_EPOCH)
-			.ok()
-			.and_then(|duration| i64::try_from(duration.as_micros()).ok());
-		let shared_refresh = now_unix_micros.and_then(|now_unix_micros| {
-			matching_shared_refresh(
-				&current,
-				stored.bundle(),
-				now_unix_micros,
-				read_shared_codex_credential(),
-			)
-		});
 		let preparation = AccountOperationPreparation {
 			operation_id: operation_id.clone(),
 			account_id: account_id.clone(),
@@ -1628,29 +1640,7 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		let refreshed = match shared_refresh {
-			Some(refreshed) => Ok(refreshed),
-			None => {
-				let refresher = Arc::clone(&self.refresher);
-				match tokio::task::spawn_blocking(move || refresher.refresh(stored.bundle())).await
-				{
-					Ok(refreshed) => refreshed,
-					Err(_) => {
-						return self
-							.complete_account_operation_error(
-								lease,
-								&operation_id,
-								AccountOperationPhase::ProviderEffectPending,
-								AccountOperationPhase::RecoveryRequired,
-								Some("provider_refresh_ambiguous"),
-								AccountLifecycleError::Refresh(CredentialRefreshError::Ambiguous),
-								build_response.take().expect("builder is retained"),
-							)
-							.await;
-					},
-				}
-			},
-		};
+		let refreshed = self.refresh_or_reconcile_shared(&current, stored).await;
 		let refreshed = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(error @ CredentialRefreshError::Rejected) => {
@@ -1727,6 +1717,8 @@ impl AccountService {
 				)
 				.await?,
 		)?;
+		self.commit_and_project_refresh_result(&operation_id, account_id, None)
+			.await?;
 		self.complete_account_operation_success(
 			lease,
 			&operation_id,
@@ -1743,12 +1735,31 @@ impl AccountService {
 		binding: &CredentialBinding,
 		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
-		let projection = self.project_exact(account_id, binding)?;
+		let stored = self.credentials.read_exact(account_id, binding)?;
+		// Credential rotation and its receipt stay authoritative even when the replaceable shared
+		// Codex projection cannot be written. Route owns the explicit retryable projection command
+		// and cannot advance fixed routing until that separate command succeeds.
+		let _shared_auth_projection = (self.shared_auth_reprojector)(binding, stored.bundle());
+		// A later refresh of the same binding retries this conditional projection. Explicit Route
+		// always follows with UseAccountInCodex, whose exact writer and receipt provide the immediate
+		// retry-convergence boundary without misclassifying the provider effect.
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
 		}
-		Ok(projection)
+		Ok(projection(binding, stored.bundle()))
+	}
+
+	async fn commit_and_project_refresh_result(
+		&self,
+		operation_id: &AccountOperationId,
+		account_id: &AccountId,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		self.commit_store_applied(operation_id).await?;
+		let account = self.load_account(account_id).await?;
+		let binding = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
+		self.project_refresh_result(account_id, binding, callback_generation).await
 	}
 
 	async fn require_active_callback_generation(
@@ -3409,15 +3420,6 @@ impl AccountService {
 			.ok_or(AccountLifecycleError::AccountMissing)
 	}
 
-	fn project_exact(
-		&self,
-		account_id: &AccountId,
-		binding: &CredentialBinding,
-	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
-		let stored = self.credentials.read_exact(account_id, binding)?;
-		Ok(projection(binding, stored.bundle()))
-	}
-
 	fn lock_for(
 		&self,
 		account_id: &AccountId,
@@ -3557,12 +3559,83 @@ fn matching_shared_refresh(
 		Ok(imported)
 			if imported.provider == current.provider
 				&& imported.bundle.access_token_expires_at_unix_micros() > now_unix_micros
+				&& imported.bundle.access_token_expires_at_unix_micros()
+					> current_bundle.access_token_expires_at_unix_micros()
 				&& !same_refresh_bundle(current_bundle, &imported.bundle) =>
 			Some(CredentialRefreshResult {
 				returned_provider: imported.provider,
 				bundle: imported.bundle,
 			}),
 		Ok(_) | Err(_) => None,
+	}
+}
+
+fn matching_shared_refresh_now(
+	current: &CredentialBinding,
+	current_bundle: &CredentialSecretBundle,
+) -> Option<CredentialRefreshResult> {
+	current_unix_micros().ok().and_then(|now_unix_micros| {
+		matching_shared_refresh(
+			current,
+			current_bundle,
+			now_unix_micros,
+			read_shared_codex_credential(),
+		)
+	})
+}
+
+fn recover_rejected_refresh_from_shared(
+	current: &CredentialBinding,
+	current_bundle: &CredentialSecretBundle,
+	now_unix_micros: i64,
+	shared: Result<ImportedCredential, CredentialImportError>,
+) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+	matching_shared_refresh(current, current_bundle, now_unix_micros, shared)
+		.ok_or(CredentialRefreshError::Rejected)
+}
+
+fn recover_rejected_refresh_from_shared_now(
+	current: &CredentialBinding,
+	current_bundle: &CredentialSecretBundle,
+) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+	let now_unix_micros = current_unix_micros().map_err(|_| CredentialRefreshError::Rejected)?;
+	recover_rejected_refresh_from_shared(
+		current,
+		current_bundle,
+		now_unix_micros,
+		read_shared_codex_credential(),
+	)
+}
+
+fn reproject_shared_codex_auth_if_current(
+	binding: &CredentialBinding,
+	bundle: &CredentialSecretBundle,
+) -> Result<(), AccountLifecycleError> {
+	reproject_shared_codex_auth_if_current_with(
+		binding,
+		bundle,
+		read_shared_codex_auth_identity,
+		project_shared_codex_auth,
+	)
+}
+
+fn reproject_shared_codex_auth_if_current_with<ReadIdentity, Project>(
+	binding: &CredentialBinding,
+	bundle: &CredentialSecretBundle,
+	read_identity: ReadIdentity,
+	project: Project,
+) -> Result<(), AccountLifecycleError>
+where
+	ReadIdentity: FnOnce() -> Result<SharedCodexAuthIdentity, CodexAuthProjectionError>,
+	Project: FnOnce(&CredentialSecretBundle, &str) -> Result<(), CodexAuthProjectionError>,
+{
+	match read_identity() {
+		Ok(SharedCodexAuthIdentity::Chatgpt { provider_account_id })
+			if binding.provider.provider() == AccountProvider::Chatgpt
+				&& provider_account_id == binding.provider.account_id() =>
+			project(bundle, binding.provider.account_id()).map_err(projection_error),
+		Ok(SharedCodexAuthIdentity::Chatgpt { .. } | SharedCodexAuthIdentity::Unmanaged)
+		| Err(_) => Ok(()),
 	}
 }
 
@@ -3817,18 +3890,25 @@ mod tests {
 		CredentialSecretBundle, CredentialStoreError, HostCredentialStore, ImportedCredential,
 		PROVIDER_REFRESH_OUTCOME_UNKNOWN, PreparedRefreshReconciliation,
 		ReauthenticationReplayDisposition, RefreshResponse, UseInCodexProjectionError,
-		access_token_needs_refresh, account_lock_for, classify_prepared_refresh_reconciliation,
+		accepted_phase, access_token_needs_refresh, account_lock_for,
+		classify_prepared_refresh_reconciliation,
 		classify_reauthentication_replay, codex_auth_projection_digest, credential_refresh_result,
 		matching_shared_refresh, projection_binding, reauthentication_current,
 		reauthentication_target, refreshed_credential_target,
+		recover_rejected_refresh_from_shared,
+		reproject_shared_codex_auth_if_current_with,
 		require_refreshed_access_token_for_observation, resolve_reauthentication_store_effect,
 		stable_account_alias, use_in_codex_receipt_result,
 	};
 	use std::{
+		cell::Cell,
 		collections::{HashMap, HashSet},
 		fs,
 		os::unix::fs::PermissionsExt as _,
-		sync::{Arc, Mutex},
+		sync::{
+			Arc, Mutex,
+			atomic::{AtomicUsize, Ordering},
+		},
 		time::Duration,
 	};
 	use tempfile::tempdir;
@@ -3846,6 +3926,16 @@ mod tests {
 		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
 			panic!("verified reauthentication must not call the provider refresh adapter")
 		}
+	}
+
+	static FAILED_SHARED_REPROJECTIONS: AtomicUsize = AtomicUsize::new(0);
+
+	fn fail_shared_auth_reprojection(
+		_binding: &CredentialBinding,
+		_bundle: &CredentialSecretBundle,
+	) -> Result<(), AccountLifecycleError> {
+		FAILED_SHARED_REPROJECTIONS.fetch_add(1, Ordering::Relaxed);
+		Err(AccountLifecycleError::CoordinatorUnavailable)
 	}
 
 	#[test]
@@ -3889,6 +3979,196 @@ mod tests {
 				&& bytes[0].is_ascii_uppercase()
 				&& bytes[1..].iter().all(u8::is_ascii_lowercase)
 		}));
+	}
+
+	#[tokio::test]
+	#[allow(clippy::too_many_lines)] // The precommitted refresh fixture and receipt readback form one crash-window proof.
+	async fn committed_refresh_finishes_its_receipt_when_shared_reprojection_fails() {
+		FAILED_SHARED_REPROJECTIONS.store(0, Ordering::Relaxed);
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, "receipt-provider-account")
+			.expect("provider identity");
+		let account_id =
+			AccountId::new("21000000-0000-4000-8000-000000000031").expect("account identity");
+		let enrollment_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000031")
+				.expect("enrollment operation");
+		let initial_bundle = shared_bundle(provider.account_id(), "initial-access", 2_000_000);
+		let initial_binding = initial_bundle
+			.binding_for(
+				&account_id,
+				&enrollment_operation,
+				CredentialVersion::new(1).expect("initial version"),
+				&provider,
+			)
+			.expect("initial binding");
+		accepted_phase(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: enrollment_operation.clone(),
+					account_id: account_id.clone(),
+					kind: AccountOperationKind::Enroll,
+					display_label: Some(stable_account_alias(&provider)),
+					enabled: Some(true),
+					expected_account_revision: None,
+					expected: None,
+					target: Some(initial_binding.clone()),
+					provider: provider.clone(),
+				})
+				.await
+				.expect("prepare enrollment"),
+		)
+		.expect("accept enrollment preparation");
+		credentials
+			.create(&account_id, &initial_binding, initial_bundle)
+			.expect("create initial credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&enrollment_operation,
+					AccountOperationPhase::Prepared,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await
+				.expect("record enrollment store effect"),
+		)
+		.expect("accept enrollment store effect");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&enrollment_operation,
+					AccountOperationPhase::StoreApplied,
+					AccountOperationPhase::Committed,
+					None,
+				)
+				.await
+				.expect("commit enrollment"),
+		)
+		.expect("accept enrollment commit");
+
+		let refresh_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000032")
+				.expect("refresh operation");
+		let refreshed_bundle = shared_bundle(provider.account_id(), "refreshed-access", 3_000_000);
+		let refreshed_binding = refreshed_bundle
+			.binding_for(
+				&account_id,
+				&refresh_operation,
+				CredentialVersion::new(2).expect("refreshed version"),
+				&provider,
+			)
+			.expect("refreshed binding");
+		accepted_phase(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: refresh_operation.clone(),
+					account_id: account_id.clone(),
+					kind: AccountOperationKind::Refresh,
+					display_label: None,
+					enabled: None,
+					expected_account_revision: Some(1),
+					expected: Some(initial_binding.clone()),
+					target: None,
+					provider: provider.clone(),
+				})
+				.await
+				.expect("prepare refresh"),
+		)
+		.expect("accept refresh preparation");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&refresh_operation,
+					AccountOperationPhase::Prepared,
+					AccountOperationPhase::ProviderEffectPending,
+					None,
+				)
+				.await
+				.expect("record provider effect boundary"),
+		)
+		.expect("accept provider effect boundary");
+		accepted_phase(
+			store
+				.set_account_operation_target(&refresh_operation, &refreshed_binding)
+				.await
+				.expect("record refresh target"),
+		)
+		.expect("accept refresh target");
+		credentials
+			.compare_and_swap_rotate(
+				&account_id,
+				&initial_binding,
+				&refreshed_binding,
+				refreshed_bundle,
+			)
+			.expect("persist refreshed credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&refresh_operation,
+					AccountOperationPhase::ProviderEffectPending,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await
+				.expect("record refresh store effect"),
+		)
+		.expect("accept refresh store effect");
+
+		let command = CommandIdentity::new("refresh-reprojection-receipt", b"exact refresh replay")
+			.expect("command identity");
+		let lease = match store
+			.reserve_account_command(&command, AccountCommandKind::Refresh, account_id.as_str(), Some(1))
+			.await
+			.expect("reserve refresh command")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Replayed(_) => panic!("new refresh command replayed"),
+		};
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(UnusedCredentialRefresher),
+		)
+		.with_shared_auth_reprojector(fail_shared_auth_reprojection);
+		let response = service
+			.refresh_command(lease, refresh_operation.clone(), &account_id, 1, |result| {
+				Ok(match result {
+					Ok(account) => json!({
+						"outcome": "succeeded",
+						"account_revision": account.revision,
+					}),
+					Err(_) => json!({"outcome": "unexpected"}),
+				})
+			})
+			.await
+			.expect("complete committed refresh command");
+
+		assert_eq!(response, json!({"outcome": "succeeded", "account_revision": 2}));
+		assert_eq!(FAILED_SHARED_REPROJECTIONS.load(Ordering::Relaxed), 1);
+		let refreshed = service.inspect(&account_id).await.expect("read refreshed account").account;
+		assert_eq!(refreshed.revision, 2);
+		assert_eq!(refreshed.credential.as_ref(), Some(&refreshed_binding));
+		let operation = store
+			.read_account_operation(&refresh_operation)
+			.await
+			.expect("read refresh operation")
+			.expect("refresh operation exists");
+		assert_eq!(operation.phase, AccountOperationPhase::Committed);
+		match store
+			.reserve_account_command(&command, AccountCommandKind::Refresh, account_id.as_str(), Some(1))
+			.await
+			.expect("replay refresh command")
+		{
+			AccountCommandReceiptClaim::Replayed(replayed) => assert_eq!(replayed, response),
+			AccountCommandReceiptClaim::Owned(_) => panic!("committed refresh receipt was not terminal"),
+		}
 	}
 
 	#[test]
@@ -4981,6 +5261,99 @@ mod tests {
 	}
 
 	#[test]
+	fn matching_shared_identity_reprojects_the_exact_persisted_refresh_bundle() {
+		let binding = binding("projected-provider-account", 8);
+		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
+		let projected = Cell::new(false);
+
+		reproject_shared_codex_auth_if_current_with(
+			&binding,
+			&persisted,
+			|| {
+				Ok(super::SharedCodexAuthIdentity::Chatgpt {
+					provider_account_id: binding.provider.account_id().to_owned(),
+				})
+			},
+			|bundle, provider_account_id| {
+				assert_eq!(provider_account_id, binding.provider.account_id());
+				assert!(super::same_refresh_bundle(bundle, &persisted));
+				projected.set(true);
+				Ok(())
+			},
+		)
+		.unwrap();
+
+		assert!(projected.get());
+	}
+
+	#[test]
+	fn mismatched_shared_identity_cannot_trigger_refresh_reprojection() {
+		let binding = binding("expected-provider-account", 8);
+		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
+
+		reproject_shared_codex_auth_if_current_with(
+			&binding,
+			&persisted,
+			|| {
+				Ok(super::SharedCodexAuthIdentity::Chatgpt {
+					provider_account_id: "different-provider-account".to_owned(),
+				})
+			},
+			|_, _| panic!("mismatched shared auth must not be overwritten"),
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn shared_identity_read_failure_does_not_authorize_refresh_reprojection() {
+		let binding = binding("expected-provider-account", 8);
+		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
+
+		reproject_shared_codex_auth_if_current_with(
+			&binding,
+			&persisted,
+			|| Err(super::CodexAuthProjectionError::Unavailable),
+			|_, _| panic!("unreadable shared auth must not be overwritten"),
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn rejected_provider_refresh_recovers_only_from_a_newer_matching_shared_bundle() {
+		let provider_account_id = "expected-provider-account";
+		let current = binding(provider_account_id, 7);
+		let current_bundle = shared_bundle(provider_account_id, "current-access", 2_000_000);
+
+		let recovered = recover_rejected_refresh_from_shared(
+			&current,
+			&current_bundle,
+			OBSERVED_AT_MICROS,
+			Ok(imported(provider_account_id, "newer-access", 3_000_000)),
+		)
+		.expect("newer exact-identity shared auth must recover provider rejection");
+		assert_eq!(recovered.returned_provider, current.provider);
+
+		assert!(matches!(
+			recover_rejected_refresh_from_shared(
+				&current,
+				&current_bundle,
+				OBSERVED_AT_MICROS,
+				Ok(imported("different-provider-account", "different-access", 3_000_000)),
+			),
+			Err(CredentialRefreshError::Rejected)
+		));
+		assert!(matches!(
+			recover_rejected_refresh_from_shared(
+				&current,
+				&current_bundle,
+				OBSERVED_AT_MICROS,
+				Ok(imported(provider_account_id, "older-access", 1_500_000)),
+			),
+			Err(CredentialRefreshError::Rejected)
+		));
+	}
+
+	#[test]
 	fn mismatched_shared_provider_preserves_provider_refresh_fallback() {
 		let current = binding("expected-provider-account", 7);
 
@@ -5011,7 +5384,7 @@ mod tests {
 	}
 
 	#[test]
-	fn unchanged_or_expired_shared_credential_preserves_provider_refresh_fallback() {
+	fn unchanged_not_newer_or_expired_shared_credential_preserves_provider_refresh_fallback() {
 		let provider_account_id = "expected-provider-account";
 		let current = binding(provider_account_id, 7);
 		let current_bundle = shared_bundle(provider_account_id, "same-access", 3_000_000);
@@ -5022,6 +5395,15 @@ mod tests {
 				&current_bundle,
 				OBSERVED_AT_MICROS,
 				Ok(imported(provider_account_id, "same-access", 3_000_000)),
+			)
+			.is_none()
+		);
+		assert!(
+			matching_shared_refresh(
+				&current,
+				&current_bundle,
+				OBSERVED_AT_MICROS,
+				Ok(imported(provider_account_id, "different-access", 2_500_000)),
 			)
 			.is_none()
 		);

--- a/crates/decodex-runtime/src/auth_projection.rs
+++ b/crates/decodex-runtime/src/auth_projection.rs
@@ -987,6 +987,20 @@ mod tests {
 	}
 
 	#[test]
+	fn later_projection_replaces_a_stale_bundle_for_the_same_provider_identity() {
+		let home = fixture_home();
+		let directory = open_codex_directory(home.path()).unwrap();
+		let initial = bundle(Some("id-one"), "one");
+		let rotated = bundle(Some("id-two"), "two");
+		project_to_directory(&directory, &initial, "provider-one").unwrap();
+
+		project_to_directory(&directory, &rotated, "provider-one").unwrap();
+
+		assert!(current_auth_matches(&directory, &rotated, "id-two", "provider-one").unwrap());
+		assert!(!current_auth_matches(&directory, &initial, "id-one", "provider-one").unwrap());
+	}
+
+	#[test]
 	fn projection_atomically_replaces_another_account() {
 		let home = fixture_home();
 		let directory = open_codex_directory(home.path()).unwrap();

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -328,6 +328,34 @@ has supplied a current value. An absent, unknown, unsupported, or failed five-ho
 does not create a synthetic `5 HOUR` row. It remains a typed protocol fact for routing and
 diagnostics.
 
+### Menu-bar Route preparation evidence
+
+The 2026-08-21 focused repair restores credential preparation before the Swift menu-bar
+Route changes fixed routing. Deterministic store tests prove `RefreshAccount`, exact latest
+projection, and fixed selection in that order. They also prove Account and credential-version
+advancement, no projection or routing after refresh rejection, no fixed routing after
+projection failure, exact projection-receipt reuse, fixed-only retry after later partial
+success, and serialized cross-account Route actions.
+
+Account Service tests prove that only a valid newer same-identity shared bundle is absorbed,
+including the one bounded read after provider rejection. Different identity, unreadable auth,
+unchanged data, older data, and expired data remain fail-closed. A committed-refresh fixture
+starts at `StoreApplied`, forces conditional shared projection failure, and proves that the
+Account operation commits and its refresh command receipt remains terminal and replayable.
+The safe projection writer also proves that a later bundle replaces stale shared auth for the
+same provider identity.
+
+Focused validation passed 30 Account Service tests, the exact later-projection Rust test, the
+native FFI refresh-request test, 17 Swift native-client tests, and 33 Swift account-control
+store tests. The affected-package gate then passed all 22 FFI tests, 212 runtime unit tests
+with one intentional installed-Codex skip, every runtime integration and doc test, strict
+Clippy with warnings denied, and all 225 Swift tests. Both account-login and vNext architecture
+gates passed, and the SwiftPM production build completed with the same Xcode toolchain. The
+first Swift attempt under the active Command Line Tools directory failed
+before source compilation because `SwiftUIMacros` was unavailable. The supported rerun used
+`/Applications/Xcode-beta.app` with Swift 6.4 and passed; the initial toolchain failure is not
+product evidence.
+
 The staged nested bundle passed strict deep code-signature verification. A direct call through
 its embedded FFI negotiated the running daemon, returned `available`, and read six accounts.
 The older installed FFI remained the negative control and continued to return the typed minor

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -200,6 +200,12 @@ The projection affects future Codex launches and new app-server processes. It do
 claim to hot-switch an already running Codex process. There is no watcher, backup,
 per-account Codex home, token environment projection, legacy helper, or fallback.
 
+The commands remain independent protocol authorities, but the Swift menu-bar `Route`
+control composes them with credential refresh. Route must receive the committed successor
+Account revision, project that exact latest credential, and only then set fixed routing.
+Projection failure leaves fixed routing unchanged. Retry state retains the exact refresh
+receipt or the proved prepared revision so a completed credential effect is not repeated.
+
 ## Account operations
 
 Cross-store changes use one finite per-account operation journal:
@@ -222,12 +228,23 @@ use one operation-scoped private temporary home. It is removed after verified im
 recovery and never becomes a runner home. Import accepts a daemon-opened owner-private
 source descriptor, not credential bytes in the public protocol.
 
-Refresh reads one exact credential version, records `provider_effect_pending` before
-the provider call, validates the returned provider identity, and writes the complete
-rotated bundle with one compare-and-swap. Concurrent callers serialize on that
-operation. After restart, an exact store write can be committed. A provider request with
-no proved store write is not replayed unless the provider has an accepted idempotent
-result-readback contract. Otherwise, the account becomes `reauth_required`.
+Refresh reads one exact credential version and records `provider_effect_pending` before
+the provider call. Immediately before provider work, it can absorb only a valid shared
+Codex bundle with the exact provider identity and a later expiry than the stored bundle.
+It validates the returned or reconciled provider identity and writes the complete rotated
+bundle with one compare-and-swap. Concurrent callers serialize on that operation. After
+provider rejection, one bounded shared-auth read can still supply that exact newer bundle;
+otherwise the operation is cancelled and the rejection remains terminal. After restart,
+an exact store write can be committed. A provider request with no proved store write is
+not replayed unless the provider has an accepted idempotent result-readback contract.
+Otherwise, the account becomes `reauth_required`.
+
+Every committed refresh reads the exact persisted successor bundle. When the current
+shared-auth identity still names the same provider account, Account Service attempts to
+re-project that bundle. An unreadable identity is not overwrite authority. Projection
+failure does not undo or make the provider effect ambiguous, and the terminal refresh
+receipt still completes. Explicit `UseAccountInCodex` owns retryable fail-closed projection
+for menu-bar Route.
 
 Logout disables new launch admission and rejects with `account_in_use` while an active
 ProcessGeneration or unsettled ProviderAttempt is bound to the account. It then deletes

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -6,9 +6,9 @@ tags: [local-product, sqlite, quick-task, adaptive-factory, domain-pack, app-ser
 openwiki:
   roles: [architecture, domain, workflow]
   change_kinds: [lifecycle, public-api, runtime]
-  source_paths: [crates/decodex-app-client-ffi/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
+  source_paths: [crates/decodex-app-client-ffi/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
   symbols: [QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
-  test_paths: [tests/scripts/test_account_login_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
+  test_paths: [tests/scripts/test_account_login_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-app-client-ffi/src/lib.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
   invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
   validation_commands: [cargo test --workspace --all-targets]
 ---
@@ -423,6 +423,38 @@ The rejection does not expose an email address or provider identity.
 The SQLite file is plaintext owner-private storage, consistent with the source Codex
 authentication file and the explicit local-device threat model. No credential value can
 appear in Debug output, protocol data, logs, migration output, or transfer reports.
+
+## Menu-bar Route preparation
+
+The Swift menu-bar `Route` action composes three existing typed commands in this order:
+
+1. `RefreshAccount` reconciles and persists the target account credential.
+2. `UseAccountInCodex` projects the exact persisted latest bundle to shared
+   `~/.codex/auth.json` with the returned Account revision.
+3. `SetFixedAccountSelection` uses that same Account revision and the captured routing
+   revision.
+
+Before a provider refresh, Account Service performs one bounded shared-auth read. It can
+absorb that bundle only when the decoded provider identity is exact, the bundle is valid,
+and its access-token expiry is later than both the current time and the stored bundle. If
+the provider rejects refresh, the service performs one more bounded shared-auth read. A
+newer exact-identity bundle can complete the existing journal and credential CAS. Any
+unreadable, unchanged, older, expired, or different-identity bundle leaves the rejection
+terminal. Swift does not project auth or change fixed routing after that rejection.
+
+After a successful credential CAS, SQLite commits the Account operation and revision.
+Account Service then reads the exact persisted successor bundle and conditionally re-projects
+it only when the current shared-auth identity still matches. A shared-identity read failure
+does not authorize an overwrite. A conditional projection write failure also cannot relabel
+the committed provider effect or strand its refresh receipt. The separate
+`UseAccountInCodex` command is the mandatory fail-closed projection boundary for Route, so
+fixed routing cannot advance until the safe writer succeeds.
+
+Swift validates that the refresh result advances both the Account revision and credential
+version by one without changing provider identity. It retains the exact refresh operation,
+refresh idempotency key, prepared revision, and projection idempotency key across uncertain
+or partial outcomes. A retry resumes at the first incomplete step instead of repeating a
+proved refresh or selecting a fixed route over stale auth.
 
 ## Deferred capabilities
 


### PR DESCRIPTION
Summary:
- reconcile only newer matching shared Codex auth before provider refresh
- persist and re-project rotated credentials before fixed menu-bar routing
- preserve terminal refresh receipts and retry-convergent projection semantics

Validation:
- 30 focused Account Service tests
- 33 focused Swift Route tests
- affected Rust packages, strict Clippy, all 225 Swift tests, and architecture gates