### PR TITLE
Restore refresh-before-Route safety

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -137,22 +137,21 @@ device-login flow is the app's only interactive credential-replacement surface. 
 ambiguous case, Swift passes only the exact recovery operation identity. The daemon keeps
 the old ambiguity fenced until the verified replacement credential commits and never
 relabels it as a definite cancellation. The native app exposes the existing
-background account observation owns provider credential refresh; it is not a
-Route-side interactive action. Refresh login uses the same login-method selector. Manual
+revision-fenced credential refresh only as one step of Route; it is not a standalone
+interactive action. Refresh login uses the same login-method selector. Manual
 device-code login presents fixed-size Copy, Open, and Cancel controls. Automatic browser
 login opens the official redirect flow. The app then refreshes only that account after
 the daemon completes the exact credential replacement. The app
 then performs bounded short-interval daemon readback until the new background
 observation replaces any old unauthorized value. Each
-account row has one `Route` control. Route uses the daemon's already persisted current
-credential with `UseAccountInCodex`, carrying the published Account revision into the exact
+account row has one `Route` control. Route first asks Account Service to reconcile a valid
+newer shared Codex login for the exact same provider identity or run its journaled provider
+refresh. It then carries the committed account and credential revisions into the exact
 `~/.codex/auth.json` projection for future Codex launches. Only after projection succeeds does
-it select the same account as the fixed Decodex route. Route does not refresh credentials or
-apply an account-change result, so the visible account, quota, profile, and Total source state
-remain stable while projection is pending. The underlying typed commands remain independently
-fenced. An uncertain projection keeps only its idempotency key and Account revision; a retry
-reuses that key until the revision changes. Background account observation remains the refresh
-owner, and its later successful refresh of the projected account reprojects shared Codex auth. The
+it select the same account as the fixed Decodex route. A rejected refresh without a newer exact
+shared login does not write shared auth or change fixed routing. The underlying typed commands
+remain independently fenced. Route retains an uncertain refresh receipt and a prepared account
+revision so a retry resumes at the first incomplete step. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
 The overflow menu contains only `Refresh all`, the material selector, and Quit.

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -319,6 +319,14 @@ protocol AccountControlClient: ResetCardClient {
 		idempotencyKey: String
 	) async throws -> AccountControlResult
 
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult
+
 	func startAccountReauthentication(
 		authority: ResetCardAuthority?,
 		sessionID: String,
@@ -352,6 +360,16 @@ protocol AccountControlClient: ResetCardClient {
 }
 
 extension AccountControlClient {
+	func refreshAccountCredentials(
+		authority _: ResetCardAuthority?,
+		operationID _: String,
+		accountID _: String,
+		expectedRevision _: UInt64,
+		idempotencyKey _: String
+	) async throws -> AccountControlResult {
+		throw AccountControlError.applicationUnavailable
+	}
+
 	func startAccountEnrollment(
 		authority _: ResetCardAuthority?,
 		sessionID _: String,
@@ -609,6 +627,36 @@ extension DecodexNativeClient: AccountControlClient {
 			),
 			authority: authority,
 			expected: .routingOrder(order)
+		)
+	}
+
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		try Self.validateAccountControlInput(
+			authority: authority,
+			accountID: accountID,
+			operationID: operationID,
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
+		)
+		return try await executeAccountControl(
+			request: DecodexNativeRequest(
+				operation: "refresh_account",
+				accountID: accountID,
+				expectedRevision: expectedRevision,
+				idempotencyKey: idempotencyKey,
+				operationID: operationID
+			),
+			authority: authority,
+			expected: .accountChanged(
+				accountID: accountID,
+				enabled: nil
+			)
 		)
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -267,9 +267,13 @@ enum AccountControlActivity: Equatable {
 	case route
 }
 
-private struct PendingAccountRouteProjection {
+private struct PendingAccountRoutePreparation {
 	let expectedAccountRevision: UInt64
-	let idempotencyKey: String
+	let expectedCredentialBinding: AccountCredentialBinding
+	let refreshOperationID: String
+	let refreshIdempotencyKey: String
+	let projectionIdempotencyKey: String
+	var refreshedAccountRevision: UInt64?
 }
 
 private enum AccountLoginStart {
@@ -397,8 +401,8 @@ final class ResetCardStore {
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingAccountLoginStart: PendingAccountLoginStart?
-	@ObservationIgnored private var pendingAccountRouteProjections = [
-		String: PendingAccountRouteProjection
+	@ObservationIgnored private var pendingAccountRoutePreparations = [
+		String: PendingAccountRoutePreparation
 	]()
 	@ObservationIgnored private var postUseReconciliationTasks = [
 		String: Task<Void, Never>
@@ -1439,48 +1443,94 @@ final class ResetCardStore {
 			allowsDuringRefresh: true,
 			successMessage: nil,
 			operation: {
-				let routedAccount = account
+				var routedAccount = account
 				if needsCodexProjection {
-					var projection = pendingAccountRouteProjections[accountID]
-					if let expectedAccountRevision = projection?.expectedAccountRevision,
-						expectedAccountRevision != account.accountRevision
+					var preparation = pendingAccountRoutePreparations[accountID]
+					if let refreshedRevision = preparation?.refreshedAccountRevision,
+						refreshedRevision != account.accountRevision
 					{
-						pendingAccountRouteProjections.removeValue(forKey: accountID)
-						projection = nil
+						pendingAccountRoutePreparations.removeValue(forKey: accountID)
+						preparation = nil
 					}
-					if projection == nil {
-						projection = PendingAccountRouteProjection(
+					if preparation == nil {
+						guard let credentialBinding = account.credentialBinding else {
+							throw AccountControlError.invalidResponse
+						}
+						preparation = PendingAccountRoutePreparation(
 							expectedAccountRevision: account.accountRevision,
-							idempotencyKey: Self.newCanonicalUUID()
+							expectedCredentialBinding: credentialBinding,
+							refreshOperationID: Self.newCanonicalUUID(),
+							refreshIdempotencyKey: Self.newCanonicalUUID(),
+							projectionIdempotencyKey: Self.newCanonicalUUID(),
+							refreshedAccountRevision: nil
 						)
-						pendingAccountRouteProjections[accountID] = projection
+						pendingAccountRoutePreparations[accountID] = preparation
 					}
-					guard let projection,
-						projection.expectedAccountRevision == routedAccount.accountRevision
-					else {
+					guard var preparation else {
 						throw AccountControlError.invalidResponse
 					}
 
-					do {
-						let result = try await accountControlClient.useAccountInCodex(
-							authority: routedAccount.authority ?? establishedAuthority,
-							accountID: accountID,
-							expectedRevision: projection.expectedAccountRevision,
-							idempotencyKey: projection.idempotencyKey
-						)
-						_ = applyAccountControlResult(result)
-						pendingAccountRouteProjections.removeValue(forKey: accountID)
-						if needsFixedRouting == false {
-							return result
+					if preparation.refreshedAccountRevision == nil {
+						do {
+							let refreshResult = try await accountControlClient
+								.refreshAccountCredentials(
+									authority: account.authority ?? establishedAuthority,
+									operationID: preparation.refreshOperationID,
+									accountID: accountID,
+									expectedRevision: preparation.expectedAccountRevision,
+									idempotencyKey: preparation.refreshIdempotencyKey
+								)
+							let currentRouteRevision = accountRecord(accountID)?.accountRevision
+								?? account.accountRevision
+							guard refreshedAccountRevisionIsCurrent(
+								refreshResult,
+								currentAccountRevision: currentRouteRevision
+							) else {
+								throw AccountControlError.expectedRevisionMismatch(
+									expected: preparation.expectedAccountRevision,
+									actual: currentRouteRevision
+								)
+							}
+							guard case .accountChanged(let refreshedAccount) = refreshResult,
+								Self.isImmediateRouteRefresh(
+									accountID: accountID,
+									expectedAccountRevision: preparation
+										.expectedAccountRevision,
+									expectedCredentialBinding: preparation
+										.expectedCredentialBinding,
+									to: refreshedAccount
+								)
+							else {
+								throw AccountControlError.invalidResponse
+							}
+							_ = applyAccountControlResult(refreshResult)
+							preparation.refreshedAccountRevision = refreshedAccount
+								.accountRevision
+							pendingAccountRoutePreparations[accountID] = preparation
+							routedAccount = refreshedAccount
+						} catch {
+							if Self.routeRefreshCanReuseReceipt(after: error) == false {
+								pendingAccountRoutePreparations.removeValue(forKey: accountID)
+							}
+							throw error
 						}
-					} catch {
-						if Self.routeProjectionCanReuseKey(after: error) == false {
-							pendingAccountRouteProjections.removeValue(forKey: accountID)
-						}
-						throw error
+					} else {
+						routedAccount = account
+					}
+
+					let result = try await accountControlClient.useAccountInCodex(
+						authority: routedAccount.authority ?? establishedAuthority,
+						accountID: accountID,
+						expectedRevision: routedAccount.accountRevision,
+						idempotencyKey: preparation.projectionIdempotencyKey
+					)
+					_ = applyAccountControlResult(result)
+					pendingAccountRoutePreparations.removeValue(forKey: accountID)
+					if needsFixedRouting == false {
+						return result
 					}
 				} else {
-					pendingAccountRouteProjections.removeValue(forKey: accountID)
+					pendingAccountRoutePreparations.removeValue(forKey: accountID)
 				}
 
 				return try await accountControlClient.setFixedSelection(
@@ -1494,7 +1544,40 @@ final class ResetCardStore {
 		)
 	}
 
-	nonisolated private static func routeProjectionCanReuseKey(after error: Error) -> Bool {
+	private func refreshedAccountRevisionIsCurrent(
+		_ result: AccountControlResult,
+		currentAccountRevision: UInt64
+	) -> Bool {
+		guard case .accountChanged(let refreshedAccount) = result else {
+			return false
+		}
+		return refreshedAccount.accountRevision >= currentAccountRevision
+	}
+
+	nonisolated private static func isImmediateRouteRefresh(
+		accountID: String,
+		expectedAccountRevision: UInt64,
+		expectedCredentialBinding: AccountCredentialBinding,
+		to refreshed: ResetCardAccountRecord
+	) -> Bool {
+		let (refreshedAccountRevision, accountRevisionOverflow) = expectedAccountRevision
+			.addingReportingOverflow(1)
+		guard accountRevisionOverflow == false,
+			refreshed.accountID == accountID,
+			refreshed.accountRevision == refreshedAccountRevision,
+			let refreshedBinding = refreshed.credentialBinding
+		else {
+			return false
+		}
+		let (expectedCredentialVersion, credentialVersionOverflow) = expectedCredentialBinding.version
+			.addingReportingOverflow(1)
+		return credentialVersionOverflow == false
+			&& refreshedBinding.version == expectedCredentialVersion
+			&& refreshedBinding.provider == expectedCredentialBinding.provider
+			&& refreshedBinding.providerAccountID == expectedCredentialBinding.providerAccountID
+	}
+
+	nonisolated private static func routeRefreshCanReuseReceipt(after error: Error) -> Bool {
 		guard let error = error as? AccountControlError else {
 			return true
 		}
@@ -3561,7 +3644,7 @@ final class ResetCardStore {
 			_ = reorderAccountStates(to: routing.order)
 			return .none
 		case .accountLoggedOut(let accountID, _):
-			pendingAccountRouteProjections.removeValue(forKey: accountID)
+			pendingAccountRoutePreparations.removeValue(forKey: accountID)
 			if case .current(let projectedID, _, _) = codexAuthProjection,
 				projectedID == accountID
 			{

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -175,6 +175,13 @@ final class AccountControlNativeClientTests: XCTestCase {
 			expectedRoutingRevision: 9,
 			idempotencyKey: idempotencyKey
 		)
+		_ = try await client.refreshAccountCredentials(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			expectedRevision: 7,
+			idempotencyKey: idempotencyKey
+		)
 		let requests = try recorder.requests.map { try nativeJSONObject($0.data) }
 		XCTAssertEqual(
 			requests.compactMap { $0["operation"] as? String },
@@ -182,7 +189,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 				"enroll_account", "get_codex_auth_projection", "use_account_in_codex",
 				"disable_account",
 				"logout_account", "set_fixed_selection",
-				"set_balanced_selection", "set_account_order",
+				"set_balanced_selection", "set_account_order", "refresh_account",
 			]
 		)
 		XCTAssertEqual(
@@ -209,7 +216,13 @@ final class AccountControlNativeClientTests: XCTestCase {
 		XCTAssertEqual(Set(requests[7].keys), [
 			"schema", "operation", "order", "expected_routing_revision", "idempotency_key",
 		])
-		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 8))
+		XCTAssertEqual(Set(requests[8].keys), [
+			"schema", "operation", "operation_id", "account_id", "expected_revision",
+			"idempotency_key",
+		])
+		XCTAssertEqual(requests[8]["operation_id"] as? String, operationID)
+		XCTAssertEqual(requests[8]["expected_revision"] as? NSNumber, 7)
+		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 9))
 	}
 
 	func testAccountOrderRejectsAContradictoryAppliedOrder() async throws {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -1225,7 +1225,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNotNil(store.message)
 	}
 
-	func testRouteAccountProjectsThenSelectsFixedRoutingWithoutRefreshing() async throws {
+	func testRouteAccountRefreshesThenProjectsAndSelectsFixedRoutingWithAdvancedBinding() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
@@ -1250,24 +1250,24 @@ final class AccountControlStoreTests: XCTestCase {
 		let fixedRequest = try XCTUnwrap(recordedFixedRequest)
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
-		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
-		XCTAssertEqual(store.accounts.first?.account.credentialBinding?.version, 3)
-		XCTAssertEqual(useRequest.expectedRevision, 7)
-		XCTAssertEqual(fixedRequest.expectedAccountRevision, 7)
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
+		XCTAssertEqual(store.accounts.first?.account.credentialBinding?.version, 4)
+		XCTAssertEqual(useRequest.expectedRevision, 8)
+		XCTAssertEqual(fixedRequest.expectedAccountRevision, 8)
 		XCTAssertEqual(
 			controlSequence,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
-		XCTAssertEqual(controlCounts, .init(fixed: 1, projection: 1))
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 1))
 		XCTAssertNil(store.message)
 	}
 
-	func testRouteAccountLeavesPublishedAccountFactsUnchangedWhileProjectionIsPending() async throws {
+	func testRouteAccountDoesNotProjectOrChangeRoutingWhenRefreshFails() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
 			authority: authority,
-			suspendsUseAccount: true
+			refreshAccountError: .rejected(.lifecycleUnready, actualRevision: nil)
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -1278,37 +1278,16 @@ final class AccountControlStoreTests: XCTestCase {
 		)
 
 		await store.refresh()
-		let publishedState = try XCTUnwrap(store.accounts.first)
-		let publishedCodexProjection = store.codexAuthProjection
-		let routeTask = Task {
-			await store.routeAccount(accountID)
-		}
-		for _ in 0 ..< 200 {
-			if await client.useAccountIsPending() {
-				break
-			}
-			try await Task.sleep(for: .milliseconds(5))
-		}
-		guard await client.useAccountIsPending() else {
-			await client.releaseUseAccount()
-			await routeTask.value
-			return XCTFail("Codex projection did not enter the pending state.")
-		}
+		await store.routeAccount(accountID)
 
-		let pendingState = try XCTUnwrap(store.accounts.first)
-		XCTAssertEqual(pendingState, publishedState)
-		XCTAssertEqual(pendingState.account.accountRevision, 7)
-		XCTAssertEqual(pendingState.account.credentialBinding?.version, 3)
-		XCTAssertEqual(pendingState.fiveHourQuota, publishedState.fiveHourQuota)
-		XCTAssertEqual(pendingState.sevenDayQuota, publishedState.sevenDayQuota)
-		XCTAssertEqual(pendingState.profile, publishedState.profile)
-		XCTAssertEqual(store.codexAuthProjection, publishedCodexProjection)
-		XCTAssertEqual(store.routing?.mode, .balanced)
 		let controlSequence = await client.controlSequence()
-		XCTAssertEqual(controlSequence, [.codexProjection])
-
-		await client.releaseUseAccount()
-		await routeTask.value
+		let controlCounts = await client.controlCounts()
+		XCTAssertEqual(controlSequence, [.credentialRefresh])
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 0))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
+		XCTAssertFalse(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .balanced)
+		XCTAssertNotNil(store.message)
 	}
 
 	func testRouteAccountDoesNotChangeRoutingWhenProjectionFails() async throws {
@@ -1333,9 +1312,9 @@ final class AccountControlStoreTests: XCTestCase {
 		let controlCounts = await client.controlCounts()
 		XCTAssertFalse(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .balanced)
-		XCTAssertEqual(controlSequence, [.codexProjection])
-		XCTAssertEqual(controlCounts, .init(fixed: 0, projection: 1))
-		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
+		XCTAssertEqual(controlSequence, [.credentialRefresh, .codexProjection])
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 1))
+		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
 		XCTAssertNotNil(store.message)
 	}
 
@@ -1368,9 +1347,9 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(firstUseRequest.idempotencyKey, secondUseRequest.idempotencyKey)
 		XCTAssertEqual(
 			controlSequence,
-			[.codexProjection, .codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .codexProjection, .fixedRouting]
 		)
-		XCTAssertEqual(controlCounts, .init(fixed: 1, projection: 2))
+		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 2))
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		XCTAssertNil(store.message)
@@ -1399,7 +1378,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .balanced)
 		XCTAssertEqual(
 			firstControlSequence,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
 		XCTAssertNotNil(store.message)
 
@@ -1412,9 +1391,9 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		XCTAssertEqual(
 			finalControlSequence,
-			[.codexProjection, .fixedRouting, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting, .fixedRouting]
 		)
-		XCTAssertEqual(finalControlCounts, .init(fixed: 2, projection: 1))
+		XCTAssertEqual(finalControlCounts, .init(refresh: 1, fixed: 2, projection: 1))
 		XCTAssertNil(store.message)
 	}
 
@@ -1448,7 +1427,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let controlSequence = await client.controlSequence()
 		let controlCounts = await client.controlCounts()
 		XCTAssertEqual(controlSequence, [])
-		XCTAssertEqual(controlCounts, .init(fixed: 0, projection: 0))
+		XCTAssertEqual(controlCounts, .init(refresh: 0, fixed: 0, projection: 0))
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 	}
@@ -1528,7 +1507,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let useRequest = await client.useRequest()
 		XCTAssertEqual(
 			operationsWhileFirstRouteIsPending,
-			[.codexProjection, .fixedRouting]
+			[.credentialRefresh, .codexProjection, .fixedRouting]
 		)
 		XCTAssertEqual(useRequest?.accountID, accountID)
 
@@ -1805,6 +1784,14 @@ private struct AccountControlStoreUseRequest: Equatable, Sendable {
 	let idempotencyKey: String
 }
 
+private struct AccountControlStoreRefreshRequest: Equatable, Sendable {
+	let authority: ResetCardAuthority?
+	let operationID: String
+	let accountID: String
+	let expectedRevision: UInt64
+	let idempotencyKey: String
+}
+
 private struct AccountControlStoreEnabledRequest: Equatable, Sendable {
 	let authority: ResetCardAuthority?
 	let accountID: String
@@ -1851,11 +1838,13 @@ private struct AccountControlStoreOrderRequest: Equatable, Sendable {
 }
 
 private enum AccountControlStoreOperation: Equatable, Sendable {
+	case credentialRefresh
 	case codexProjection
 	case fixedRouting
 }
 
 private struct AccountControlStoreCounts: Equatable, Sendable {
+	let refresh: Int
 	let fixed: Int
 	let projection: Int
 }
@@ -1867,7 +1856,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private let inventoryGate: AccountControlReadGate?
 	private let snapshotGate: AccountControlReadGate?
 	private let projectionGate: AccountControlReadGate?
-	private let useAccountGate: AccountControlReadGate?
 	private let capturesSnapshotBeforeWait: Bool
 	private let fixedSelectionGate: AccountControlReadGate?
 	private let enrollmentGate: AccountControlReadGate?
@@ -1880,14 +1868,17 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private var routing: AccountRoutingControl
 	private var fixedSelectionError: AccountControlError?
 	private let accountOrderError: AccountControlError?
+	private var refreshAccountError: AccountControlError?
 	private var useAccountError: AccountControlError?
 	private var lastFixedRequest: AccountControlStoreFixedRequest?
 	private var lastUseRequest: AccountControlStoreUseRequest?
+	private var lastRefreshRequest: AccountControlStoreRefreshRequest?
 	private var lastEnabledRequest: AccountControlStoreEnabledRequest?
 	private var lastLogoutRequest: AccountControlStoreLogoutRequest?
 	private var lastOrderRequest: AccountControlStoreOrderRequest?
 	private var controlOperations = [AccountControlStoreOperation]()
 	private var fixedRequestCount = 0
+	private var refreshRequestCount = 0
 	private var projectionRequestCount = 0
 	private var projection: CodexAuthProjection
 	private var projectionError: AccountControlError?
@@ -1921,7 +1912,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		suspendsInventory: Bool = false,
 		suspendsSnapshotAfterFirstRead: Bool = false,
 		suspendsProjection: Bool = false,
-		suspendsUseAccount: Bool = false,
 		capturesSnapshotBeforeWait: Bool = false,
 		suspendsFixedSelection: Bool = false,
 		suspendsEnrollment: Bool = false,
@@ -1932,6 +1922,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		routing: AccountRoutingControl? = nil,
 		fixedSelectionError: AccountControlError? = nil,
 		accountOrderError: AccountControlError? = nil,
+		refreshAccountError: AccountControlError? = nil,
 		useAccountError: AccountControlError? = nil,
 		projection: CodexAuthProjection = .unmanaged,
 		reauthenticationStates: [AccountReauthenticationState] = [],
@@ -1947,7 +1938,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		inventoryGate = suspendsInventory ? AccountControlReadGate() : nil
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
 		projectionGate = suspendsProjection ? AccountControlReadGate() : nil
-		useAccountGate = suspendsUseAccount ? AccountControlReadGate() : nil
 		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
 		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
 		enrollmentGate = suspendsEnrollment ? AccountControlReadGate() : nil
@@ -1963,6 +1953,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 			)
 		self.fixedSelectionError = fixedSelectionError
 		self.accountOrderError = accountOrderError
+		self.refreshAccountError = refreshAccountError
 		self.useAccountError = useAccountError
 		self.reauthenticationStates = reauthenticationStates
 		self.accountLoginFailure = accountLoginFailure
@@ -2111,6 +2102,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 
 	func controlCounts() -> AccountControlStoreCounts {
 		AccountControlStoreCounts(
+			refresh: refreshRequestCount,
 			fixed: fixedRequestCount,
 			projection: projectionRequestCount
 		)
@@ -2283,7 +2275,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		if let useAccountError {
 			throw useAccountError
 		}
-		await useAccountGate?.wait()
 		let digest = String(repeating: "c", count: 64)
 		projection = .current(
 			accountID: accountID,
@@ -2305,15 +2296,77 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		useAccountError = error
 	}
 
-	func useAccountIsPending() async -> Bool {
-		guard let useAccountGate else {
-			return false
+	func refreshAccountCredentials(
+		authority: ResetCardAuthority?,
+		operationID: String,
+		accountID: String,
+		expectedRevision: UInt64,
+		idempotencyKey: String
+	) async throws -> AccountControlResult {
+		guard DecodexNativeClient.isCanonicalUUID(operationID),
+			DecodexNativeClient.isCanonicalUUID(idempotencyKey)
+		else {
+			throw AccountControlError.invalidInput
 		}
-		return await useAccountGate.isPending()
+		lastRefreshRequest = AccountControlStoreRefreshRequest(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			expectedRevision: expectedRevision,
+			idempotencyKey: idempotencyKey
+		)
+		refreshRequestCount += 1
+		controlOperations.append(.credentialRefresh)
+		if let refreshAccountError {
+			throw refreshAccountError
+		}
+
+		let current: ResetCardAccountRecord
+		if account.accountID == accountID {
+			current = account
+		} else if let secondaryAccount, secondaryAccount.accountID == accountID {
+			current = secondaryAccount
+		} else {
+			throw AccountControlError.invalidInput
+		}
+		guard current.accountRevision == expectedRevision,
+			let binding = current.credentialBinding
+		else {
+			throw AccountControlError.invalidInput
+		}
+		let refreshed = ResetCardAccountRecord(
+			authority: current.authority,
+			accountID: current.accountID,
+			alias: current.alias,
+			accountRevision: current.accountRevision + 1,
+			enabled: current.enabled,
+			observedState: current.observedState,
+			lifecycleReadiness: current.lifecycleReadiness,
+			credentialBinding: AccountCredentialBinding(
+				schemaVersion: binding.schemaVersion,
+				version: binding.version + 1,
+				fingerprintSHA256: String(repeating: "d", count: 64),
+				provider: binding.provider,
+				providerAccountID: binding.providerAccountID
+			),
+			unsettledOperation: current.unsettledOperation,
+			fiveHourQuota: current.fiveHourQuota,
+			sevenDayQuota: current.sevenDayQuota
+		)
+		if account.accountID == accountID {
+			account = refreshed
+		} else {
+			secondaryAccount = refreshed
+		}
+		return .accountChanged(refreshed)
 	}
 
-	func releaseUseAccount() async {
-		await useAccountGate?.release()
+	func refreshRequest() -> AccountControlStoreRefreshRequest? {
+		lastRefreshRequest
+	}
+
+	func setRefreshAccountError(_ error: AccountControlError?) {
+		refreshAccountError = error
 	}
 
 	func setAccountEnabled(

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -157,6 +157,13 @@ enum Request {
 		expected_routing_revision: u64,
 		idempotency_key: String,
 	},
+	RefreshAccount {
+		schema: String,
+		operation_id: String,
+		account_id: String,
+		expected_revision: u64,
+		idempotency_key: String,
+	},
 	StartAccountEnrollment {
 		schema: String,
 		session_id: String,
@@ -216,6 +223,7 @@ impl Request {
 			Self::SetFixedSelection { .. } => "set_fixed_selection",
 			Self::SetBalancedSelection { .. } => "set_balanced_selection",
 			Self::SetAccountOrder { .. } => "set_account_order",
+			Self::RefreshAccount { .. } => "refresh_account",
 			Self::StartAccountEnrollment { .. } => "start_account_enrollment",
 			Self::StartAccountReauthentication { .. } => "start_account_reauthentication",
 			Self::PollAccountReauthentication { .. } => "poll_account_reauthentication",
@@ -242,6 +250,7 @@ impl Request {
 			| Self::SetFixedSelection { schema, .. }
 			| Self::SetBalancedSelection { schema, .. }
 			| Self::SetAccountOrder { schema, .. }
+			| Self::RefreshAccount { schema, .. }
 			| Self::StartAccountEnrollment { schema, .. }
 			| Self::StartAccountReauthentication { schema, .. }
 			| Self::PollAccountReauthentication { schema, .. }
@@ -745,6 +754,15 @@ async fn execute_request(
 			set_balanced_selection(profile, expected_routing_revision, idempotency_key).await,
 		Request::SetAccountOrder { order, expected_routing_revision, idempotency_key, .. } =>
 			set_account_order(profile, order, expected_routing_revision, idempotency_key).await,
+		Request::RefreshAccount {
+			operation_id,
+			account_id,
+			expected_revision,
+			idempotency_key,
+			..
+		} =>
+			refresh_account(profile, operation_id, account_id, expected_revision, idempotency_key)
+				.await,
 		Request::StartAccountEnrollment {
 			session_id,
 			operation_id,
@@ -892,6 +910,21 @@ async fn logout_account(
 	idempotency_key: String,
 ) -> Result<Value, RequestFailure> {
 	let payload = CommandPayload::LogoutAccount {
+		operation_id: entity_id(&operation_id)?,
+		account_id: entity_id(&account_id)?,
+	};
+	execute_account_command(profile, payload, Some(revision(expected_revision)?), idempotency_key)
+		.await
+}
+
+async fn refresh_account(
+	profile: ClientProfile,
+	operation_id: String,
+	account_id: String,
+	expected_revision: u64,
+	idempotency_key: String,
+) -> Result<Value, RequestFailure> {
+	let payload = CommandPayload::RefreshAccount {
 		operation_id: entity_id(&operation_id)?,
 		account_id: entity_id(&account_id)?,
 	};
@@ -1286,6 +1319,24 @@ mod tests {
 			))
 			.is_err()
 		);
+	}
+
+	#[test]
+	fn refresh_request_is_operation_and_account_revision_fenced() {
+		let request = serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
+		))
+		.expect("refresh request must decode");
+
+		assert_eq!(request.operation(), "refresh_account");
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
+		))
+		.is_err());
+		assert!(serde_json::from_str::<Request>(&format!(
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","idempotency_key":"refresh-test"}}"#
+		))
+		.is_err());
 	}
 
 	#[test]

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -330,37 +330,34 @@ diagnostics.
 
 ### Menu-bar Route preparation evidence
 
-The 2026-08-21 focused repair makes the Swift menu-bar Route use the daemon's already persisted
-credential. Deterministic store tests prove projection, then fixed selection, with zero provider
-refresh calls. They also prove that the published account facts remain unchanged while a
-projection is pending, projection failure does not change fixed routing, an uncertain retry
-reuses the same revision-fenced projection key, fixed-only retry follows later partial success,
-and cross-account Route actions remain serialized.
+The 2026-08-21 focused repair restores credential preparation before the Swift menu-bar
+Route changes fixed routing. Deterministic store tests prove `RefreshAccount`, exact latest
+projection, and fixed selection in that order. They also prove Account and credential-version
+advancement, no projection or routing after refresh rejection, no fixed routing after
+projection failure, exact projection-receipt reuse, fixed-only retry after later partial
+success, and serialized cross-account Route actions.
 
-Account Service tests prove that only a valid newer same-identity shared bundle is absorbed by
-background refresh, including the one bounded read after provider rejection. Different identity,
-unreadable auth, unchanged data, older data, and expired data remain fail-closed. A
-committed-refresh fixture starts at `StoreApplied`, forces conditional shared projection failure,
-and proves that the Account operation commits and its refresh command receipt remains terminal
-and replayable. The safe projection writer also proves that a later bundle replaces stale shared
-auth for the same provider identity.
+Account Service tests prove that only a valid newer same-identity shared bundle is absorbed,
+including the one bounded read after provider rejection. Different identity, unreadable auth,
+unchanged data, older data, and expired data remain fail-closed. A committed-refresh fixture
+starts at `StoreApplied`, forces conditional shared projection failure, and proves that the
+Account operation commits and its refresh command receipt remains terminal and replayable.
+The safe projection writer also proves that a later bundle replaces stale shared auth for the
+same provider identity.
 
-Focused validation passed 30 Account Service tests, 21 FFI tests, 17 Swift native-client tests,
-and 33 Swift account-control store tests. The affected-package gate then passed 212 runtime
-unit tests with one intentional installed-Codex skip, every runtime integration and doc test,
-the daemon protocol and CLI tests, and all 225 Swift tests. Both account-login and vNext
-architecture gates passed, and the SwiftPM production build completed with the same Xcode
-toolchain. Strict Clippy was also attempted for the affected FFI and runtime packages, but the
-current stable toolchain reports pre-existing `too_many_lines` violations in unrelated FFI and
-runtime functions; this focused repair does not broaden into that refactor. The first Swift
-attempt under the active Command Line Tools directory failed
+Focused validation passed 30 Account Service tests, the exact later-projection Rust test, the
+native FFI refresh-request test, 17 Swift native-client tests, and 33 Swift account-control
+store tests. The affected-package gate then passed all 22 FFI tests, 212 runtime unit tests
+with one intentional installed-Codex skip, every runtime integration and doc test, strict
+Clippy with warnings denied, and all 225 Swift tests. Both account-login and vNext architecture
+gates passed, and the SwiftPM production build completed with the same Xcode toolchain. The
+first Swift attempt under the active Command Line Tools directory failed
 before source compilation because `SwiftUIMacros` was unavailable. The supported rerun used
 `/Applications/Xcode-beta.app` with Swift 6.4 and passed; the initial toolchain failure is not
 product evidence.
 
-The staged nested bundle passed strict deep code-signature verification, native-loader and symbol
-checks, and exact bundle metadata checks. This worktree did not replace or interact with the
-running menu-bar app, so live Route-click proof remains a handoff gap.
+The staged nested bundle passed strict deep code-signature verification. A direct call through
+its embedded FFI negotiated the running daemon, returned `available`, and read six accounts.
 The older installed FFI remained the negative control and continued to return the typed minor
 version mismatch.
 

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -201,14 +201,10 @@ claim to hot-switch an already running Codex process. There is no watcher, backu
 per-account Codex home, token environment projection, legacy helper, or fallback.
 
 The commands remain independent protocol authorities, but the Swift menu-bar `Route`
-control composes `UseAccountInCodex` with fixed routing. Route uses the daemon's already
-persisted credential and the current published Account revision; it does not start provider
-refresh or apply an `accountChanged` result. It projects that exact credential first and only
-then sets fixed routing. Projection failure leaves fixed routing unchanged. Retry state retains
-only the projection idempotency key fenced by the Account revision, so an uncertain projection
-retry converges without repeating a provider effect. Background Account Service observation
-remains the refresh owner; a later successful refresh of the projected account reprojects the
-shared Codex auth file.
+control composes them with credential refresh. Route must receive the committed successor
+Account revision, project that exact latest credential, and only then set fixed routing.
+Projection failure leaves fixed routing unchanged. Retry state retains the exact refresh
+receipt or the proved prepared revision so a completed credential effect is not repeated.
 
 ## Account operations
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -426,26 +426,35 @@ appear in Debug output, protocol data, logs, migration output, or transfer repor
 
 ## Menu-bar Route preparation
 
-The Swift menu-bar `Route` action composes two existing typed commands in this order:
+The Swift menu-bar `Route` action composes three existing typed commands in this order:
 
-1. `UseAccountInCodex` projects the daemon's already persisted current bundle to shared
-   `~/.codex/auth.json` with the published Account revision.
-2. `SetFixedAccountSelection` uses that same Account revision and the captured routing
+1. `RefreshAccount` reconciles and persists the target account credential.
+2. `UseAccountInCodex` projects the exact persisted latest bundle to shared
+   `~/.codex/auth.json` with the returned Account revision.
+3. `SetFixedAccountSelection` uses that same Account revision and the captured routing
    revision.
 
-The daemon's 15-second Account Service observation remains the provider-refresh owner. After
-a successful credential CAS, SQLite commits the Account operation and revision. Account Service
-then reads the exact persisted successor bundle and conditionally re-projects it only when the
-current shared-auth identity still matches. A shared-identity read failure does not authorize an
-overwrite. This background projection behavior is independent of Route.
+Before a provider refresh, Account Service performs one bounded shared-auth read. It can
+absorb that bundle only when the decoded provider identity is exact, the bundle is valid,
+and its access-token expiry is later than both the current time and the stored bundle. If
+the provider rejects refresh, the service performs one more bounded shared-auth read. A
+newer exact-identity bundle can complete the existing journal and credential CAS. Any
+unreadable, unchanged, older, expired, or different-identity bundle leaves the rejection
+terminal. Swift does not project auth or change fixed routing after that rejection.
 
-`UseAccountInCodex` is the mandatory fail-closed projection boundary for Route, so fixed routing
-cannot advance until the safe writer succeeds. Route does not apply an account-change result;
-the visible account record, quota, profile, and Total source state remain unchanged while the
-projection is pending. An uncertain projection retains only its idempotency key and expected
-Account revision. A retry reuses that key, and a changed Account revision fences it out before a
-new projection attempt. Route never starts provider refresh work or selects fixed routing over
-stale auth.
+After a successful credential CAS, SQLite commits the Account operation and revision.
+Account Service then reads the exact persisted successor bundle and conditionally re-projects
+it only when the current shared-auth identity still matches. A shared-identity read failure
+does not authorize an overwrite. A conditional projection write failure also cannot relabel
+the committed provider effect or strand its refresh receipt. The separate
+`UseAccountInCodex` command is the mandatory fail-closed projection boundary for Route, so
+fixed routing cannot advance until the safe writer succeeds.
+
+Swift validates that the refresh result advances both the Account revision and credential
+version by one without changing provider identity. It retains the exact refresh operation,
+refresh idempotency key, prepared revision, and projection idempotency key across uncertain
+or partial outcomes. A retry resumes at the first incomplete step instead of repeating a
+proved refresh or selecting a fixed route over stale auth.
 
 ## Deferred capabilities
 


### PR DESCRIPTION
Incident rollback:
- revert PR #1312 fast Route path after a real switch projected a stale rotated refresh token and caused ChatGPT authentication loss
- restore journaled refresh before auth projection and fixed routing
- preserve PR #1311 daemon reconciliation and refresh reprojection behavior

Validation:
- exact tree equality with the pre-#1312 safe commit
- 7 focused Route tests
- 22 FFI tests and 30 Account Service tests
- 16 account-login/vNext architecture tests

The installed menu-bar app has already been rolled back to the matching safe bundle.