### PR TITLE
Preserve Total during Route refresh

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -151,7 +151,10 @@ refresh. It then carries the committed account and credential revisions into the
 it select the same account as the fixed Decodex route. A rejected refresh without a newer exact
 shared login does not write shared auth or change fixed routing. The underlying typed commands
 remain independently fenced. Route retains an uncertain refresh receipt and a prepared account
-revision so a retry resumes at the first incomplete step. The
+revision so a retry resumes at the first incomplete step. While a committed refresh waits for
+projection, the row keeps its last-known inventory, quota bars, profile, and profile degradation
+facts visible. That inventory remains display-only until the matching account revision arrives,
+so stale Reset Card actions stay fenced. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
 The overflow menu contains only `Refresh all`, the material selector, and Quit.

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -1444,6 +1444,14 @@ final class ResetCardStore {
 			successMessage: nil,
 			operation: {
 				var routedAccount = account
+				var shouldReconcileRouteAccount = false
+				defer {
+					if shouldReconcileRouteAccount {
+						scheduleAccountControlFollowUp(
+							.account(accountID, refreshInventory: true)
+						)
+					}
+				}
 				if needsCodexProjection {
 					var preparation = pendingAccountRoutePreparations[accountID]
 					if let refreshedRevision = preparation?.refreshedAccountRevision,
@@ -1503,7 +1511,15 @@ final class ResetCardStore {
 							else {
 								throw AccountControlError.invalidResponse
 							}
-							_ = applyAccountControlResult(refreshResult)
+							guard applyImmediateRouteAccountRefresh(
+								refreshedAccount,
+								accountID: accountID,
+								expectedAccountRevision: preparation.expectedAccountRevision,
+								expectedCredentialBinding: preparation.expectedCredentialBinding
+							) else {
+								throw AccountControlError.invalidResponse
+							}
+							shouldReconcileRouteAccount = true
 							preparation.refreshedAccountRevision = refreshedAccount
 								.accountRevision
 							pendingAccountRoutePreparations[accountID] = preparation
@@ -1575,6 +1591,46 @@ final class ResetCardStore {
 			&& refreshedBinding.version == expectedCredentialVersion
 			&& refreshedBinding.provider == expectedCredentialBinding.provider
 			&& refreshedBinding.providerAccountID == expectedCredentialBinding.providerAccountID
+	}
+
+	private func applyImmediateRouteAccountRefresh(
+		_ refreshedAccount: ResetCardAccountRecord,
+		accountID: String,
+		expectedAccountRevision: UInt64,
+		expectedCredentialBinding: AccountCredentialBinding
+	) -> Bool {
+		guard Self.isImmediateRouteRefresh(
+			accountID: accountID,
+			expectedAccountRevision: expectedAccountRevision,
+			expectedCredentialBinding: expectedCredentialBinding,
+			to: refreshedAccount
+		), let index = accounts.firstIndex(where: {
+			$0.account.accountID == accountID
+		}) else {
+			return false
+		}
+
+		let existing = accounts[index]
+		let authority = refreshedAccount.authority
+			?? existing.account.authority
+			?? existing.inventory?.authority
+		let bound = Self.account(refreshedAccount, authority: authority)
+		accounts[index] = ResetCardAccountState(
+			account: bound,
+			inventory: existing.inventory,
+			error: nil,
+			isRefreshing: true,
+			profile: existing.profile,
+			profileUnavailable: existing.profileUnavailable,
+			profileError: existing.profileError,
+			isProfileRefreshing: accountProfileClient != nil
+		)
+		reconcileAccountSkeletonRevisionTargets()
+		invalidateCodexProjectionAfterRevisionChange(
+			accountID: bound.accountID,
+			accountRevision: bound.accountRevision
+		)
+		return true
 	}
 
 	nonisolated private static func routeRefreshCanReuseReceipt(after error: Error) -> Bool {

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -1262,6 +1262,139 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNil(store.message)
 	}
 
+	func testRouteAccountPreservesPresentationUntilGatedProjectionSucceeds() async throws {
+		let fiveHourQuota = ResetCardQuotaWindow(
+			durationMinutes: 300,
+			observedAtUnixMicros: 1_000_000,
+			state: .current(
+				usedPercent: 25,
+				resetsAtUnixMicros: 2_000_000
+			)
+		)
+		let sevenDayQuota = ResetCardQuotaWindow(
+			durationMinutes: 10_080,
+			observedAtUnixMicros: 1_000_000,
+			state: .current(
+				usedPercent: 50,
+				resetsAtUnixMicros: 3_000_000
+			)
+		)
+		let account = accountRecord(
+			fiveHourQuota: fiveHourQuota,
+			sevenDayQuota: sevenDayQuota
+		)
+		let profile = AccountProfileObservation(
+			accountID: accountID,
+			accountRevision: account.accountRevision,
+			observedAtUnixMicros: 1_785_276_000_000_000,
+			email: "iris@example.com",
+			planType: "pro",
+			displayName: "Iris",
+			username: "iris",
+			snapshot: AccountProfileSnapshot(
+				lifetimeTokens: 9_001,
+				peakDailyTokens: 4_000,
+				longestTaskSeconds: 125,
+				currentStreakDays: 3,
+				longestStreakDays: 8,
+				dailyUsage: [
+					AccountProfileDailyUsage(date: "2026-07-28", tokens: 4_000),
+				]
+			),
+			freshness: .cached(refreshError: .providerUnavailable)
+		)
+		let profileUnavailable = AccountProfileUnavailable(
+			error: .providerUnavailable,
+			claims: AccountProfileClaims(email: "iris@example.com", planType: "pro")
+		)
+		let client = AccountControlStoreClient(
+			account: account,
+			authority: authority,
+			suspendsUseAccount: true,
+			profileResults: [
+				.available(profile),
+				.unavailable(profileUnavailable),
+			]
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+
+		await store.refresh()
+		await store.refresh()
+		let beforeRoute = try XCTUnwrap(store.accounts.first)
+		let priorTotal = AccountProfileAggregate.make(
+			store.accounts.compactMap { $0.profile?.snapshot }
+		)
+		XCTAssertNotNil(beforeRoute.profile)
+		XCTAssertNotNil(beforeRoute.profileUnavailable)
+
+		let routeTask = Task {
+			await store.routeAccount(accountID)
+		}
+		for _ in 0 ..< 200 {
+			if await client.useAccountIsPending() {
+				break
+			}
+			try await Task.sleep(for: .milliseconds(5))
+		}
+		guard await client.useAccountIsPending() else {
+			await client.releaseUseAccount()
+			await routeTask.value
+			return XCTFail("UseAccountInCodex did not enter the pending state.")
+		}
+
+		let whileProjectionIsPending = try XCTUnwrap(store.accounts.first)
+		XCTAssertEqual(whileProjectionIsPending.account.accountRevision, 8)
+		XCTAssertEqual(whileProjectionIsPending.account.credentialBinding?.version, 4)
+		XCTAssertEqual(whileProjectionIsPending.inventory, beforeRoute.inventory)
+		XCTAssertFalse(whileProjectionIsPending.inventoryIsCurrent)
+		XCTAssertTrue(whileProjectionIsPending.targets.isEmpty)
+		XCTAssertEqual(whileProjectionIsPending.fiveHourQuota, beforeRoute.fiveHourQuota)
+		XCTAssertEqual(whileProjectionIsPending.sevenDayQuota, beforeRoute.sevenDayQuota)
+		XCTAssertEqual(whileProjectionIsPending.profile, beforeRoute.profile)
+		XCTAssertEqual(
+			whileProjectionIsPending.profileUnavailable,
+			beforeRoute.profileUnavailable
+		)
+		XCTAssertEqual(whileProjectionIsPending.profileError, beforeRoute.profileError)
+		XCTAssertEqual(
+			whileProjectionIsPending.profileDegradationText,
+			beforeRoute.profileDegradationText
+		)
+		XCTAssertEqual(
+			AccountProfileAggregate.make(
+				store.accounts.compactMap { $0.profile?.snapshot }
+			),
+			priorTotal,
+			"The aggregate Total source must remain available while Route projection is pending."
+		)
+		XCTAssertFalse(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .balanced)
+		let pendingControlSequence = await client.controlSequence()
+		let pendingFixedRequest = await client.fixedRequest()
+		XCTAssertEqual(
+			pendingControlSequence,
+			[.credentialRefresh, .codexProjection]
+		)
+		XCTAssertNil(pendingFixedRequest)
+
+		await client.releaseUseAccount()
+		await routeTask.value
+
+		XCTAssertTrue(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		let completedControlSequence = await client.controlSequence()
+		XCTAssertEqual(
+			completedControlSequence,
+			[.credentialRefresh, .codexProjection, .fixedRouting]
+		)
+	}
+
 	func testRouteAccountDoesNotProjectOrChangeRoutingWhenRefreshFails() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
@@ -1723,6 +1856,7 @@ final class AccountControlStoreTests: XCTestCase {
 		observedState: ResetCardObservedState = .available,
 		lifecycleReadiness: ResetCardLifecycleReadiness = .ready,
 		unsettledOperation: AccountUnsettledOperation? = nil,
+		fiveHourQuota: ResetCardQuotaWindow = .unknown(durationMinutes: 300),
 		sevenDayQuota: ResetCardQuotaWindow = .unknown(durationMinutes: 10_080)
 	) -> ResetCardAccountRecord {
 		let accountID = accountID ?? self.accountID
@@ -1742,7 +1876,7 @@ final class AccountControlStoreTests: XCTestCase {
 				providerAccountID: accountID == self.accountID ? "provider-a" : "provider-b"
 			),
 			unsettledOperation: unsettledOperation,
-			fiveHourQuota: .unknown(durationMinutes: 300),
+			fiveHourQuota: fiveHourQuota,
 			sevenDayQuota: sevenDayQuota
 		)
 	}
@@ -1849,7 +1983,8 @@ private struct AccountControlStoreCounts: Equatable, Sendable {
 	let projection: Int
 }
 
-private actor AccountControlStoreClient: AccountControlClient, AccountObservationClient {
+private actor AccountControlStoreClient: AccountControlClient, AccountObservationClient,
+	AccountProfileClient {
 	private var account: ResetCardAccountRecord
 	private var secondaryAccount: ResetCardAccountRecord?
 	private let authority: ResetCardAuthority
@@ -1861,6 +1996,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private let enrollmentGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
 	private let maxSuccessfulInventoryReads: Int?
+	private let useAccountGate: AccountControlReadGate?
 	private var inventoryRevisionsByAccountID = [String: UInt64]()
 	private var resetCardStatus: ResetCardOperationState = .notFound
 	private let allowsEnrollment: Bool
@@ -1883,6 +2019,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private var projection: CodexAuthProjection
 	private var projectionError: AccountControlError?
 	private var projectionReads = 0
+	private var profileResults: [AccountProfileRead]
 	private var snapshotReadCount = 0
 	private var inventoryReadCount = 0
 	private var observationGenerations = [UInt64]()
@@ -1917,6 +2054,8 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		suspendsEnrollment: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
 		maxSuccessfulInventoryReads: Int? = nil,
+		suspendsUseAccount: Bool = false,
+		profileResults: [AccountProfileRead] = [],
 		allowsEnrollment: Bool = false,
 		enrollmentError: AccountControlError? = nil,
 		routing: AccountRoutingControl? = nil,
@@ -1943,6 +2082,8 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		enrollmentGate = suspendsEnrollment ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
 		self.maxSuccessfulInventoryReads = maxSuccessfulInventoryReads
+		useAccountGate = suspendsUseAccount ? AccountControlReadGate() : nil
+		self.profileResults = profileResults
 		self.allowsEnrollment = allowsEnrollment
 		self.enrollmentError = enrollmentError
 		self.routing = routing
@@ -2255,6 +2396,29 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		await projectionGate?.release()
 	}
 
+	func profile(
+		for _: ResetCardAccountRecord,
+		includeEmail _: Bool
+	) async throws -> AccountProfileRead {
+		guard profileResults.isEmpty == false else {
+			throw ResetCardClientError.invalidResponse
+		}
+		return profileResults.count == 1
+			? profileResults[0]
+			: profileResults.removeFirst()
+	}
+
+	func useAccountIsPending() async -> Bool {
+		guard let useAccountGate else {
+			return false
+		}
+		return await useAccountGate.isPending()
+	}
+
+	func releaseUseAccount() async {
+		await useAccountGate?.release()
+	}
+
 	func useAccountInCodex(
 		authority: ResetCardAuthority?,
 		accountID: String,
@@ -2275,6 +2439,7 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		if let useAccountError {
 			throw useAccountError
 		}
+		await useAccountGate?.wait()
 		let digest = String(repeating: "c", count: 64)
 		projection = .current(
 			accountID: accountID,

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -345,11 +345,20 @@ Account operation commits and its refresh command receipt remains terminal and r
 The safe projection writer also proves that a later bundle replaces stale shared auth for the
 same provider identity.
 
+The focused Swift Route presentation test gates `UseAccountInCodex` after a successful credential
+refresh. It proves that the Account revision and credential version advance before projection,
+the last-known inventory and both quota windows remain visible, the profile and its degradation
+facts remain available, and the aggregate profile Total stays equal. The retained inventory is
+not current for the successor revision, so its Reset Card targets remain fenced. Fixed routing
+stays unchanged until projection succeeds, and the control sequence remains credential refresh,
+Codex projection, then fixed routing. The existing refresh-rejection test continues to prove
+fail-closed behavior.
+
 Focused validation passed 30 Account Service tests, the exact later-projection Rust test, the
-native FFI refresh-request test, 17 Swift native-client tests, and 33 Swift account-control
+native FFI refresh-request test, 17 Swift native-client tests, and 34 Swift account-control
 store tests. The affected-package gate then passed all 22 FFI tests, 212 runtime unit tests
 with one intentional installed-Codex skip, every runtime integration and doc test, strict
-Clippy with warnings denied, and all 225 Swift tests. Both account-login and vNext architecture
+Clippy with warnings denied, and all 226 Swift tests. Both account-login and vNext architecture
 gates passed, and the SwiftPM production build completed with the same Xcode toolchain. The
 first Swift attempt under the active Command Line Tools directory failed
 before source compilation because `SwiftUIMacros` was unavailable. The supported rerun used


### PR DESCRIPTION
Summary:
- keep the safe journaled refresh -> projection -> fixed-routing sequence unchanged
- apply the validated Route credential successor without clearing last-known quota/profile presentation
- retain stale reset-card inventory only for display; revision fencing keeps it non-actionable until background reconciliation

Validation:
- new gated post-refresh/pre-projection regression test
- 34 AccountControlStore tests and full 226-test Swift debug/release suites
- 22 FFI and 30 Account Service tests
- architecture and local-database gates
- signed App staging/native-loader verification