### PR TITLE
Make shared Codex auth routing reliable

### DIFF
--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -224,9 +224,12 @@ The bundle contains only:
 - app and status-item icon resources
 
 The script builds the Rust native client and Swift app in release mode, signs
-the native library and app with the selected Apple Development identity,
-enables hardened runtime, and verifies the staged bundle. Set
-`DECODEX_APP_SIGN_IDENTITY` to select a signing identity and
+the native library and app with the selected Apple signing identity, enables
+hardened runtime, and verifies the staged bundle. The default selector is the
+current paid developer account. A matching `Developer ID Application` identity
+is preferred and receives a secure timestamp; `Apple Development` remains valid
+for local development. The script fails closed instead of signing with another
+account. Set `DECODEX_APP_SIGN_IDENTITY` to select a signing identity and
 `DECODEX_APP_STAGE_DIR` to select a staging directory.
 If the active developer directory lacks the required SwiftUI macros, the script
 uses `/Applications/Xcode-beta.app/Contents/Developer`.

--- a/apps/decodex-app/README.md
+++ b/apps/decodex-app/README.md
@@ -136,25 +136,29 @@ with one targetless provider-refresh ambiguity, shows `Refresh login`; this offi
 device-login flow is the app's only interactive credential-replacement surface. For the
 ambiguous case, Swift passes only the exact recovery operation identity. The daemon keeps
 the old ambiguity fenced until the verified replacement credential commits and never
-relabels it as a definite cancellation. The native app exposes the existing
-revision-fenced credential refresh only as one step of Route; it is not a standalone
-interactive action. Refresh login uses the same login-method selector. Manual
+relabels it as a definite cancellation. The daemon uses revision-fenced credential refresh
+inside Route; the native app exposes no standalone refresh action or refresh command.
+Refresh login uses the same login-method selector. Manual
 device-code login presents fixed-size Copy, Open, and Cancel controls. Automatic browser
 login opens the official redirect flow. The app then refreshes only that account after
 the daemon completes the exact credential replacement. The app
 then performs bounded short-interval daemon readback until the new background
 observation replaces any old unauthorized value. Each
-account row has one `Route` control. Route first asks Account Service to reconcile a valid
-newer shared Codex login for the exact same provider identity or run its journaled provider
-refresh. It then carries the committed account and credential revisions into the exact
-`~/.codex/auth.json` projection for future Codex launches. Only after projection succeeds does
-it select the same account as the fixed Decodex route. A rejected refresh without a newer exact
-shared login does not write shared auth or change fixed routing. The underlying typed commands
-remain independently fenced. Route retains an uncertain refresh receipt and a prepared account
-revision so a retry resumes at the first incomplete step. While a committed refresh waits for
-projection, the row keeps its last-known inventory, quota bars, profile, and profile degradation
-facts visible. That inventory remains display-only until the matching account revision arrives,
-so stale Reset Card actions stay fenced. The
+account row has one `Route` control. While Codex Desktop or app-server may be running, the daemon
+records one durable pending Route, follows stable `~/.codex/auth.json` reads without writing, and
+imports valid newer or equal-expiry rotations for known accounts. A partial or unreadable file is
+not logout evidence. Ordinary refresh also avoids the provider while a running Codex process can
+hold that refresh-token family.
+
+The target row shows `Pending`, all routing controls are disabled, and help text states that the
+switch occurs automatically after Codex closes. After natural exit, the daemon imports the final
+stable source, prepares the target, rechecks liveness, and compares the exact source metadata and
+file digest before one atomic replacement. It then commits fixed routing and the final receipt.
+Source drift remains pending. Stale routing or unrelated target revision drift fails closed.
+
+The app sends one Route command and projects the daemon-owned pending or final result. It keeps no
+wait, retry, partial Route, or Total-preservation workflow. It does not terminate, restart, or
+signal Codex Desktop, and it does not claim to hot-switch a running Codex process. The
 Fast control updates only the current Codex `[features].fast_mode` preference
 through the in-process native client.
 The overflow menu contains only `Refresh all`, the material selector, and Quit.
@@ -176,7 +180,9 @@ actions through the same command path. The app does not save a separate local
 account order.
 
 The app is intentionally menu-bar-only and uses the accessory activation
-policy. It does not own daemon startup or credential persistence.
+policy. It disables automatic and sudden termination because its status item is
+the persistent UI owner, and closing its last panel does not terminate the app.
+It does not own daemon startup or credential persistence.
 
 ## Development
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -48,6 +48,42 @@ struct AccountControlSnapshot: Equatable, Sendable {
 	let authority: ResetCardAuthority?
 	let accounts: [ResetCardAccountRecord]
 	let routing: AccountRoutingControl?
+	let pendingRoute: AccountRoutePending?
+}
+
+struct AccountRoutePending: Decodable, Equatable, Sendable {
+	let operationID: String
+	let accountID: String
+	let routingRevision: UInt64
+
+	init(operationID: String, accountID: String, routingRevision: UInt64) {
+		self.operationID = operationID
+		self.accountID = accountID
+		self.routingRevision = routingRevision
+	}
+
+	init(from decoder: Decoder) throws {
+		try requireExactFields(
+			in: decoder,
+			expected: ["operation_id", "account_id", "routing_revision"]
+		)
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		operationID = try container.decode(String.self, forKey: .operationID)
+		accountID = try container.decode(String.self, forKey: .accountID)
+		routingRevision = try container.decode(UInt64.self, forKey: .routingRevision)
+		guard DecodexNativeClient.isCanonicalAccountID(operationID),
+			DecodexNativeClient.isCanonicalAccountID(accountID),
+			routingRevision > 0
+		else {
+			throw AccountControlError.invalidResponse
+		}
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case operationID = "operation_id"
+		case accountID = "account_id"
+		case routingRevision = "routing_revision"
+	}
 }
 
 enum CodexAuthProjection: Equatable, Sendable {
@@ -60,7 +96,12 @@ enum AccountControlResult: Equatable, Sendable {
 	case accountChanged(ResetCardAccountRecord)
 	case accountLoggedOut(accountID: String, tombstoneRevision: UInt64)
 	case routingChanged(AccountRoutingControl)
-	case codexAuthProjected(accountID: String, accountRevision: UInt64, projectionDigest: String)
+	case routed(
+		account: ResetCardAccountRecord,
+		routing: AccountRoutingControl,
+		projectionDigest: String
+	)
+	case routePending(AccountRoutePending)
 }
 
 enum AccountControlRejection: String, Decodable, Equatable, Sendable {
@@ -76,6 +117,8 @@ enum AccountControlRejection: String, Decodable, Equatable, Sendable {
 	case providerAlreadyEnrolled = "provider_already_enrolled"
 	case providerMismatch = "provider_mismatch"
 	case lifecycleUnready = "lifecycle_unready"
+	case sharedAuthOwnerBusy = "shared_auth_owner_busy"
+	case routeSuperseded = "route_superseded"
 	case routingOrderInvalid = "routing_order_invalid"
 	case manualRecoveryRequired = "manual_recovery_required"
 
@@ -105,6 +148,10 @@ enum AccountControlRejection: String, Decodable, Equatable, Sendable {
 			return "The provider account does not match."
 		case .lifecycleUnready:
 			return "The account is not ready for this action."
+		case .sharedAuthOwnerBusy:
+			return "Codex is still using this login. Close Codex and try again."
+		case .routeSuperseded:
+			return "A newer account choice replaced this pending route."
 		case .routingOrderInvalid:
 			return "The account routing order is invalid."
 		case .manualRecoveryRequired:
@@ -275,13 +322,6 @@ protocol AccountControlClient: ResetCardClient {
 		authority: ResetCardAuthority?
 	) async throws -> CodexAuthProjection
 
-	func useAccountInCodex(
-		authority: ResetCardAuthority?,
-		accountID: String,
-		expectedRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult
-
 	func setAccountEnabled(
 		authority: ResetCardAuthority?,
 		accountID: String,
@@ -298,8 +338,9 @@ protocol AccountControlClient: ResetCardClient {
 		idempotencyKey: String
 	) async throws -> AccountControlResult
 
-	func setFixedSelection(
+	func routeAccount(
 		authority: ResetCardAuthority?,
+		operationID: String,
 		accountID: String,
 		expectedAccountRevision: UInt64,
 		expectedRoutingRevision: UInt64,
@@ -316,14 +357,6 @@ protocol AccountControlClient: ResetCardClient {
 		authority: ResetCardAuthority?,
 		order: [String],
 		expectedRoutingRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult
-
-	func refreshAccountCredentials(
-		authority: ResetCardAuthority?,
-		operationID: String,
-		accountID: String,
-		expectedRevision: UInt64,
 		idempotencyKey: String
 	) async throws -> AccountControlResult
 
@@ -360,11 +393,12 @@ protocol AccountControlClient: ResetCardClient {
 }
 
 extension AccountControlClient {
-	func refreshAccountCredentials(
+	func routeAccount(
 		authority _: ResetCardAuthority?,
 		operationID _: String,
 		accountID _: String,
-		expectedRevision _: UInt64,
+		expectedAccountRevision _: UInt64,
+		expectedRoutingRevision _: UInt64,
 		idempotencyKey _: String
 	) async throws -> AccountControlResult {
 		throw AccountControlError.applicationUnavailable
@@ -467,34 +501,6 @@ extension DecodexNativeClient: AccountControlClient {
 		return response.data.projection
 	}
 
-	func useAccountInCodex(
-		authority: ResetCardAuthority?,
-		accountID: String,
-		expectedRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult {
-		try Self.validateAccountControlInput(
-			authority: authority,
-			accountID: accountID,
-			operationID: nil,
-			expectedRevision: expectedRevision,
-			idempotencyKey: idempotencyKey
-		)
-		return try await executeAccountControl(
-			request: DecodexNativeRequest(
-				operation: "use_account_in_codex",
-				accountID: accountID,
-				expectedRevision: expectedRevision,
-				idempotencyKey: idempotencyKey
-			),
-			authority: authority,
-			expected: .codexAuthProjected(
-				accountID: accountID,
-				accountRevision: expectedRevision
-			)
-		)
-	}
-
 	func setAccountEnabled(
 		authority: ResetCardAuthority?,
 		accountID: String,
@@ -551,8 +557,9 @@ extension DecodexNativeClient: AccountControlClient {
 		)
 	}
 
-	func setFixedSelection(
+	func routeAccount(
 		authority: ResetCardAuthority?,
+		operationID: String,
 		accountID: String,
 		expectedAccountRevision: UInt64,
 		expectedRoutingRevision: UInt64,
@@ -561,7 +568,7 @@ extension DecodexNativeClient: AccountControlClient {
 		try Self.validateAccountControlInput(
 			authority: authority,
 			accountID: accountID,
-			operationID: nil,
+			operationID: operationID,
 			expectedRevision: expectedAccountRevision,
 			idempotencyKey: idempotencyKey
 		)
@@ -570,14 +577,15 @@ extension DecodexNativeClient: AccountControlClient {
 		}
 		return try await executeAccountControl(
 			request: DecodexNativeRequest(
-				operation: "set_fixed_selection",
+				operation: "route_account",
 				accountID: accountID,
 				expectedAccountRevision: expectedAccountRevision,
 				expectedRoutingRevision: expectedRoutingRevision,
-				idempotencyKey: idempotencyKey
+				idempotencyKey: idempotencyKey,
+				operationID: operationID
 			),
 			authority: authority,
-			expected: .routing(mode: .fixed(accountID: accountID))
+			expected: .routed(accountID: accountID)
 		)
 	}
 
@@ -627,36 +635,6 @@ extension DecodexNativeClient: AccountControlClient {
 			),
 			authority: authority,
 			expected: .routingOrder(order)
-		)
-	}
-
-	func refreshAccountCredentials(
-		authority: ResetCardAuthority?,
-		operationID: String,
-		accountID: String,
-		expectedRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult {
-		try Self.validateAccountControlInput(
-			authority: authority,
-			accountID: accountID,
-			operationID: operationID,
-			expectedRevision: expectedRevision,
-			idempotencyKey: idempotencyKey
-		)
-		return try await executeAccountControl(
-			request: DecodexNativeRequest(
-				operation: "refresh_account",
-				accountID: accountID,
-				expectedRevision: expectedRevision,
-				idempotencyKey: idempotencyKey,
-				operationID: operationID
-			),
-			authority: authority,
-			expected: .accountChanged(
-				accountID: accountID,
-				enabled: nil
-			)
 		)
 	}
 
@@ -1011,7 +989,7 @@ private enum AccountControlExpectedResult {
 	case accountLoggedOut(accountID: String)
 	case routing(mode: AccountRoutingMode)
 	case routingOrder([String])
-	case codexAuthProjected(accountID: String, accountRevision: UInt64)
+	case routed(accountID: String)
 }
 
 private enum CodexAuthProjectionWire: Decodable {
@@ -1192,7 +1170,8 @@ private enum AccountControlResultPayloadWire: Decodable {
 	case accountRestored(requestedAccountID: String, account: ResetCardAccountWire)
 	case accountLoggedOut(accountID: String, tombstoneRevision: UInt64)
 	case routingChanged(AccountRoutingWire)
-	case codexAuthProjected(accountID: String, accountRevision: UInt64, projectionDigest: String)
+	case routed(account: ResetCardAccountWire, routing: AccountRoutingWire, projectionDigest: String)
+	case routePending(AccountRoutePending)
 
 	init(from decoder: Decoder) throws {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -1227,20 +1206,21 @@ private enum AccountControlResultPayloadWire: Decodable {
 			try requireExactFields(in: decoder, expected: ["name", "data"])
 			let data = try container.decode(AccountRoutingChangedData.self, forKey: .data)
 			self = .routingChanged(data.routing)
-		case "codex_auth_projected":
+		case "account_routed":
 			try requireExactFields(in: decoder, expected: ["name", "data"])
-			let data = try container.decode(CodexAuthProjectedData.self, forKey: .data)
-			guard DecodexNativeClient.isCanonicalAccountID(data.accountID),
-				data.accountRevision > 0,
-				CodexAuthProjectionWire.isSHA256(data.projectionDigest)
-			else {
+			let data = try container.decode(AccountRoutedData.self, forKey: .data)
+			guard CodexAuthProjectionWire.isSHA256(data.projectionDigest) else {
 				throw AccountControlError.invalidResponse
 			}
-			self = .codexAuthProjected(
-				accountID: data.accountID,
-				accountRevision: data.accountRevision,
+			self = .routed(
+				account: data.account,
+				routing: data.routing,
 				projectionDigest: data.projectionDigest
 			)
+		case "account_route_pending":
+			try requireExactFields(in: decoder, expected: ["name", "data"])
+			let data = try container.decode(AccountRoutePendingData.self, forKey: .data)
+			self = .routePending(data.pending)
 		default:
 			throw AccountControlError.invalidResponse
 		}
@@ -1327,20 +1307,31 @@ private enum AccountControlResultPayloadWire: Decodable {
 			}
 			return .routingChanged(routing)
 		case (
-			.codexAuthProjected(let accountID, let accountRevision, let projectionDigest),
-			.codexAuthProjected(let expectedID, let expectedRevision)
+			.routed(let accountWire, let routingWire, let projectionDigest),
+			.routed(let expectedID)
 		):
-			guard accountID == expectedID,
-				accountRevision == expectedRevision,
-				entityRevision == expectedRevision
+			let account = try accountWire.record()
+			let routing = routingWire.routing
+			guard account.accountID == expectedID,
+				account.accountRevision > 0,
+				routing.revision == entityRevision,
+				routing.mode == .fixed(accountID: expectedID),
+				CodexAuthProjectionWire.isSHA256(projectionDigest)
 			else {
 				throw AccountControlError.invalidResponse
 			}
-			return .codexAuthProjected(
-				accountID: accountID,
-				accountRevision: accountRevision,
+			return .routed(
+				account: account.withAuthority(authority),
+				routing: routing,
 				projectionDigest: projectionDigest
 			)
+		case (.routePending(let pending), .routed(let expectedID)):
+			guard pending.accountID == expectedID,
+				pending.routingRevision == entityRevision
+			else {
+				throw AccountControlError.invalidResponse
+			}
+			return .routePending(pending)
 		default:
 			throw AccountControlError.invalidResponse
 		}
@@ -1417,26 +1408,40 @@ private enum AccountControlResultPayloadWire: Decodable {
 		}
 	}
 
-	private struct CodexAuthProjectedData: Decodable {
-		let accountID: String
-		let accountRevision: UInt64
+	private struct AccountRoutedData: Decodable {
+		let account: ResetCardAccountWire
+		let routing: AccountRoutingWire
 		let projectionDigest: String
 
 		init(from decoder: Decoder) throws {
 			try requireExactFields(
 				in: decoder,
-				expected: ["account_id", "account_revision", "projection_digest"]
+				expected: ["account", "routing", "projection_digest"]
 			)
 			let container = try decoder.container(keyedBy: CodingKeys.self)
-			accountID = try container.decode(String.self, forKey: .accountID)
-			accountRevision = try container.decode(UInt64.self, forKey: .accountRevision)
+			account = try container.decode(ResetCardAccountWire.self, forKey: .account)
+			routing = try container.decode(AccountRoutingWire.self, forKey: .routing)
 			projectionDigest = try container.decode(String.self, forKey: .projectionDigest)
 		}
 
 		private enum CodingKeys: String, CodingKey {
-			case accountID = "account_id"
-			case accountRevision = "account_revision"
+			case account
+			case routing
 			case projectionDigest = "projection_digest"
+		}
+	}
+
+	private struct AccountRoutePendingData: Decodable {
+		let pending: AccountRoutePending
+
+		init(from decoder: Decoder) throws {
+			try requireExactFields(in: decoder, expected: ["pending"])
+			let container = try decoder.container(keyedBy: CodingKeys.self)
+			pending = try container.decode(AccountRoutePending.self, forKey: .pending)
+		}
+
+		private enum CodingKeys: String, CodingKey {
+			case pending
 		}
 	}
 

--- a/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-app/Sources/DecodexApp/AccountControlViews.swift
@@ -36,10 +36,14 @@ struct AccountPrimaryActionsView: View {
 	var body: some View {
 		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
-				title: presentation.isCurrent ? "Routed" : "Route",
-				symbol: presentation.isCurrent
-					? "point.3.connected.trianglepath.dotted"
-					: "arrow.triangle.branch",
+				title: isPendingTarget
+					? "Pending"
+					: (keepsCurrentRoute ? "Keep" : (presentation.isCurrent ? "Routed" : "Route")),
+				symbol: isPendingTarget
+					? "clock"
+					: (presentation.isCurrent
+						? "point.3.connected.trianglepath.dotted"
+						: "arrow.triangle.branch"),
 				isActive: presentation.isCurrent,
 				isDisabled: presentation.isDisabled,
 				isVisuallyDisabled: presentation.isVisuallyDisabled,
@@ -48,9 +52,13 @@ struct AccountPrimaryActionsView: View {
 					state.account.accountID,
 					activity: .route
 				),
-				help: presentation.isCurrent
-					? "This account is used by Decodex routing and new Codex processes."
-					: "Route Decodex and use this account for new Codex processes."
+				help: isPendingTarget
+					? "Quit ChatGPT and keep it closed until Pending changes to Routed, then reopen it."
+					: (keepsCurrentRoute
+						? "Keep this account and replace the other pending route."
+						: (presentation.isCurrent
+						? "This account is used by Decodex routing and new Codex processes."
+						: "Route Decodex and use this account for new Codex processes."))
 			) {
 				Task {
 					await store.routeAccount(state.account.accountID)
@@ -66,7 +74,11 @@ struct AccountPrimaryActionsView: View {
 	}
 
 	private var isRouteCurrent: Bool {
-		isCodexProjection && isFixed
+		isCodexProjection && isFixed && store.pendingRoute == nil
+	}
+
+	private var keepsCurrentRoute: Bool {
+		isCodexProjection && isFixed && store.pendingRoute != nil && isPendingTarget == false
 	}
 
 	private var presentation: AccountRouteActionPresentation {
@@ -80,7 +92,11 @@ struct AccountPrimaryActionsView: View {
 	}
 
 	private var canSelect: Bool {
-		state.routeCapability == .ready
+		state.routeCapability == .ready && store.pendingRoute?.accountID != state.account.accountID
+	}
+
+	private var isPendingTarget: Bool {
+		store.pendingRoute?.accountID == state.account.accountID
 	}
 
 	private var isFixed: Bool {
@@ -189,6 +205,7 @@ struct AccountUtilityActionsView: View {
 
 	private var lifecycleActionIsDisabled: Bool {
 		store.canPerformDirectAccountControl == false
+			|| store.pendingRoute != nil
 			|| store.isAccountControlInProgress
 			|| store.submittingKey != nil
 	}

--- a/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexApp.swift
@@ -8,6 +8,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	private var terminationIsPending = false
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
+		ProcessInfo.processInfo.automaticTerminationSupportEnabled = false
+		ProcessInfo.processInfo.disableAutomaticTermination(
+			"Decodex owns a persistent menu bar status item."
+		)
+		ProcessInfo.processInfo.disableSuddenTermination()
 		NSApp.setActivationPolicy(.accessory)
 		let store = ResetCardStore()
 		self.store = store
@@ -26,6 +31,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			sender.reply(toApplicationShouldTerminate: true)
 		}
 		return .terminateLater
+	}
+
+	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+		false
 	}
 }
 

--- a/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift
+++ b/apps/decodex-app/Sources/DecodexApp/DecodexNativeCompatibility.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 let decodexNativeClientABIVersion: UInt32 = 1
-let decodexNativeArtifactCohort: UInt32 = 2
+let decodexNativeArtifactCohort: UInt32 = 5
 
 enum DecodexNativeCompatibility {
 	private typealias Version = @convention(c) () -> UInt32

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -672,12 +672,17 @@ private enum AccountListWireResult: Decodable {
 struct AccountListWireData: Decodable {
 	let accounts: [ResetCardAccountWire]
 	let routing: AccountRoutingWire?
+	let pendingRoute: AccountRoutePending?
 
 	init(from decoder: Decoder) throws {
-		try rejectUnknownFields(in: decoder, allowed: ["accounts", "routing"])
+		try rejectUnknownFields(in: decoder, allowed: ["accounts", "routing", "pending_route"])
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		accounts = try container.decode([ResetCardAccountWire].self, forKey: .accounts)
 		routing = try container.decodeIfPresent(AccountRoutingWire.self, forKey: .routing)
+		pendingRoute = try container.decodeIfPresent(
+			AccountRoutePending.self,
+			forKey: .pendingRoute
+		)
 	}
 
 	func snapshot(
@@ -726,10 +731,18 @@ struct AccountListWireData: Decodable {
 			// retried. Preserve the daemon's registry order until a routing snapshot arrives.
 			ordered = records
 		}
+		if let pendingRoute {
+			guard byID[pendingRoute.accountID] != nil,
+				routing.map({ $0.revision == pendingRoute.routingRevision }) ?? true
+			else {
+				throw ResetCardClientError.invalidResponse
+			}
+		}
 		return AccountControlSnapshot(
 			authority: authority,
 			accounts: ordered,
-			routing: routing?.routing
+			routing: routing?.routing,
+			pendingRoute: pendingRoute
 		)
 	}
 
@@ -740,6 +753,7 @@ struct AccountListWireData: Decodable {
 	private enum CodingKeys: String, CodingKey {
 		case accounts
 		case routing
+		case pendingRoute = "pending_route"
 	}
 }
 
@@ -1755,6 +1769,8 @@ private enum ResetCardAccountCommandRejectionWire: String, Decodable {
 	case credentialStoreUnavailable = "credential_store_unavailable"
 	case providerMismatch = "provider_mismatch"
 	case lifecycleUnready = "lifecycle_unready"
+	case sharedAuthOwnerBusy = "shared_auth_owner_busy"
+	case routeSuperseded = "route_superseded"
 	case routingOrderInvalid = "routing_order_invalid"
 	case manualRecoveryRequired = "manual_recovery_required"
 }

--- a/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift
@@ -267,15 +267,6 @@ enum AccountControlActivity: Equatable {
 	case route
 }
 
-private struct PendingAccountRoutePreparation {
-	let expectedAccountRevision: UInt64
-	let expectedCredentialBinding: AccountCredentialBinding
-	let refreshOperationID: String
-	let refreshIdempotencyKey: String
-	let projectionIdempotencyKey: String
-	var refreshedAccountRevision: UInt64?
-}
-
 private enum AccountLoginStart {
 	case enrollment(enabled: Bool)
 	case reauthentication(
@@ -360,6 +351,7 @@ final class ResetCardStore {
 
 	private(set) var accounts = [ResetCardAccountState]()
 	private(set) var routing: AccountRoutingControl?
+	private(set) var pendingRoute: AccountRoutePending?
 	private(set) var codexAuthProjection: CodexAuthProjection?
 	private(set) var isRefreshing = false
 	private(set) var refreshSkeletonIsPublished = false
@@ -401,9 +393,6 @@ final class ResetCardStore {
 	@ObservationIgnored private var pendingRecoveryTask: Task<Void, Never>?
 	@ObservationIgnored private var accountReauthenticationTask: Task<Void, Never>?
 	@ObservationIgnored private var pendingAccountLoginStart: PendingAccountLoginStart?
-	@ObservationIgnored private var pendingAccountRoutePreparations = [
-		String: PendingAccountRoutePreparation
-	]()
 	@ObservationIgnored private var postUseReconciliationTasks = [
 		String: Task<Void, Never>
 	]()
@@ -483,6 +472,7 @@ final class ResetCardStore {
 
 	var canBeginEnrollment: Bool {
 		accountControlClient != nil
+			&& pendingRoute == nil
 			&& canPerformDirectAccountControl
 			&& isAccountControlInProgress == false
 	}
@@ -493,6 +483,7 @@ final class ResetCardStore {
 		}
 		let accountIDs = accounts.map { $0.account.accountID }
 		return accountControlClient != nil
+			&& pendingRoute == nil
 			&& accountIDs.count > 1
 			&& accountIDs.count == routing.order.count
 			&& Set(accountIDs) == Set(routing.order)
@@ -937,6 +928,7 @@ final class ResetCardStore {
 				{
 					routing = snapshotRouting
 				}
+				pendingRoute = snapshot.pendingRoute
 				discovered = snapshot.accounts
 			} else {
 				discovered = try await client.accounts(authority: retainedAuthority)
@@ -1298,6 +1290,9 @@ final class ResetCardStore {
 	}
 
 	func canRouteAccount(_ accountID: String) -> Bool {
+		guard pendingRoute?.accountID != accountID else {
+			return false
+		}
 		guard let state = accounts.first(where: { $0.account.accountID == accountID }) else {
 			return false
 		}
@@ -1340,7 +1335,8 @@ final class ResetCardStore {
 		_ accountID: String,
 		enabled: Bool
 	) async {
-		guard let account = accountRecord(accountID),
+		guard pendingRoute == nil,
+			let account = accountRecord(accountID),
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -1364,7 +1360,8 @@ final class ResetCardStore {
 	}
 
 	func logoutAccount(_ accountID: String) async {
-		guard let account = accountRecord(accountID),
+		guard pendingRoute == nil,
+			let account = accountRecord(accountID),
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -1389,32 +1386,6 @@ final class ResetCardStore {
 		)
 	}
 
-	func selectFixedAccount(_ accountID: String) async {
-		guard let account = accountRecord(accountID),
-			canRouteAccount(accountID),
-			let routing,
-			routing.order.contains(accountID),
-			let accountControlClient
-		else {
-			presentAccountControlUnavailable()
-			return
-		}
-		await performAccountControl(
-			isRoutingControl: true,
-			allowsDuringRefresh: true,
-			successMessage: nil,
-			operation: {
-				try await accountControlClient.setFixedSelection(
-					authority: account.authority ?? establishedAuthority,
-					accountID: accountID,
-					expectedAccountRevision: account.accountRevision,
-					expectedRoutingRevision: routing.revision,
-					idempotencyKey: Self.newCanonicalUUID()
-				)
-			}
-		)
-	}
-
 	func routeAccount(_ accountID: String) async {
 		guard let account = accountRecord(accountID),
 			canRouteAccount(accountID),
@@ -1432,7 +1403,8 @@ final class ResetCardStore {
 		} else {
 			needsFixedRouting = true
 		}
-		guard needsCodexProjection || needsFixedRouting else {
+		let replacesPendingRoute = pendingRoute != nil
+		guard needsCodexProjection || needsFixedRouting || replacesPendingRoute else {
 			return
 		}
 
@@ -1443,116 +1415,11 @@ final class ResetCardStore {
 			allowsDuringRefresh: true,
 			successMessage: nil,
 			operation: {
-				var routedAccount = account
-				var shouldReconcileRouteAccount = false
-				defer {
-					if shouldReconcileRouteAccount {
-						scheduleAccountControlFollowUp(
-							.account(accountID, refreshInventory: true)
-						)
-					}
-				}
-				if needsCodexProjection {
-					var preparation = pendingAccountRoutePreparations[accountID]
-					if let refreshedRevision = preparation?.refreshedAccountRevision,
-						refreshedRevision != account.accountRevision
-					{
-						pendingAccountRoutePreparations.removeValue(forKey: accountID)
-						preparation = nil
-					}
-					if preparation == nil {
-						guard let credentialBinding = account.credentialBinding else {
-							throw AccountControlError.invalidResponse
-						}
-						preparation = PendingAccountRoutePreparation(
-							expectedAccountRevision: account.accountRevision,
-							expectedCredentialBinding: credentialBinding,
-							refreshOperationID: Self.newCanonicalUUID(),
-							refreshIdempotencyKey: Self.newCanonicalUUID(),
-							projectionIdempotencyKey: Self.newCanonicalUUID(),
-							refreshedAccountRevision: nil
-						)
-						pendingAccountRoutePreparations[accountID] = preparation
-					}
-					guard var preparation else {
-						throw AccountControlError.invalidResponse
-					}
-
-					if preparation.refreshedAccountRevision == nil {
-						do {
-							let refreshResult = try await accountControlClient
-								.refreshAccountCredentials(
-									authority: account.authority ?? establishedAuthority,
-									operationID: preparation.refreshOperationID,
-									accountID: accountID,
-									expectedRevision: preparation.expectedAccountRevision,
-									idempotencyKey: preparation.refreshIdempotencyKey
-								)
-							let currentRouteRevision = accountRecord(accountID)?.accountRevision
-								?? account.accountRevision
-							guard refreshedAccountRevisionIsCurrent(
-								refreshResult,
-								currentAccountRevision: currentRouteRevision
-							) else {
-								throw AccountControlError.expectedRevisionMismatch(
-									expected: preparation.expectedAccountRevision,
-									actual: currentRouteRevision
-								)
-							}
-							guard case .accountChanged(let refreshedAccount) = refreshResult,
-								Self.isImmediateRouteRefresh(
-									accountID: accountID,
-									expectedAccountRevision: preparation
-										.expectedAccountRevision,
-									expectedCredentialBinding: preparation
-										.expectedCredentialBinding,
-									to: refreshedAccount
-								)
-							else {
-								throw AccountControlError.invalidResponse
-							}
-							guard applyImmediateRouteAccountRefresh(
-								refreshedAccount,
-								accountID: accountID,
-								expectedAccountRevision: preparation.expectedAccountRevision,
-								expectedCredentialBinding: preparation.expectedCredentialBinding
-							) else {
-								throw AccountControlError.invalidResponse
-							}
-							shouldReconcileRouteAccount = true
-							preparation.refreshedAccountRevision = refreshedAccount
-								.accountRevision
-							pendingAccountRoutePreparations[accountID] = preparation
-							routedAccount = refreshedAccount
-						} catch {
-							if Self.routeRefreshCanReuseReceipt(after: error) == false {
-								pendingAccountRoutePreparations.removeValue(forKey: accountID)
-							}
-							throw error
-						}
-					} else {
-						routedAccount = account
-					}
-
-					let result = try await accountControlClient.useAccountInCodex(
-						authority: routedAccount.authority ?? establishedAuthority,
-						accountID: accountID,
-						expectedRevision: routedAccount.accountRevision,
-						idempotencyKey: preparation.projectionIdempotencyKey
-					)
-					_ = applyAccountControlResult(result)
-					pendingAccountRoutePreparations.removeValue(forKey: accountID)
-					if needsFixedRouting == false {
-						return result
-					}
-				} else {
-					pendingAccountRoutePreparations.removeValue(forKey: accountID)
-				}
-
-				return try await accountControlClient.setFixedSelection(
-					authority: routedAccount.authority ?? establishedAuthority,
+				try await accountControlClient.routeAccount(
+					authority: account.authority ?? establishedAuthority,
+					operationID: Self.newCanonicalUUID(),
 					accountID: accountID,
-					expectedAccountRevision: routedAccount.accountRevision,
+					expectedAccountRevision: account.accountRevision,
 					expectedRoutingRevision: routing.revision,
 					idempotencyKey: Self.newCanonicalUUID()
 				)
@@ -1560,94 +1427,9 @@ final class ResetCardStore {
 		)
 	}
 
-	private func refreshedAccountRevisionIsCurrent(
-		_ result: AccountControlResult,
-		currentAccountRevision: UInt64
-	) -> Bool {
-		guard case .accountChanged(let refreshedAccount) = result else {
-			return false
-		}
-		return refreshedAccount.accountRevision >= currentAccountRevision
-	}
-
-	nonisolated private static func isImmediateRouteRefresh(
-		accountID: String,
-		expectedAccountRevision: UInt64,
-		expectedCredentialBinding: AccountCredentialBinding,
-		to refreshed: ResetCardAccountRecord
-	) -> Bool {
-		let (refreshedAccountRevision, accountRevisionOverflow) = expectedAccountRevision
-			.addingReportingOverflow(1)
-		guard accountRevisionOverflow == false,
-			refreshed.accountID == accountID,
-			refreshed.accountRevision == refreshedAccountRevision,
-			let refreshedBinding = refreshed.credentialBinding
-		else {
-			return false
-		}
-		let (expectedCredentialVersion, credentialVersionOverflow) = expectedCredentialBinding.version
-			.addingReportingOverflow(1)
-		return credentialVersionOverflow == false
-			&& refreshedBinding.version == expectedCredentialVersion
-			&& refreshedBinding.provider == expectedCredentialBinding.provider
-			&& refreshedBinding.providerAccountID == expectedCredentialBinding.providerAccountID
-	}
-
-	private func applyImmediateRouteAccountRefresh(
-		_ refreshedAccount: ResetCardAccountRecord,
-		accountID: String,
-		expectedAccountRevision: UInt64,
-		expectedCredentialBinding: AccountCredentialBinding
-	) -> Bool {
-		guard Self.isImmediateRouteRefresh(
-			accountID: accountID,
-			expectedAccountRevision: expectedAccountRevision,
-			expectedCredentialBinding: expectedCredentialBinding,
-			to: refreshedAccount
-		), let index = accounts.firstIndex(where: {
-			$0.account.accountID == accountID
-		}) else {
-			return false
-		}
-
-		let existing = accounts[index]
-		let authority = refreshedAccount.authority
-			?? existing.account.authority
-			?? existing.inventory?.authority
-		let bound = Self.account(refreshedAccount, authority: authority)
-		accounts[index] = ResetCardAccountState(
-			account: bound,
-			inventory: existing.inventory,
-			error: nil,
-			isRefreshing: true,
-			profile: existing.profile,
-			profileUnavailable: existing.profileUnavailable,
-			profileError: existing.profileError,
-			isProfileRefreshing: accountProfileClient != nil
-		)
-		reconcileAccountSkeletonRevisionTargets()
-		invalidateCodexProjectionAfterRevisionChange(
-			accountID: bound.accountID,
-			accountRevision: bound.accountRevision
-		)
-		return true
-	}
-
-	nonisolated private static func routeRefreshCanReuseReceipt(after error: Error) -> Bool {
-		guard let error = error as? AccountControlError else {
-			return true
-		}
-		switch error {
-		case .invalidInput, .invalidResponse, .expectedRevisionMismatch, .idempotencyConflict,
-			.idempotencyCapacityExceeded, .rejected:
-			return false
-		case .client, .applicationUnavailable, .acceptanceUnknown, .potentiallyDispatched:
-			return true
-		}
-	}
-
 	func selectBalancedAccounts() async {
-		guard let routing,
+		guard pendingRoute == nil,
+			let routing,
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -1988,29 +1770,6 @@ final class ResetCardStore {
 		finishAccountReauthentication(
 			accountID: presentation.accountID,
 			sessionID: presentation.sessionID
-		)
-	}
-
-	func useAccountInCodex(_ accountID: String) async {
-		guard let account = accountRecord(accountID),
-			let accountControlClient
-		else {
-			presentAccountControlUnavailable()
-			return
-		}
-		await performAccountControl(
-			accountID: accountID,
-			activity: .route,
-			allowsDuringRefresh: true,
-			successMessage: nil,
-			operation: {
-				try await accountControlClient.useAccountInCodex(
-					authority: account.authority ?? establishedAuthority,
-					accountID: accountID,
-					expectedRevision: account.accountRevision,
-					idempotencyKey: Self.newCanonicalUUID()
-				)
-			}
 		)
 	}
 
@@ -2525,6 +2284,7 @@ final class ResetCardStore {
 			if let snapshotRouting = snapshot.routing {
 				routing = snapshotRouting
 			}
+			pendingRoute = snapshot.pendingRoute
 			var accountsNeedingDetails = [(
 				accountID: String,
 				refreshInventory: Bool
@@ -3687,20 +3447,26 @@ final class ResetCardStore {
 		_ result: AccountControlResult
 	) -> AccountControlFollowUp {
 		switch result {
-		case .codexAuthProjected(let accountID, let accountRevision, let projectionDigest):
-			codexProjectionRequestGeneration &+= 1
-			codexAuthProjection = .current(
-				accountID: accountID,
-				accountRevision: accountRevision,
-				projectionDigest: projectionDigest
-			)
-			return .none
 		case .routingChanged(let routing):
 			self.routing = routing
 			_ = reorderAccountStates(to: routing.order)
 			return .none
+		case .routed(let account, let routing, let projectionDigest):
+			let followUp = applyAccountChange(account)
+			self.routing = routing
+			pendingRoute = nil
+			_ = reorderAccountStates(to: routing.order)
+			codexProjectionRequestGeneration &+= 1
+			codexAuthProjection = .current(
+				accountID: account.accountID,
+				accountRevision: account.accountRevision,
+				projectionDigest: projectionDigest
+			)
+			return followUp
+		case .routePending(let pending):
+			pendingRoute = pending
+			return .none
 		case .accountLoggedOut(let accountID, _):
-			pendingAccountRoutePreparations.removeValue(forKey: accountID)
 			if case .current(let projectedID, _, _) = codexAuthProjection,
 				projectedID == accountID
 			{
@@ -3716,38 +3482,40 @@ final class ResetCardStore {
 			}
 			return .skeleton
 		case .accountChanged(let account):
-			guard let index = accounts.firstIndex(where: {
-				$0.account.accountID == account.accountID
-			}) else {
-				return .skeleton
-			}
-			let existing = accounts[index]
-			let authority = account.authority
-				?? existing.account.authority
-				?? existing.inventory?.authority
-			let bound = Self.account(account, authority: authority)
-			let sameRevision = existing.account.accountRevision == bound.accountRevision
-			accounts[index] = ResetCardAccountState(
-				account: bound,
-				inventory: existing.inventory,
-				error: nil,
-				isRefreshing: sameRevision == false,
-				profile: sameRevision ? existing.profile : nil,
-				profileUnavailable: sameRevision ? existing.profileUnavailable : nil,
-				profileError: nil,
-				isProfileRefreshing: sameRevision == false && accountProfileClient != nil
-			)
-			reconcileAccountSkeletonRevisionTargets()
-			if sameRevision == false {
-				invalidateCodexProjectionAfterRevisionChange(
-					accountID: account.accountID,
-					accountRevision: bound.accountRevision
-				)
-			}
-			return sameRevision
-				? .none
-				: .account(account.accountID, refreshInventory: true)
+			return applyAccountChange(account)
 		}
+	}
+
+	private func applyAccountChange(_ account: ResetCardAccountRecord) -> AccountControlFollowUp {
+		guard let index = accounts.firstIndex(where: {
+			$0.account.accountID == account.accountID
+		}) else {
+			return .skeleton
+		}
+		let existing = accounts[index]
+		let authority = account.authority
+			?? existing.account.authority
+			?? existing.inventory?.authority
+		let bound = Self.account(account, authority: authority)
+		let sameRevision = existing.account.accountRevision == bound.accountRevision
+		accounts[index] = ResetCardAccountState(
+			account: bound,
+			inventory: existing.inventory,
+			error: nil,
+			isRefreshing: sameRevision == false,
+			profile: sameRevision ? existing.profile : nil,
+			profileUnavailable: sameRevision ? existing.profileUnavailable : nil,
+			profileError: nil,
+			isProfileRefreshing: sameRevision == false && accountProfileClient != nil
+		)
+		reconcileAccountSkeletonRevisionTargets()
+		if sameRevision == false {
+			invalidateCodexProjectionAfterRevisionChange(
+				accountID: account.accountID,
+				accountRevision: bound.accountRevision
+			)
+		}
+		return sameRevision ? .none : .account(account.accountID, refreshInventory: true)
 	}
 
 	@discardableResult

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -28,7 +28,8 @@ final class AccountControlNativeClientTests: XCTestCase {
 				    \(controlAccountJSON(accountID: accountID, alias: "Iris", revision: 7)),
 				    \(controlUnsettledAccountJSON(accountID: secondAccountID, operationID: operationID))
 				  ],
-				  "routing":{"revision":9,"mode":{"mode":"fixed","account_id":"\(secondAccountID)"},"order":["\(secondAccountID)","\(accountID)"]}
+				  "routing":{"revision":9,"mode":{"mode":"fixed","account_id":"\(secondAccountID)"},"order":["\(secondAccountID)","\(accountID)"]},
+				  "pending_route":{"operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9}
 				}}
 				"""
 			)
@@ -46,6 +47,14 @@ final class AccountControlNativeClientTests: XCTestCase {
 			)
 		)
 		XCTAssertEqual(snapshot.accounts.map(\.accountID), [secondAccountID, accountID])
+		XCTAssertEqual(
+			snapshot.pendingRoute,
+			AccountRoutePending(
+				operationID: operationID,
+				accountID: accountID,
+				routingRevision: 9
+			)
+		)
 		XCTAssertEqual(snapshot.accounts[1].credentialBinding?.version, 3)
 		XCTAssertEqual(
 			snapshot.accounts[0].unsettledOperation,
@@ -54,6 +63,44 @@ final class AccountControlNativeClientTests: XCTestCase {
 				kind: .refresh,
 				phase: .recoveryRequired,
 				recoveryCode: "provider_identity_changed"
+			)
+		)
+	}
+
+	func testRouteDecodesDurablePendingResult() async throws {
+		let authority = authority
+		let operationID = operationID
+		let accountID = accountID
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "route_account",
+				authority: authority,
+				data: """
+				{"outcome":"applied","data":{"entity_revision":9,
+				  "result":{"name":"account_route_pending","data":{"pending":{
+				    "operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9
+				  }}}}}
+				"""
+			)
+		}
+
+		let result = try await client.routeAccount(
+			authority: authority,
+			operationID: operationID,
+			accountID: accountID,
+			expectedAccountRevision: 7,
+			expectedRoutingRevision: 9,
+			idempotencyKey: idempotencyKey
+		)
+
+		XCTAssertEqual(
+			result,
+			.routePending(
+				AccountRoutePending(
+					operationID: operationID,
+					accountID: accountID,
+					routingRevision: 9
+				)
 			)
 		)
 	}
@@ -76,11 +123,12 @@ final class AccountControlNativeClientTests: XCTestCase {
 				{"outcome":"current","data":{"account_id":"\(accountID)",
 				  "account_revision":7,"projection_digest":"\(String(repeating: "c", count: 64))"}}
 				"""
-			case "use_account_in_codex":
+			case "route_account":
 				payload = """
-				{"outcome":"applied","data":{"entity_revision":7,
-				  "result":{"name":"codex_auth_projected","data":{
-				    "account_id":"\(accountID)","account_revision":7,
+				{"outcome":"applied","data":{"entity_revision":10,
+				  "result":{"name":"account_routed","data":{
+				    "account":\(controlAccountJSON(accountID: accountID, alias: "Iris", revision: 8)),
+				    "routing":{"revision":10,"mode":{"mode":"fixed","account_id":"\(accountID)"},"order":["\(accountID)","\(secondAccountID)"]},
 				    "projection_digest":"\(String(repeating: "c", count: 64))"}}}}
 				"""
 			case "logout_account":
@@ -88,12 +136,6 @@ final class AccountControlNativeClientTests: XCTestCase {
 				{"outcome":"applied","data":{"entity_revision":8,
 				  "result":{"name":"account_logged_out","data":{"account_id":"\(accountID)","tombstone_revision":8}}}}
 				"""
-			case "set_fixed_selection":
-				payload = controlRoutingAppliedJSON(
-					revision: 10,
-					mode: #"{"mode":"fixed","account_id":"\#(accountID)"}"#,
-					order: [accountID, secondAccountID]
-				)
 			case "set_balanced_selection":
 				payload = controlRoutingAppliedJSON(
 					revision: 10,
@@ -137,10 +179,12 @@ final class AccountControlNativeClientTests: XCTestCase {
 				projectionDigest: String(repeating: "c", count: 64)
 			)
 		)
-		_ = try await client.useAccountInCodex(
+		_ = try await client.routeAccount(
 			authority: authority,
+			operationID: operationID,
 			accountID: accountID,
-			expectedRevision: 7,
+			expectedAccountRevision: 7,
+			expectedRoutingRevision: 9,
 			idempotencyKey: idempotencyKey
 		)
 		_ = try await client.setAccountEnabled(
@@ -157,13 +201,6 @@ final class AccountControlNativeClientTests: XCTestCase {
 			expectedRevision: 7,
 			idempotencyKey: idempotencyKey
 		)
-		_ = try await client.setFixedSelection(
-			authority: authority,
-			accountID: accountID,
-			expectedAccountRevision: 7,
-			expectedRoutingRevision: 9,
-			idempotencyKey: idempotencyKey
-		)
 		_ = try await client.setBalancedSelection(
 			authority: authority,
 			expectedRoutingRevision: 9,
@@ -175,21 +212,13 @@ final class AccountControlNativeClientTests: XCTestCase {
 			expectedRoutingRevision: 9,
 			idempotencyKey: idempotencyKey
 		)
-		_ = try await client.refreshAccountCredentials(
-			authority: authority,
-			operationID: operationID,
-			accountID: accountID,
-			expectedRevision: 7,
-			idempotencyKey: idempotencyKey
-		)
 		let requests = try recorder.requests.map { try nativeJSONObject($0.data) }
 		XCTAssertEqual(
 			requests.compactMap { $0["operation"] as? String },
 			[
-				"enroll_account", "get_codex_auth_projection", "use_account_in_codex",
+				"enroll_account", "get_codex_auth_projection", "route_account",
 				"disable_account",
-				"logout_account", "set_fixed_selection",
-				"set_balanced_selection", "set_account_order", "refresh_account",
+				"logout_account", "set_balanced_selection", "set_account_order",
 			]
 		)
 		XCTAssertEqual(
@@ -200,29 +229,23 @@ final class AccountControlNativeClientTests: XCTestCase {
 			]
 		)
 		XCTAssertEqual(Set(requests[1].keys), ["schema", "operation"])
-		XCTAssertEqual(requests[2]["expected_revision"] as? NSNumber, 7)
+		XCTAssertEqual(requests[2]["operation_id"] as? String, operationID)
+		XCTAssertEqual(requests[2]["expected_account_revision"] as? NSNumber, 7)
+		XCTAssertEqual(requests[2]["expected_routing_revision"] as? NSNumber, 9)
 		XCTAssertEqual(requests[3]["enabled"] as? Bool, nil)
 		XCTAssertEqual(requests[3]["expected_revision"] as? NSNumber, 7)
 		XCTAssertEqual(requests[4]["operation_id"] as? String, operationID)
-		XCTAssertEqual(requests[5]["expected_account_revision"] as? NSNumber, 7)
-		XCTAssertEqual(requests[5]["expected_routing_revision"] as? NSNumber, 9)
-		XCTAssertEqual(Set(requests[6].keys), [
+		XCTAssertEqual(Set(requests[5].keys), [
 			"schema", "operation", "expected_routing_revision", "idempotency_key",
 		])
 		XCTAssertEqual(
-			requests[7]["order"] as? [String],
+			requests[6]["order"] as? [String],
 			[secondAccountID, accountID]
 		)
-		XCTAssertEqual(Set(requests[7].keys), [
+		XCTAssertEqual(Set(requests[6].keys), [
 			"schema", "operation", "order", "expected_routing_revision", "idempotency_key",
 		])
-		XCTAssertEqual(Set(requests[8].keys), [
-			"schema", "operation", "operation_id", "account_id", "expected_revision",
-			"idempotency_key",
-		])
-		XCTAssertEqual(requests[8]["operation_id"] as? String, operationID)
-		XCTAssertEqual(requests[8]["expected_revision"] as? NSNumber, 7)
-		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 9))
+		XCTAssertEqual(recorder.requests.map(\.authority), Array(repeating: authority, count: 7))
 	}
 
 	func testAccountOrderRejectsAContradictoryAppliedOrder() async throws {
@@ -254,7 +277,7 @@ final class AccountControlNativeClientTests: XCTestCase {
 		}
 	}
 
-	func testUseInCodexRejectsNoncanonicalIdentityRevisionAndAuthorityBeforeDispatch() async {
+	func testRouteRejectsInvalidIdentityRevisionsAndAuthorityBeforeDispatch() async {
 		let recorder = NativeRequestRecorder()
 		let authority = authority
 		let client = DecodexNativeClient { request, requestedAuthority in
@@ -266,17 +289,20 @@ final class AccountControlNativeClientTests: XCTestCase {
 			serverID: serverID
 		)
 		let uppercaseAccountID = "abcdefab-cdef-4abc-8def-abcdefabcdef".uppercased()
-		let inputs: [(ResetCardAuthority?, String, UInt64)] = [
-			(authority, uppercaseAccountID, 1),
-			(authority, accountID, 0),
-			(invalidAuthority, accountID, 1),
+		let inputs: [(ResetCardAuthority?, String, UInt64, UInt64)] = [
+			(authority, uppercaseAccountID, 1, 1),
+			(authority, accountID, 0, 1),
+			(authority, accountID, 1, 0),
+			(invalidAuthority, accountID, 1, 1),
 		]
-		for (authority, accountID, revision) in inputs {
+		for (authority, accountID, accountRevision, routingRevision) in inputs {
 			do {
-				_ = try await client.useAccountInCodex(
+				_ = try await client.routeAccount(
 					authority: authority,
+					operationID: operationID,
 					accountID: accountID,
-					expectedRevision: revision,
+					expectedAccountRevision: accountRevision,
+					expectedRoutingRevision: routingRevision,
 					idempotencyKey: idempotencyKey
 				)
 				XCTFail("Invalid account command must fail")
@@ -287,42 +313,6 @@ final class AccountControlNativeClientTests: XCTestCase {
 			}
 		}
 		XCTAssertTrue(recorder.requests.isEmpty)
-	}
-
-	func testFixedSelectionDecodesStrictAppliedRoutingResult() async throws {
-		let authority = authority
-		let accountID = accountID
-		let secondAccountID = secondAccountID
-		let client = DecodexNativeClient { _, _ in
-			nativeSuccess(
-				operation: "set_fixed_selection",
-				authority: authority,
-				data: controlRoutingAppliedJSON(
-					revision: 10,
-					mode: #"{"mode":"fixed","account_id":"\#(accountID)"}"#,
-					order: [accountID, secondAccountID]
-				)
-			)
-		}
-
-		let result = try await client.setFixedSelection(
-			authority: authority,
-			accountID: accountID,
-			expectedAccountRevision: 7,
-			expectedRoutingRevision: 9,
-			idempotencyKey: idempotencyKey
-		)
-
-		XCTAssertEqual(
-			result,
-			AccountControlResult.routingChanged(
-				AccountRoutingControl(
-					revision: 10,
-					mode: .fixed(accountID: accountID),
-					order: [accountID, secondAccountID]
-				)
-			)
-		)
 	}
 
 	func testTypedRejectionRetainsCurrentOwningRevision() async throws {
@@ -352,6 +342,35 @@ final class AccountControlNativeClientTests: XCTestCase {
 				error,
 				.rejected(.staleRoutingControl, actualRevision: 10)
 			)
+		}
+	}
+
+	func testSupersededRouteDecodesAsATerminalTypedRejection() async throws {
+		let authority = authority
+		let client = DecodexNativeClient { _, _ in
+			nativeSuccess(
+				operation: "route_account",
+				authority: authority,
+				data: """
+				{"outcome":"rejected","data":{"error":{
+				  "reason":"account_command_rejected",
+				  "rejection":"route_superseded"
+				}}}
+				"""
+			)
+		}
+		do {
+			_ = try await client.routeAccount(
+				authority: authority,
+				operationID: operationID,
+				accountID: accountID,
+				expectedAccountRevision: 7,
+				expectedRoutingRevision: 9,
+				idempotencyKey: idempotencyKey
+			)
+			XCTFail("Superseded Route must not appear applied")
+		} catch let error as AccountControlError {
+			XCTAssertEqual(error, .rejected(.routeSuperseded, actualRevision: nil))
 		}
 	}
 

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -10,7 +10,7 @@ final class AccountControlStoreTests: XCTestCase {
 		serverID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 	)
 
-	func testStoreRetainsRoutingAndUsesBothFixedSelectionRevisions() async throws {
+	func testStoreRoutesWithBothAccountAndRoutingRevisions() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
@@ -37,18 +37,15 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertEqual(store.accounts.first?.account.credentialBinding?.version, 3)
 
 		store.message = ResetCardStoreMessage(tone: .error, text: "Old unrelated error")
-		await store.selectFixedAccount(accountID)
+		await store.routeAccount(accountID)
 
-		let fixedRequest = await client.fixedRequest()
+		let recordedRequest = await client.routeRequest()
+		let routeRequest = try XCTUnwrap(recordedRequest)
 		XCTAssertEqual(
-			fixedRequest,
-			AccountControlStoreFixedRequest(
-				authority: authority,
-				accountID: accountID,
-				expectedAccountRevision: 7,
-				expectedRoutingRevision: 9
-			)
+			routeRequest.expectedAccountRevision,
+			7
 		)
+		XCTAssertEqual(routeRequest.expectedRoutingRevision, 9)
 		XCTAssertEqual(
 			store.routing,
 			AccountRoutingControl(
@@ -57,10 +54,80 @@ final class AccountControlStoreTests: XCTestCase {
 				order: [accountID]
 			)
 		)
-		let readCounts = await client.readCounts()
-		XCTAssertEqual(readCounts.snapshot, 1)
-		XCTAssertEqual(readCounts.inventory, 1)
 		XCTAssertNil(store.message)
+	}
+
+	func testNewRouteCanReplaceADifferentPendingTarget() async throws {
+		let secondID = "22222222-2222-4222-8222-222222222222"
+		let first = accountRecord()
+		let second = accountRecord(accountID: secondID, alias: "Second")
+		let client = AccountControlStoreClient(
+			account: first,
+			secondaryAccount: second,
+			authority: authority,
+			pendingRoute: AccountRoutePending(
+				operationID: "33333333-3333-4333-8333-333333333333",
+				accountID: accountID,
+				routingRevision: 9
+			)
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+		await store.refresh()
+
+		XCTAssertFalse(store.canRouteAccount(accountID))
+		XCTAssertTrue(store.canRouteAccount(secondID))
+		await store.routeAccount(secondID)
+		let routeRequest = await client.routeRequest()
+		XCTAssertEqual(routeRequest?.accountID, secondID)
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: secondID))
+		XCTAssertNil(store.pendingRoute)
+	}
+
+	func testCurrentRouteCanCancelADifferentPendingTarget() async throws {
+		let secondID = "22222222-2222-4222-8222-222222222222"
+		let first = accountRecord()
+		let second = accountRecord(accountID: secondID, alias: "Second")
+		let client = AccountControlStoreClient(
+			account: first,
+			secondaryAccount: second,
+			authority: authority,
+			routing: AccountRoutingControl(
+				revision: 9,
+				mode: .fixed(accountID: accountID),
+				order: [accountID, secondID]
+			),
+			pendingRoute: AccountRoutePending(
+				operationID: "33333333-3333-4333-8333-333333333333",
+				accountID: secondID,
+				routingRevision: 9
+			),
+			projection: .current(
+				accountID: accountID,
+				accountRevision: first.accountRevision,
+				projectionDigest: String(repeating: "c", count: 64)
+			)
+		)
+		let fixture = pendingFixture()
+		defer { fixture.remove() }
+		let store = ResetCardStore(
+			client: client,
+			pendingStore: fixture.store,
+			startupRetryDelays: []
+		)
+		await store.refresh()
+
+		XCTAssertTrue(store.canRouteAccount(accountID))
+		await store.routeAccount(accountID)
+		let routeRequest = await client.routeRequest()
+		XCTAssertEqual(routeRequest?.accountID, accountID)
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		XCTAssertNil(store.pendingRoute)
 	}
 
 	func testDirectActionsWaitForTheCurrentSkeletonBeforeDispatch() async throws {
@@ -100,16 +167,13 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertFalse(store.refreshSkeletonIsPublished)
 		XCTAssertFalse(store.canPerformDirectAccountControl)
 
-		await store.selectFixedAccount(accountID)
 		await store.setAccount(accountID, enabled: false)
-		await store.useAccountInCodex(accountID)
+		await store.routeAccount(accountID)
 
-		let blockedFixedRequest = await client.fixedRequest()
 		let blockedEnabledRequest = await client.enabledRequest()
-		let blockedUseRequest = await client.useRequest()
-		XCTAssertNil(blockedFixedRequest)
+		let blockedRouteRequest = await client.routeRequest()
 		XCTAssertNil(blockedEnabledRequest)
-		XCTAssertNil(blockedUseRequest)
+		XCTAssertNil(blockedRouteRequest)
 		XCTAssertEqual(store.routing?.mode, .balanced)
 		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
 
@@ -117,9 +181,9 @@ final class AccountControlStoreTests: XCTestCase {
 		await refreshTask.value
 
 		XCTAssertTrue(store.canPerformDirectAccountControl)
-		await store.selectFixedAccount(accountID)
-		let completedFixedRequest = await client.fixedRequest()
-		XCTAssertNotNil(completedFixedRequest)
+		await store.routeAccount(accountID)
+		let completedRouteRequest = await client.routeRequest()
+		XCTAssertNotNil(completedRouteRequest)
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 	}
 
@@ -128,7 +192,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let client = AccountControlStoreClient(
 			account: account,
 			authority: authority,
-			suspendsFixedSelection: true
+			suspendsRoute: true
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -140,18 +204,18 @@ final class AccountControlStoreTests: XCTestCase {
 		await store.refresh()
 
 		let routingTask = Task {
-			await store.selectFixedAccount(accountID)
+			await store.routeAccount(accountID)
 		}
 		var routingIsPending = false
 		for _ in 0 ..< 200 {
-			if await client.fixedSelectionIsPending() {
+			if await client.routeIsPending() {
 				routingIsPending = true
 				break
 			}
 			try await Task.sleep(for: .milliseconds(5))
 		}
 		guard routingIsPending else {
-			await client.releaseFixedSelection()
+			await client.releaseRoute()
 			await routingTask.value
 			return XCTFail("Routing control did not enter the pending state.")
 		}
@@ -161,7 +225,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let readsWhileControlIsPending = await client.readCounts()
 		XCTAssertEqual(readsWhileControlIsPending.snapshot, 1)
 
-		await client.releaseFixedSelection()
+		await client.releaseRoute()
 		await routingTask.value
 
 		XCTAssertFalse(store.isAccountControlInProgress)
@@ -175,7 +239,7 @@ final class AccountControlStoreTests: XCTestCase {
 		let client = AccountControlStoreClient(
 			account: account,
 			authority: authority,
-			suspendsFixedSelection: true
+			suspendsRoute: true
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -204,16 +268,16 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertTrue(store.accounts.first?.inventoryIsCurrent == true)
 
 		let routingTask = Task {
-			await store.selectFixedAccount(accountID)
+			await store.routeAccount(accountID)
 		}
 		for _ in 0 ..< 200 {
-			if await client.fixedSelectionIsPending() {
+			if await client.routeIsPending() {
 				break
 			}
 			try await Task.sleep(for: .milliseconds(5))
 		}
-		guard await client.fixedSelectionIsPending() else {
-			await client.releaseFixedSelection()
+		guard await client.routeIsPending() else {
+			await client.releaseRoute()
 			await routingTask.value
 			await stopObservation()
 			return XCTFail("Routing control did not enter the pending state.")
@@ -228,7 +292,7 @@ final class AccountControlStoreTests: XCTestCase {
 			try await Task.sleep(for: .milliseconds(5))
 		}
 		guard await client.observationIsPending() else {
-			await client.releaseFixedSelection()
+			await client.releaseRoute()
 			await routingTask.value
 			await stopObservation()
 			return XCTFail("Account observation signal did not enter the pending state.")
@@ -241,7 +305,7 @@ final class AccountControlStoreTests: XCTestCase {
 			try await Task.sleep(for: .milliseconds(5))
 		}
 
-		await client.releaseFixedSelection()
+		await client.releaseRoute()
 		await routingTask.value
 
 		for _ in 0 ..< 200 {
@@ -321,7 +385,7 @@ final class AccountControlStoreTests: XCTestCase {
 			return XCTFail("Background account snapshot did not enter the pending state.")
 		}
 
-		await store.selectFixedAccount(accountID)
+		await store.routeAccount(accountID)
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		store.message = ResetCardStoreMessage(tone: .error, text: "Keep this message")
 
@@ -463,12 +527,9 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertFalse(store.accounts.first?.isRefreshing == true)
 		XCTAssertEqual(store.accounts.first?.routeCapability, .ready)
 
-		await store.selectFixedAccount(accountID)
-		await store.useAccountInCodex(accountID)
-		let fixedRequest = await client.fixedRequest()
-		let useRequest = await client.useRequest()
-		XCTAssertEqual(fixedRequest?.expectedAccountRevision, 8)
-		XCTAssertEqual(useRequest?.expectedRevision, 8)
+		await store.routeAccount(accountID)
+		let routeRequest = await client.routeRequest()
+		XCTAssertEqual(routeRequest?.expectedAccountRevision, 8)
 
 		let refreshedAccount = accountRecord(
 			alias: "Account 00000-00008",
@@ -659,7 +720,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertGreaterThanOrEqual(reads.snapshot, 3)
 	}
 
-	func testRoutingCompletesWhileDetailReadIsPendingWithoutFullRefresh() async throws {
+	func testRoutingCompletesWhileDetailReadIsPendingThenReconcilesTheAdvancedAccount() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
@@ -692,7 +753,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertTrue(store.isRefreshing)
 		XCTAssertEqual(store.accounts.map(\.account.accountID), [accountID])
 
-		await store.selectFixedAccount(accountID)
+		await store.routeAccount(accountID)
 
 		XCTAssertTrue(store.isRefreshing)
 		XCTAssertEqual(
@@ -706,8 +767,8 @@ final class AccountControlStoreTests: XCTestCase {
 		let readsWhilePending = await client.readCounts()
 		XCTAssertEqual(readsWhilePending.snapshot, 1)
 		XCTAssertEqual(readsWhilePending.inventory, 1)
-		let fixedRequest = await client.fixedRequest()
-		XCTAssertNotNil(fixedRequest)
+		let routeRequest = await client.routeRequest()
+		XCTAssertNotNil(routeRequest)
 
 		await client.releaseInventory()
 		await refreshTask.value
@@ -715,7 +776,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertFalse(store.isRefreshing)
 		let finalReads = await client.readCounts()
 		XCTAssertEqual(finalReads.snapshot, 1)
-		XCTAssertEqual(finalReads.inventory, 1)
+		XCTAssertEqual(finalReads.inventory, 2)
 	}
 
 	func testEnrollmentStartsAfterSkeletonPublishesWhileDetailReadIsPending() async throws {
@@ -1062,7 +1123,7 @@ final class AccountControlStoreTests: XCTestCase {
 		await refreshTask.value
 	}
 
-	func testUseInCodexCompletesWhileDetailReadIsPendingWithoutChangingRouting() async throws {
+	func testRouteCompletesWhileDetailReadIsPending() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
@@ -1086,18 +1147,18 @@ final class AccountControlStoreTests: XCTestCase {
 		}
 		XCTAssertTrue(store.isRefreshing)
 
-		await store.useAccountInCodex(accountID)
+		await store.routeAccount(accountID)
 
 		XCTAssertTrue(store.isRefreshing)
 		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .balanced)
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		XCTAssertNil(store.message)
-		let useRequest = await client.useRequest()
-		XCTAssertEqual(useRequest?.authority, nil)
-		XCTAssertEqual(useRequest?.accountID, accountID)
-		XCTAssertEqual(useRequest?.expectedRevision, 7)
+		let routeRequest = await client.routeRequest()
+		XCTAssertEqual(routeRequest?.authority, nil)
+		XCTAssertEqual(routeRequest?.accountID, accountID)
+		XCTAssertEqual(routeRequest?.expectedAccountRevision, 7)
 		XCTAssertTrue(
-			useRequest.map { DecodexNativeClient.isCanonicalUUID($0.idempotencyKey) } ?? false
+			routeRequest.map { DecodexNativeClient.isCanonicalUUID($0.idempotencyKey) } ?? false
 		)
 
 		await client.releaseInventory()
@@ -1225,12 +1286,9 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNotNil(store.message)
 	}
 
-	func testRouteAccountRefreshesThenProjectsAndSelectsFixedRoutingWithAdvancedBinding() async throws {
+	func testRouteAccountSubmitsOneDaemonCommandAndAppliesOneAuthoritativeResult() async throws {
 		let account = accountRecord()
-		let client = AccountControlStoreClient(
-			account: account,
-			authority: authority
-		)
+		let client = AccountControlStoreClient(account: account, authority: authority)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
 		let store = ResetCardStore(
@@ -1242,165 +1300,27 @@ final class AccountControlStoreTests: XCTestCase {
 		await store.refresh()
 		await store.routeAccount(accountID)
 
-		let controlSequence = await client.controlSequence()
-		let controlCounts = await client.controlCounts()
-		let recordedUseRequest = await client.useRequest()
-		let recordedFixedRequest = await client.fixedRequest()
-		let useRequest = try XCTUnwrap(recordedUseRequest)
-		let fixedRequest = try XCTUnwrap(recordedFixedRequest)
-		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
+		let recordedRequest = await client.routeRequest()
+		let request = try XCTUnwrap(recordedRequest)
+		XCTAssertEqual(request.authority, authority)
+		XCTAssertEqual(request.accountID, accountID)
+		XCTAssertEqual(request.expectedAccountRevision, 7)
+		XCTAssertEqual(request.expectedRoutingRevision, 9)
+		XCTAssertTrue(DecodexNativeClient.isCanonicalUUID(request.operationID))
+		XCTAssertTrue(DecodexNativeClient.isCanonicalUUID(request.idempotencyKey))
 		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
 		XCTAssertEqual(store.accounts.first?.account.credentialBinding?.version, 4)
-		XCTAssertEqual(useRequest.expectedRevision, 8)
-		XCTAssertEqual(fixedRequest.expectedAccountRevision, 8)
-		XCTAssertEqual(
-			controlSequence,
-			[.credentialRefresh, .codexProjection, .fixedRouting]
-		)
-		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 1))
+		XCTAssertTrue(store.isCodexProjection(accountID))
+		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 		XCTAssertNil(store.message)
 	}
 
-	func testRouteAccountPreservesPresentationUntilGatedProjectionSucceeds() async throws {
-		let fiveHourQuota = ResetCardQuotaWindow(
-			durationMinutes: 300,
-			observedAtUnixMicros: 1_000_000,
-			state: .current(
-				usedPercent: 25,
-				resetsAtUnixMicros: 2_000_000
-			)
-		)
-		let sevenDayQuota = ResetCardQuotaWindow(
-			durationMinutes: 10_080,
-			observedAtUnixMicros: 1_000_000,
-			state: .current(
-				usedPercent: 50,
-				resetsAtUnixMicros: 3_000_000
-			)
-		)
-		let account = accountRecord(
-			fiveHourQuota: fiveHourQuota,
-			sevenDayQuota: sevenDayQuota
-		)
-		let profile = AccountProfileObservation(
-			accountID: accountID,
-			accountRevision: account.accountRevision,
-			observedAtUnixMicros: 1_785_276_000_000_000,
-			email: "iris@example.com",
-			planType: "pro",
-			displayName: "Iris",
-			username: "iris",
-			snapshot: AccountProfileSnapshot(
-				lifetimeTokens: 9_001,
-				peakDailyTokens: 4_000,
-				longestTaskSeconds: 125,
-				currentStreakDays: 3,
-				longestStreakDays: 8,
-				dailyUsage: [
-					AccountProfileDailyUsage(date: "2026-07-28", tokens: 4_000),
-				]
-			),
-			freshness: .cached(refreshError: .providerUnavailable)
-		)
-		let profileUnavailable = AccountProfileUnavailable(
-			error: .providerUnavailable,
-			claims: AccountProfileClaims(email: "iris@example.com", planType: "pro")
-		)
-		let client = AccountControlStoreClient(
-			account: account,
-			authority: authority,
-			suspendsUseAccount: true,
-			profileResults: [
-				.available(profile),
-				.unavailable(profileUnavailable),
-			]
-		)
-		let fixture = pendingFixture()
-		defer { fixture.remove() }
-		let store = ResetCardStore(
-			client: client,
-			pendingStore: fixture.store,
-			startupRetryDelays: []
-		)
-
-		await store.refresh()
-		await store.refresh()
-		let beforeRoute = try XCTUnwrap(store.accounts.first)
-		let priorTotal = AccountProfileAggregate.make(
-			store.accounts.compactMap { $0.profile?.snapshot }
-		)
-		XCTAssertNotNil(beforeRoute.profile)
-		XCTAssertNotNil(beforeRoute.profileUnavailable)
-
-		let routeTask = Task {
-			await store.routeAccount(accountID)
-		}
-		for _ in 0 ..< 200 {
-			if await client.useAccountIsPending() {
-				break
-			}
-			try await Task.sleep(for: .milliseconds(5))
-		}
-		guard await client.useAccountIsPending() else {
-			await client.releaseUseAccount()
-			await routeTask.value
-			return XCTFail("UseAccountInCodex did not enter the pending state.")
-		}
-
-		let whileProjectionIsPending = try XCTUnwrap(store.accounts.first)
-		XCTAssertEqual(whileProjectionIsPending.account.accountRevision, 8)
-		XCTAssertEqual(whileProjectionIsPending.account.credentialBinding?.version, 4)
-		XCTAssertEqual(whileProjectionIsPending.inventory, beforeRoute.inventory)
-		XCTAssertFalse(whileProjectionIsPending.inventoryIsCurrent)
-		XCTAssertTrue(whileProjectionIsPending.targets.isEmpty)
-		XCTAssertEqual(whileProjectionIsPending.fiveHourQuota, beforeRoute.fiveHourQuota)
-		XCTAssertEqual(whileProjectionIsPending.sevenDayQuota, beforeRoute.sevenDayQuota)
-		XCTAssertEqual(whileProjectionIsPending.profile, beforeRoute.profile)
-		XCTAssertEqual(
-			whileProjectionIsPending.profileUnavailable,
-			beforeRoute.profileUnavailable
-		)
-		XCTAssertEqual(whileProjectionIsPending.profileError, beforeRoute.profileError)
-		XCTAssertEqual(
-			whileProjectionIsPending.profileDegradationText,
-			beforeRoute.profileDegradationText
-		)
-		XCTAssertEqual(
-			AccountProfileAggregate.make(
-				store.accounts.compactMap { $0.profile?.snapshot }
-			),
-			priorTotal,
-			"The aggregate Total source must remain available while Route projection is pending."
-		)
-		XCTAssertFalse(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .balanced)
-		let pendingControlSequence = await client.controlSequence()
-		let pendingFixedRequest = await client.fixedRequest()
-		XCTAssertEqual(
-			pendingControlSequence,
-			[.credentialRefresh, .codexProjection]
-		)
-		XCTAssertNil(pendingFixedRequest)
-
-		await client.releaseUseAccount()
-		await routeTask.value
-
-		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
-		let completedControlSequence = await client.controlSequence()
-		XCTAssertEqual(
-			completedControlSequence,
-			[.credentialRefresh, .codexProjection, .fixedRouting]
-		)
-	}
-
-	func testRouteAccountDoesNotProjectOrChangeRoutingWhenRefreshFails() async throws {
+	func testRouteAccountFailureLeavesTheAuthoritativeProjectionUnchanged() async throws {
 		let account = accountRecord()
 		let client = AccountControlStoreClient(
 			account: account,
 			authority: authority,
-			refreshAccountError: .rejected(.lifecycleUnready, actualRevision: nil)
+			routeAccountError: .rejected(.lifecycleUnready, actualRevision: nil)
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -1413,121 +1333,10 @@ final class AccountControlStoreTests: XCTestCase {
 		await store.refresh()
 		await store.routeAccount(accountID)
 
-		let controlSequence = await client.controlSequence()
-		let controlCounts = await client.controlCounts()
-		XCTAssertEqual(controlSequence, [.credentialRefresh])
-		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 0))
 		XCTAssertEqual(store.accounts.first?.account.accountRevision, 7)
 		XCTAssertFalse(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .balanced)
 		XCTAssertNotNil(store.message)
-	}
-
-	func testRouteAccountDoesNotChangeRoutingWhenProjectionFails() async throws {
-		let account = accountRecord()
-		let client = AccountControlStoreClient(
-			account: account,
-			authority: authority,
-			useAccountError: .applicationUnavailable
-		)
-		let fixture = pendingFixture()
-		defer { fixture.remove() }
-		let store = ResetCardStore(
-			client: client,
-			pendingStore: fixture.store,
-			startupRetryDelays: []
-		)
-
-		await store.refresh()
-		await store.routeAccount(accountID)
-
-		let controlSequence = await client.controlSequence()
-		let controlCounts = await client.controlCounts()
-		XCTAssertFalse(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .balanced)
-		XCTAssertEqual(controlSequence, [.credentialRefresh, .codexProjection])
-		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 0, projection: 1))
-		XCTAssertEqual(store.accounts.first?.account.accountRevision, 8)
-		XCTAssertNotNil(store.message)
-	}
-
-	func testRouteAccountRetriesProjectionWithTheSameReceiptWithoutRefreshingAgain() async throws {
-		let account = accountRecord()
-		let client = AccountControlStoreClient(
-			account: account,
-			authority: authority,
-			useAccountError: .applicationUnavailable
-		)
-		let fixture = pendingFixture()
-		defer { fixture.remove() }
-		let store = ResetCardStore(
-			client: client,
-			pendingStore: fixture.store,
-			startupRetryDelays: []
-		)
-
-		await store.refresh()
-		await store.routeAccount(accountID)
-		let recordedFirstUseRequest = await client.useRequest()
-		let firstUseRequest = try XCTUnwrap(recordedFirstUseRequest)
-		await client.setUseAccountError(nil)
-		await store.routeAccount(accountID)
-		let recordedSecondUseRequest = await client.useRequest()
-		let secondUseRequest = try XCTUnwrap(recordedSecondUseRequest)
-		let controlSequence = await client.controlSequence()
-		let controlCounts = await client.controlCounts()
-
-		XCTAssertEqual(firstUseRequest.idempotencyKey, secondUseRequest.idempotencyKey)
-		XCTAssertEqual(
-			controlSequence,
-			[.credentialRefresh, .codexProjection, .codexProjection, .fixedRouting]
-		)
-		XCTAssertEqual(controlCounts, .init(refresh: 1, fixed: 1, projection: 2))
-		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
-		XCTAssertNil(store.message)
-	}
-
-	func testRouteAccountRetriesOnlyRoutingAfterPartialSuccess() async throws {
-		let account = accountRecord()
-		let client = AccountControlStoreClient(
-			account: account,
-			authority: authority,
-			fixedSelectionError: .expectedRevisionMismatch(expected: 9, actual: 10)
-		)
-		let fixture = pendingFixture()
-		defer { fixture.remove() }
-		let store = ResetCardStore(
-			client: client,
-			pendingStore: fixture.store,
-			startupRetryDelays: []
-		)
-
-		await store.refresh()
-		await store.routeAccount(accountID)
-
-		let firstControlSequence = await client.controlSequence()
-		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .balanced)
-		XCTAssertEqual(
-			firstControlSequence,
-			[.credentialRefresh, .codexProjection, .fixedRouting]
-		)
-		XCTAssertNotNil(store.message)
-
-		await client.setFixedSelectionError(nil)
-		await store.routeAccount(accountID)
-
-		let finalControlSequence = await client.controlSequence()
-		let finalControlCounts = await client.controlCounts()
-		XCTAssertTrue(store.isCodexProjection(accountID))
-		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
-		XCTAssertEqual(
-			finalControlSequence,
-			[.credentialRefresh, .codexProjection, .fixedRouting, .fixedRouting]
-		)
-		XCTAssertEqual(finalControlCounts, .init(refresh: 1, fixed: 2, projection: 1))
-		XCTAssertNil(store.message)
 	}
 
 	func testRouteAccountIsNoOpWhenBothStatesAreCurrent() async throws {
@@ -1557,10 +1366,8 @@ final class AccountControlStoreTests: XCTestCase {
 		await store.refresh()
 		await store.routeAccount(accountID)
 
-		let controlSequence = await client.controlSequence()
-		let controlCounts = await client.controlCounts()
-		XCTAssertEqual(controlSequence, [])
-		XCTAssertEqual(controlCounts, .init(refresh: 0, fixed: 0, projection: 0))
+		let routeRequest = await client.routeRequest()
+		XCTAssertNil(routeRequest)
 		XCTAssertTrue(store.isCodexProjection(accountID))
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
 	}
@@ -1611,7 +1418,7 @@ final class AccountControlStoreTests: XCTestCase {
 				alias: "Account 00000-00002"
 			),
 			authority: authority,
-			suspendsFixedSelection: true
+			suspendsRoute: true
 		)
 		let fixture = pendingFixture()
 		defer { fixture.remove() }
@@ -1626,25 +1433,20 @@ final class AccountControlStoreTests: XCTestCase {
 			await store.routeAccount(accountID)
 		}
 		for _ in 0 ..< 200 {
-			if await client.fixedSelectionIsPending() {
+			if await client.routeIsPending() {
 				break
 			}
 			try await Task.sleep(for: .milliseconds(5))
 		}
-		let firstRouteIsPending = await client.fixedSelectionIsPending()
+		let firstRouteIsPending = await client.routeIsPending()
 		XCTAssertTrue(firstRouteIsPending)
 
 		await store.routeAccount(secondAccountID)
 
-		let operationsWhileFirstRouteIsPending = await client.controlSequence()
-		let useRequest = await client.useRequest()
-		XCTAssertEqual(
-			operationsWhileFirstRouteIsPending,
-			[.credentialRefresh, .codexProjection, .fixedRouting]
-		)
-		XCTAssertEqual(useRequest?.accountID, accountID)
+		let routeRequest = await client.routeRequest()
+		XCTAssertEqual(routeRequest?.accountID, accountID)
 
-		await client.releaseFixedSelection()
+		await client.releaseRoute()
 		await firstRoute.value
 
 		XCTAssertTrue(store.isCodexProjection(accountID))
@@ -1904,25 +1706,12 @@ final class AccountControlStoreTests: XCTestCase {
 	}
 }
 
-private struct AccountControlStoreFixedRequest: Equatable, Sendable {
-	let authority: ResetCardAuthority?
-	let accountID: String
-	let expectedAccountRevision: UInt64
-	let expectedRoutingRevision: UInt64
-}
-
-private struct AccountControlStoreUseRequest: Equatable, Sendable {
-	let authority: ResetCardAuthority?
-	let accountID: String
-	let expectedRevision: UInt64
-	let idempotencyKey: String
-}
-
-private struct AccountControlStoreRefreshRequest: Equatable, Sendable {
+private struct AccountControlStoreRouteRequest: Equatable, Sendable {
 	let authority: ResetCardAuthority?
 	let operationID: String
 	let accountID: String
-	let expectedRevision: UInt64
+	let expectedAccountRevision: UInt64
+	let expectedRoutingRevision: UInt64
 	let idempotencyKey: String
 }
 
@@ -1971,18 +1760,6 @@ private struct AccountControlStoreOrderRequest: Equatable, Sendable {
 	let expectedRoutingRevision: UInt64
 }
 
-private enum AccountControlStoreOperation: Equatable, Sendable {
-	case credentialRefresh
-	case codexProjection
-	case fixedRouting
-}
-
-private struct AccountControlStoreCounts: Equatable, Sendable {
-	let refresh: Int
-	let fixed: Int
-	let projection: Int
-}
-
 private actor AccountControlStoreClient: AccountControlClient, AccountObservationClient,
 	AccountProfileClient {
 	private var account: ResetCardAccountRecord
@@ -1992,30 +1769,22 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 	private let snapshotGate: AccountControlReadGate?
 	private let projectionGate: AccountControlReadGate?
 	private let capturesSnapshotBeforeWait: Bool
-	private let fixedSelectionGate: AccountControlReadGate?
+	private let routeGate: AccountControlReadGate?
 	private let enrollmentGate: AccountControlReadGate?
 	private let inventoryRevisionOverride: UInt64?
 	private let maxSuccessfulInventoryReads: Int?
-	private let useAccountGate: AccountControlReadGate?
 	private var inventoryRevisionsByAccountID = [String: UInt64]()
 	private var resetCardStatus: ResetCardOperationState = .notFound
 	private let allowsEnrollment: Bool
 	private let enrollmentError: AccountControlError?
 	private var routing: AccountRoutingControl
-	private var fixedSelectionError: AccountControlError?
+	private var routeAccountError: AccountControlError?
+	private var pendingRoute: AccountRoutePending?
 	private let accountOrderError: AccountControlError?
-	private var refreshAccountError: AccountControlError?
-	private var useAccountError: AccountControlError?
-	private var lastFixedRequest: AccountControlStoreFixedRequest?
-	private var lastUseRequest: AccountControlStoreUseRequest?
-	private var lastRefreshRequest: AccountControlStoreRefreshRequest?
+	private var lastRouteRequest: AccountControlStoreRouteRequest?
 	private var lastEnabledRequest: AccountControlStoreEnabledRequest?
 	private var lastLogoutRequest: AccountControlStoreLogoutRequest?
 	private var lastOrderRequest: AccountControlStoreOrderRequest?
-	private var controlOperations = [AccountControlStoreOperation]()
-	private var fixedRequestCount = 0
-	private var refreshRequestCount = 0
-	private var projectionRequestCount = 0
 	private var projection: CodexAuthProjection
 	private var projectionError: AccountControlError?
 	private var projectionReads = 0
@@ -2050,19 +1819,17 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		suspendsSnapshotAfterFirstRead: Bool = false,
 		suspendsProjection: Bool = false,
 		capturesSnapshotBeforeWait: Bool = false,
-		suspendsFixedSelection: Bool = false,
+		suspendsRoute: Bool = false,
 		suspendsEnrollment: Bool = false,
 		inventoryRevisionOverride: UInt64? = nil,
 		maxSuccessfulInventoryReads: Int? = nil,
-		suspendsUseAccount: Bool = false,
 		profileResults: [AccountProfileRead] = [],
 		allowsEnrollment: Bool = false,
 		enrollmentError: AccountControlError? = nil,
 		routing: AccountRoutingControl? = nil,
-		fixedSelectionError: AccountControlError? = nil,
+		routeAccountError: AccountControlError? = nil,
+		pendingRoute: AccountRoutePending? = nil,
 		accountOrderError: AccountControlError? = nil,
-		refreshAccountError: AccountControlError? = nil,
-		useAccountError: AccountControlError? = nil,
 		projection: CodexAuthProjection = .unmanaged,
 		reauthenticationStates: [AccountReauthenticationState] = [],
 		accountLoginFailure: AccountReauthenticationFailure? = nil,
@@ -2078,11 +1845,10 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		snapshotGate = suspendsSnapshotAfterFirstRead ? AccountControlReadGate() : nil
 		projectionGate = suspendsProjection ? AccountControlReadGate() : nil
 		self.capturesSnapshotBeforeWait = capturesSnapshotBeforeWait
-		fixedSelectionGate = suspendsFixedSelection ? AccountControlReadGate() : nil
+		routeGate = suspendsRoute ? AccountControlReadGate() : nil
 		enrollmentGate = suspendsEnrollment ? AccountControlReadGate() : nil
 		self.inventoryRevisionOverride = inventoryRevisionOverride
 		self.maxSuccessfulInventoryReads = maxSuccessfulInventoryReads
-		useAccountGate = suspendsUseAccount ? AccountControlReadGate() : nil
 		self.profileResults = profileResults
 		self.allowsEnrollment = allowsEnrollment
 		self.enrollmentError = enrollmentError
@@ -2092,10 +1858,9 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 				mode: .balanced,
 				order: [account.accountID] + (secondaryAccount.map { [$0.accountID] } ?? [])
 			)
-		self.fixedSelectionError = fixedSelectionError
+		self.routeAccountError = routeAccountError
+		self.pendingRoute = pendingRoute
 		self.accountOrderError = accountOrderError
-		self.refreshAccountError = refreshAccountError
-		self.useAccountError = useAccountError
 		self.reauthenticationStates = reauthenticationStates
 		self.accountLoginFailure = accountLoginFailure
 		self.reauthenticationObservationDelayReads = reauthenticationObservationDelayReads
@@ -2131,7 +1896,8 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 						? secondaryAccount
 						: nil
 				},
-			routing: routing
+			routing: routing,
+			pendingRoute: pendingRoute
 		)
 	}
 
@@ -2199,54 +1965,111 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		inventoryRevisionsByAccountID[accountID] = revision
 	}
 
-	func setFixedSelection(
+	func routeAccount(
 		authority: ResetCardAuthority?,
+		operationID: String,
 		accountID: String,
 		expectedAccountRevision: UInt64,
 		expectedRoutingRevision: UInt64,
 		idempotencyKey: String
 	) async throws -> AccountControlResult {
-		guard DecodexNativeClient.isCanonicalUUID(idempotencyKey) else {
+		guard DecodexNativeClient.isCanonicalUUID(operationID),
+			DecodexNativeClient.isCanonicalUUID(idempotencyKey),
+			expectedRoutingRevision == routing.revision
+		else {
 			throw AccountControlError.invalidInput
 		}
-		lastFixedRequest = AccountControlStoreFixedRequest(
+		lastRouteRequest = AccountControlStoreRouteRequest(
 			authority: authority,
+			operationID: operationID,
 			accountID: accountID,
 			expectedAccountRevision: expectedAccountRevision,
-			expectedRoutingRevision: expectedRoutingRevision
+			expectedRoutingRevision: expectedRoutingRevision,
+			idempotencyKey: idempotencyKey
 		)
-		fixedRequestCount += 1
-		controlOperations.append(.fixedRouting)
-		if let fixedSelectionError {
-			throw fixedSelectionError
+		if let routeAccountError {
+			throw routeAccountError
 		}
-		await fixedSelectionGate?.wait()
-		routing = AccountRoutingControl(
-			revision: 10,
-			mode: .fixed(accountID: accountID),
-			order: routing.order
+		await routeGate?.wait()
+
+		let current: ResetCardAccountRecord
+		if account.accountID == accountID {
+			current = account
+		} else if let secondaryAccount, secondaryAccount.accountID == accountID {
+			current = secondaryAccount
+		} else {
+			throw AccountControlError.invalidInput
+		}
+		guard current.accountRevision == expectedAccountRevision,
+			let binding = current.credentialBinding
+		else {
+			throw AccountControlError.invalidInput
+		}
+		let projectionIsCurrent = if case .current(
+			let projectedID,
+			let projectedRevision,
+			_
+		) = projection {
+			projectedID == accountID && projectedRevision == current.accountRevision
+		} else {
+			false
+		}
+		let routed = projectionIsCurrent
+			? current
+			: ResetCardAccountRecord(
+				authority: current.authority,
+				accountID: current.accountID,
+				alias: current.alias,
+				accountRevision: current.accountRevision + 1,
+				enabled: current.enabled,
+				observedState: current.observedState,
+				lifecycleReadiness: current.lifecycleReadiness,
+				credentialBinding: AccountCredentialBinding(
+					schemaVersion: binding.schemaVersion,
+					version: binding.version + 1,
+					fingerprintSHA256: String(repeating: "d", count: 64),
+					provider: binding.provider,
+					providerAccountID: binding.providerAccountID
+				),
+				unsettledOperation: current.unsettledOperation,
+				fiveHourQuota: current.fiveHourQuota,
+				sevenDayQuota: current.sevenDayQuota
+			)
+		if account.accountID == accountID {
+			account = routed
+		} else {
+			secondaryAccount = routed
+		}
+		if routing.mode != .fixed(accountID: accountID) {
+			routing = AccountRoutingControl(
+				revision: routing.revision + 1,
+				mode: .fixed(accountID: accountID),
+				order: routing.order
+			)
+		}
+		let digest = String(repeating: "c", count: 64)
+		projection = .current(
+			accountID: accountID,
+			accountRevision: routed.accountRevision,
+			projectionDigest: digest
 		)
-		return .routingChanged(routing)
+		pendingRoute = nil
+		return .routed(account: routed, routing: routing, projectionDigest: digest)
 	}
 
-	func fixedRequest() -> AccountControlStoreFixedRequest? {
-		lastFixedRequest
+	func routeRequest() -> AccountControlStoreRouteRequest? {
+		lastRouteRequest
 	}
 
-	func setFixedSelectionError(_ error: AccountControlError?) {
-		fixedSelectionError = error
+	func routeIsPending() async -> Bool {
+		guard let routeGate else {
+			return false
+		}
+		return await routeGate.isPending()
 	}
 
-	func controlSequence() -> [AccountControlStoreOperation] {
-		controlOperations
-	}
-
-	func controlCounts() -> AccountControlStoreCounts {
-		AccountControlStoreCounts(
-			refresh: refreshRequestCount,
-			fixed: fixedRequestCount,
-			projection: projectionRequestCount
-		)
+	func releaseRoute() async {
+		await routeGate?.release()
 	}
 
 	func readCounts() -> (snapshot: Int, inventory: Int) {
@@ -2307,17 +2130,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 
 	func releaseSnapshot() async {
 		await snapshotGate?.release()
-	}
-
-	func fixedSelectionIsPending() async -> Bool {
-		guard let fixedSelectionGate else {
-			return false
-		}
-		return await fixedSelectionGate.isPending()
-	}
-
-	func releaseFixedSelection() async {
-		await fixedSelectionGate?.release()
 	}
 
 	func replaceAccount(_ account: ResetCardAccountRecord) {
@@ -2406,132 +2218,6 @@ private actor AccountControlStoreClient: AccountControlClient, AccountObservatio
 		return profileResults.count == 1
 			? profileResults[0]
 			: profileResults.removeFirst()
-	}
-
-	func useAccountIsPending() async -> Bool {
-		guard let useAccountGate else {
-			return false
-		}
-		return await useAccountGate.isPending()
-	}
-
-	func releaseUseAccount() async {
-		await useAccountGate?.release()
-	}
-
-	func useAccountInCodex(
-		authority: ResetCardAuthority?,
-		accountID: String,
-		expectedRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult {
-		guard DecodexNativeClient.isCanonicalUUID(idempotencyKey) else {
-			throw AccountControlError.invalidInput
-		}
-		lastUseRequest = AccountControlStoreUseRequest(
-			authority: authority,
-			accountID: accountID,
-			expectedRevision: expectedRevision,
-			idempotencyKey: idempotencyKey
-		)
-		projectionRequestCount += 1
-		controlOperations.append(.codexProjection)
-		if let useAccountError {
-			throw useAccountError
-		}
-		await useAccountGate?.wait()
-		let digest = String(repeating: "c", count: 64)
-		projection = .current(
-			accountID: accountID,
-			accountRevision: expectedRevision,
-			projectionDigest: digest
-		)
-		return .codexAuthProjected(
-			accountID: accountID,
-			accountRevision: expectedRevision,
-			projectionDigest: digest
-		)
-	}
-
-	func useRequest() -> AccountControlStoreUseRequest? {
-		lastUseRequest
-	}
-
-	func setUseAccountError(_ error: AccountControlError?) {
-		useAccountError = error
-	}
-
-	func refreshAccountCredentials(
-		authority: ResetCardAuthority?,
-		operationID: String,
-		accountID: String,
-		expectedRevision: UInt64,
-		idempotencyKey: String
-	) async throws -> AccountControlResult {
-		guard DecodexNativeClient.isCanonicalUUID(operationID),
-			DecodexNativeClient.isCanonicalUUID(idempotencyKey)
-		else {
-			throw AccountControlError.invalidInput
-		}
-		lastRefreshRequest = AccountControlStoreRefreshRequest(
-			authority: authority,
-			operationID: operationID,
-			accountID: accountID,
-			expectedRevision: expectedRevision,
-			idempotencyKey: idempotencyKey
-		)
-		refreshRequestCount += 1
-		controlOperations.append(.credentialRefresh)
-		if let refreshAccountError {
-			throw refreshAccountError
-		}
-
-		let current: ResetCardAccountRecord
-		if account.accountID == accountID {
-			current = account
-		} else if let secondaryAccount, secondaryAccount.accountID == accountID {
-			current = secondaryAccount
-		} else {
-			throw AccountControlError.invalidInput
-		}
-		guard current.accountRevision == expectedRevision,
-			let binding = current.credentialBinding
-		else {
-			throw AccountControlError.invalidInput
-		}
-		let refreshed = ResetCardAccountRecord(
-			authority: current.authority,
-			accountID: current.accountID,
-			alias: current.alias,
-			accountRevision: current.accountRevision + 1,
-			enabled: current.enabled,
-			observedState: current.observedState,
-			lifecycleReadiness: current.lifecycleReadiness,
-			credentialBinding: AccountCredentialBinding(
-				schemaVersion: binding.schemaVersion,
-				version: binding.version + 1,
-				fingerprintSHA256: String(repeating: "d", count: 64),
-				provider: binding.provider,
-				providerAccountID: binding.providerAccountID
-			),
-			unsettledOperation: current.unsettledOperation,
-			fiveHourQuota: current.fiveHourQuota,
-			sevenDayQuota: current.sevenDayQuota
-		)
-		if account.accountID == accountID {
-			account = refreshed
-		} else {
-			secondaryAccount = refreshed
-		}
-		return .accountChanged(refreshed)
-	}
-
-	func refreshRequest() -> AccountControlStoreRefreshRequest? {
-		lastRefreshRequest
-	}
-
-	func setRefreshAccountError(_ error: AccountControlError?) {
-		refreshAccountError = error
 	}
 
 	func setAccountEnabled(

--- a/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/AccountProfileStoreTests.swift
@@ -987,7 +987,8 @@ private actor PerAccountGenerationClient: AccountControlClient, AccountProfileCl
 				revision: 1,
 				mode: .balanced,
 				order: [firstAccount.accountID, secondAccount.accountID]
-			)
+			),
+			pendingRoute: nil
 		)
 	}
 
@@ -1158,16 +1159,6 @@ private actor PerAccountGenerationClient: AccountControlClient, AccountProfileCl
 		throw AccountControlError.applicationUnavailable
 	}
 
-	func setFixedSelection(
-		authority _: ResetCardAuthority?,
-		accountID _: String,
-		expectedAccountRevision _: UInt64,
-		expectedRoutingRevision _: UInt64,
-		idempotencyKey _: String
-	) async throws -> AccountControlResult {
-		throw AccountControlError.applicationUnavailable
-	}
-
 	func setBalancedSelection(
 		authority _: ResetCardAuthority?,
 		expectedRoutingRevision _: UInt64,
@@ -1180,15 +1171,6 @@ private actor PerAccountGenerationClient: AccountControlClient, AccountProfileCl
 		authority _: ResetCardAuthority?,
 		order _: [String],
 		expectedRoutingRevision _: UInt64,
-		idempotencyKey _: String
-	) async throws -> AccountControlResult {
-		throw AccountControlError.applicationUnavailable
-	}
-
-	func useAccountInCodex(
-		authority _: ResetCardAuthority?,
-		accountID _: String,
-		expectedRevision _: UInt64,
 		idempotencyKey _: String
 	) async throws -> AccountControlResult {
 		throw AccountControlError.applicationUnavailable

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -606,6 +606,72 @@ final class ResetCardArchitectureTests: XCTestCase {
 		)
 	}
 
+	func testRouteIsOneDaemonOwnedCommandWithoutSwiftPreparationState() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp", isDirectory: true)
+		let store = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardStore.swift"),
+			encoding: .utf8
+		)
+		let client = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountControlCLIClient.swift"),
+			encoding: .utf8
+		)
+		let actions = try String(
+			contentsOf: sourceURL.appendingPathComponent("AccountControlViews.swift"),
+			encoding: .utf8
+		)
+
+		XCTAssertTrue(store.contains("accountControlClient.routeAccount("))
+		XCTAssertFalse(store.contains("PendingAccountRoutePreparation"))
+		XCTAssertFalse(store.contains("pendingAccountRoutePreparations"))
+		XCTAssertFalse(store.contains("applyImmediateRouteAccountRefresh"))
+		XCTAssertFalse(store.contains("refreshAccountCredentials("))
+		XCTAssertFalse(store.contains("useAccountInCodex("))
+		XCTAssertFalse(store.contains("setFixedSelection("))
+		XCTAssertTrue(client.contains(#"operation: "route_account""#))
+		XCTAssertFalse(client.contains(#"operation: "use_account_in_codex""#))
+		XCTAssertFalse(client.contains(#"operation: "set_fixed_selection""#))
+		XCTAssertTrue(store.contains("guard pendingRoute == nil"))
+		XCTAssertTrue(store.contains("&& pendingRoute == nil"))
+		XCTAssertTrue(store.contains("pendingRoute?.accountID != accountID"))
+		XCTAssertTrue(store.contains("replacesPendingRoute = pendingRoute != nil"))
+		XCTAssertTrue(actions.contains("title: isPendingTarget"))
+		XCTAssertTrue(actions.contains(#"? "Pending""#))
+		XCTAssertTrue(actions.contains(#"keepsCurrentRoute ? "Keep""#))
+		XCTAssertTrue(
+			actions.contains("keep it closed until Pending changes to Routed")
+		)
+		XCTAssertTrue(
+			actions.contains("store.pendingRoute?.accountID != state.account.accountID")
+		)
+	}
+
+	func testMenuBarOwnerDisablesAutomaticAndSuddenTermination() throws {
+		let sourceURL = URL(fileURLWithPath: #filePath)
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("Sources/DecodexApp/DecodexApp.swift")
+		let source = try String(contentsOf: sourceURL, encoding: .utf8)
+		XCTAssertTrue(source.contains("disableAutomaticTermination"))
+		XCTAssertTrue(source.contains("disableSuddenTermination"))
+		XCTAssertTrue(source.contains("automaticTerminationSupportEnabled = false"))
+		XCTAssertTrue(source.contains("applicationShouldTerminateAfterLastWindowClosed"))
+
+		let scriptURL = sourceURL
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.deletingLastPathComponent()
+			.appendingPathComponent("script/build_and_run.sh")
+		let script = try String(contentsOf: scriptURL, encoding: .utf8)
+		XCTAssertTrue(script.contains("<key>NSSupportsAutomaticTermination</key>"))
+		XCTAssertTrue(script.contains("<key>NSSupportsSuddenTermination</key>"))
+	}
+
 	func testProductionSourceUsesOnlyTheNativeResetCardAuthority() throws {
 		let testsURL = URL(fileURLWithPath: #filePath)
 			.deletingLastPathComponent()
@@ -726,7 +792,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 			compatibility.contains("decodexNativeClientABIVersion: UInt32 = 1")
 		)
 		XCTAssertTrue(
-			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 2")
+			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 5")
 		)
 		XCTAssertTrue(
 			compatibility.contains("static func openLibrary(at libraryURL: URL)")

--- a/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-app/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -789,6 +789,16 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(script.contains("linker-flavor=ld64.lld"))
 		XCTAssertTrue(script.contains("NATIVE_CLIENT_MIN_SYSTEM_VERSION=\"11.0\""))
 		XCTAssertTrue(
+			script.contains(
+				#"DEFAULT_SIGN_IDENTITY="aurevoirxavier.hk@gmail.com""#
+			)
+		)
+		let developerIDPreference = try XCTUnwrap(
+			script.range(of: #""Developer ID Application:" "Apple Development:""#)
+		)
+		XCTAssertLessThan(developerIDPreference.lowerBound, script.endIndex)
+		XCTAssertTrue(script.contains(#"SIGN_TIMESTAMP_FLAGS=(--timestamp)"#))
+		XCTAssertTrue(
 			compatibility.contains("decodexNativeClientABIVersion: UInt32 = 1")
 		)
 		XCTAssertTrue(

--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -110,6 +110,10 @@ write_info_plist() {
   <string>$MIN_SYSTEM_VERSION</string>
   <key>LSUIElement</key>
   <true/>
+  <key>NSSupportsAutomaticTermination</key>
+  <false/>
+  <key>NSSupportsSuddenTermination</key>
+  <false/>
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSPrincipalClass</key>

--- a/apps/decodex-app/script/build_and_run.sh
+++ b/apps/decodex-app/script/build_and_run.sh
@@ -9,7 +9,7 @@ BUNDLE_ID="${DECODEX_APP_BUNDLE_ID:-space.decodex.app}"
 BUNDLE_DISPLAY_NAME="${DECODEX_APP_DISPLAY_NAME:-Decodex}"
 MIN_SYSTEM_VERSION="27.0"
 NATIVE_CLIENT_MIN_SYSTEM_VERSION="11.0"
-DEFAULT_SIGN_IDENTITY="x@acg.box"
+DEFAULT_SIGN_IDENTITY="aurevoirxavier.hk@gmail.com"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKTREE_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -35,6 +35,7 @@ BUILD_ROOT=""
 BUILD_BINARY=""
 NATIVE_CLIENT_BINARY=""
 RESOLVED_SIGN_IDENTITY=""
+SIGN_TIMESTAMP_FLAGS=()
 RUST_PROFILE="release"
 RUST_HOST=""
 RUST_LLD=""
@@ -124,29 +125,25 @@ PLIST
 }
 
 resolve_signing_identity() {
-	local requested_identity identity_list identity
+	local requested_identity identity_list identity preferred_prefix
 
 	requested_identity="${DECODEX_APP_SIGN_IDENTITY:-$DEFAULT_SIGN_IDENTITY}"
 	identity_list="$(security find-identity -v -p codesigning 2>/dev/null || true)"
-	if [[ -n "$requested_identity" ]]; then
+	for preferred_prefix in "Developer ID Application:" "Apple Development:" ""; do
 		while IFS= read -r line; do
 			identity="${line#*\"}"
 			identity="${identity%%\"*}"
-			if [[ -n "$identity" && "$identity" == *"$requested_identity"* ]]; then
+			if [[ -n "$identity" \
+				&& "$identity" == *"$requested_identity"* \
+				&& ( -z "$preferred_prefix" || "$identity" == "$preferred_prefix"* ) ]]; then
 				RESOLVED_SIGN_IDENTITY="$identity"
+				if [[ "$identity" == Developer\ ID\ Application:* ]]; then
+					SIGN_TIMESTAMP_FLAGS=(--timestamp)
+				fi
 				return 0
 			fi
 		done <<<"$identity_list"
-	fi
-
-	while IFS= read -r line; do
-		identity="${line#*\"}"
-		identity="${identity%%\"*}"
-		if [[ -n "$identity" && "$identity" == Apple\ Development:* ]]; then
-			RESOLVED_SIGN_IDENTITY="$identity"
-			return 0
-		fi
-	done <<<"$identity_list"
+	done
 
 	return 1
 }
@@ -165,6 +162,7 @@ sign_staged_app_bundle() {
 	codesign \
 		--force \
 		--options runtime \
+		"${SIGN_TIMESTAMP_FLAGS[@]}" \
 		--sign "$RESOLVED_SIGN_IDENTITY" \
 		"$APP_NATIVE_CLIENT"
 
@@ -174,6 +172,7 @@ sign_staged_app_bundle() {
 			--force \
 			--deep \
 			--options runtime \
+			"${SIGN_TIMESTAMP_FLAGS[@]}" \
 			--sign "$RESOLVED_SIGN_IDENTITY" \
 			--entitlements "$entitlements_file" \
 			"$APP_BUNDLE"
@@ -182,6 +181,7 @@ sign_staged_app_bundle() {
 			--force \
 			--deep \
 			--options runtime \
+			"${SIGN_TIMESTAMP_FLAGS[@]}" \
 			--sign "$RESOLVED_SIGN_IDENTITY" \
 			"$APP_BUNDLE"
 	fi

--- a/apps/decodex-cli/src/account.rs
+++ b/apps/decodex-cli/src/account.rs
@@ -1,4 +1,4 @@
-//! Operator account client over the same-UID V2.6 daemon protocol.
+//! Operator account client over the same-UID V2.9 daemon protocol.
 
 use std::path::{Path, PathBuf};
 
@@ -27,16 +27,14 @@ pub enum AccountCommand {
 	Enroll(EnrollArgs),
 	/// Import one owner-private versioned credential file.
 	Import(ImportArgs),
-	/// Project one exact daemon account into normal shared Codex auth.
-	UseInCodex(AdministrationArgs),
 	/// Enable new work admission for one account.
 	Enable(AdministrationArgs),
 	/// Disable new work admission for one account.
 	Disable(AdministrationArgs),
 	/// Log out and tombstone one account.
 	Logout(OperationAccountArgs),
-	/// Select one fixed account.
-	SetFixedSelection(FixedSelectionArgs),
+	/// Refresh, project, and select one account through one daemon-owned Route command.
+	Route(RouteArgs),
 	/// Select balanced initial account routing.
 	SetBalancedSelection(RoutingRevisionArgs),
 	/// Replace the complete deterministic account order.
@@ -111,7 +109,9 @@ pub struct OperationAccountArgs {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Args)]
-pub struct FixedSelectionArgs {
+pub struct RouteArgs {
+	#[arg(long)]
+	operation_id: String,
 	#[arg(long)]
 	account_id: String,
 	#[arg(long)]
@@ -194,37 +194,32 @@ pub async fn execute(
 			};
 			return render("profile", format, client.profile(account_id, args.include_email).await);
 		},
-		AccountCommand::CodexProjection =>
-			return render("codex_projection", format, client.codex_auth_projection().await),
-		AccountCommand::UseInCodex(args) => {
-			let input = (
-				entity(&args.account_id),
-				revision(args.expected_revision),
-				idempotency_key(args.idempotency_key),
-			);
-			let (Ok(account_id), Ok(account_revision), Ok(key)) = input else {
-				return invalid_input();
-			};
-			return render_command(
-				format,
-				client.use_account_in_codex(account_id, account_revision, key).await,
-			);
+		AccountCommand::CodexProjection => {
+			return render("codex_projection", format, client.codex_auth_projection().await);
 		},
-		AccountCommand::SetFixedSelection(args) => {
+		AccountCommand::Route(args) => {
 			let input = (
+				entity(&args.operation_id),
 				entity(&args.account_id),
 				revision(args.expected_account_revision),
 				revision(args.expected_revision),
 				idempotency_key(args.idempotency_key),
 			);
-			let (Ok(account_id), Ok(account_revision), Ok(routing_revision), Ok(key)) = input
+			let (
+				Ok(operation_id),
+				Ok(account_id),
+				Ok(account_revision),
+				Ok(routing_revision),
+				Ok(key),
+			) = input
 			else {
 				return invalid_input();
 			};
 			return render_command(
 				format,
 				client
-					.set_fixed_account_selection(
+					.route_account(
+						operation_id,
 						account_id,
 						account_revision,
 						routing_revision,
@@ -326,10 +321,12 @@ fn prepare_command(command: AccountCommand) -> Result<PreparedCommand, CommandOu
 			CommandPayload::RecoverAccountOperation {
 				operation_id: entity(&args.operation_id)?,
 				action: match args.action {
-					RecoveryAction::Reconcile =>
-						AccountManualRecoveryActionDto::ReconcileExactStoreState,
-					RecoveryAction::CancelBeforeEffect =>
-						AccountManualRecoveryActionDto::CancelBeforeEffect,
+					RecoveryAction::Reconcile => {
+						AccountManualRecoveryActionDto::ReconcileExactStoreState
+					},
+					RecoveryAction::CancelBeforeEffect => {
+						AccountManualRecoveryActionDto::CancelBeforeEffect
+					},
 				},
 			},
 			Some(EntityRevision(args.expected_revision)),
@@ -339,8 +336,7 @@ fn prepare_command(command: AccountCommand) -> Result<PreparedCommand, CommandOu
 		| AccountCommand::Inspect(_)
 		| AccountCommand::Profile(_)
 		| AccountCommand::CodexProjection
-		| AccountCommand::UseInCodex(_)
-		| AccountCommand::SetFixedSelection(_)
+		| AccountCommand::Route(_)
 		| AccountCommand::SetBalancedSelection(_)
 		| AccountCommand::SetAccountOrder(_) => Err(invalid_input()),
 	}
@@ -527,27 +523,31 @@ mod tests {
 	}
 
 	#[test]
-	fn projection_status_and_use_in_codex_are_distinct_from_routing() {
+	fn projection_status_remains_read_only_while_route_is_one_command() {
 		let status = Cli::try_parse_from(["decodex", "account", "codex-projection"])
 			.expect("projection status must parse");
-		let use_in_codex = Cli::try_parse_from([
+		let route = Cli::try_parse_from([
 			"decodex",
 			"account",
-			"use-in-codex",
+			"route",
+			"--operation-id",
+			OPERATION_ID,
 			"--account-id",
 			ACCOUNT_ID,
-			"--expected-revision",
+			"--expected-account-revision",
 			"7",
+			"--expected-revision",
+			"2",
 			"--idempotency-key",
-			"use-in-codex",
+			"route-account",
 		])
-		.expect("explicit Codex projection must parse");
+		.expect("daemon-owned Route must parse");
 
 		assert!(matches!(status.command, Command::Account(AccountCommand::CodexProjection)));
 		assert!(matches!(
-			use_in_codex.command,
-			Command::Account(AccountCommand::UseInCodex(args))
-				if args.expected_revision == 7
+			route.command,
+			Command::Account(AccountCommand::Route(args))
+				if args.expected_account_revision == 7 && args.expected_revision == 2
 		));
 		assert!(
 			Cli::try_parse_from(["decodex", "account", "rename", "--account-id", ACCOUNT_ID,])
@@ -556,21 +556,7 @@ mod tests {
 	}
 
 	#[test]
-	fn routing_uses_three_explicit_subcommands_without_the_combined_alias() {
-		let fixed = Cli::try_parse_from([
-			"decodex",
-			"account",
-			"set-fixed-selection",
-			"--account-id",
-			ACCOUNT_ID,
-			"--expected-account-revision",
-			"4",
-			"--expected-revision",
-			"2",
-			"--idempotency-key",
-			"fixed-selection",
-		])
-		.expect("fixed selection must parse");
+	fn routing_uses_route_balanced_and_order_without_split_fixed_projection_commands() {
 		let balanced = Cli::try_parse_from([
 			"decodex",
 			"account",
@@ -595,11 +581,6 @@ mod tests {
 		.expect("account order must parse");
 
 		assert!(matches!(
-			fixed.command,
-			Command::Account(AccountCommand::SetFixedSelection(args))
-				if args.expected_account_revision == 4 && args.expected_revision == 2
-		));
-		assert!(matches!(
 			balanced.command,
 			Command::Account(AccountCommand::SetBalancedSelection(args))
 				if args.expected_revision == 2
@@ -609,7 +590,8 @@ mod tests {
 			Command::Account(AccountCommand::SetAccountOrder(args))
 				if args.order == vec![ACCOUNT_ID.to_owned()]
 		));
-		assert!(Cli::try_parse_from(["decodex", "account", "route"]).is_err());
+		assert!(Cli::try_parse_from(["decodex", "account", "use-in-codex"]).is_err());
+		assert!(Cli::try_parse_from(["decodex", "account", "set-fixed-selection"]).is_err());
 	}
 
 	#[test]

--- a/apps/decodex-cli/src/lib.rs
+++ b/apps/decodex-cli/src/lib.rs
@@ -122,7 +122,7 @@ pub enum Command {
 	/// Observe and consume reset cards through the common daemon authority.
 	#[command(subcommand)]
 	ResetCard(reset_card::ResetCardCommand),
-	/// Manage daemon-owned accounts through the same-UID V2.6 protocol.
+	/// Manage daemon-owned accounts through the same-UID V2.9 protocol.
 	#[command(subcommand)]
 	Account(account::AccountCommand),
 	/// Read or update the current user's local Codex Fast mode setting.
@@ -295,8 +295,9 @@ fn render_failure(
 			.expect("closed failure serialization cannot fail"),
 			false,
 		),
-		OutputFormat::Human =>
-			(format!("decodex {} failed: {failure}", command_name(command)), true),
+		OutputFormat::Human => {
+			(format!("decodex {} failed: {failure}", command_name(command)), true)
+		},
 	};
 
 	CommandOutput { text, exit_code: 2, error_stream }
@@ -323,14 +324,15 @@ fn render_human(
 	);
 
 	match command {
-		DiagnosticCommand::Doctor =>
+		DiagnosticCommand::Doctor => {
 			for check in report.checks() {
 				output.push_str(&format!(
 					"\n{}: {}",
 					component_name(check.component),
 					status_name(check.status),
 				));
-			},
+			}
+		},
 		DiagnosticCommand::Status => {
 			output.push_str("\nstates:");
 
@@ -599,8 +601,9 @@ mod tests {
 	#[test]
 	fn status_retains_ready_unavailable_and_unknown_states() {
 		let statuses = DoctorComponent::ALL.map(|component| match component {
-			DoctorComponent::ProductStore =>
-				DoctorStatus::Unavailable(DoctorIssue::DatabaseUnreachable),
+			DoctorComponent::ProductStore => {
+				DoctorStatus::Unavailable(DoctorIssue::DatabaseUnreachable)
+			},
 			DoctorComponent::QuickTask => DoctorStatus::Unknown(DoctorIssue::NotProbed),
 			_ => DoctorStatus::Ready,
 		});

--- a/apps/decodex-gpui/src/accounts.rs
+++ b/apps/decodex-gpui/src/accounts.rs
@@ -12,11 +12,11 @@ use sha2::{Digest, Sha256};
 use tokio::sync::Notify;
 
 use decodex_protocol::{
-	CURRENT_VERSION, AccountDto, AccountRoutingControlDto, AccountSelectionModeDto, AccountsResult,
-	CausationId, ClientCommandId, CommandEnvelope, CommandOutcome, CommandPayload, CommandReceipt,
-	CommandResultEnvelope, CorrelationId, EntityId, EntityRevision, EventEnvelope, EventPayload,
-	IdempotencyKey, QueryEnvelope, QueryId, QueryPayload, QueryResultEnvelope, QueryResultPayload,
-	ReceiptDisposition, ResultPayload, ServerId,
+	AccountDto, AccountRoutePendingDto, AccountRoutingControlDto, AccountSelectionModeDto,
+	AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId, CommandEnvelope, CommandOutcome,
+	CommandPayload, CommandReceipt, CommandResultEnvelope, CorrelationId, EntityId, EntityRevision,
+	EventEnvelope, EventPayload, IdempotencyKey, QueryEnvelope, QueryId, QueryPayload,
+	QueryResultEnvelope, QueryResultPayload, ReceiptDisposition, ResultPayload, ServerId,
 };
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
@@ -28,7 +28,9 @@ pub(crate) struct AccountsSnapshot {
 	pub(crate) command: AccountCommandState,
 	pub(crate) accounts: Vec<AccountDto>,
 	pub(crate) routing: Option<AccountRoutingControlDto>,
+	pub(crate) pending_route: Option<AccountRoutePendingDto>,
 	pub(crate) can_manage: bool,
+	pub(crate) can_route: bool,
 }
 
 /// Finite account-pool readback state.
@@ -175,6 +177,9 @@ impl AccountsController {
 
 	pub(crate) fn select_fixed(&self, account_id: &EntityId) -> Result<(), AccountInputError> {
 		let mut state = self.lock();
+		if state.pending_route.as_ref().is_some_and(|pending| &pending.account_id == account_id) {
+			return Err(AccountInputError::Busy);
+		}
 		let account_revision = state
 			.accounts
 			.iter()
@@ -186,8 +191,11 @@ impl AccountsController {
 			.as_ref()
 			.map(|routing| routing.revision)
 			.ok_or(AccountInputError::RoutingUnavailable)?;
+		let operation_id = EntityId::new(canonical_uuid_v4()?)
+			.map_err(|_| AccountInputError::IdentityUnavailable)?;
 		state.queue_command(
-			CommandPayload::SetFixedAccountSelection {
+			CommandPayload::RouteAccount {
+				operation_id,
 				account_id: account_id.clone(),
 				expected_account_revision: account_revision,
 			},
@@ -205,10 +213,7 @@ impl AccountsController {
 			.as_ref()
 			.map(|routing| routing.revision)
 			.ok_or(AccountInputError::RoutingUnavailable)?;
-		state.queue_command(
-			CommandPayload::SetBalancedAccountSelection,
-			Some(routing_revision),
-		)?;
+		state.queue_command(CommandPayload::SetBalancedAccountSelection, Some(routing_revision))?;
 		drop(state);
 		self.inner.notify.notify_one();
 		Ok(())
@@ -272,11 +277,7 @@ impl AccountsController {
 		}
 	}
 
-	fn try_take_dispatch(
-		&self,
-		generation: u64,
-		server_id: &ServerId,
-	) -> Option<AccountDispatch> {
+	fn try_take_dispatch(&self, generation: u64, server_id: &ServerId) -> Option<AccountDispatch> {
 		let mut state = self.lock();
 		let binding = SessionBinding { generation, server_id: server_id.clone() };
 		if state.session.as_ref() != Some(&binding) {
@@ -285,19 +286,14 @@ impl AccountsController {
 		if state.in_flight_command.is_none()
 			&& let Some(envelope) = state.pending_command.take()
 		{
-			state.in_flight_command = Some(InFlightCommand {
-				envelope: envelope.clone(),
-				binding,
-			});
+			state.in_flight_command = Some(InFlightCommand { envelope: envelope.clone(), binding });
 			return Some(AccountDispatch::Command(envelope));
 		}
 		if state.in_flight_query.is_none()
 			&& let Some(envelope) = state.pending_query.take()
 		{
-			state.in_flight_query = Some(InFlightQuery {
-				query_id: envelope.query_id.clone(),
-				binding,
-			});
+			state.in_flight_query =
+				Some(InFlightQuery { query_id: envelope.query_id.clone(), binding });
 			return Some(AccountDispatch::Query(envelope));
 		}
 		None
@@ -337,7 +333,8 @@ impl AccountsController {
 				state.upsert_account((**account).clone());
 			},
 			EventPayload::AccountLoggedOut { account_id, tombstone_revision }
-				if account_id == &event.entity_id && tombstone_revision == &event.entity_revision =>
+				if account_id == &event.entity_id
+					&& tombstone_revision == &event.entity_revision =>
 			{
 				state.accounts.retain(|account| account.account_id != *account_id);
 			},
@@ -346,6 +343,18 @@ impl AccountsController {
 			{
 				state.routing = Some(routing.clone());
 				state.sort_accounts();
+			},
+			EventPayload::AccountRouted { account, routing, .. }
+				if matches!(&routing.mode, AccountSelectionModeDto::Fixed(selected) if selected == &account.account_id)
+					&& routing.revision == event.entity_revision =>
+			{
+				state.upsert_account((**account).clone());
+				state.routing = Some(routing.clone());
+				state.pending_route = None;
+				state.sort_accounts();
+			},
+			EventPayload::AccountRoutePending { pending } => {
+				state.pending_route = Some(pending.clone());
 			},
 			_ => {},
 		}
@@ -376,9 +385,14 @@ impl AccountsController {
 		}
 		state.in_flight_query = None;
 		match &result.payload {
-			QueryResultPayload::Accounts(AccountsResult::Available { accounts, routing }) => {
+			QueryResultPayload::Accounts(AccountsResult::Available {
+				accounts,
+				routing,
+				pending_route,
+			}) => {
 				state.accounts = accounts.clone();
 				state.routing = routing.clone();
+				state.pending_route = pending_route.clone();
 				state.sort_accounts();
 				state.load = AccountsLoadState::Ready;
 				AccountRouteOutcome::Fresh
@@ -452,10 +466,8 @@ impl AccountsController {
 			state.latch_in_flight_outcome_unknown();
 			return AccountRouteOutcome::Refused;
 		}
-		let in_flight = state
-			.in_flight_command
-			.take()
-			.expect("matching account command remains in flight");
+		let in_flight =
+			state.in_flight_command.take().expect("matching account command remains in flight");
 		match result.outcome {
 			CommandOutcome::Succeeded => {
 				if state.apply_success(&in_flight.envelope, result) {
@@ -511,6 +523,7 @@ struct State {
 	command: AccountCommandState,
 	accounts: Vec<AccountDto>,
 	routing: Option<AccountRoutingControlDto>,
+	pending_route: Option<AccountRoutePendingDto>,
 }
 
 impl State {
@@ -528,25 +541,29 @@ impl State {
 			command: AccountCommandState::Idle,
 			accounts: Vec::new(),
 			routing: None,
+			pending_route: None,
 		}
 	}
 
 	fn snapshot(&self) -> AccountsSnapshot {
+		let idle = self.session.is_some()
+			&& self.load == AccountsLoadState::Ready
+			&& self.pending_command.is_none()
+			&& self.in_flight_command.is_none()
+			&& !matches!(
+				self.command,
+				AccountCommandState::Sending
+					| AccountCommandState::AwaitingResult
+					| AccountCommandState::OutcomeUnknown
+			);
 		AccountsSnapshot {
 			load: self.load,
 			command: self.command,
 			accounts: self.accounts.clone(),
 			routing: self.routing.clone(),
-			can_manage: self.session.is_some()
-				&& self.load == AccountsLoadState::Ready
-				&& self.pending_command.is_none()
-				&& self.in_flight_command.is_none()
-				&& !matches!(
-					self.command,
-					AccountCommandState::Sending
-						| AccountCommandState::AwaitingResult
-						| AccountCommandState::OutcomeUnknown
-				),
+			pending_route: self.pending_route.clone(),
+			can_manage: idle && self.pending_route.is_none(),
+			can_route: idle,
 		}
 	}
 
@@ -587,8 +604,7 @@ impl State {
 				AccountCommandState::Sending
 					| AccountCommandState::AwaitingResult
 					| AccountCommandState::OutcomeUnknown
-			)
-		{
+			) {
 			return Err(AccountInputError::Busy);
 		}
 		let identity = command_identity()?;
@@ -617,10 +633,8 @@ impl State {
 	}
 
 	fn upsert_account(&mut self, account: AccountDto) {
-		if let Some(existing) = self
-			.accounts
-			.iter_mut()
-			.find(|existing| existing.account_id == account.account_id)
+		if let Some(existing) =
+			self.accounts.iter_mut().find(|existing| existing.account_id == account.account_id)
 		{
 			if account.account_revision >= existing.account_revision {
 				*existing = account;
@@ -645,11 +659,7 @@ impl State {
 		}
 	}
 
-	fn apply_success(
-		&mut self,
-		command: &CommandEnvelope,
-		result: &CommandResultEnvelope,
-	) -> bool {
+	fn apply_success(&mut self, command: &CommandEnvelope, result: &CommandResultEnvelope) -> bool {
 		match (&command.payload, result.payload.as_ref()) {
 			(
 				CommandPayload::SetAccountEnabled { account_id, enabled },
@@ -662,13 +672,24 @@ impl State {
 				true
 			},
 			(
-				CommandPayload::SetFixedAccountSelection { account_id, .. },
-				Some(ResultPayload::AccountRoutingChanged { routing }),
-			) if matches!(&routing.mode, AccountSelectionModeDto::Fixed(selected) if selected == account_id)
+				CommandPayload::RouteAccount { account_id, .. },
+				Some(ResultPayload::AccountRouted { account, routing, .. }),
+			) if account.account_id == *account_id
+				&& matches!(&routing.mode, AccountSelectionModeDto::Fixed(selected) if selected == account_id)
 				&& result.entity_revision == Some(routing.revision) =>
 			{
+				self.upsert_account((**account).clone());
 				self.routing = Some(routing.clone());
 				self.sort_accounts();
+				true
+			},
+			(
+				CommandPayload::RouteAccount { account_id, .. },
+				Some(ResultPayload::AccountRoutePending { pending }),
+			) if pending.account_id == *account_id
+				&& result.entity_revision == Some(pending.routing_revision) =>
+			{
+				self.pending_route = Some(pending.clone());
 				true
 			},
 			(
@@ -714,9 +735,8 @@ fn canonical_uuid_v4() -> Result<String, AccountInputError> {
 	digest.update(std::process::id().to_be_bytes());
 	digest.update(nanos.to_be_bytes());
 	digest.update(sequence.to_be_bytes());
-	let mut bytes: [u8; 16] = digest.finalize()[..16]
-		.try_into()
-		.expect("SHA-256 always contains sixteen identity bytes");
+	let mut bytes: [u8; 16] =
+		digest.finalize()[..16].try_into().expect("SHA-256 always contains sixteen identity bytes");
 	bytes[6] = (bytes[6] & 0x0f) | 0x40;
 	bytes[8] = (bytes[8] & 0x3f) | 0x80;
 	Ok(format!(
@@ -801,9 +821,8 @@ mod tests {
 		let second = account("10000000-0000-4000-8000-000000000002", "Reserve", true, 7);
 		controller.bind_session(2, server.clone());
 		controller.activate();
-		let AccountDispatch::Query(query) = controller
-			.try_take_dispatch(2, &server)
-			.expect("account query is reserved")
+		let AccountDispatch::Query(query) =
+			controller.try_take_dispatch(2, &server).expect("account query is reserved")
 		else {
 			panic!("account activation must query")
 		};
@@ -823,6 +842,7 @@ mod tests {
 					payload: QueryResultPayload::Accounts(AccountsResult::Available {
 						accounts: vec![second.clone(), first.clone()],
 						routing: Some(routing),
+						pending_route: None,
 					}),
 				},
 			),
@@ -835,19 +855,74 @@ mod tests {
 		controller
 			.select_fixed(&second.account_id)
 			.expect("ready account can become the fixed route");
-		let AccountDispatch::Command(command) = controller
-			.try_take_dispatch(2, &server)
-			.expect("fixed selection queues one command")
+		let AccountDispatch::Command(command) =
+			controller.try_take_dispatch(2, &server).expect("fixed selection queues one command")
 		else {
 			panic!("fixed selection must dispatch a command")
 		};
 		assert_eq!(command.expected_revision, Some(EntityRevision(5)));
 		assert!(matches!(
 			command.payload,
-			CommandPayload::SetFixedAccountSelection {
+			CommandPayload::RouteAccount {
+				ref operation_id,
 				ref account_id,
 				expected_account_revision: EntityRevision(7),
-			} if account_id == &second.account_id
+			} if account_id == &second.account_id && operation_id.as_str().len() == 36
+		));
+	}
+
+	#[test]
+	fn current_fixed_account_can_replace_a_different_pending_route() {
+		let controller = AccountsController::production();
+		let server = server();
+		let first = account("10000000-0000-4000-8000-000000000001", "Primary", true, 3);
+		let second = account("10000000-0000-4000-8000-000000000002", "Reserve", true, 7);
+		controller.bind_session(2, server.clone());
+		controller.activate();
+		let AccountDispatch::Query(query) = controller.try_take_dispatch(2, &server).unwrap() else {
+			panic!("account activation must query")
+		};
+		let routing = AccountRoutingControlDto {
+			revision: EntityRevision(5),
+			mode: AccountSelectionModeDto::Fixed(second.account_id.clone()),
+			order: vec![first.account_id.clone(), second.account_id.clone()],
+		};
+		assert_eq!(
+			controller.route_query_result(
+				2,
+				&server,
+				&QueryResultEnvelope {
+					version: CURRENT_VERSION,
+					server_id: server.clone(),
+					query_id: query.query_id,
+					payload: QueryResultPayload::Accounts(AccountsResult::Available {
+						accounts: vec![first.clone(), second.clone()],
+						routing: Some(routing),
+						pending_route: Some(AccountRoutePendingDto {
+							operation_id: EntityId::new(
+								"30000000-0000-4000-8000-000000000001",
+							)
+							.unwrap(),
+							account_id: first.account_id.clone(),
+							routing_revision: EntityRevision(5),
+						}),
+					}),
+				},
+			),
+			AccountRouteOutcome::Fresh
+		);
+		let snapshot = controller.snapshot();
+		assert!(!snapshot.can_manage);
+		assert!(snapshot.can_route);
+		assert!(controller.select_fixed(&first.account_id).is_err());
+		controller.select_fixed(&second.account_id).expect("new target replaces pending Route");
+		let AccountDispatch::Command(command) = controller.try_take_dispatch(2, &server).unwrap()
+		else {
+			panic!("replacement must dispatch a command")
+		};
+		assert!(matches!(
+			command.payload,
+			CommandPayload::RouteAccount { account_id, .. } if account_id == second.account_id
 		));
 	}
 }

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -16,13 +16,13 @@ use tempfile::TempDir;
 
 use decodex_protocol::{
 	CURRENT_VERSION, Channel, ClientProfile, CommandEnvelope, ConversationHistoryPage,
-	ConversationHistoryResult, CorrelationId, Cursor, DoctorReport, EntityId, EntityRevision,
-	EventEnvelope, EventPayload, HistoryCursorToken, QueryEnvelope, QueryPayload,
-	PAPER_INVESTMENT_DOMAIN_PACK_ID, DEVELOPMENT_DOMAIN_PACK_ID, ProgramCycleDraftDto,
-	ProgramEvidenceDraftDto, ProgramNodeKind, ProgramReviewClassification, ProgramReviewDraftDto,
-	QueryResultEnvelope, QueryResultPayload, QuickTaskState, QuickTaskWorkingDirectory,
-	RetainedSessionConfig, RetainedSessionFailure, ServerId, ServerInstanceId, SessionCheckpoint,
-	SnapshotEnvelope, SnapshotItem, WireText,
+	ConversationHistoryResult, CorrelationId, Cursor, DEVELOPMENT_DOMAIN_PACK_ID, DoctorReport,
+	EntityId, EntityRevision, EventEnvelope, EventPayload, HistoryCursorToken,
+	PAPER_INVESTMENT_DOMAIN_PACK_ID, ProgramCycleDraftDto, ProgramEvidenceDraftDto,
+	ProgramNodeKind, ProgramReviewClassification, ProgramReviewDraftDto, QueryEnvelope,
+	QueryPayload, QueryResultEnvelope, QueryResultPayload, QuickTaskState,
+	QuickTaskWorkingDirectory, RetainedSessionConfig, RetainedSessionFailure, ServerId,
+	ServerInstanceId, SessionCheckpoint, SnapshotEnvelope, SnapshotItem, WireText,
 };
 
 use crate::{
@@ -102,16 +102,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_6() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_9() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.6");
+		.expect("production lifecycle constructs at protocol V2.9");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 6);
+	assert_eq!(CURRENT_VERSION.minor, 9);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =
@@ -813,8 +813,9 @@ async fn run_with_io_dispatches_history_and_restarts_from_head_after_reconnect()
 	let routes = queries
 		.iter()
 		.map(|query| match &query.payload {
-			QueryPayload::GetConversationHistory { conversation_id, after, .. } =>
-				(conversation_id.clone(), after.clone()),
+			QueryPayload::GetConversationHistory { conversation_id, after, .. } => {
+				(conversation_id.clone(), after.clone())
+			},
 			_ => panic!("history pager sends only ConversationHistory queries"),
 		})
 		.collect::<Vec<_>>();
@@ -2333,8 +2334,7 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 	const PAPER_OBJECTIVE_ID: &str = "d5000000-0000-4000-8000-000000000001";
 	const PAPER_WORK_ITEM_ID: &str = "d6000000-0000-4000-8000-000000000001";
 	const PAPER_REVIEW_ID: &str = "e1000000-0000-4000-8000-000000000001";
-	const PAPER_DETERMINISTIC_EVIDENCE_ID: &str =
-		"e2000000-0000-4000-8000-000000000001";
+	const PAPER_DETERMINISTIC_EVIDENCE_ID: &str = "e2000000-0000-4000-8000-000000000001";
 	const PAPER_EXTERNAL_EVIDENCE_ID: &str = "e3000000-0000-4000-8000-000000000001";
 
 	fn text(value: &str) -> WireText {
@@ -2360,10 +2360,7 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 		.canonicalize()
 		.expect("live test working directory canonicalizes");
 	let working_directory = QuickTaskWorkingDirectory::new(
-		working_directory
-			.to_str()
-			.expect("live test working directory is UTF-8")
-			.to_owned(),
+		working_directory.to_str().expect("live test working directory is UTF-8").to_owned(),
 	)
 	.expect("live test working directory is accepted");
 	let profile = ClientProfile::load_default(None).expect("the live profile is configured");
@@ -2430,10 +2427,7 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 						&& pack.relations.len() == 2 =>
 				{
 					assert_eq!(
-						pack.entities
-							.iter()
-							.map(|entity| entity.id.as_str())
-							.collect::<Vec<_>>(),
+						pack.entities.iter().map(|entity| entity.id.as_str()).collect::<Vec<_>>(),
 						vec![
 							"4ab46bd9-8378-494b-aa14-db4408b814ef",
 							"19639395-365c-4060-b160-9833783a33d4",
@@ -2441,12 +2435,15 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 						],
 					);
 					break;
-				}
-				Some(_) => {}
+				},
+				Some(_) => {},
 			}
 		}
 		assert!(
-			!matches!(snapshot.command, ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused),
+			!matches!(
+				snapshot.command,
+				ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused
+			),
 			"Development Pack binding did not settle: {:?}",
 			snapshot.command,
 		);
@@ -2461,12 +2458,7 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 	}
 
 	let paper_program_id = entity(PAPER_PROGRAM_ID);
-	if !programs
-		.snapshot()
-		.programs
-		.iter()
-		.any(|program| program.program_id == paper_program_id)
-	{
+	if !programs.snapshot().programs.iter().any(|program| program.program_id == paper_program_id) {
 		programs
 			.create(ProgramCycleDraftDto {
 				program_id: paper_program_id.clone(),
@@ -2529,9 +2521,8 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 	let paper_projection_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
 	let mut paper_cycle = loop {
 		let snapshot = programs.snapshot();
-		if let Some(cycle) = snapshot
-			.cycle
-			.filter(|cycle| cycle.program.program_id == paper_program_id)
+		if let Some(cycle) =
+			snapshot.cycle.filter(|cycle| cycle.program.program_id == paper_program_id)
 		{
 			let pack = cycle.domain_pack.as_ref().expect("paper Program has an immutable Pack");
 			assert_eq!(pack.descriptor.id.as_str(), PAPER_INVESTMENT_DOMAIN_PACK_ID);
@@ -2549,7 +2540,10 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 			break cycle;
 		}
 		assert!(
-			!matches!(snapshot.command, ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused),
+			!matches!(
+				snapshot.command,
+				ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused
+			),
 			"paper Program command did not settle: {:?}",
 			snapshot.command,
 		);
@@ -2689,13 +2683,18 @@ async fn live_daemon_completes_the_builtin_domain_pack_pressure_test() {
 		}) {
 			let pack = cycle.domain_pack.as_ref().expect("completed paper Pack projection");
 			assert_eq!(pack.descriptor.id.as_str(), PAPER_INVESTMENT_DOMAIN_PACK_ID);
-			assert!(pack.relations.iter().any(|relation| {
-				relation.kind.as_str() == "finance.compared_with"
-			}));
+			assert!(
+				pack.relations
+					.iter()
+					.any(|relation| { relation.kind.as_str() == "finance.compared_with" })
+			);
 			break;
 		}
 		assert!(
-			!matches!(snapshot.command, ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused),
+			!matches!(
+				snapshot.command,
+				ProgramCommandState::OutcomeUnknown | ProgramCommandState::Refused
+			),
 			"paper Review did not settle: {:?}; prior cycle revision was {}",
 			snapshot.command,
 			paper_cycle.program.revision.0,

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -390,8 +390,9 @@ fn connection_presentation(view: ConnectionView) -> ConnectionPresentation {
 				CompatibilityReason::InvalidEndpoint => "Selected endpoint is not supported",
 				CompatibilityReason::ProtocolMajor => "Protocol generation does not match",
 				CompatibilityReason::ProtocolMinor => "Protocol revision is not supported",
-				CompatibilityReason::PublicationIdentityUnavailable =>
-					"Publication identity is unavailable",
+				CompatibilityReason::PublicationIdentityUnavailable => {
+					"Publication identity is unavailable"
+				},
 			}
 			.into(),
 			color: 0xef4444,
@@ -422,8 +423,9 @@ const fn startup_failure(failure: ClientFailure) -> &'static str {
 		ClientFailure::ProfileMissing => "Selected server profile is missing",
 		ClientFailure::UnsafeHostPath => "Client configuration path is unsafe",
 		ClientFailure::ServerIdentityUnavailable => "Stable server identity is unavailable",
-		ClientFailure::RemoteMutationUnsupported =>
-			"Reset-card operations require a local pinned profile",
+		ClientFailure::RemoteMutationUnsupported => {
+			"Reset-card operations require a local pinned profile"
+		},
 		ClientFailure::LocalTransportDisabled => "Local daemon transport is disabled",
 		ClientFailure::RemoteTransportDisabled => "Remote daemon transport is disabled",
 		ClientFailure::LocalTransportUnsupported => "Local daemon transport is unsupported",
@@ -813,16 +815,20 @@ impl Shell {
 				mode: AccountSelectionModeDto::Fixed(primary.account_id.clone()),
 				order: vec![primary.account_id, reserve.account_id, research.account_id],
 			}),
+			pending_route: None,
 			can_manage: true,
+			can_route: true,
 		};
 		let health_checks = DoctorComponent::ALL
 			.into_iter()
 			.map(|component| {
 				let status = match component {
-					DoctorComponent::AppServerCapability(_) | DoctorComponent::BlobIntegrity =>
-						DoctorStatus::Unknown(DoctorIssue::NotProbed),
-					DoctorComponent::ManagedRepository =>
-						DoctorStatus::Unavailable(DoctorIssue::Disabled),
+					DoctorComponent::AppServerCapability(_) | DoctorComponent::BlobIntegrity => {
+						DoctorStatus::Unknown(DoctorIssue::NotProbed)
+					},
+					DoctorComponent::ManagedRepository => {
+						DoctorStatus::Unavailable(DoctorIssue::Disabled)
+					},
 					DoctorComponent::PluginReadiness => DoctorStatus::Unknown(DoctorIssue::Plugin),
 					_ => DoctorStatus::Ready,
 				};
@@ -1560,8 +1566,9 @@ const fn input_error_label(error: QuickTaskInputError) -> &'static str {
 		QuickTaskInputError::NotReady => "The selected Quick Task is not ready for this command.",
 		QuickTaskInputError::NotInterruptible => "The selected turn is not running.",
 		QuickTaskInputError::IdentityUnavailable => "A command identity could not be created.",
-		QuickTaskInputError::WorkingDirectoryUnavailable =>
-			"The local Quick Task working directory is unavailable.",
+		QuickTaskInputError::WorkingDirectoryUnavailable => {
+			"The local Quick Task working directory is unavailable."
+		},
 	}
 }
 
@@ -2266,8 +2273,9 @@ fn component_label(component: DoctorComponent) -> &'static str {
 
 fn component_presentation(status: Option<DoctorStatus>) -> HealthPresentation {
 	match status {
-		Some(DoctorStatus::Ready) =>
-			HealthPresentation { label: "Ready", detail: "", color: 0x22c55e },
+		Some(DoctorStatus::Ready) => {
+			HealthPresentation { label: "Ready", detail: "", color: 0x22c55e }
+		},
 		Some(DoctorStatus::Unavailable(DoctorIssue::Disabled))
 		| Some(DoctorStatus::Unknown(DoctorIssue::Disabled)) => HealthPresentation {
 			label: "Disabled",
@@ -2585,18 +2593,32 @@ fn accounts_content(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 		.as_ref()
 		.is_some_and(|routing| routing.mode == AccountSelectionModeDto::Balanced);
 	let can_manage = snapshot.can_manage;
+	let can_route = snapshot.can_route;
+	let pending_target = snapshot.pending_route.as_ref().map(|pending| &pending.account_id);
 	let rows = snapshot
 		.accounts
 		.iter()
 		.enumerate()
 		.map(|(index, account)| {
-			account_pool_row(account, index, fixed == Some(&account.account_id), can_manage, cx)
+			account_pool_row(
+				account,
+				index,
+				fixed == Some(&account.account_id),
+				pending_target,
+				can_manage,
+				can_route,
+				cx,
+			)
 		})
 		.collect::<Vec<_>>();
-	let status = shell
-		.account_status
+	let status = snapshot
+		.pending_route
 		.as_ref()
-		.map(SharedString::to_string)
+		.map(|_| {
+			"Quit ChatGPT and keep it closed until Pending changes to Routed, then reopen it."
+				.to_owned()
+		})
+		.or_else(|| shell.account_status.as_ref().map(SharedString::to_string))
 		.or_else(|| account_command_label(snapshot.command).map(str::to_owned))
 		.unwrap_or_else(|| accounts_load_label(snapshot.load).to_owned());
 	let count = snapshot.accounts.len();
@@ -2795,13 +2817,18 @@ fn account_pool_row(
 	account: &AccountDto,
 	index: usize,
 	fixed: bool,
+	pending_target: Option<&EntityId>,
 	can_manage: bool,
+	can_route: bool,
 	cx: &mut Context<Shell>,
 ) -> AnyElement {
 	let account_id = account.account_id.clone();
 	let toggle_account_id = account.account_id.clone();
 	let enabled = account.enabled;
-	let pin_enabled = can_manage && enabled && !fixed;
+	let pending = pending_target == Some(&account.account_id);
+	let has_pending_route = pending_target.is_some();
+	let keeps_current_route = fixed && has_pending_route && !pending;
+	let pin_enabled = can_route && enabled && (!fixed || keeps_current_route) && !pending;
 	let toggle_enabled = can_manage;
 	let state_color = account_state_color(account);
 	let short_id = account.account_id.as_str().get(..8).unwrap_or(account.account_id.as_str());
@@ -2898,7 +2925,15 @@ fn account_pool_row(
 									shell.select_fixed_account(&account_id, cx);
 								}))
 						})
-						.child(if fixed { "Pinned" } else { "Route" }),
+						.child(if pending {
+							"Pending"
+						} else if keeps_current_route {
+							"Keep"
+						} else if fixed {
+							"Pinned"
+						} else {
+							"Route"
+						}),
 				)
 				.child(
 					div()
@@ -3018,8 +3053,9 @@ fn account_command_label(command: AccountCommandState) -> Option<&'static str> {
 		AccountCommandState::Sending => Some("Sending account command…"),
 		AccountCommandState::AwaitingResult => Some("Waiting for durable account result…"),
 		AccountCommandState::Accepted => Some("Account pool updated."),
-		AccountCommandState::OutcomeUnknown =>
-			Some("Outcome is unknown. Refresh readback before another account change."),
+		AccountCommandState::OutcomeUnknown => {
+			Some("Outcome is unknown. Refresh readback before another account change.")
+		},
 		AccountCommandState::Refused => Some("The account change was refused. Refresh and retry."),
 	}
 }
@@ -3068,8 +3104,9 @@ fn command_status(command: QuickTaskCommandState) -> Option<&'static str> {
 		QuickTaskCommandState::AwaitingResult => Some("Waiting for durable result"),
 		QuickTaskCommandState::Accepted => Some("Command accepted"),
 		QuickTaskCommandState::ManualRecovery(action) => Some(recovery_action_label(action)),
-		QuickTaskCommandState::OutcomeUnknown =>
-			Some("Connection interrupted. Decodex will check durable state before continuing."),
+		QuickTaskCommandState::OutcomeUnknown => {
+			Some("Connection interrupted. Decodex will check durable state before continuing.")
+		},
 		QuickTaskCommandState::Refused => Some("The command was refused."),
 	}
 }
@@ -3077,37 +3114,51 @@ fn command_status(command: QuickTaskCommandState) -> Option<&'static str> {
 fn recovery_action_label(action: QuickTaskRecoveryAction) -> &'static str {
 	match action {
 		QuickTaskRecoveryAction::ResumeRouting => "Resume the pending account route.",
-		QuickTaskRecoveryAction::CreateRoutingSuccessor =>
-			"Create a new conversation and route it explicitly.",
-		QuickTaskRecoveryAction::ResumeEstablishment =>
-			"Resume the selected account session establishment.",
+		QuickTaskRecoveryAction::CreateRoutingSuccessor => {
+			"Create a new conversation and route it explicitly."
+		},
+		QuickTaskRecoveryAction::ResumeEstablishment => {
+			"Resume the selected account session establishment."
+		},
 		QuickTaskRecoveryAction::ConfigureAccount => "Configure an account before continuing.",
 		QuickTaskRecoveryAction::EnableAccount => "Enable the selected account before continuing.",
-		QuickTaskRecoveryAction::EnrollCredentials =>
-			"Enroll account credentials before continuing.",
-		QuickTaskRecoveryAction::ResolveAccountOperation =>
-			"Resolve the unsettled account operation before continuing.",
-		QuickTaskRecoveryAction::RepairCredentialStore =>
-			"Repair the protected credential store before continuing.",
-		QuickTaskRecoveryAction::RestoreProviderAgreement =>
-			"Restore provider account agreement before continuing.",
+		QuickTaskRecoveryAction::EnrollCredentials => {
+			"Enroll account credentials before continuing."
+		},
+		QuickTaskRecoveryAction::ResolveAccountOperation => {
+			"Resolve the unsettled account operation before continuing."
+		},
+		QuickTaskRecoveryAction::RepairCredentialStore => {
+			"Repair the protected credential store before continuing."
+		},
+		QuickTaskRecoveryAction::RestoreProviderAgreement => {
+			"Restore provider account agreement before continuing."
+		},
 		QuickTaskRecoveryAction::RefreshQuota => "Refresh account quota before continuing.",
-		QuickTaskRecoveryAction::UpgradeCodex =>
-			"Use a Codex build with the required app-server methods.",
-		QuickTaskRecoveryAction::SelectWorkingDirectory =>
-			"Select an owned local working directory before continuing.",
-		QuickTaskRecoveryAction::StartNewConversation =>
-			"This thread cannot resume. Start a new conversation.",
-		QuickTaskRecoveryAction::ResolvePriorActiveTurn =>
-			"Resolve the prior active turn before continuing.",
-		QuickTaskRecoveryAction::ResolvePriorAttempt =>
-			"Resolve the prior provider attempt before continuing.",
-		QuickTaskRecoveryAction::RestoreProcessReadiness =>
-			"Restore process readiness before continuing.",
-		QuickTaskRecoveryAction::WaitForCurrentCommand =>
-			"Wait for the current command or turn to settle.",
-		QuickTaskRecoveryAction::RefreshConversation =>
-			"Refresh this conversation before continuing.",
+		QuickTaskRecoveryAction::UpgradeCodex => {
+			"Use a Codex build with the required app-server methods."
+		},
+		QuickTaskRecoveryAction::SelectWorkingDirectory => {
+			"Select an owned local working directory before continuing."
+		},
+		QuickTaskRecoveryAction::StartNewConversation => {
+			"This thread cannot resume. Start a new conversation."
+		},
+		QuickTaskRecoveryAction::ResolvePriorActiveTurn => {
+			"Resolve the prior active turn before continuing."
+		},
+		QuickTaskRecoveryAction::ResolvePriorAttempt => {
+			"Resolve the prior provider attempt before continuing."
+		},
+		QuickTaskRecoveryAction::RestoreProcessReadiness => {
+			"Restore process readiness before continuing."
+		},
+		QuickTaskRecoveryAction::WaitForCurrentCommand => {
+			"Wait for the current command or turn to settle."
+		},
+		QuickTaskRecoveryAction::RefreshConversation => {
+			"Refresh this conversation before continuing."
+		},
 	}
 }
 
@@ -3115,8 +3166,9 @@ fn quick_task_load_status(load: QuickTasksLoadState) -> &'static str {
 	match load {
 		QuickTasksLoadState::NeverRequested => "Quick Tasks have not loaded.",
 		QuickTasksLoadState::Loading => "Loading Quick Tasks",
-		QuickTasksLoadState::Ready =>
-			"Local task list loaded. Open or refresh a task for latest Codex state.",
+		QuickTasksLoadState::Ready => {
+			"Local task list loaded. Open or refresh a task for latest Codex state."
+		},
 		QuickTasksLoadState::Offline => "Offline. Retained conversation state remains visible.",
 		QuickTasksLoadState::Unavailable => "Quick Task state is temporarily unavailable.",
 		QuickTasksLoadState::Refused => "Quick Task readback was refused.",
@@ -3126,12 +3178,15 @@ fn quick_task_load_status(load: QuickTasksLoadState) -> &'static str {
 fn quick_task_refresh_status(refresh: QuickTaskRefreshState) -> Option<String> {
 	match refresh {
 		QuickTaskRefreshState::Idle => None,
-		QuickTaskRefreshState::Refreshing { completed, total, archived, failed } =>
-			Some(format!("Syncing {completed}/{total} · {archived} archived · {failed} skipped")),
-		QuickTaskRefreshState::Complete { checked, archived, failed } =>
-			Some(format!("{checked} checked · {archived} archived · {failed} skipped")),
-		QuickTaskRefreshState::Stopped { checked, total, archived, failed } =>
-			Some(format!("Stopped {checked}/{total} · {archived} archived · {failed} skipped")),
+		QuickTaskRefreshState::Refreshing { completed, total, archived, failed } => {
+			Some(format!("Syncing {completed}/{total} · {archived} archived · {failed} skipped"))
+		},
+		QuickTaskRefreshState::Complete { checked, archived, failed } => {
+			Some(format!("{checked} checked · {archived} archived · {failed} skipped"))
+		},
+		QuickTaskRefreshState::Stopped { checked, total, archived, failed } => {
+			Some(format!("Stopped {checked}/{total} · {archived} archived · {failed} skipped"))
+		},
 	}
 }
 
@@ -4027,17 +4082,20 @@ fn quick_task_transcript(
 	let history_status = history.map_or_else(
 		|| (!has_rows).then_some("Conversation history is not connected."),
 		|history| match history.load {
-			HistoryLoadState::Inactive =>
-				(!has_rows).then_some("Select a conversation or start a new conversation."),
-			HistoryLoadState::InitialLoading | HistoryLoadState::RefreshingVisible =>
+			HistoryLoadState::Inactive => {
+				(!has_rows).then_some("Select a conversation or start a new conversation.")
+			},
+			HistoryLoadState::InitialLoading | HistoryLoadState::RefreshingVisible => {
 				Some(if has_rows {
 					"Syncing earlier context"
 				} else {
 					"Loading conversation history"
-				}),
+				})
+			},
 			HistoryLoadState::PrefetchingAdjacent | HistoryLoadState::Visible => None,
-			HistoryLoadState::RetryableUnavailable(_) =>
-				Some("History is temporarily unavailable. Reconnect or retry."),
+			HistoryLoadState::RetryableUnavailable(_) => {
+				Some("History is temporarily unavailable. Reconnect or retry.")
+			},
 			HistoryLoadState::ClosedUnavailable(_) => Some("History readback was refused."),
 		},
 	);
@@ -5101,10 +5159,12 @@ mod tests {
 			.into_iter()
 			.map(|component| {
 				let status = match component {
-					DoctorComponent::AppServerCapability(_) | DoctorComponent::BlobIntegrity =>
-						DoctorStatus::Unknown(DoctorIssue::NotProbed),
-					DoctorComponent::ManagedRepository =>
-						DoctorStatus::Unavailable(DoctorIssue::Disabled),
+					DoctorComponent::AppServerCapability(_) | DoctorComponent::BlobIntegrity => {
+						DoctorStatus::Unknown(DoctorIssue::NotProbed)
+					},
+					DoctorComponent::ManagedRepository => {
+						DoctorStatus::Unavailable(DoctorIssue::Disabled)
+					},
 					DoctorComponent::PluginReadiness => DoctorStatus::Unknown(DoctorIssue::Plugin),
 					_ => DoctorStatus::Ready,
 				};

--- a/crates/decodex-app-client-ffi/src/lib.rs
+++ b/crates/decodex-app-client-ffi/src/lib.rs
@@ -43,10 +43,8 @@ struct NativeClient {
 
 impl NativeClient {
 	fn record_login_status(&self, status: &AccountLoginStatus) {
-		let mut active = self
-			.active_login_session
-			.lock()
-			.unwrap_or_else(std::sync::PoisonError::into_inner);
+		let mut active =
+			self.active_login_session.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
 		if matches!(
 			status.state,
 			AccountLoginState::Completed | AccountLoginState::Failed | AccountLoginState::Cancelled
@@ -60,10 +58,7 @@ impl NativeClient {
 	}
 
 	fn take_active_login_session(&self) -> Option<EntityId> {
-		self.active_login_session
-			.lock()
-			.unwrap_or_else(std::sync::PoisonError::into_inner)
-			.take()
+		self.active_login_session.lock().unwrap_or_else(std::sync::PoisonError::into_inner).take()
 	}
 }
 
@@ -139,8 +134,9 @@ enum Request {
 		expected_revision: u64,
 		idempotency_key: String,
 	},
-	SetFixedSelection {
+	RouteAccount {
 		schema: String,
+		operation_id: String,
 		account_id: String,
 		expected_account_revision: u64,
 		expected_routing_revision: u64,
@@ -155,13 +151,6 @@ enum Request {
 		schema: String,
 		order: Vec<String>,
 		expected_routing_revision: u64,
-		idempotency_key: String,
-	},
-	RefreshAccount {
-		schema: String,
-		operation_id: String,
-		account_id: String,
-		expected_revision: u64,
 		idempotency_key: String,
 	},
 	StartAccountEnrollment {
@@ -191,12 +180,6 @@ enum Request {
 		schema: String,
 		session_id: String,
 	},
-	UseAccountInCodex {
-		schema: String,
-		account_id: String,
-		expected_revision: u64,
-		idempotency_key: String,
-	},
 	FastModeStatus {
 		schema: String,
 	},
@@ -220,15 +203,13 @@ impl Request {
 			Self::EnableAccount { .. } => "enable_account",
 			Self::DisableAccount { .. } => "disable_account",
 			Self::LogoutAccount { .. } => "logout_account",
-			Self::SetFixedSelection { .. } => "set_fixed_selection",
+			Self::RouteAccount { .. } => "route_account",
 			Self::SetBalancedSelection { .. } => "set_balanced_selection",
 			Self::SetAccountOrder { .. } => "set_account_order",
-			Self::RefreshAccount { .. } => "refresh_account",
 			Self::StartAccountEnrollment { .. } => "start_account_enrollment",
 			Self::StartAccountReauthentication { .. } => "start_account_reauthentication",
 			Self::PollAccountReauthentication { .. } => "poll_account_reauthentication",
 			Self::CancelAccountReauthentication { .. } => "cancel_account_reauthentication",
-			Self::UseAccountInCodex { .. } => "use_account_in_codex",
 			Self::FastModeStatus { .. } => "fast_mode_status",
 			Self::SetFastMode { .. } => "set_fast_mode",
 		}
@@ -247,15 +228,13 @@ impl Request {
 			| Self::EnableAccount { schema, .. }
 			| Self::DisableAccount { schema, .. }
 			| Self::LogoutAccount { schema, .. }
-			| Self::SetFixedSelection { schema, .. }
+			| Self::RouteAccount { schema, .. }
 			| Self::SetBalancedSelection { schema, .. }
 			| Self::SetAccountOrder { schema, .. }
-			| Self::RefreshAccount { schema, .. }
 			| Self::StartAccountEnrollment { schema, .. }
 			| Self::StartAccountReauthentication { schema, .. }
 			| Self::PollAccountReauthentication { schema, .. }
 			| Self::CancelAccountReauthentication { schema, .. }
-			| Self::UseAccountInCodex { schema, .. }
 			| Self::FastModeStatus { schema }
 			| Self::SetFastMode { schema, .. } => schema,
 		}
@@ -331,8 +310,9 @@ impl From<ResetCardConsumeResponse> for ResetCardConsumeDto {
 				entity_revision,
 			} => Self::Accepted { account_id, descriptor, state, entity_revision },
 			ResetCardConsumeResponse::Rejected { error } => Self::Rejected { error },
-			ResetCardConsumeResponse::PotentiallyDispatched { failure } =>
-				Self::PotentiallyDispatched { failure },
+			ResetCardConsumeResponse::PotentiallyDispatched { failure } => {
+				Self::PotentiallyDispatched { failure }
+			},
 		}
 	}
 }
@@ -695,13 +675,16 @@ async fn execute_request(
 	match request {
 		Request::ListAccounts { .. } => list_accounts(profile).await,
 		Request::GetResetCards { account_id, .. } => get_reset_cards(profile, account_id).await,
-		Request::GetAccountProfile { account_id, include_email, .. } =>
-			get_account_profile(profile, account_id, include_email).await,
+		Request::GetAccountProfile { account_id, include_email, .. } => {
+			get_account_profile(profile, account_id, include_email).await
+		},
 		Request::GetCodexAuthProjection { .. } => get_codex_auth_projection(profile).await,
-		Request::WaitForAccountObservation { after_generation, request_refresh, .. } =>
-			wait_for_account_observation(profile, after_generation, request_refresh).await,
-		Request::ResetCardStatus { idempotency_key, .. } =>
-			get_reset_card_status(profile, idempotency_key).await,
+		Request::WaitForAccountObservation { after_generation, request_refresh, .. } => {
+			wait_for_account_observation(profile, after_generation, request_refresh).await
+		},
+		Request::ResetCardStatus { idempotency_key, .. } => {
+			get_reset_card_status(profile, idempotency_key).await
+		},
 		Request::UseResetCard {
 			account_id,
 			granted_at_unix_seconds,
@@ -709,7 +692,7 @@ async fn execute_request(
 			expected_revision,
 			idempotency_key,
 			..
-		} =>
+		} => {
 			consume_reset_card(
 				profile,
 				account_id,
@@ -718,51 +701,52 @@ async fn execute_request(
 				expected_revision,
 				idempotency_key,
 			)
-			.await,
-		Request::EnrollAccount { operation_id, account_id, enabled, idempotency_key, .. } =>
-			enroll_account(profile, operation_id, account_id, enabled, idempotency_key).await,
-		Request::EnableAccount { account_id, expected_revision, idempotency_key, .. } =>
-			set_account_enabled(profile, account_id, true, expected_revision, idempotency_key).await,
-		Request::DisableAccount { account_id, expected_revision, idempotency_key, .. } =>
+			.await
+		},
+		Request::EnrollAccount { operation_id, account_id, enabled, idempotency_key, .. } => {
+			enroll_account(profile, operation_id, account_id, enabled, idempotency_key).await
+		},
+		Request::EnableAccount { account_id, expected_revision, idempotency_key, .. } => {
+			set_account_enabled(profile, account_id, true, expected_revision, idempotency_key).await
+		},
+		Request::DisableAccount { account_id, expected_revision, idempotency_key, .. } => {
 			set_account_enabled(profile, account_id, false, expected_revision, idempotency_key)
-				.await,
+				.await
+		},
 		Request::LogoutAccount {
 			operation_id,
 			account_id,
 			expected_revision,
 			idempotency_key,
 			..
-		} =>
+		} => {
 			logout_account(profile, operation_id, account_id, expected_revision, idempotency_key)
-				.await,
-		Request::SetFixedSelection {
+				.await
+		},
+		Request::RouteAccount {
+			operation_id,
 			account_id,
 			expected_account_revision,
 			expected_routing_revision,
 			idempotency_key,
 			..
-		} =>
-			set_fixed_selection(
+		} => {
+			route_account(
 				profile,
+				operation_id,
 				account_id,
 				expected_account_revision,
 				expected_routing_revision,
 				idempotency_key,
 			)
-			.await,
-		Request::SetBalancedSelection { expected_routing_revision, idempotency_key, .. } =>
-			set_balanced_selection(profile, expected_routing_revision, idempotency_key).await,
-		Request::SetAccountOrder { order, expected_routing_revision, idempotency_key, .. } =>
-			set_account_order(profile, order, expected_routing_revision, idempotency_key).await,
-		Request::RefreshAccount {
-			operation_id,
-			account_id,
-			expected_revision,
-			idempotency_key,
-			..
-		} =>
-			refresh_account(profile, operation_id, account_id, expected_revision, idempotency_key)
-				.await,
+			.await
+		},
+		Request::SetBalancedSelection { expected_routing_revision, idempotency_key, .. } => {
+			set_balanced_selection(profile, expected_routing_revision, idempotency_key).await
+		},
+		Request::SetAccountOrder { order, expected_routing_revision, idempotency_key, .. } => {
+			set_account_order(profile, order, expected_routing_revision, idempotency_key).await
+		},
 		Request::StartAccountEnrollment {
 			session_id,
 			operation_id,
@@ -811,12 +795,12 @@ async fn execute_request(
 			)
 			.await
 		},
-		Request::PollAccountReauthentication { session_id, .. } =>
-			poll_account_reauthentication(&native_client, profile, session_id).await,
-		Request::CancelAccountReauthentication { session_id, .. } =>
-			cancel_account_reauthentication(&native_client, profile, session_id).await,
-		Request::UseAccountInCodex { account_id, expected_revision, idempotency_key, .. } =>
-			use_account_in_codex(profile, account_id, expected_revision, idempotency_key).await,
+		Request::PollAccountReauthentication { session_id, .. } => {
+			poll_account_reauthentication(&native_client, profile, session_id).await
+		},
+		Request::CancelAccountReauthentication { session_id, .. } => {
+			cancel_account_reauthentication(&native_client, profile, session_id).await
+		},
 		Request::FastModeStatus { .. } => fast_mode_status(),
 		Request::SetFastMode { enabled, .. } => set_fast_mode(enabled),
 	}
@@ -917,21 +901,6 @@ async fn logout_account(
 		.await
 }
 
-async fn refresh_account(
-	profile: ClientProfile,
-	operation_id: String,
-	account_id: String,
-	expected_revision: u64,
-	idempotency_key: String,
-) -> Result<Value, RequestFailure> {
-	let payload = CommandPayload::RefreshAccount {
-		operation_id: entity_id(&operation_id)?,
-		account_id: entity_id(&account_id)?,
-	};
-	execute_account_command(profile, payload, Some(revision(expected_revision)?), idempotency_key)
-		.await
-}
-
 async fn start_account_reauthentication(
 	native_client: &NativeClient,
 	profile: ClientProfile,
@@ -954,10 +923,8 @@ async fn start_account_reauthentication(
 			idempotency_key: parse_idempotency_key(input.idempotency_key)?,
 		},
 	};
-	let status = AccountLoginClient::new(profile)
-		.start(start)
-		.await
-		.map_err(RequestFailure::Client)?;
+	let status =
+		AccountLoginClient::new(profile).start(start).await.map_err(RequestFailure::Client)?;
 	native_client.record_login_status(&status);
 	to_value(status)
 }
@@ -977,10 +944,8 @@ async fn start_account_enrollment(
 			idempotency_key: parse_idempotency_key(input.idempotency_key)?,
 		},
 	};
-	let status = AccountLoginClient::new(profile)
-		.start(start)
-		.await
-		.map_err(RequestFailure::Client)?;
+	let status =
+		AccountLoginClient::new(profile).start(start).await.map_err(RequestFailure::Client)?;
 	native_client.record_login_status(&status);
 	to_value(status)
 }
@@ -1068,15 +1033,17 @@ async fn consume_reset_card(
 	to_value(ResetCardConsumeDto::from(response))
 }
 
-async fn set_fixed_selection(
+async fn route_account(
 	profile: ClientProfile,
+	operation_id: String,
 	account_id: String,
 	expected_account_revision: u64,
 	expected_routing_revision: u64,
 	idempotency_key: String,
 ) -> Result<Value, RequestFailure> {
 	let response = AccountClient::new(profile)
-		.set_fixed_account_selection(
+		.route_account(
+			entity_id(&operation_id)?,
 			entity_id(&account_id)?,
 			revision(expected_account_revision)?,
 			revision(expected_routing_revision)?,
@@ -1116,23 +1083,6 @@ async fn set_account_order(
 		.set_account_order(
 			order,
 			revision(expected_routing_revision)?,
-			parse_idempotency_key(idempotency_key)?,
-		)
-		.await
-		.map_err(RequestFailure::Client)?;
-	to_value(response)
-}
-
-async fn use_account_in_codex(
-	profile: ClientProfile,
-	account_id: String,
-	expected_revision: u64,
-	idempotency_key: String,
-) -> Result<Value, RequestFailure> {
-	let response = AccountClient::new(profile)
-		.use_account_in_codex(
-			entity_id(&account_id)?,
-			revision(expected_revision)?,
 			parse_idempotency_key(idempotency_key)?,
 		)
 		.await
@@ -1322,33 +1272,15 @@ mod tests {
 	}
 
 	#[test]
-	fn refresh_request_is_operation_and_account_revision_fenced() {
+	fn route_request_is_operation_account_and_routing_revision_fenced() {
 		let request = serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"route_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","expected_account_revision":7,"expected_routing_revision":9,"idempotency_key":"route-account-test"}}"#
 		))
-		.expect("refresh request must decode");
+		.expect("Route request must decode");
 
-		assert_eq!(request.operation(), "refresh_account");
+		assert_eq!(request.operation(), "route_account");
 		assert!(serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"refresh-test"}}"#
-		))
-		.is_err());
-		assert!(serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"refresh_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","idempotency_key":"refresh-test"}}"#
-		))
-		.is_err());
-	}
-
-	#[test]
-	fn use_in_codex_request_is_account_revision_fenced() {
-		let request = serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"use_account_in_codex","account_id":"{ACCOUNT_ID}","expected_revision":7,"idempotency_key":"use-account-test"}}"#
-		))
-		.expect("use-in-Codex request must decode");
-
-		assert_eq!(request.operation(), "use_account_in_codex");
-		assert!(serde_json::from_str::<Request>(&format!(
-			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"use_account_in_codex","account_id":"{ACCOUNT_ID}","idempotency_key":"use-account-test"}}"#
+			r#"{{"schema":"{RESPONSE_SCHEMA}","operation":"route_account","operation_id":"028f0f9e-7b6e-4a31-8f4c-1d2e3f405163","account_id":"{ACCOUNT_ID}","expected_account_revision":7,"idempotency_key":"route-account-test"}}"#
 		))
 		.is_err());
 	}

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -19,17 +19,15 @@ use tokio_tungstenite::{
 use crate::{
 	AccountInitialSelectionResult, AccountInspectResult, AccountLoginRequest,
 	AccountLoginRequestEnvelope, AccountLoginResponseEnvelope, AccountLoginStart,
-	AccountLoginStatus, AccountObservationSignal,
-	AccountProfileEmailDto, AccountProfileResult, AccountSelectionModeDto, AccountsResult,
-	CURRENT_ARTIFACT_COHORT, CURRENT_VERSION, ClientCommandId, ClientHello, ClientMessage,
-	CodexAuthProjectionResult,
-	CommandEnvelope, CommandError, CommandOutcome, CommandPayload, CorrelationId, DoctorReport,
-	EntityId, EntityRevision, IdempotencyKey, ProtocolVersion, QueryEnvelope, QueryId,
-	QueryPayload, QueryResultPayload, ReceiptDisposition, Refusal, RefusalEnvelope,
-	ResetCardDescriptorDto, ResetCardInventoryResult, ResetCardOperationResult, ResultPayload,
-	RetainedSessionConfig, RetainedSessionFailure, ServerId, ServerMessage, VersionRefusal,
-	WorkItemBoardPageSize, WorkItemBoardProjectId, WorkItemBoardResult, WorkItemBoardWorkItemId,
-	WorkItemState,
+	AccountLoginStatus, AccountObservationSignal, AccountProfileEmailDto, AccountProfileResult,
+	AccountSelectionModeDto, AccountsResult, CURRENT_ARTIFACT_COHORT, CURRENT_VERSION,
+	ClientCommandId, ClientHello, ClientMessage, CodexAuthProjectionResult, CommandEnvelope,
+	CommandError, CommandOutcome, CommandPayload, CorrelationId, DoctorReport, EntityId,
+	EntityRevision, IdempotencyKey, ProtocolVersion, QueryEnvelope, QueryId, QueryPayload,
+	QueryResultPayload, ReceiptDisposition, Refusal, RefusalEnvelope, ResetCardDescriptorDto,
+	ResetCardInventoryResult, ResetCardOperationResult, ResultPayload, RetainedSessionConfig,
+	RetainedSessionFailure, ServerId, ServerMessage, VersionRefusal, WorkItemBoardPageSize,
+	WorkItemBoardProjectId, WorkItemBoardResult, WorkItemBoardWorkItemId, WorkItemState,
 	local_transport::{LocalTransportAuthority, LocalTransportRefusal, LocalTransportStream},
 };
 use decodex_core::{
@@ -466,8 +464,9 @@ impl ResetCardClient {
 			QueryResultPayload::ResetCards(result) => {
 				let mismatched = match &result {
 					ResetCardInventoryResult::Available { account_id, .. }
-					| ResetCardInventoryResult::ObservationFailed { account_id, .. } =>
-						account_id != &expected_account_id,
+					| ResetCardInventoryResult::ObservationFailed { account_id, .. } => {
+						account_id != &expected_account_id
+					},
 					ResetCardInventoryResult::Unavailable { .. } => false,
 				};
 				if mismatched { Err(ClientFailure::ProtocolMalformed) } else { Ok(result) }
@@ -537,8 +536,9 @@ impl ResetCardClient {
 
 		match result {
 			Ok(response) => Ok(response),
-			Err(failure) if dispatch_attempted.load(Ordering::Acquire) =>
-				Ok(ResetCardConsumeResponse::PotentiallyDispatched { failure }),
+			Err(failure) if dispatch_attempted.load(Ordering::Acquire) => {
+				Ok(ResetCardConsumeResponse::PotentiallyDispatched { failure })
+			},
 			Err(failure) => Err(failure),
 		}
 	}
@@ -580,8 +580,9 @@ impl ResetCardClient {
 					}
 					return Ok(CompletedOneShot::new(result.payload, socket));
 				},
-				ServerMessage::Event(event) =>
-					self.verify_version_and_server(event.version, &event.server_id)?,
+				ServerMessage::Event(event) => {
+					self.verify_version_and_server(event.version, &event.server_id)?
+				},
 				ServerMessage::Refusal(refusal) => return Err(self.refusal_failure(refusal)),
 				_ => return Err(ClientFailure::ProtocolMalformed),
 			}
@@ -675,12 +676,14 @@ impl ResetCardClient {
 						) if result_account_id == account_id
 							&& result_descriptor == descriptor
 							&& entity_revision == expected_revision =>
+						{
 							Ok(ResetCardConsumeResponse::Accepted {
 								account_id,
 								descriptor,
 								state,
 								entity_revision,
-							}),
+							})
+						},
 						(
 							CommandOutcome::Succeeded,
 							Some(entity_revision),
@@ -693,15 +696,19 @@ impl ResetCardClient {
 						) if result_account_id == account_id
 							&& result_descriptor == descriptor
 							&& entity_revision == expected_revision =>
+						{
 							Ok(ResetCardConsumeResponse::Accepted {
 								account_id,
 								descriptor,
 								state: ResetCardOperationResult::Completed { outcome },
 								entity_revision,
-							}),
+							})
+						},
 						(CommandOutcome::Rejected, None, None, Some(error))
 							if !matches!(&error, CommandError::AcceptanceUnknown) =>
-							Ok(ResetCardConsumeResponse::Rejected { error }),
+						{
+							Ok(ResetCardConsumeResponse::Rejected { error })
+						},
 						(
 							CommandOutcome::AcceptanceUnknown,
 							None,
@@ -715,8 +722,9 @@ impl ResetCardClient {
 
 					return response.map(|value| CompletedOneShot::new(value, socket));
 				},
-				ServerMessage::Event(event) =>
-					self.verify_version_and_server(event.version, &event.server_id)?,
+				ServerMessage::Event(event) => {
+					self.verify_version_and_server(event.version, &event.server_id)?
+				},
 				ServerMessage::Refusal(refusal) => return Err(self.refusal_failure(refusal)),
 				_ => return Err(ClientFailure::ProtocolMalformed),
 			}
@@ -785,8 +793,9 @@ impl ResetCardClient {
 
 					return Ok(socket);
 				},
-				ServerMessage::Event(event) =>
-					self.verify_version_and_server(event.version, &event.server_id)?,
+				ServerMessage::Event(event) => {
+					self.verify_version_and_server(event.version, &event.server_id)?
+				},
 				ServerMessage::Refusal(refusal) => return Err(self.refusal_failure(refusal)),
 				_ => return Err(ClientFailure::ProtocolMalformed),
 			}
@@ -857,7 +866,7 @@ impl ResetCardClient {
 	}
 }
 
-/// Read-only V2.6 client for bounded canonical WorkItem board pages.
+/// Read-only V2.9 client for bounded canonical WorkItem board pages.
 pub struct WorkItemBoardClient {
 	transport: ResetCardClient,
 }
@@ -928,7 +937,10 @@ impl AccountLoginClient {
 	}
 
 	/// Start or idempotently read one exact daemon-owned login session.
-	pub async fn start(&self, start: AccountLoginStart) -> Result<AccountLoginStatus, ClientFailure> {
+	pub async fn start(
+		&self,
+		start: AccountLoginStart,
+	) -> Result<AccountLoginStatus, ClientFailure> {
 		let expected_session_id = start.session_id.clone();
 		self.exchange(
 			"decodex-account-login-start",
@@ -939,10 +951,7 @@ impl AccountLoginClient {
 	}
 
 	/// Read one daemon-lifetime login status without retaining it in a client cache.
-	pub async fn status(
-		&self,
-		session_id: EntityId,
-	) -> Result<AccountLoginStatus, ClientFailure> {
+	pub async fn status(&self, session_id: EntityId) -> Result<AccountLoginStatus, ClientFailure> {
 		let expected_session_id = session_id.clone();
 		self.exchange(
 			"decodex-account-login-status",
@@ -953,10 +962,7 @@ impl AccountLoginClient {
 	}
 
 	/// Cancel one session and wait for daemon-owned terminal cleanup.
-	pub async fn cancel(
-		&self,
-		session_id: EntityId,
-	) -> Result<AccountLoginStatus, ClientFailure> {
+	pub async fn cancel(&self, session_id: EntityId) -> Result<AccountLoginStatus, ClientFailure> {
 		let expected_session_id = session_id.clone();
 		self.exchange(
 			"decodex-account-login-cancel",
@@ -976,12 +982,10 @@ impl AccountLoginClient {
 		if request.validate().is_err() {
 			return Err(ClientFailure::ProtocolMalformed);
 		}
-		let completed = time::timeout(
-			self.transport.timeout,
-			self.exchange_inner(request_identity, request),
-		)
-		.await
-		.map_err(|_| ClientFailure::ProtocolTimeout)??;
+		let completed =
+			time::timeout(self.transport.timeout, self.exchange_inner(request_identity, request))
+				.await
+				.map_err(|_| ClientFailure::ProtocolTimeout)??;
 		close_one_shot_socket(completed.socket).await;
 		let status = completed.value.status;
 		if status.session_id != *expected_session_id || status.validate().is_err() {
@@ -1019,9 +1023,9 @@ impl AccountLoginClient {
 					}
 					return Ok(CompletedOneShot::new(response, socket));
 				},
-				ServerMessage::Event(event) => self
-					.transport
-					.verify_version_and_server(event.version, &event.server_id)?,
+				ServerMessage::Event(event) => {
+					self.transport.verify_version_and_server(event.version, &event.server_id)?
+				},
 				ServerMessage::Refusal(refusal) => {
 					return Err(self.transport.refusal_failure(refusal));
 				},
@@ -1055,7 +1059,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.6 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.9 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1136,12 +1140,14 @@ impl AccountClient {
 			QueryResultPayload::AccountProfile(result) => {
 				let matches = match &result {
 					AccountProfileResult::Current(profile)
-					| AccountProfileResult::Cached { profile, .. } =>
+					| AccountProfileResult::Cached { profile, .. } => {
 						profile.account_id == expected
 							&& (include_email
-								|| matches!(profile.email, AccountProfileEmailDto::Redacted)),
-					AccountProfileResult::Unavailable { email, .. } =>
-						include_email || matches!(email, AccountProfileEmailDto::Redacted),
+								|| matches!(profile.email, AccountProfileEmailDto::Redacted))
+					},
+					AccountProfileResult::Unavailable { email, .. } => {
+						include_email || matches!(email, AccountProfileEmailDto::Redacted)
+					},
 				};
 				if matches { Ok(result) } else { Err(ClientFailure::ProtocolMalformed) }
 			},
@@ -1229,16 +1235,17 @@ impl AccountClient {
 		}
 	}
 
-	/// Select one fixed account under routing-control and target-account revision guards.
-	pub async fn set_fixed_account_selection(
+	/// Refresh, project, and select one account through one daemon-owned Route command.
+	pub async fn route_account(
 		&self,
+		operation_id: EntityId,
 		account_id: EntityId,
 		expected_account_revision: EntityRevision,
 		expected_routing_revision: EntityRevision,
 		idempotency_key: IdempotencyKey,
 	) -> Result<AccountCommandResponse, ClientFailure> {
 		self.execute(
-			CommandPayload::SetFixedAccountSelection { account_id, expected_account_revision },
+			CommandPayload::RouteAccount { operation_id, account_id, expected_account_revision },
 			Some(expected_routing_revision),
 			idempotency_key,
 		)
@@ -1274,22 +1281,7 @@ impl AccountClient {
 		.await
 	}
 
-	/// Project one exact account into Codex shared auth without changing Decodex routing.
-	pub async fn use_account_in_codex(
-		&self,
-		account_id: EntityId,
-		expected_account_revision: EntityRevision,
-		idempotency_key: IdempotencyKey,
-	) -> Result<AccountCommandResponse, ClientFailure> {
-		self.execute(
-			CommandPayload::UseAccountInCodex { account_id },
-			Some(expected_account_revision),
-			idempotency_key,
-		)
-		.await
-	}
-
-	/// Execute one V2.6 lifecycle command exactly once on one connection.
+	/// Execute one exact-current lifecycle command exactly once on one connection.
 	pub async fn execute(
 		&self,
 		payload: CommandPayload,
@@ -1298,16 +1290,15 @@ impl AccountClient {
 	) -> Result<AccountCommandResponse, ClientFailure> {
 		self.transport.require_local_profile()?;
 		if !matches!(
-				&payload,
-				CommandPayload::EnrollAccountFromSharedCodex { .. }
-					| CommandPayload::ImportAccountCredentialFile { .. }
+			&payload,
+			CommandPayload::EnrollAccountFromSharedCodex { .. }
+				| CommandPayload::ImportAccountCredentialFile { .. }
 				| CommandPayload::SetAccountEnabled { .. }
 				| CommandPayload::LogoutAccount { .. }
-				| CommandPayload::SetFixedAccountSelection { .. }
+				| CommandPayload::RouteAccount { .. }
 				| CommandPayload::SetBalancedAccountSelection
 				| CommandPayload::SetAccountOrder { .. }
 				| CommandPayload::RefreshAccount { .. }
-				| CommandPayload::UseAccountInCodex { .. }
 				| CommandPayload::RecoverAccountOperation { .. }
 		) {
 			return Err(ClientFailure::ProtocolMalformed);
@@ -1328,8 +1319,9 @@ impl AccountClient {
 		};
 		match result {
 			Ok(response) => Ok(response),
-			Err(failure) if dispatch_attempted.load(Ordering::Acquire) =>
-				Ok(AccountCommandResponse::PotentiallyDispatched { failure }),
+			Err(failure) if dispatch_attempted.load(Ordering::Acquire) => {
+				Ok(AccountCommandResponse::PotentiallyDispatched { failure })
+			},
 			Err(failure) => Err(failure),
 		}
 	}
@@ -1393,13 +1385,17 @@ impl AccountClient {
 					) {
 						(CommandOutcome::Succeeded, Some(entity_revision), Some(result), None)
 							if account_result_matches(&payload, entity_revision, &result) =>
+						{
 							Ok(AccountCommandResponse::Applied {
 								entity_revision,
 								result: Box::new(result),
-							}),
+							})
+						},
 						(CommandOutcome::Rejected, None, None, Some(error))
 							if !matches!(error, CommandError::AcceptanceUnknown) =>
-							Ok(AccountCommandResponse::Rejected { error }),
+						{
+							Ok(AccountCommandResponse::Rejected { error })
+						},
 						(
 							CommandOutcome::AcceptanceUnknown,
 							None,
@@ -1413,8 +1409,9 @@ impl AccountClient {
 
 					return response.map(|value| CompletedOneShot::new(value, socket));
 				},
-				ServerMessage::Event(event) =>
-					self.transport.verify_version_and_server(event.version, &event.server_id)?,
+				ServerMessage::Event(event) => {
+					self.transport.verify_version_and_server(event.version, &event.server_id)?
+				},
 				ServerMessage::Refusal(refusal) => {
 					return Err(self.transport.refusal_failure(refusal));
 				},
@@ -1449,31 +1446,43 @@ fn account_result_matches(
 		| (
 			CommandPayload::RefreshAccount { account_id, .. },
 			ResultPayload::AccountChanged { account },
-		)
-			=> account_id == &account.account_id && entity_revision == account.account_revision,
+		) => account_id == &account.account_id && entity_revision == account.account_revision,
 		(
 			CommandPayload::EnrollAccountFromSharedCodex { account_id, .. }
 			| CommandPayload::ImportAccountCredentialFile { account_id, .. },
 			ResultPayload::AccountRestored { requested_account_id, account },
-		) =>
+		) => {
 			account_id == requested_account_id
 				&& account.account_id != *requested_account_id
-				&& entity_revision == account.account_revision,
+				&& entity_revision == account.account_revision
+		},
 		(
 			CommandPayload::LogoutAccount { account_id, .. },
 			ResultPayload::AccountLoggedOut { account_id: result_id, tombstone_revision },
 		) => account_id == result_id && *tombstone_revision == entity_revision,
 		(
-			CommandPayload::SetFixedAccountSelection { account_id, .. },
-			ResultPayload::AccountRoutingChanged { routing },
-		) =>
-			routing.revision == entity_revision
-				&& routing.mode == AccountSelectionModeDto::Fixed(account_id.clone()),
+			CommandPayload::RouteAccount { account_id, .. },
+			ResultPayload::AccountRouted { account, routing, projection_digest: _ },
+		) => {
+			account.account_id == *account_id
+				&& account.account_revision.0 > 0
+				&& routing.revision == entity_revision
+				&& routing.mode == AccountSelectionModeDto::Fixed(account_id.clone())
+		},
+		(
+			CommandPayload::RouteAccount { operation_id, account_id, .. },
+			ResultPayload::AccountRoutePending { pending },
+		) => {
+			pending.operation_id == *operation_id
+				&& pending.account_id == *account_id
+				&& pending.routing_revision == entity_revision
+		},
 		(
 			CommandPayload::SetBalancedAccountSelection,
 			ResultPayload::AccountRoutingChanged { routing },
-		) =>
-			routing.revision == entity_revision && routing.mode == AccountSelectionModeDto::Balanced,
+		) => {
+			routing.revision == entity_revision && routing.mode == AccountSelectionModeDto::Balanced
+		},
 		(
 			CommandPayload::SetAccountOrder { order },
 			ResultPayload::AccountRoutingChanged { routing },
@@ -1482,15 +1491,6 @@ fn account_result_matches(
 			CommandPayload::RecoverAccountOperation { operation_id, .. },
 			ResultPayload::AccountOperationRecovered { operation_id: result_id, .. },
 		) => operation_id == result_id,
-		(
-			CommandPayload::UseAccountInCodex { account_id },
-			ResultPayload::CodexAuthProjected {
-				account_id: result_id,
-				account_revision,
-				projection_digest: _,
-			},
-		) =>
-			account_id == result_id && entity_revision == *account_revision && entity_revision.0 > 0,
 		_ => false,
 	}
 }
@@ -1556,12 +1556,14 @@ impl Display for ClientFailure {
 			Self::ProfileMissing => "selected profile is missing",
 			Self::UnsafeHostPath => "client configuration path is unsafe",
 			Self::ServerIdentityUnavailable => "stable server identity is unavailable",
-			Self::RemoteMutationUnsupported =>
-				"reset-card operations require a local pinned profile",
+			Self::RemoteMutationUnsupported => {
+				"reset-card operations require a local pinned profile"
+			},
 			Self::LocalTransportDisabled => "local daemon transport is disabled",
 			Self::RemoteTransportDisabled => "remote daemon transport is disabled",
-			Self::LocalTransportUnsupported =>
-				"local daemon transport is unsupported on this platform",
+			Self::LocalTransportUnsupported => {
+				"local daemon transport is unsupported on this platform"
+			},
 			Self::UnsafeLocalEndpoint => "local daemon endpoint is unsafe",
 			Self::LocalPeerIdentityUnavailable => "local daemon peer identity is unavailable",
 			Self::LocalPeerUidMismatch => "local daemon peer UID does not match",
@@ -1574,8 +1576,9 @@ impl Display for ClientFailure {
 			Self::ProtocolMalformed => "daemon protocol response is malformed",
 			Self::ProtocolViolation => "daemon refused the protocol operation",
 			Self::ProtocolBackpressure => "daemon protocol backpressure limit was reached",
-			Self::ApplicationAcceptanceUnknown =>
-				"daemon could not establish whether application acceptance committed",
+			Self::ApplicationAcceptanceUnknown => {
+				"daemon could not establish whether application acceptance committed"
+			},
 		})
 	}
 }
@@ -1596,8 +1599,9 @@ fn map_config_error(error: ConfigError) -> ClientFailure {
 	match error {
 		ConfigError::UnsupportedVersion => ClientFailure::ConfigurationVersion,
 		ConfigError::MissingProfile => ClientFailure::ProfileMissing,
-		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) =>
-			ClientFailure::ConfigurationMissing,
+		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) => {
+			ClientFailure::ConfigurationMissing
+		},
 		ConfigError::Path(_) => ClientFailure::UnsafeHostPath,
 		_ => ClientFailure::ConfigurationMalformed,
 	}
@@ -1615,18 +1619,22 @@ fn map_identity_error(error: ConfigError) -> ClientFailure {
 fn map_local_transport_failure(failure: LocalTransportRefusal) -> ClientFailure {
 	match failure {
 		LocalTransportRefusal::Disabled => ClientFailure::LocalTransportDisabled,
-		LocalTransportRefusal::InvalidPolicy | LocalTransportRefusal::ConfigurationUnavailable =>
-			ClientFailure::ConfigurationMalformed,
+		LocalTransportRefusal::InvalidPolicy | LocalTransportRefusal::ConfigurationUnavailable => {
+			ClientFailure::ConfigurationMalformed
+		},
 		LocalTransportRefusal::UnsupportedPlatform => ClientFailure::LocalTransportUnsupported,
-		LocalTransportRefusal::EffectiveUidMismatch | LocalTransportRefusal::PeerUidMismatch =>
-			ClientFailure::LocalPeerUidMismatch,
+		LocalTransportRefusal::EffectiveUidMismatch | LocalTransportRefusal::PeerUidMismatch => {
+			ClientFailure::LocalPeerUidMismatch
+		},
 		LocalTransportRefusal::UnsafeDirectory
 		| LocalTransportRefusal::UnsafeEndpoint
 		| LocalTransportRefusal::EndpointReplaced => ClientFailure::UnsafeLocalEndpoint,
-		LocalTransportRefusal::PeerCredentialsUnavailable =>
-			ClientFailure::LocalPeerIdentityUnavailable,
-		LocalTransportRefusal::EndpointUnavailable | LocalTransportRefusal::EndpointInUse =>
-			ClientFailure::ProtocolDisconnected,
+		LocalTransportRefusal::PeerCredentialsUnavailable => {
+			ClientFailure::LocalPeerIdentityUnavailable
+		},
+		LocalTransportRefusal::EndpointUnavailable | LocalTransportRefusal::EndpointInUse => {
+			ClientFailure::ProtocolDisconnected
+		},
 	}
 }
 
@@ -1651,10 +1659,12 @@ fn map_receive_error(error: tokio_tungstenite::tungstenite::Error) -> ClientFail
 
 fn map_refusal(refusal: Refusal) -> ClientFailure {
 	match refusal {
-		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) =>
-			ClientFailure::ProtocolMajorMismatch,
-		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) =>
-			ClientFailure::ProtocolMinorMismatch,
+		Refusal::UnsupportedVersion(VersionRefusal::MajorMismatch { .. }) => {
+			ClientFailure::ProtocolMajorMismatch
+		},
+		Refusal::UnsupportedVersion(VersionRefusal::UnsupportedMinor { .. }) => {
+			ClientFailure::ProtocolMinorMismatch
+		},
 		Refusal::ArtifactCohortMismatch { .. } => ClientFailure::ArtifactCohortMismatch,
 		Refusal::ServerIdentityMismatch { .. } => ClientFailure::ServerIdentityMismatch,
 		Refusal::ProtocolViolation { .. } => ClientFailure::ProtocolViolation,
@@ -1672,7 +1682,8 @@ fn version_failure(version: ProtocolVersion) -> ClientFailure {
 
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 mod tests {
-	#[cfg(unix)] use std::os::unix::fs::PermissionsExt as _;
+	#[cfg(unix)]
+	use std::os::unix::fs::PermissionsExt as _;
 	use std::{fs, time::Duration};
 
 	use futures_util::{SinkExt as _, StreamExt as _};
@@ -1681,11 +1692,13 @@ mod tests {
 	use tokio_tungstenite::{self, tungstenite::Message};
 
 	use crate::{
-		AccountClient, AccountProfileDto, AccountProfileEmailDto, AccountProfileErrorDto,
-		AccountProfileResult, CURRENT_ARTIFACT_COHORT, CURRENT_VERSION, Channel, ClientCommandId,
-		ClientFailure,
-		ClientMessage, ClientProfile, CommandError, CommandOutcome, CommandReceipt,
-		CommandResultEnvelope, CorrelationId, Cursor, DoctorCheck, DoctorClient, DoctorComponent,
+		AccountClient, AccountCommandResponse, AccountProfileDto, AccountProfileEmailDto,
+		AccountProfileErrorDto,
+		AccountProfileResult, AccountRoutePendingDto, CURRENT_ARTIFACT_COHORT, CURRENT_VERSION,
+		Channel, ClientCommandId,
+		ClientFailure, ClientMessage, ClientProfile, CommandError, CommandOutcome, CommandPayload,
+		CommandReceipt, CommandResultEnvelope, CorrelationId, Cursor, DoctorCheck, DoctorClient,
+		DoctorComponent,
 		DoctorIssue, DoctorReport, DoctorStatus, EntityId, EntityRevision, EventEnvelope,
 		EventPayload, IdempotencyKey, LocalTransportAuthority, PREVIOUS_MINOR_VERSION, ProfileKind,
 		ProtocolVersion, QueryId, QueryResultEnvelope, QueryResultPayload, ReceiptDisposition,
@@ -1737,6 +1750,128 @@ mod tests {
 				.collect(),
 		)
 		.expect("test operation must succeed")
+	}
+
+	#[test]
+	fn account_route_pending_is_a_typed_success_for_the_exact_route() {
+		let operation_id =
+			EntityId::new("30000000-0000-4000-8000-000000000001").expect("operation ID");
+		let account_id =
+			EntityId::new("40000000-0000-4000-8000-000000000001").expect("account ID");
+		let command = CommandPayload::RouteAccount {
+			operation_id: operation_id.clone(),
+			account_id: account_id.clone(),
+			expected_account_revision: EntityRevision(7),
+		};
+		let result = ResultPayload::AccountRoutePending {
+			pending: AccountRoutePendingDto {
+				operation_id,
+				account_id,
+				routing_revision: EntityRevision(9),
+			},
+		};
+		assert!(super::account_result_matches(&command, EntityRevision(9), &result));
+		assert!(!super::account_result_matches(&command, EntityRevision(10), &result));
+	}
+
+	#[tokio::test]
+	async fn account_client_returns_pending_route_as_confirmed_applied_state() {
+		let (temp, authority) = local_transport();
+		let mut listener = authority.bind().await.expect("test listener must bind");
+		let operation_id =
+			EntityId::new("30000000-0000-4000-8000-000000000001").expect("operation ID");
+		let account_id =
+			EntityId::new("40000000-0000-4000-8000-000000000001").expect("account ID");
+		let expected_operation_id = operation_id.clone();
+		let expected_account_id = account_id.clone();
+		let task = tokio::spawn(async move {
+			let _temp = temp;
+			let stream = listener.accept().await.expect("test connection must arrive");
+			let mut socket =
+				tokio_tungstenite::accept_async(stream).await.expect("test socket must upgrade");
+			let _ = socket.next().await;
+			for response in initial(SERVER_ID) {
+				socket.send(response).await.expect("initial response must send");
+			}
+			let Message::Text(request) = socket
+				.next()
+				.await
+				.expect("command must arrive")
+				.expect("command must decode")
+			else {
+				panic!("expected text command")
+			};
+			let ClientMessage::Command(command) =
+				serde_json::from_str::<ClientMessage>(&request).expect("typed command")
+			else {
+				panic!("expected command")
+			};
+			assert!(matches!(
+				command.payload,
+				CommandPayload::RouteAccount {
+					ref operation_id,
+					ref account_id,
+					expected_account_revision: EntityRevision(7),
+				} if operation_id == &expected_operation_id && account_id == &expected_account_id
+			));
+			socket
+				.send(typed(ServerMessage::CommandReceipt(CommandReceipt {
+					version: CURRENT_VERSION,
+					server_id: ServerId::new(SERVER_ID).unwrap(),
+					client_command_id: command.client_command_id.clone(),
+					idempotency_key: command.idempotency_key.clone(),
+					disposition: ReceiptDisposition::Executed,
+					original_client_command_id: command.client_command_id.clone(),
+				})))
+				.await
+				.unwrap();
+			socket
+				.send(typed(ServerMessage::CommandResult(CommandResultEnvelope {
+					version: CURRENT_VERSION,
+					server_id: ServerId::new(SERVER_ID).unwrap(),
+					client_command_id: command.client_command_id,
+					idempotency_key: command.idempotency_key,
+					outcome: CommandOutcome::Succeeded,
+					entity_revision: Some(EntityRevision(9)),
+					payload: Some(ResultPayload::AccountRoutePending {
+						pending: AccountRoutePendingDto {
+							operation_id: expected_operation_id,
+							account_id: expected_account_id,
+							routing_revision: EntityRevision(9),
+						},
+					}),
+					error: None,
+				})))
+				.await
+				.unwrap();
+			drop(socket);
+			listener.cleanup().unwrap();
+		});
+		let response = AccountClient::new(ClientProfile::fixture(
+			authority,
+			ServerId::new(SERVER_ID).unwrap(),
+		))
+		.route_account(
+			operation_id.clone(),
+			account_id.clone(),
+			EntityRevision(7),
+			EntityRevision(9),
+			IdempotencyKey::new("pending-route-key").unwrap(),
+		)
+		.await
+		.unwrap();
+		assert!(matches!(
+			response,
+			AccountCommandResponse::Applied {
+				entity_revision: EntityRevision(9),
+				result,
+			} if matches!(
+				&*result,
+				ResultPayload::AccountRoutePending { pending }
+					if pending.operation_id == operation_id && pending.account_id == account_id
+			)
+		));
+		task.await.unwrap();
 	}
 
 	fn profile_result(account_id: &str, email: AccountProfileEmailDto) -> AccountProfileResult {
@@ -1935,12 +2070,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_6_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 6 });
+	fn protocol_constants_expose_only_the_exact_v2_9_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 9 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 6, maximum_minor: 6 },
+			SupportedVersions { major: 2, minimum_minor: 9, maximum_minor: 9 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}
@@ -2345,10 +2480,7 @@ max_entry_bytes = 0
 				ClientFailure::ProtocolMinorMismatch,
 			),
 			(
-				Refusal::ArtifactCohortMismatch {
-					expected: CURRENT_ARTIFACT_COHORT,
-					actual: None,
-				},
+				Refusal::ArtifactCohortMismatch { expected: CURRENT_ARTIFACT_COHORT, actual: None },
 				ClientFailure::ArtifactCohortMismatch,
 			),
 			(
@@ -3105,26 +3237,6 @@ max_entry_bytes = 0
 			.unwrap_err();
 
 		assert_eq!(failure, ClientFailure::ProtocolDisconnected);
-	}
-
-	#[test]
-	fn use_account_in_codex_result_requires_exact_account_and_revision() {
-		let account_id =
-			EntityId::new("41234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
-		let command = crate::CommandPayload::UseAccountInCodex { account_id: account_id.clone() };
-		let exact = ResultPayload::CodexAuthProjected {
-			account_id: account_id.clone(),
-			account_revision: EntityRevision(11),
-			projection_digest: crate::Sha256Digest::new("a".repeat(64)).unwrap(),
-		};
-		let stale = ResultPayload::CodexAuthProjected {
-			account_id,
-			account_revision: EntityRevision(10),
-			projection_digest: crate::Sha256Digest::new("a".repeat(64)).unwrap(),
-		};
-
-		assert!(super::account_result_matches(&command, EntityRevision(11), &exact));
-		assert!(!super::account_result_matches(&command, EntityRevision(11), &stale));
 	}
 
 	#[tokio::test]

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -27,11 +27,11 @@ pub use self::{
 		DoctorReport, DoctorStatus, MAX_DOCTOR_CHECKS,
 	},
 	domain_pack::{
-		DomainEntityDto, DomainEntityFieldDto, DomainPackCapabilityDto,
+		DEVELOPMENT_DOMAIN_PACK_ID, DomainEntityDto, DomainEntityFieldDto, DomainPackCapabilityDto,
 		DomainPackCapabilityStatus, DomainPackContractError, DomainPackDescriptorDto,
 		DomainPackProjectionDto, DomainPackViewKind, DomainRelationDto,
-		DEVELOPMENT_DOMAIN_PACK_ID, PAPER_INVESTMENT_DOMAIN_PACK_ID,
 		MAX_DOMAIN_PACK_CAPABILITIES, MAX_DOMAIN_PACK_ENTITIES, MAX_DOMAIN_PACK_RELATIONS,
+		PAPER_INVESTMENT_DOMAIN_PACK_ID,
 	},
 	local_transport::{
 		LocalTransportAuthority, LocalTransportListener, LocalTransportRefusal,
@@ -39,11 +39,11 @@ pub use self::{
 	},
 	program_cycle::{
 		MAX_PROGRAM_EDGES, MAX_PROGRAM_LIST_ITEMS, MAX_PROGRAM_LIST_VALUES, MAX_PROGRAM_NODES,
-			ProgramContinuationDraftDto, ProgramCycleContractError, ProgramCycleDraftDto,
-			ProgramCycleDto, ProgramCycleResult, ProgramEdgeDto, ProgramEvidenceDraftDto,
-			ProgramListResult, ProgramNodeDto,
-		ProgramNodeFieldDto, ProgramNodeKind, ProgramRelationKind, ProgramReviewClassification,
-		ProgramReviewDraftDto, ProgramState, ProgramSummaryDto,
+		ProgramContinuationDraftDto, ProgramCycleContractError, ProgramCycleDraftDto,
+		ProgramCycleDto, ProgramCycleResult, ProgramEdgeDto, ProgramEvidenceDraftDto,
+		ProgramListResult, ProgramNodeDto, ProgramNodeFieldDto, ProgramNodeKind,
+		ProgramRelationKind, ProgramReviewClassification, ProgramReviewDraftDto, ProgramState,
+		ProgramSummaryDto,
 	},
 	quick_task::{
 		MAX_QUICK_TASK_LIST_SIZE, MAX_QUICK_TASK_MODEL_BYTES,
@@ -64,24 +64,24 @@ pub use self::{
 		AccountObservedStateDto, AccountOperationKindDto, AccountOperationPhaseDto,
 		AccountProfileDailyUsageDto, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto, AccountProfileResult, AccountProviderDto, AccountQuotaErrorDto,
-		AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutingControlDto,
-		AccountSelectionModeDto, AccountSelectionRecoveryDto, AccountUnsettledOperationDto,
-		AccountsResult, CausationId, Channel, ClientCommandId, ClientHello, ClientMessage,
-		CodexAuthProjectionResult, CommandEnvelope, CommandError, CommandOutcome, CommandPayload,
-		CommandReceipt, CommandResultEnvelope, ConversationHistoryPage, ConversationHistoryResult,
-		CorrelationId, Cursor, EntityId, EntityRevision, EventEnvelope, EventPayload,
-		ExecutionConsumerDto, ExecutionDecisionDto, ExecutionDecisionQueryError,
-		ExecutionDecisionResult, ExecutionQuotaExclusionDto, ExecutionQuotaWindowDto,
-		ExecutionRouteBlockerDto, ExecutionRouteCauseDto, ExecutionRouteDto, HistoryArtifactId,
-		HistoryArtifactReference, HistoryArtifactRevision, HistoryBlobLength, HistoryBlobReference,
-		HistoryCursorToken, HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto,
-		HistoryMediaType, HistoryMetadata, HistoryMetadataValue, HistoryPayloadDto,
-		HistoryQueryError, HistorySideEffectState, HistoryText, HistoryTurnRole, IdempotencyKey,
-		IdempotencyKeyError, MAX_ACCOUNT_PROFILE_DAILY_USAGE, MAX_HISTORY_INLINE_BYTES,
-		MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
-		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
-		MAX_PROJECT_LIST_ITEMS, MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES,
-		MAX_WORK_ITEM_BOARD_OBJECTIVES, MAX_WORK_ITEM_BOARD_PAGE_SIZE,
+		AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutePendingDto,
+		AccountRoutingControlDto, AccountSelectionModeDto, AccountSelectionRecoveryDto,
+		AccountUnsettledOperationDto, AccountsResult, CausationId, Channel, ClientCommandId,
+		ClientHello, ClientMessage, CodexAuthProjectionResult, CommandEnvelope, CommandError,
+		CommandOutcome, CommandPayload, CommandReceipt, CommandResultEnvelope,
+		ConversationHistoryPage, ConversationHistoryResult, CorrelationId, Cursor, EntityId,
+		EntityRevision, EventEnvelope, EventPayload, ExecutionConsumerDto, ExecutionDecisionDto,
+		ExecutionDecisionQueryError, ExecutionDecisionResult, ExecutionQuotaExclusionDto,
+		ExecutionQuotaWindowDto, ExecutionRouteBlockerDto, ExecutionRouteCauseDto,
+		ExecutionRouteDto, HistoryArtifactId, HistoryArtifactReference, HistoryArtifactRevision,
+		HistoryBlobLength, HistoryBlobReference, HistoryCursorToken, HistoryItemDto,
+		HistoryItemKindDto, HistoryItemStatusDto, HistoryMediaType, HistoryMetadata,
+		HistoryMetadataValue, HistoryPayloadDto, HistoryQueryError, HistorySideEffectState,
+		HistoryText, HistoryTurnRole, IdempotencyKey, IdempotencyKeyError,
+		MAX_ACCOUNT_PROFILE_DAILY_USAGE, MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
+		MAX_HISTORY_METADATA_KEY_BYTES, MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE,
+		MAX_IDEMPOTENCY_KEY_BYTES, MAX_PROJECT_LIST_ITEMS, MAX_RESET_CARD_ITEMS,
+		MAX_WIRE_TEXT_BYTES, MAX_WORK_ITEM_BOARD_OBJECTIVES, MAX_WORK_ITEM_BOARD_PAGE_SIZE,
 		MAX_WORK_ITEM_BOARD_RELATIONS, MAX_WORK_ITEM_BOARD_TITLE_BYTES, ProjectList,
 		ProjectListContractError, ProjectListResult, ProjectSummary, QueryEnvelope, QueryId,
 		QueryPayload, QueryResultEnvelope, QueryResultPayload, ReceiptDisposition, ReconnectMode,
@@ -102,9 +102,9 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 6 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 9 };
 /// Build/protocol cohort that must agree across the daemon and every local consumer.
-pub const CURRENT_ARTIFACT_COHORT: u32 = 2;
+pub const CURRENT_ARTIFACT_COHORT: u32 = 5;
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -15,7 +15,8 @@ use std::{
 	fmt::{Debug, Display, Formatter},
 	path::{Path, PathBuf},
 };
-#[cfg(target_os = "macos")] use std::{fs::File, os::fd::RawFd};
+#[cfg(target_os = "macos")]
+use std::{fs::File, os::fd::RawFd};
 
 use decodex_core::{DecodexPaths, LocalTrustPolicy};
 
@@ -77,7 +78,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.6 local endpoint authority.
+/// The complete V2.9 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,
@@ -258,8 +259,9 @@ impl LocalTransportListener {
 	fn release(&mut self, report: bool) -> Result<(), LocalTransportRefusal> {
 		let result =
 			match (self.listener.as_ref(), self.binding.as_ref(), self.namespace_lock.as_ref()) {
-				(Some(listener), Some(binding), Some(namespace_lock)) =>
-					platform::remove_publication(&self.authority, listener, binding, namespace_lock),
+				(Some(listener), Some(binding), Some(namespace_lock)) => {
+					platform::remove_publication(&self.authority, listener, binding, namespace_lock)
+				},
 				_ => Err(LocalTransportRefusal::EndpointUnavailable),
 			};
 
@@ -335,8 +337,9 @@ impl Display for LocalTransportRefusal {
 			Self::InvalidPolicy => "local transport policy is invalid",
 			Self::ConfigurationUnavailable => "local transport configuration is unavailable",
 			Self::UnsupportedPlatform => "local peer identity is unsupported on this platform",
-			Self::EffectiveUidMismatch =>
-				"process effective UID does not match the local service owner",
+			Self::EffectiveUidMismatch => {
+				"process effective UID does not match the local service owner"
+			},
 			Self::UnsafeDirectory => "local endpoint directory is unsafe",
 			Self::UnsafeEndpoint => "local endpoint or namespace lock is unsafe",
 			Self::EndpointUnavailable => "local endpoint is unavailable",
@@ -448,7 +451,9 @@ mod platform {
 				if identity.file == initial.file
 					&& identity.links == initial.links
 					&& secure_socket(identity, authority.service_owner_uid) =>
-				identity,
+			{
+				identity
+			},
 			_ => {
 				directory.remove_if_file_identity(&namespace_lock, STAGE_NAME, initial);
 				drop(listener);

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.6 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.9 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -22,17 +22,16 @@ use serde_json::Error;
 
 use crate::{
 	AccountLoginRequestEnvelope, AccountLoginResponseEnvelope, DoctorReport, ProtocolVersion,
-	QuickTaskExecutionSettings, QuickTaskListCursor,
-	QuickTaskListResult, QuickTaskListSize, QuickTaskRecoveryAction, QuickTaskResult,
-	QuickTaskSummary, QuickTaskTurnOutcome, QuickTaskWorkingDirectory, SupportedVersions,
-	VersionRefusal,
+	QuickTaskExecutionSettings, QuickTaskListCursor, QuickTaskListResult, QuickTaskListSize,
+	QuickTaskRecoveryAction, QuickTaskResult, QuickTaskSummary, QuickTaskTurnOutcome,
+	QuickTaskWorkingDirectory, SupportedVersions, VersionRefusal,
 	program_cycle::{
 		ProgramContinuationDraftDto, ProgramCycleDraftDto, ProgramCycleDto, ProgramCycleResult,
 		ProgramListResult, ProgramReviewDraftDto,
 	},
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.6.
+/// Maximum UTF-8 size of any human-readable text carried by V2.9.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -157,7 +156,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded its V2.6 byte limit.
+/// A string-backed wire scalar exceeded its V2.9 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -178,7 +177,7 @@ impl Display for WireScalarTooLong {
 	}
 }
 
-/// Closed construction failures for the V2.6 WorkItem board contract.
+/// Closed construction failures for the V2.9 WorkItem board contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkItemBoardContractError {
 	/// An identity was not canonical lowercase RFC 9562 UUID-v4 text.
@@ -280,7 +279,7 @@ impl<'de> Deserialize<'de> for WorkItemBoardTitle {
 #[serde(transparent)]
 pub struct WorkItemBoardPageSize(u16);
 impl WorkItemBoardPageSize {
-	/// Construct a page size inside the closed V2.6 protocol bound.
+	/// Construct a page size inside the closed V2.9 protocol bound.
 	pub const fn new(value: u16) -> Result<Self, WorkItemBoardContractError> {
 		if value == 0 || value > MAX_WORK_ITEM_BOARD_PAGE_SIZE {
 			Err(WorkItemBoardContractError::InvalidPageSize)
@@ -445,8 +444,9 @@ impl Display for IdempotencyKeyError {
 		formatter.write_str(match self {
 			Self::Empty => "idempotency key is empty",
 			Self::TooLong => "idempotency key exceeds the 256-byte maximum",
-			Self::SurroundingWhitespace =>
-				"idempotency key contains leading or trailing whitespace",
+			Self::SurroundingWhitespace => {
+				"idempotency key contains leading or trailing whitespace"
+			},
 			Self::ControlCharacter => "idempotency key contains a control character",
 		})
 	}
@@ -559,7 +559,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.6 resume requires this field. Older hello envelopes can omit it
+	/// A V2.9 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -615,7 +615,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.6 welcome.
+	/// This is present in the exact-current V2.9 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1745,7 +1745,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.6 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.9 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -1914,6 +1914,70 @@ pub struct AccountRoutingControlDto {
 	/// Complete deterministic order of visible accounts.
 	pub order: Vec<EntityId>,
 }
+
+/// Durable daemon-owned Route intent that has not acquired shared-auth writer authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountRoutePendingDto {
+	/// Stable Route operation identity.
+	pub operation_id: EntityId,
+	/// Desired account identity.
+	pub account_id: EntityId,
+	/// Routing revision fenced when the intent was accepted.
+	pub routing_revision: EntityRevision,
+}
+
+impl Serialize for AccountRoutePendingDto {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if !is_canonical_uuid(self.operation_id.as_str())
+			|| !is_canonical_uuid(self.account_id.as_str())
+			|| self.routing_revision.0 == 0
+		{
+			return Err(S::Error::custom("pending account Route is invalid"));
+		}
+		#[derive(Serialize)]
+		struct Raw<'a> {
+			operation_id: &'a EntityId,
+			account_id: &'a EntityId,
+			routing_revision: EntityRevision,
+		}
+		Raw {
+			operation_id: &self.operation_id,
+			account_id: &self.account_id,
+			routing_revision: self.routing_revision,
+		}
+		.serialize(serializer)
+	}
+}
+
+impl<'de> Deserialize<'de> for AccountRoutePendingDto {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		#[serde(deny_unknown_fields)]
+		struct Raw {
+			operation_id: EntityId,
+			account_id: EntityId,
+			routing_revision: EntityRevision,
+		}
+		let raw = Raw::deserialize(deserializer)?;
+		if !is_canonical_uuid(raw.operation_id.as_str())
+			|| !is_canonical_uuid(raw.account_id.as_str())
+			|| raw.routing_revision.0 == 0
+		{
+			return Err(D::Error::custom("pending account Route is invalid"));
+		}
+		Ok(Self {
+			operation_id: raw.operation_id,
+			account_id: raw.account_id,
+			routing_revision: raw.routing_revision,
+		})
+	}
+}
 impl Serialize for AccountRoutingControlDto {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -2015,10 +2079,12 @@ impl Serialize for AccountInitialSelectionResult {
 
 		validate_initial_selection_result(self).map_err(S::Error::custom)?;
 		let raw = match self {
-			Self::Selected { account_id, account_revision } =>
-				RawResult::Selected { account_id, account_revision: *account_revision },
-			Self::RecoveryRequired { account_id, action } =>
-				RawResult::RecoveryRequired { account_id, action: *action },
+			Self::Selected { account_id, account_revision } => {
+				RawResult::Selected { account_id, account_revision: *account_revision }
+			},
+			Self::RecoveryRequired { account_id, action } => {
+				RawResult::RecoveryRequired { account_id, action: *action }
+			},
 			Self::Unavailable => RawResult::Unavailable,
 		};
 		raw.serialize(serializer)
@@ -2038,10 +2104,12 @@ impl<'de> Deserialize<'de> for AccountInitialSelectionResult {
 		}
 
 		let result = match RawResult::deserialize(deserializer)? {
-			RawResult::Selected { account_id, account_revision } =>
-				Self::Selected { account_id, account_revision },
-			RawResult::RecoveryRequired { account_id, action } =>
-				Self::RecoveryRequired { account_id, action },
+			RawResult::Selected { account_id, account_revision } => {
+				Self::Selected { account_id, account_revision }
+			},
+			RawResult::RecoveryRequired { account_id, action } => {
+				Self::RecoveryRequired { account_id, action }
+			},
 			RawResult::Unavailable => Self::Unavailable,
 		};
 		validate_initial_selection_result(&result).map_err(D::Error::custom)?;
@@ -2069,6 +2137,8 @@ pub enum AccountsResult {
 		/// Routing controls with an exact account permutation, when that capability read
 		/// succeeded.
 		routing: Option<AccountRoutingControlDto>,
+		/// One authoritative pending Route intent, when Codex still owns shared auth.
+		pending_route: Option<AccountRoutePendingDto>,
 	},
 	/// The account authority could not return a safe snapshot.
 	Unavailable,
@@ -2170,13 +2240,22 @@ impl Serialize for AccountsResult {
 		#[derive(Serialize)]
 		#[serde(tag = "outcome", content = "data", rename_all = "snake_case")]
 		enum Raw<'a> {
-			Available { accounts: &'a [AccountDto], routing: Option<&'a AccountRoutingControlDto> },
+			Available {
+				accounts: &'a [AccountDto],
+				routing: Option<&'a AccountRoutingControlDto>,
+				pending_route: Option<&'a AccountRoutePendingDto>,
+			},
 			Unavailable,
 		}
 		let raw = match self {
-			Self::Available { accounts, routing } => {
-				validate_accounts_result(accounts, routing.as_ref()).map_err(S::Error::custom)?;
-				Raw::Available { accounts, routing: routing.as_ref() }
+			Self::Available { accounts, routing, pending_route } => {
+				validate_accounts_result(accounts, routing.as_ref(), pending_route.as_ref())
+					.map_err(S::Error::custom)?;
+				Raw::Available {
+					accounts,
+					routing: routing.as_ref(),
+					pending_route: pending_route.as_ref(),
+				}
 			},
 			Self::Unavailable => Raw::Unavailable,
 		};
@@ -2191,13 +2270,18 @@ impl<'de> Deserialize<'de> for AccountsResult {
 		#[derive(Deserialize)]
 		#[serde(tag = "outcome", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 		enum Raw {
-			Available { accounts: Vec<AccountDto>, routing: Option<AccountRoutingControlDto> },
+			Available {
+				accounts: Vec<AccountDto>,
+				routing: Option<AccountRoutingControlDto>,
+				pending_route: Option<AccountRoutePendingDto>,
+			},
 			Unavailable,
 		}
 		match Raw::deserialize(deserializer)? {
-			Raw::Available { accounts, routing } => {
-				validate_accounts_result(&accounts, routing.as_ref()).map_err(D::Error::custom)?;
-				Ok(Self::Available { accounts, routing })
+			Raw::Available { accounts, routing, pending_route } => {
+				validate_accounts_result(&accounts, routing.as_ref(), pending_route.as_ref())
+					.map_err(D::Error::custom)?;
+				Ok(Self::Available { accounts, routing, pending_route })
 			},
 			Raw::Unavailable => Ok(Self::Unavailable),
 		}
@@ -2276,7 +2360,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.6 protocol.
+/// Live queries available through the exact-current V2.9 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2378,7 +2462,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.6 protocol.
+/// Commands available through the exact-current V2.9 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2551,11 +2635,13 @@ pub enum CommandPayload {
 		/// Canonical account identity.
 		account_id: EntityId,
 	},
-	/// Select one fixed account under routing-control and account revision guards.
-	SetFixedAccountSelection {
-		/// Canonical fixed account identity.
+	/// Refresh, project, and select one account as one daemon-owned Route command.
+	RouteAccount {
+		/// Stable finite credential-refresh operation identity.
+		operation_id: EntityId,
+		/// Canonical routed account identity.
 		account_id: EntityId,
-		/// Exact optimistic revision of the fixed account.
+		/// Exact optimistic revision of the routed account before preparation.
 		expected_account_revision: EntityRevision,
 	},
 	/// Select balanced initial account routing under the routing-control revision guard.
@@ -2569,11 +2655,6 @@ pub enum CommandPayload {
 	RefreshAccount {
 		/// Stable finite lifecycle operation identity.
 		operation_id: EntityId,
-		/// Canonical account identity.
-		account_id: EntityId,
-	},
-	/// Project one exact daemon-owned account into the normal Codex shared auth file.
-	UseAccountInCodex {
 		/// Canonical account identity.
 		account_id: EntityId,
 	},
@@ -2753,21 +2834,26 @@ pub enum EventPayload {
 		/// Complete updated routing controls.
 		routing: AccountRoutingControlDto,
 	},
+	/// One daemon-owned Route command completed as one coherent projection.
+	AccountRouted {
+		/// Complete credential-negative routed account projection.
+		account: Box<AccountDto>,
+		/// Complete updated routing controls.
+		routing: AccountRoutingControlDto,
+		/// Credential-negative digest of the projected account binding.
+		projection_digest: Sha256Digest,
+	},
+	/// One daemon-owned Route intent is durable and waiting for natural Codex exit.
+	AccountRoutePending {
+		/// Complete credential-negative pending intent.
+		pending: AccountRoutePendingDto,
+	},
 	/// One explicit account-operation recovery action completed.
 	AccountOperationRecovered {
 		/// Stable recovered operation identity.
 		operation_id: EntityId,
 		/// Finite recovery disposition.
 		outcome: AccountManualRecoveryOutcomeDto,
-	},
-	/// One exact account credential was projected into Codex shared auth.
-	CodexAuthProjected {
-		/// Canonical projected account identity.
-		account_id: EntityId,
-		/// Exact unchanged account revision used for the projection.
-		account_revision: EntityRevision,
-		/// Credential-negative digest of the projected account binding.
-		projection_digest: Sha256Digest,
 	},
 }
 impl EventPayload {
@@ -2901,6 +2987,20 @@ pub enum ResultPayload {
 		/// Complete updated routing controls.
 		routing: AccountRoutingControlDto,
 	},
+	/// One daemon-owned Route command completed as one coherent projection.
+	AccountRouted {
+		/// Complete credential-negative routed account projection.
+		account: Box<AccountDto>,
+		/// Complete updated routing controls.
+		routing: AccountRoutingControlDto,
+		/// Credential-negative digest of the projected account binding.
+		projection_digest: Sha256Digest,
+	},
+	/// One Route action was accepted into daemon-owned background coordination.
+	AccountRoutePending {
+		/// Complete credential-negative pending intent.
+		pending: AccountRoutePendingDto,
+	},
 	/// One explicit credential-operation recovery action completed.
 	AccountOperationRecovered {
 		/// Stable recovered operation identity.
@@ -2908,18 +3008,16 @@ pub enum ResultPayload {
 		/// Finite recovery disposition.
 		outcome: AccountManualRecoveryOutcomeDto,
 	},
-	/// One exact account credential was projected into Codex shared auth.
-	CodexAuthProjected {
-		/// Canonical projected account identity.
-		account_id: EntityId,
-		/// Exact unchanged account revision used for the projection.
-		account_revision: EntityRevision,
-		/// Credential-negative digest of the projected account binding.
-		projection_digest: Sha256Digest,
-	},
 }
 
-/// Typed live-query results available through the exact-current V2.6 protocol.
+impl ResultPayload {
+	/// An evolving durable receipt must be replayed by the application, not transport memory.
+	pub const fn is_evolving_receipt(&self) -> bool {
+		matches!(self, Self::AccountRoutePending { .. })
+	}
+}
+
+/// Typed live-query results available through the exact-current V2.9 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -3827,6 +3925,10 @@ pub enum AccountCommandRejectionDto {
 	ProviderMismatch,
 	/// Another lifecycle gate prevents the request.
 	LifecycleUnready,
+	/// A live or uncertain Codex process may still own the shared refresh-token family.
+	SharedAuthOwnerBusy,
+	/// A newer explicit Route replaced this pending Route before shared-auth projection.
+	RouteSuperseded,
 	/// Routing order is not an exact visible-account permutation.
 	RoutingOrderInvalid,
 	/// An explicit reconciliation command is required.
@@ -3865,12 +3967,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.6 wire encoding.
+/// Serialize a message using the only V2.9 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.6 wire encoding.
+/// Parse a client message using the only V2.9 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -3884,25 +3986,35 @@ fn validate_client_message(message: &ClientMessage) -> Result<(), &'static str> 
 		ClientMessage::Hello(hello)
 			if hello.version == crate::CURRENT_VERSION
 				&& hello.resume.as_ref().is_some_and(|resume| resume.instance_id.is_none()) =>
-			Err("current protocol resume requires a publication instance"),
+		{
+			Err("current protocol resume requires a publication instance")
+		},
 		ClientMessage::Hello(_) => Ok(()),
 		ClientMessage::Query(query) => match &query.payload {
 			QueryPayload::GetProgramCycle { program_id }
 				if !is_canonical_uuid(program_id.as_str()) =>
-				Err("Program query identity is not canonical"),
+			{
+				Err("Program query identity is not canonical")
+			},
 			QueryPayload::ListQuickTasks { after, .. }
 				if after.as_ref().is_some_and(|cursor| {
 					!is_canonical_uuid(cursor.conversation_id().as_str())
 				}) =>
-				Err("Quick Task list cursor identity is not canonical"),
+			{
+				Err("Quick Task list cursor identity is not canonical")
+			},
 			QueryPayload::GetQuickTask { conversation_id }
 				if !is_canonical_uuid(conversation_id.as_str()) =>
-				Err("Quick Task conversation identity is not canonical"),
+			{
+				Err("Quick Task conversation identity is not canonical")
+			},
 			QueryPayload::GetResetCards { account_id }
 			| QueryPayload::InspectAccount { account_id }
 			| QueryPayload::GetAccountProfile { account_id, .. }
 				if !is_canonical_uuid(account_id.as_str()) =>
-				Err("account query identity is not canonical"),
+			{
+				Err("account query identity is not canonical")
+			},
 			_ => Ok(()),
 		},
 		ClientMessage::Command(command) => validate_account_command(command),
@@ -3970,12 +4082,13 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 				Err("reset-card account identity or revision is invalid")
 			}
 		},
-		CommandPayload::EnrollAccountFromSharedCodex { operation_id, account_id, .. } =>
+		CommandPayload::EnrollAccountFromSharedCodex { operation_id, account_id, .. } => {
 			validate_account_install_command(
 				operation_id,
 				account_id,
 				command.expected_revision.is_none(),
-			),
+			)
+		},
 		CommandPayload::ImportAccountCredentialFile {
 			operation_id,
 			account_id,
@@ -4004,21 +4117,20 @@ fn validate_account_command(command: &CommandEnvelope) -> Result<(), &'static st
 			validate_canonical_account(account_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
 		},
-		CommandPayload::UseAccountInCodex { account_id } => {
-			validate_canonical_account(account_id)?;
-			positive_expected.then_some(()).ok_or("account revision is required")
-		},
-		CommandPayload::SetFixedAccountSelection { account_id, expected_account_revision } => {
+		CommandPayload::RouteAccount { operation_id, account_id, expected_account_revision } => {
+			validate_canonical_operation(operation_id)?;
 			validate_canonical_account(account_id)?;
 			if !positive_expected || expected_account_revision.0 == 0 {
-				return Err("account routing or target account revision is invalid");
+				return Err("account Route revisions are invalid");
 			}
 			Ok(())
 		},
-		CommandPayload::SetBalancedAccountSelection =>
-			positive_expected.then_some(()).ok_or("account routing revision is required"),
-		CommandPayload::SetAccountOrder { order } =>
-			validate_account_order_command(order, positive_expected),
+		CommandPayload::SetBalancedAccountSelection => {
+			positive_expected.then_some(()).ok_or("account routing revision is required")
+		},
+		CommandPayload::SetAccountOrder { order } => {
+			validate_account_order_command(order, positive_expected)
+		},
 		CommandPayload::RecoverAccountOperation { operation_id, .. } => {
 			validate_canonical_operation(operation_id)?;
 			positive_expected.then_some(()).ok_or("account revision is required")
@@ -4084,7 +4196,7 @@ fn validate_work_item_command(command: &CommandEnvelope) -> Result<(), &'static 
 				Ok(())
 			}
 		},
-		CommandPayload::StartWorkItem { work_item_id, project_id, conversation_id } =>
+		CommandPayload::StartWorkItem { work_item_id, project_id, conversation_id } => {
 			if positive_expected
 				&& is_canonical_uuid(work_item_id.as_str())
 				&& is_canonical_uuid(project_id.as_str())
@@ -4093,7 +4205,8 @@ fn validate_work_item_command(command: &CommandEnvelope) -> Result<(), &'static 
 				Ok(())
 			} else {
 				Err("WorkItem start identity or revision is invalid")
-			},
+			}
+		},
 		CommandPayload::AcceptWorkItem {
 			work_item_id,
 			project_id,
@@ -4143,7 +4256,7 @@ fn validate_quick_task_command(command: &CommandEnvelope) -> Result<(), &'static
 				Err("Quick Task recovery identity or revision is invalid")
 			}
 		},
-		CommandPayload::SubmitQuickTaskTurn { conversation_id, turn_id, message, .. } =>
+		CommandPayload::SubmitQuickTaskTurn { conversation_id, turn_id, message, .. } => {
 			if positive_expected
 				&& is_canonical_uuid(conversation_id.as_str())
 				&& is_canonical_uuid(turn_id.as_str())
@@ -4152,7 +4265,8 @@ fn validate_quick_task_command(command: &CommandEnvelope) -> Result<(), &'static
 				Ok(())
 			} else {
 				Err("Quick Task turn identity, revision, or message is invalid")
-			},
+			}
+		},
 		CommandPayload::InterruptQuickTask { conversation_id, turn_id } => {
 			if positive_expected
 				&& is_canonical_uuid(conversation_id.as_str())
@@ -4235,8 +4349,9 @@ fn validate_initial_selection_result(
 				.then_some(())
 				.ok_or("selected account revision is not positive")
 		},
-		AccountInitialSelectionResult::RecoveryRequired { account_id, .. } =>
-			account_id.as_ref().map_or(Ok(()), validate_canonical_account),
+		AccountInitialSelectionResult::RecoveryRequired { account_id, .. } => {
+			account_id.as_ref().map_or(Ok(()), validate_canonical_account)
+		},
 		AccountInitialSelectionResult::Unavailable => Ok(()),
 	}
 }
@@ -4244,6 +4359,7 @@ fn validate_initial_selection_result(
 fn validate_accounts_result(
 	accounts: &[AccountDto],
 	routing: Option<&AccountRoutingControlDto>,
+	pending_route: Option<&AccountRoutePendingDto>,
 ) -> Result<(), &'static str> {
 	if accounts.len() > 512 {
 		return Err("account result exceeds cardinality bound");
@@ -4272,6 +4388,20 @@ fn validate_accounts_result(
 			&& !universe.contains(account_id.as_str())
 		{
 			return Err("fixed account target is outside the account universe");
+		}
+	}
+	if let Some(pending) = pending_route {
+		if !is_canonical_uuid(pending.operation_id.as_str())
+			|| !is_canonical_uuid(pending.account_id.as_str())
+			|| pending.routing_revision.0 == 0
+			|| !universe.contains(pending.account_id.as_str())
+		{
+			return Err("pending account Route is invalid");
+		}
+		if let Some(routing) = routing
+			&& pending.routing_revision != routing.revision
+		{
+			return Err("pending account Route revision is stale");
 		}
 	}
 	Ok(())
@@ -4508,7 +4638,9 @@ fn validate_quota_window(
 		(None, AccountQuotaStateDto::Unknown) => Ok(()),
 		(Some(observed), AccountQuotaStateDto::Current { used_percent, resets_at_unix_micros })
 			if observed > 0 && used_percent <= 100 && resets_at_unix_micros > observed =>
-			Ok(()),
+		{
+			Ok(())
+		},
 		(Some(observed), AccountQuotaStateDto::Error { .. }) if observed > 0 => Ok(()),
 		_ => Err("account quota observation shape is invalid"),
 	}
@@ -4528,13 +4660,13 @@ mod tests {
 		AccountLifecycleReadinessDto, AccountObservationSignal, AccountObservedStateDto,
 		AccountProfileDailyUsageDto, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto, AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto,
-		AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId, CodexAuthProjectionResult,
-		CommandError, CorrelationId, EntityId, EventPayload, HistoryCursorToken, HistoryText,
-		IdempotencyKey, MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
-		MAX_HISTORY_METADATA_KEY_BYTES, MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE,
-		MAX_IDEMPOTENCY_KEY_BYTES, MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES,
-		MAX_WORK_ITEM_BOARD_PAGE_SIZE, ProgramContinuationDraftDto, ProgramCycleDraftDto, QueryId,
-		QueryResultPayload,
+		AccountRoutePendingDto, AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId,
+		CodexAuthProjectionResult, CommandError, CorrelationId, EntityId, EventPayload,
+		HistoryCursorToken, HistoryText, IdempotencyKey, MAX_HISTORY_INLINE_BYTES,
+		MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
+		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
+		MAX_RESET_CARD_ITEMS, MAX_WIRE_TEXT_BYTES, MAX_WORK_ITEM_BOARD_PAGE_SIZE,
+		ProgramContinuationDraftDto, ProgramCycleDraftDto, QueryId, QueryResultPayload,
 		QuickTaskRecoveryAction, QuickTaskState, QuickTaskSummary, QuickTaskWorkingDirectory,
 		ResetCardDescriptorDto, ResetCardOutcome, ResultPayload, ServerId, ServerInstanceId,
 		Sha256Digest, WireText, WorkItemBoardContractError, WorkItemBoardLeadId, WorkItemBoardPage,
@@ -4642,11 +4774,31 @@ mod tests {
 				seven_day_quota: unknown_quota(10_080),
 			}],
 			routing: None,
+			pending_route: None,
 		};
 
 		let encoded = serde_json::to_value(&result).expect("account rows should serialize");
 		assert!(encoded["data"]["routing"].is_null());
 		assert_eq!(serde_json::from_value::<AccountsResult>(encoded).unwrap(), result);
+	}
+
+	#[test]
+	fn pending_account_route_is_exact_typed_and_credential_negative() {
+		let pending = AccountRoutePendingDto {
+			operation_id: EntityId::new("33333333-3333-4333-8333-333333333333").unwrap(),
+			account_id: EntityId::new("11111111-1111-4111-8111-111111111111").unwrap(),
+			routing_revision: EntityRevision(9),
+		};
+		let payload = ResultPayload::AccountRoutePending { pending: pending.clone() };
+		let encoded = serde_json::to_value(&payload).unwrap();
+		assert_eq!(encoded["name"], "account_route_pending");
+		assert_eq!(encoded["data"]["pending"]["routing_revision"], 9);
+		assert_eq!(serde_json::from_value::<ResultPayload>(encoded).unwrap(), payload);
+		assert!(payload.is_evolving_receipt());
+
+		let mut invalid = serde_json::to_value(pending).unwrap();
+		invalid["routing_revision"] = serde_json::json!(0);
+		assert!(serde_json::from_value::<AccountRoutePendingDto>(invalid).is_err());
 	}
 
 	#[test]
@@ -4671,10 +4823,9 @@ mod tests {
 
 	#[test]
 	fn retired_credential_file_command_names_do_not_decode() {
-		for retired_name in [
-			"enroll_account_from_credential_file",
-			"reauthenticate_account_from_credential_file",
-		] {
+		for retired_name in
+			["enroll_account_from_credential_file", "reauthenticate_account_from_credential_file"]
+		{
 			assert!(
 				serde_json::from_value::<CommandPayload>(serde_json::json!({
 					"name": retired_name,
@@ -4783,9 +4934,7 @@ mod tests {
 			causation_id: None,
 			payload: CommandPayload::ContinueProgram { continuation: Box::new(continuation) },
 		});
-		assert!(
-			decode_client_message(&serde_json::to_string(&missing_revision).unwrap()).is_err()
-		);
+		assert!(decode_client_message(&serde_json::to_string(&missing_revision).unwrap()).is_err());
 
 		let mut invalid = draft;
 		invalid.work_item_id = invalid.objective_id.clone();
@@ -4956,12 +5105,15 @@ mod tests {
 	}
 
 	#[test]
-	fn account_routing_commands_have_three_clean_break_wire_shapes() {
+	fn account_routing_commands_have_one_route_and_two_policy_wire_shapes() {
 		let account_id =
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let other_id =
 			EntityId::new("11234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
-		let fixed = CommandPayload::SetFixedAccountSelection {
+		let operation_id =
+			EntityId::new("21234567-89ab-4def-8123-456789abcdef").expect("canonical operation ID");
+		let route = CommandPayload::RouteAccount {
+			operation_id: operation_id.clone(),
 			account_id: account_id.clone(),
 			expected_account_revision: EntityRevision(7),
 		};
@@ -4970,10 +5122,11 @@ mod tests {
 			CommandPayload::SetAccountOrder { order: vec![other_id.clone(), account_id.clone()] };
 
 		assert_eq!(
-			serde_json::to_value(&fixed).unwrap(),
+			serde_json::to_value(&route).unwrap(),
 			serde_json::json!({
-				"name": "set_fixed_account_selection",
+				"name": "route_account",
 				"arguments": {
+					"operation_id": operation_id.as_str(),
 					"account_id": account_id.as_str(),
 					"expected_account_revision": 7,
 				},
@@ -5018,7 +5171,8 @@ mod tests {
 			decode_client_message(&encoded).is_err()
 		};
 		assert!(is_rejected(
-			CommandPayload::SetFixedAccountSelection {
+			CommandPayload::RouteAccount {
+				operation_id,
 				account_id: account_id.clone(),
 				expected_account_revision: EntityRevision(0),
 			},
@@ -5056,49 +5210,14 @@ mod tests {
 			}),
 		);
 		assert_eq!(serde_json::from_value::<CommandError>(encoded).unwrap(), duplicate_provider);
-	}
 
-	#[test]
-	fn use_account_in_codex_is_a_separate_credential_negative_command() {
-		let account_id =
-			EntityId::new("21234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
-		let command = CommandPayload::UseAccountInCodex { account_id: account_id.clone() };
-		let result = ResultPayload::CodexAuthProjected {
-			account_id: account_id.clone(),
-			account_revision: EntityRevision(9),
-			projection_digest: Sha256Digest::new("a".repeat(64)).unwrap(),
+		let superseded = CommandError::AccountCommandRejected {
+			rejection: AccountCommandRejectionDto::RouteSuperseded,
+			actual_revision: None,
 		};
-
 		assert_eq!(
-			serde_json::to_value(&command).unwrap(),
-			serde_json::json!({
-				"name": "use_account_in_codex",
-				"arguments": {"account_id": account_id.as_str()},
-			}),
-		);
-		assert_eq!(
-			serde_json::to_value(&result).unwrap(),
-			serde_json::json!({
-				"name": "codex_auth_projected",
-				"data": {
-					"account_id": account_id.as_str(),
-					"account_revision": 9,
-					"projection_digest": "a".repeat(64),
-				},
-			}),
-		);
-		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 1, minor: 5 }));
-		assert!(!command.is_supported_in(crate::ProtocolVersion { major: 2, minor: 4 }));
-		assert!(command.is_supported_in(CURRENT_VERSION));
-		assert!(
-			serde_json::from_value::<CommandPayload>(serde_json::json!({
-				"name": "use_account_in_codex",
-				"arguments": {
-					"account_id": account_id.as_str(),
-					"route": true,
-				},
-			}))
-			.is_err(),
+			serde_json::to_value(superseded).unwrap()["rejection"],
+			"route_superseded",
 		);
 	}
 
@@ -5512,8 +5631,8 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":6},"#,
-				r#""artifact_cohort":2,"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":9},"#,
+				r#""artifact_cohort":5,"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -5522,7 +5641,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":6},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":9},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -5564,7 +5683,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":6},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":9},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5807,7 +5926,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 7 };
+		let future = crate::ProtocolVersion { major: 2, minor: 10 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/account_import.rs
+++ b/crates/decodex-runtime/src/account_import.rs
@@ -190,7 +190,9 @@ struct ExpiryClaims {
 	exp: i64,
 }
 
-fn parse_shared_codex(bytes: &[u8]) -> Result<ImportedCredential, CredentialImportError> {
+pub(crate) fn parse_shared_codex(
+	bytes: &[u8],
+) -> Result<ImportedCredential, CredentialImportError> {
 	let mut auth: SharedCodexAuth =
 		serde_json::from_slice(bytes).map_err(|_| CredentialImportError::InvalidCredential)?;
 	if auth.auth_mode.as_deref().is_some_and(|mode| mode != "chatgpt")

--- a/crates/decodex-runtime/src/account_login.rs
+++ b/crates/decodex-runtime/src/account_login.rs
@@ -32,8 +32,7 @@ use crate::{
 	application::{
 		account_changed_publication, account_enrollment_publication,
 		account_lifecycle_command_error, decode_account_command_receipt,
-		encode_account_command_receipt,
-		map_account_store_command_error as map_store_error,
+		encode_account_command_receipt, map_account_store_command_error as map_store_error,
 	},
 };
 
@@ -151,9 +150,8 @@ impl AccountLoginManager {
 		let worker_start = start.clone();
 		let authority = self.authority.clone();
 		let provider = self.provider.clone();
-		let worker = thread::Builder::new()
-			.name("decodexd-account-login".to_owned())
-			.spawn(move || {
+		let worker =
+			thread::Builder::new().name("decodexd-account-login".to_owned()).spawn(move || {
 				let result = run_login_session(
 					&worker_shared,
 					worker_start,
@@ -197,9 +195,8 @@ impl AccountLoginManager {
 	async fn cancel(&self, session_id: &EntityId) -> AccountLoginStatus {
 		let (shared, worker) = {
 			let mut slot = self.lock_session();
-			let Some(session) = slot
-				.as_mut()
-				.filter(|session| &session.start.session_id == session_id)
+			let Some(session) =
+				slot.as_mut().filter(|session| &session.start.session_id == session_id)
 			else {
 				return failed(session_id.clone(), AccountLoginFailure::SessionNotFound);
 			};
@@ -209,10 +206,7 @@ impl AccountLoginManager {
 		if let Some(worker) = worker
 			&& !join_worker(worker).await
 		{
-			shared.set_status(failed(
-				session_id.clone(),
-				AccountLoginFailure::ServiceUnavailable,
-			));
+			shared.set_status(failed(session_id.clone(), AccountLoginFailure::ServiceUnavailable));
 		}
 		let current = shared.status();
 		if is_terminal(&current) {
@@ -239,11 +233,7 @@ impl AccountLoginManager {
 			let Some(session) = slot.as_mut() else {
 				return;
 			};
-			(
-				Arc::clone(&session.shared),
-				session.start.session_id.clone(),
-				session.worker.take(),
-			)
+			(Arc::clone(&session.shared), session.start.session_id.clone(), session.worker.take())
 		};
 		if let Some(worker) = worker
 			&& !join_worker(worker).await
@@ -281,11 +271,11 @@ impl Drop for AccountLoginManager {
 				session.worker.take()
 			});
 		if let Some(worker) = worker {
-			let _ = thread::Builder::new()
-				.name("decodexd-account-login-drop".to_owned())
-				.spawn(move || {
+			let _ = thread::Builder::new().name("decodexd-account-login-drop".to_owned()).spawn(
+				move || {
 					let _ = worker.join();
-				});
+				},
+			);
 		}
 	}
 }
@@ -327,14 +317,7 @@ fn run_login_session(
 		let status = if is_terminal(&current) {
 			current
 		} else if error == ProviderError::Cancelled {
-			status(
-				session_id.clone(),
-				AccountLoginState::Cancelled,
-				None,
-				None,
-				None,
-				None,
-			)
+			status(session_id.clone(), AccountLoginState::Cancelled, None, None, None, None)
 		} else {
 			failed(session_id.clone(), map_provider_error(error))
 		};
@@ -348,14 +331,8 @@ fn run_login_session(
 		},
 	};
 	if shared.cancellation.is_cancelled() {
-		let status = status(
-			session_id.clone(),
-			AccountLoginState::Cancelled,
-			None,
-			None,
-			None,
-			None,
-		);
+		let status =
+			status(session_id.clone(), AccountLoginState::Cancelled, None, None, None, None);
 		return finalize_login_status(&mut home, session_id, status);
 	}
 	shared.set_status(status(
@@ -413,10 +390,7 @@ fn publish_provider_event(shared: &Shared, session_id: &EntityId, event: LoginEv
 	match converted {
 		Ok(status) => shared.set_status(status),
 		Err(_) => {
-			shared.set_status(failed(
-				session_id.clone(),
-				AccountLoginFailure::LoginFailed,
-			));
+			shared.set_status(failed(session_id.clone(), AccountLoginFailure::LoginFailed));
 			shared.cancellation.cancel();
 		},
 	}
@@ -502,8 +476,8 @@ impl AccountLoginInstallAuthority {
 			AccountLoginInstallMode::Enroll { idempotency_key, .. }
 			| AccountLoginInstallMode::Reauthenticate { idempotency_key, .. } => idempotency_key,
 		};
-		let identity = CommandIdentity::new(idempotency_key.as_str(), &request)
-			.map_err(map_store_error)?;
+		let identity =
+			CommandIdentity::new(idempotency_key.as_str(), &request).map_err(map_store_error)?;
 		let claim = self
 			.store
 			.reserve_account_command(&identity, kind, &entity_id, expected_revision)
@@ -511,8 +485,10 @@ impl AccountLoginInstallAuthority {
 			.map_err(map_store_error)?;
 		let lease = match claim {
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(value) => {
-				return decode_account_command_receipt(value).map_err(|_| CommandError::AcceptanceUnknown)?;
+			AccountCommandReceiptClaim::Pending(value)
+			| AccountCommandReceiptClaim::Replayed(value) => {
+				return decode_account_command_receipt(value)
+					.map_err(|_| CommandError::AcceptanceUnknown)?;
 			},
 		};
 		let source = credential_path.to_str().ok_or_else(invalid_request)?;
@@ -520,7 +496,8 @@ impl AccountLoginInstallAuthority {
 			AccountLoginInstallMode::Enroll { operation_id, account_id, enabled, .. } => {
 				let operation_id = AccountOperationId::new(operation_id.as_str())
 					.map_err(|_| invalid_request())?;
-				let account_id = AccountId::new(account_id.as_str()).map_err(|_| invalid_request())?;
+				let account_id =
+					AccountId::new(account_id.as_str()).map_err(|_| invalid_request())?;
 				let requested_account_id = account_id.clone();
 				self.accounts
 					.enroll_from_credential_file_command(
@@ -531,14 +508,14 @@ impl AccountLoginInstallAuthority {
 						source,
 						move |result| {
 							encode_account_command_receipt(
-								&result
-									.map_err(account_lifecycle_command_error)
-									.and_then(|account| {
+								&result.map_err(account_lifecycle_command_error).and_then(
+									|account| {
 										account_enrollment_publication(
 											&requested_account_id,
 											account.clone(),
 										)
-									}),
+									},
+								),
 							)
 						},
 					)
@@ -553,7 +530,8 @@ impl AccountLoginInstallAuthority {
 			} => {
 				let operation_id = AccountOperationId::new(operation_id.as_str())
 					.map_err(|_| invalid_request())?;
-				let account_id = AccountId::new(account_id.as_str()).map_err(|_| invalid_request())?;
+				let account_id =
+					AccountId::new(account_id.as_str()).map_err(|_| invalid_request())?;
 				let expected_revision = i64::try_from(expected_revision.0)
 					.ok()
 					.filter(|value| *value > 0)
@@ -573,11 +551,9 @@ impl AccountLoginInstallAuthority {
 						source,
 						|result| {
 							encode_account_command_receipt(
-								&result
-									.map_err(account_lifecycle_command_error)
-									.and_then(|account| {
-										account_changed_publication(account.clone())
-									}),
+								&result.map_err(account_lifecycle_command_error).and_then(
+									|account| account_changed_publication(account.clone()),
+								),
 							)
 						},
 					)
@@ -658,10 +634,11 @@ fn resolved_account_id(
 		| AccountLoginInstallMode::Reauthenticate { account_id, .. } => account_id,
 	};
 	match (&start.install_mode, result) {
-		(
-			AccountLoginInstallMode::Enroll { .. },
-			ResultPayload::AccountChanged { account },
-		) if &account.account_id == requested => Ok(account.account_id.clone()),
+		(AccountLoginInstallMode::Enroll { .. }, ResultPayload::AccountChanged { account })
+			if &account.account_id == requested =>
+		{
+			Ok(account.account_id.clone())
+		},
 		(
 			AccountLoginInstallMode::Enroll { .. },
 			ResultPayload::AccountRestored { requested_account_id, account },
@@ -689,28 +666,24 @@ fn map_install_error(error: &CommandError) -> AccountLoginFailure {
 				AccountLoginFailure::CredentialStoreUnavailable
 			},
 			AccountCommandRejectionDto::OperationNotFound
-			| AccountCommandRejectionDto::ManualRecoveryRequired => {
-				AccountLoginFailure::RecoveryChanged
-			},
+			| AccountCommandRejectionDto::ManualRecoveryRequired => AccountLoginFailure::RecoveryChanged,
 			AccountCommandRejectionDto::AccountNotFound
 			| AccountCommandRejectionDto::CredentialAbsent
 			| AccountCommandRejectionDto::LifecycleUnready
+			| AccountCommandRejectionDto::SharedAuthOwnerBusy
 			| AccountCommandRejectionDto::OperationUnsettled
 			| AccountCommandRejectionDto::InvalidRequest
 			| AccountCommandRejectionDto::AccountInUse
-			| AccountCommandRejectionDto::RoutingOrderInvalid => {
-				AccountLoginFailure::AccountUnavailable
-			},
-			AccountCommandRejectionDto::StaleRoutingControl => AccountLoginFailure::AccountChanged,
+			| AccountCommandRejectionDto::RoutingOrderInvalid => AccountLoginFailure::AccountUnavailable,
+			AccountCommandRejectionDto::StaleRoutingControl
+			| AccountCommandRejectionDto::RouteSuperseded => AccountLoginFailure::AccountChanged,
 		},
 		CommandError::AcceptanceUnknown => AccountLoginFailure::OutcomeUnknown,
 		CommandError::IdempotencyConflict
 		| CommandError::IdempotencyCapacityExceeded { .. }
 		| CommandError::ApplicationUnavailable { .. }
 		| CommandError::QuickTaskUnavailable { .. }
-		| CommandError::QuickTaskRecoveryRequired { .. } => {
-			AccountLoginFailure::ServiceUnavailable
-		},
+		| CommandError::QuickTaskRecoveryRequired { .. } => AccountLoginFailure::ServiceUnavailable,
 	}
 }
 
@@ -774,9 +747,7 @@ mod tests {
 				operation_id: entity("028f0f9e-7b6e-4a31-8f4c-1d2e3f405163"),
 				account_id: entity("038f0f9e-7b6e-4a31-8f4c-1d2e3f405164"),
 				expected_revision: EntityRevision(7),
-				recovery_operation_id: Some(entity(
-					"048f0f9e-7b6e-4a31-8f4c-1d2e3f405165",
-				)),
+				recovery_operation_id: Some(entity("048f0f9e-7b6e-4a31-8f4c-1d2e3f405165")),
 				idempotency_key: IdempotencyKey::new("account-login-fixture")
 					.expect("fixture idempotency key"),
 			},
@@ -803,23 +774,15 @@ mod tests {
 	#[tokio::test(flavor = "current_thread")]
 	async fn singleton_returns_same_session_and_rejects_another_active_session() {
 		let manager = AccountLoginManager::unavailable_for_test();
-		let first = start(
-			"018f0f9e-7b6e-4a31-8f4c-1d2e3f405162",
-			AccountLoginMethod::BrowserRedirect,
-		);
+		let first =
+			start("018f0f9e-7b6e-4a31-8f4c-1d2e3f405162", AccountLoginMethod::BrowserRedirect);
 		let shared = Arc::new(Shared::new(first.session_id.clone(), first.method));
-		*manager.lock_session() = Some(Session {
-			start: first.clone(),
-			shared: Arc::clone(&shared),
-			worker: None,
-		});
+		*manager.lock_session() =
+			Some(Session { start: first.clone(), shared: Arc::clone(&shared), worker: None });
 		let runtime = Handle::current();
 
 		assert_eq!(manager.start(first.clone(), runtime.clone()).await, shared.status());
-		let second = start(
-			"058f0f9e-7b6e-4a31-8f4c-1d2e3f405166",
-			AccountLoginMethod::DeviceCode,
-		);
+		let second = start("058f0f9e-7b6e-4a31-8f4c-1d2e3f405166", AccountLoginMethod::DeviceCode);
 		assert_eq!(
 			manager.start(second.clone(), runtime).await.failure,
 			Some(AccountLoginFailure::Busy)
@@ -829,10 +792,8 @@ mod tests {
 	#[tokio::test(flavor = "current_thread")]
 	async fn cancel_joins_off_runtime_after_terminal_cleanup() {
 		let manager = AccountLoginManager::unavailable_for_test();
-		let start = start(
-			"068f0f9e-7b6e-4a31-8f4c-1d2e3f405167",
-			AccountLoginMethod::BrowserRedirect,
-		);
+		let start =
+			start("068f0f9e-7b6e-4a31-8f4c-1d2e3f405167", AccountLoginMethod::BrowserRedirect);
 		let shared = Arc::new(Shared::new(start.session_id.clone(), start.method));
 		let worker_shared = Arc::clone(&shared);
 		let worker_session_id = start.session_id.clone();
@@ -854,19 +815,17 @@ mod tests {
 				None,
 			));
 		});
-		*manager.lock_session() = Some(Session {
-			start: start.clone(),
-			shared,
-			worker: Some(worker),
-		});
+		*manager.lock_session() =
+			Some(Session { start: start.clone(), shared, worker: Some(worker) });
 
 		tokio::spawn(async move {
 			tokio::task::yield_now().await;
 			let _ = release_sender.send(());
 		});
-		let result = tokio::time::timeout(Duration::from_secs(1), manager.cancel(&start.session_id))
-			.await
-			.expect("current-thread cancellation must not deadlock");
+		let result =
+			tokio::time::timeout(Duration::from_secs(1), manager.cancel(&start.session_id))
+				.await
+				.expect("current-thread cancellation must not deadlock");
 
 		assert_eq!(result.state, AccountLoginState::Cancelled);
 		assert!(manager.lock_session().as_ref().is_some_and(|session| session.worker.is_none()));
@@ -875,10 +834,7 @@ mod tests {
 	#[tokio::test(flavor = "current_thread")]
 	async fn shutdown_signals_then_joins_off_runtime() {
 		let manager = AccountLoginManager::unavailable_for_test();
-		let start = start(
-			"088f0f9e-7b6e-4a31-8f4c-1d2e3f405169",
-			AccountLoginMethod::DeviceCode,
-		);
+		let start = start("088f0f9e-7b6e-4a31-8f4c-1d2e3f405169", AccountLoginMethod::DeviceCode);
 		let shared = Arc::new(Shared::new(start.session_id.clone(), start.method));
 		let worker_shared = Arc::clone(&shared);
 		let runtime = Handle::current();
@@ -908,10 +864,7 @@ mod tests {
 	#[test]
 	fn manager_drop_cancels_and_reaps_its_worker_off_thread() {
 		let manager = AccountLoginManager::unavailable_for_test();
-		let start = start(
-			"078f0f9e-7b6e-4a31-8f4c-1d2e3f405168",
-			AccountLoginMethod::DeviceCode,
-		);
+		let start = start("078f0f9e-7b6e-4a31-8f4c-1d2e3f405168", AccountLoginMethod::DeviceCode);
 		let shared = Arc::new(Shared::new(start.session_id.clone(), start.method));
 		let worker_shared = Arc::clone(&shared);
 		let settled = Arc::new(AtomicBool::new(false));

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -14,8 +14,9 @@ use std::{
 use decodex_core::{
 	AccountId, AccountLifecycleReadiness, AccountOperation, AccountOperationId,
 	AccountOperationKind, AccountOperationPhase, AccountProvider, AccountRecord,
-	AccountSelectionMode, AccountSelectionRecovery, CredentialBinding, CredentialVersion,
-	ProcessGenerationAccountBinding, ProcessGenerationId, ProcessGenerationState, ProviderIdentity,
+	AccountRoutingControl, AccountSelectionMode, AccountSelectionRecovery, CredentialBinding,
+	CredentialVersion, ProcessGenerationAccountBinding, ProcessGenerationId,
+	ProcessGenerationState, ProviderIdentity,
 };
 use decodex_database::{
 	AccountAdministrationOutcome, AccountCommandReceiptLease, AccountEnrollmentResolution,
@@ -25,7 +26,7 @@ use decodex_database::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, OwnedMutexGuard, broadcast};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
@@ -34,12 +35,12 @@ use crate::{
 		read_explicit_credential_file, read_explicit_shared_codex_credential_file,
 		read_shared_codex_credential,
 	},
-	auth_projection::{
-		CodexAuthProjectionError, SharedCodexAuthIdentity, project_shared_codex_auth,
-		read_shared_codex_auth_identity, shared_codex_auth_matches,
-	},
+	auth_projection::{CodexAuthProjectionError, SharedCodexAuthSnapshot, SharedCodexAuthVersion},
 	host_credentials::{
 		CredentialSecretBundle, CredentialStoreError, HostCredentialStore, StoredCredential,
+	},
+	shared_auth_coordinator::{
+		CodexLiveness, SharedAuthCoordinator, StableSharedAuthPoll, StableSharedAuthRead,
 	},
 };
 
@@ -51,6 +52,8 @@ const PROVIDER_REFRESH_OUTCOME_UNKNOWN: &str = "provider_refresh_outcome_unknown
 const TOMBSTONE_ENROLLMENT_COLLISION: &str = "tombstone_enrollment_collision";
 const ACCOUNT_ALIAS_DOMAIN: &[u8] = b"decodex/account-alias/v2\0";
 const CODEX_AUTH_PROJECTION_DOMAIN: &[u8] = b"decodex/codex-auth-projection/v1\0";
+const ROUTE_REFRESH_OPERATION_DOMAIN: &[u8] = b"decodex/route-refresh-operation/v1\0";
+const SHARED_AUTH_IMPORT_OPERATION_DOMAIN: &[u8] = b"decodex/shared-auth-import-operation/v1\0";
 const ACCOUNT_ALIAS_WORDS: [&str; 44] = [
 	"Alex", "Avery", "Bailey", "Blake", "Casey", "Charlie", "Clara", "Dana", "Drew", "Eden",
 	"Elliot", "Emery", "Evan", "Finley", "Harper", "Hayden", "Iris", "Jamie", "Jordan", "Kai",
@@ -97,19 +100,158 @@ fn codex_auth_projection_digest(account: &AccountRecord, binding: &CredentialBin
 	encoded
 }
 
+fn route_refresh_operation_id(
+	route_operation_id: &AccountOperationId,
+	account_id: &AccountId,
+) -> Result<AccountOperationId, AccountLifecycleError> {
+	let digest = Sha256::new()
+		.chain_update(ROUTE_REFRESH_OPERATION_DOMAIN)
+		.chain_update(route_operation_id.as_str().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(account_id.as_str().as_bytes())
+		.finalize();
+	operation_id_from_digest(&digest)
+}
+
+fn shared_auth_import_operation_id(
+	account_id: &AccountId,
+	current: &CredentialBinding,
+	bundle: &CredentialSecretBundle,
+) -> Result<AccountOperationId, AccountLifecycleError> {
+	let digest = Sha256::new()
+		.chain_update(SHARED_AUTH_IMPORT_OPERATION_DOMAIN)
+		.chain_update(account_id.as_str().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(current.fingerprint.as_str().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(bundle.access_token().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(bundle.refresh_token().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(bundle.id_token().unwrap_or_default().as_bytes())
+		.chain_update(b"\0")
+		.chain_update(bundle.access_token_expires_at_unix_micros().to_be_bytes())
+		.finalize();
+	operation_id_from_digest(&digest)
+}
+
+fn operation_id_from_digest(digest: &[u8]) -> Result<AccountOperationId, AccountLifecycleError> {
+	let mut bytes = [0_u8; 16];
+	bytes.copy_from_slice(&digest[..16]);
+	bytes[6] = (bytes[6] & 0x0f) | 0x50;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	AccountOperationId::new(format!(
+		"{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+		bytes[0],
+		bytes[1],
+		bytes[2],
+		bytes[3],
+		bytes[4],
+		bytes[5],
+		bytes[6],
+		bytes[7],
+		bytes[8],
+		bytes[9],
+		bytes[10],
+		bytes[11],
+		bytes[12],
+		bytes[13],
+		bytes[14],
+		bytes[15],
+	))
+	.map_err(|_| AccountLifecycleError::InvalidOperation)
+}
+
 pub(crate) struct CredentialRefreshResult {
 	returned_provider: ProviderIdentity,
 	bundle: CredentialSecretBundle,
 }
 
-type SharedAuthReprojector =
-	fn(&CredentialBinding, &CredentialSecretBundle) -> Result<(), AccountLifecycleError>;
+struct RefreshPlan {
+	allow_disabled: bool,
+	shared_family: SharedFamilyRefreshPolicy,
+	supplied_refresh: Option<CredentialRefreshResult>,
+}
+
+#[derive(Clone, Copy)]
+enum SharedFamilyRefreshPolicy {
+	Guard,
+	ProvedInactive,
+}
+
+impl RefreshPlan {
+	const ADMISSION: Self = Self {
+		allow_disabled: false,
+		shared_family: SharedFamilyRefreshPolicy::Guard,
+		supplied_refresh: None,
+	};
+	const EXISTING_WORK: Self = Self {
+		allow_disabled: true,
+		shared_family: SharedFamilyRefreshPolicy::Guard,
+		supplied_refresh: None,
+	};
+	const ROUTE_TARGET: Self = Self {
+		allow_disabled: false,
+		shared_family: SharedFamilyRefreshPolicy::ProvedInactive,
+		supplied_refresh: None,
+	};
+
+	fn route_source(supplied_refresh: CredentialRefreshResult) -> Self {
+		Self {
+			allow_disabled: true,
+			shared_family: SharedFamilyRefreshPolicy::Guard,
+			supplied_refresh: Some(supplied_refresh),
+		}
+	}
+}
 
 /// Credential-negative readback of the normal shared Codex auth projection.
 pub(crate) enum CodexAuthProjectionInspection {
 	Current { account_id: AccountId, account_revision: i64, projection_digest: String },
 	Unmanaged,
 	Unavailable,
+}
+
+/// Complete credential-negative result of one daemon-owned Route command.
+#[derive(Clone)]
+pub(crate) struct AccountRouteCommit {
+	pub(crate) account: AccountRecord,
+	pub(crate) routing: AccountRoutingControl,
+	pub(crate) projection_digest: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct AccountRouteCompletion {
+	pub(crate) operation_id: AccountOperationId,
+	pub(crate) commit: AccountRouteCommit,
+}
+
+/// Credential-negative accepted state while Codex retains shared-auth writer authority.
+pub(crate) struct AccountRoutePending {
+	pub(crate) operation_id: AccountOperationId,
+	pub(crate) account_id: AccountId,
+	pub(crate) routing_revision: i64,
+}
+
+pub(crate) enum AccountRouteResult {
+	Pending(AccountRoutePending),
+	Committed(Box<AccountRouteCommit>),
+}
+
+/// Closed failure passed to the Route publication builder before its receipt commits.
+pub(crate) enum AccountRouteFailure {
+	Lifecycle(AccountLifecycleError),
+	Routing(RoutingControlOutcome),
+}
+
+struct RouteSharedAuthSource {
+	account_id: AccountId,
+	credential: ImportedCredential,
+}
+
+struct RouteSharedAuthSnapshot {
+	version: SharedCodexAuthVersion,
+	source: Option<RouteSharedAuthSource>,
 }
 
 /// Provider refresh boundary. Implementations receive secrets only in short-lived memory.
@@ -233,6 +375,8 @@ fn credential_refresh_result(
 /// Provider refresh result classification without response bodies or tokens.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CredentialRefreshError {
+	/// A live or uncertain Codex owner may still hold the same refresh-token family.
+	OwnerBusy,
 	/// The provider adapter could not complete before an effect.
 	Unavailable,
 	/// The provider rejected the refresh request.
@@ -244,6 +388,7 @@ impl Error for CredentialRefreshError {}
 impl Display for CredentialRefreshError {
 	fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
 		formatter.write_str(match self {
+			Self::OwnerBusy => "shared Codex auth owner is still active",
 			Self::Unavailable => "credential refresh adapter unavailable",
 			Self::Rejected => "credential refresh rejected",
 			Self::Ambiguous => "credential refresh outcome ambiguous",
@@ -411,7 +556,10 @@ pub struct AccountService {
 	store: SqliteStore,
 	credentials: Arc<dyn HostCredentialStore>,
 	refresher: Arc<dyn CredentialRefreshPort>,
-	shared_auth_reprojector: SharedAuthReprojector,
+	shared_auth: Arc<SharedAuthCoordinator>,
+	route_events: broadcast::Sender<AccountRouteCompletion>,
+	route_command_lock: AsyncMutex<()>,
+	routing_lock: AsyncMutex<()>,
 	account_locks: Mutex<HashMap<AccountId, Arc<AsyncMutex<()>>>>,
 	callback_ready: AtomicBool,
 	callback_profile_sha256: Mutex<Option<String>>,
@@ -423,21 +571,115 @@ impl AccountService {
 		credentials: Arc<dyn HostCredentialStore>,
 		refresher: Arc<dyn CredentialRefreshPort>,
 	) -> Self {
+		let (route_events, _) = broadcast::channel(16);
 		Self {
 			store,
 			credentials,
 			refresher,
-			shared_auth_reprojector: reproject_shared_codex_auth_if_current,
+			shared_auth: Arc::new(SharedAuthCoordinator::production()),
+			route_events,
+			route_command_lock: AsyncMutex::new(()),
+			routing_lock: AsyncMutex::new(()),
 			account_locks: Mutex::new(HashMap::new()),
 			callback_ready: AtomicBool::new(false),
 			callback_profile_sha256: Mutex::new(None),
 		}
 	}
 
+	pub(crate) fn subscribe_route_events(&self) -> broadcast::Receiver<AccountRouteCompletion> {
+		self.route_events.subscribe()
+	}
+
+	pub(crate) async fn lock_route_command(&self) -> AsyncMutexGuard<'_, ()> {
+		self.route_command_lock.lock().await
+	}
+
 	#[cfg(test)]
-	fn with_shared_auth_reprojector(mut self, reprojector: SharedAuthReprojector) -> Self {
-		self.shared_auth_reprojector = reprojector;
+	fn with_shared_auth_coordinator(mut self, coordinator: Arc<SharedAuthCoordinator>) -> Self {
+		self.shared_auth = coordinator;
 		self
+	}
+
+	/// Import one stable known-account rotation and never interpret absence or failure as logout.
+	pub(crate) async fn follow_shared_auth_once(
+		&self,
+	) -> Result<Option<AccountRecord>, AccountLifecycleError> {
+		let StableSharedAuthPoll::Changed(snapshot) = self.shared_auth.poll_stable_change() else {
+			return Ok(None);
+		};
+		let crate::auth_projection::SharedCodexAuthSnapshot::Managed { credential, .. } = *snapshot
+		else {
+			return Ok(None);
+		};
+		self.import_known_shared_auth_rotation(credential).await
+	}
+
+	pub(crate) fn shared_auth_may_be_running(&self) -> bool {
+		self.shared_auth.liveness() == CodexLiveness::MayBeRunning
+	}
+
+	pub(crate) async fn shared_auth_is_current_for(&self, account_id: &AccountId) -> bool {
+		let Ok(lock) = self.lock_for(account_id) else {
+			return false;
+		};
+		let _guard = lock.lock().await;
+		let Ok(account) = self.load_account(account_id).await else {
+			return false;
+		};
+		let StableSharedAuthRead::Ready(snapshot) = self.shared_auth.read_current_stable() else {
+			return false;
+		};
+		self.confirm_shared_auth_target_locked(account_id, account.revision, &snapshot)
+			.await
+			.ok()
+			.flatten()
+			.is_some()
+	}
+
+	async fn import_known_shared_auth_rotation(
+		&self,
+		credential: ImportedCredential,
+	) -> Result<Option<AccountRecord>, AccountLifecycleError> {
+		let mut matches =
+			self.store.read_account_registry(None, MAX_ACCOUNT_READ).await?.into_iter().filter(
+				|account| {
+					!account.tombstoned
+						&& account
+							.credential
+							.as_ref()
+							.is_some_and(|binding| binding.provider == credential.provider)
+				},
+			);
+		let Some(candidate) = matches.next() else { return Ok(None) };
+		if matches.next().is_some() {
+			return Err(AccountLifecycleError::CoordinatorUnavailable);
+		}
+		let account_id = candidate.account_id;
+		let lock = self.lock_for(&account_id)?;
+		let _guard = lock.lock().await;
+		let account = self.load_account(&account_id).await?;
+		let binding = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
+		let stored = self.credentials.read_exact(&account_id, binding)?;
+		let Some(supplied_refresh) = matching_shared_refresh(
+			binding,
+			stored.bundle(),
+			current_unix_micros()?,
+			Ok(credential),
+		) else {
+			return Ok(None);
+		};
+		let operation_id =
+			shared_auth_import_operation_id(&account_id, binding, &supplied_refresh.bundle)?;
+		self.refresh_while_locked(
+			operation_id,
+			&account_id,
+			Some(account.revision),
+			None,
+			None,
+			RefreshPlan::route_source(supplied_refresh),
+		)
+		.await?;
+		self.load_account(&account_id).await.map(Some)
 	}
 
 	fn set_callback_capability(&self, profile_sha256: String, ready: bool) {
@@ -491,13 +733,18 @@ impl AccountService {
 
 	/// Match the safe shared Codex auth identity against current credential-negative bindings.
 	pub(crate) async fn codex_auth_projection(&self) -> CodexAuthProjectionInspection {
-		let provider_account_id = match read_shared_codex_auth_identity() {
-			Ok(SharedCodexAuthIdentity::Chatgpt { provider_account_id }) => provider_account_id,
-			Ok(SharedCodexAuthIdentity::Unmanaged) => {
-				return CodexAuthProjectionInspection::Unmanaged;
+		let credential = match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) => match *snapshot {
+				SharedCodexAuthSnapshot::Managed { credential, .. } => credential,
+				SharedCodexAuthSnapshot::Unmanaged { .. } => {
+					return CodexAuthProjectionInspection::Unmanaged;
+				},
 			},
-			Err(_) => return CodexAuthProjectionInspection::Unavailable,
+			StableSharedAuthRead::Waiting | StableSharedAuthRead::Unavailable => {
+				return CodexAuthProjectionInspection::Unavailable;
+			},
 		};
+		let provider_account_id = credential.provider.account_id();
 		let Ok(accounts) = self.store.read_account_registry(None, MAX_ACCOUNT_READ).await else {
 			return CodexAuthProjectionInspection::Unavailable;
 		};
@@ -536,20 +783,9 @@ impl AccountService {
 		let Ok(stored) = self.credentials.read_exact(&account.account_id, binding) else {
 			return CodexAuthProjectionInspection::Unavailable;
 		};
-		let Some(id_token) = stored.bundle().id_token() else {
-			return CodexAuthProjectionInspection::Unmanaged;
-		};
-		let Ok(identity) = decode_chatgpt_identity(id_token) else {
-			return CodexAuthProjectionInspection::Unmanaged;
-		};
-		if identity.provider != binding.provider {
+		if !same_refresh_bundle(stored.bundle(), &credential.bundle) {
 			return CodexAuthProjectionInspection::Unmanaged;
 		}
-		match shared_codex_auth_matches(stored.bundle(), binding.provider.account_id()) {
-			Ok(true) => {},
-			Ok(false) => return CodexAuthProjectionInspection::Unmanaged,
-			Err(_) => return CodexAuthProjectionInspection::Unavailable,
-		};
 		CodexAuthProjectionInspection::Current {
 			account_id: account.account_id.clone(),
 			account_revision: account.revision,
@@ -557,73 +793,521 @@ impl AccountService {
 		}
 	}
 
-	/// Project and durably complete one exact logical command while the account writer is held.
-	pub(crate) async fn use_account_in_codex_command<F>(
+	async fn shared_auth_route_source(
+		&self,
+		target_account_id: &AccountId,
+		target_binding: &CredentialBinding,
+		snapshot: SharedCodexAuthSnapshot,
+	) -> Result<RouteSharedAuthSnapshot, AccountLifecycleError> {
+		let (version, credential) = match snapshot {
+			SharedCodexAuthSnapshot::Managed { version, credential } => (version, credential),
+			SharedCodexAuthSnapshot::Unmanaged { version } => {
+				return Ok(RouteSharedAuthSnapshot { version, source: None });
+			},
+		};
+		if target_binding.provider == credential.provider {
+			return Ok(RouteSharedAuthSnapshot {
+				version,
+				source: Some(RouteSharedAuthSource {
+					account_id: target_account_id.clone(),
+					credential,
+				}),
+			});
+		}
+
+		let mut sources =
+			self.store.read_account_registry(None, MAX_ACCOUNT_READ).await?.into_iter().filter(
+				|account| {
+					!account.tombstoned
+						&& account
+							.credential
+							.as_ref()
+							.is_some_and(|binding| binding.provider == credential.provider)
+				},
+			);
+		let source = sources
+			.next()
+			.map(|account| account.account_id)
+			.ok_or(AccountLifecycleError::ProviderMismatch)?;
+		if sources.next().is_some() {
+			return Err(AccountLifecycleError::CoordinatorUnavailable);
+		}
+		Ok(RouteSharedAuthSnapshot {
+			version,
+			source: Some(RouteSharedAuthSource { account_id: source, credential }),
+		})
+	}
+
+	async fn reconcile_shared_auth_route_source(
+		&self,
+		route_operation_id: &AccountOperationId,
+		source: &RouteSharedAuthSource,
+	) -> Result<(), AccountLifecycleError> {
+		let lock = self.lock_for(&source.account_id)?;
+		let _guard = lock.lock().await;
+		self.reconcile_shared_auth_route_source_while_locked(route_operation_id, source).await
+	}
+
+	async fn reconcile_shared_auth_route_source_while_locked(
+		&self,
+		route_operation_id: &AccountOperationId,
+		source: &RouteSharedAuthSource,
+	) -> Result<(), AccountLifecycleError> {
+		let source_account_id = &source.account_id;
+		let source_operation_id =
+			route_refresh_operation_id(route_operation_id, source_account_id)?;
+		let account = self.load_account(source_account_id).await?;
+		if account.tombstoned {
+			return Err(AccountLifecycleError::NotReady(AccountLifecycleReadiness::Tombstoned));
+		}
+		if account.unsettled_operation.is_some() {
+			return Err(AccountLifecycleError::NotReady(
+				AccountLifecycleReadiness::OperationUnsettled,
+			));
+		}
+		let binding = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
+		let stored = self.credentials.read_exact(source_account_id, binding)?;
+		if binding.provider != source.credential.provider {
+			return Err(AccountLifecycleError::ProviderMismatch);
+		}
+		if same_refresh_bundle(stored.bundle(), &source.credential.bundle) {
+			return Ok(());
+		}
+		let supplied_refresh = matching_shared_refresh(
+			binding,
+			stored.bundle(),
+			current_unix_micros()?,
+			Ok(ImportedCredential {
+				provider: source.credential.provider.clone(),
+				bundle: source.credential.bundle.clone(),
+			}),
+		)
+		.ok_or(AccountLifecycleError::CoordinatorUnavailable)?;
+		self.refresh_while_locked(
+			source_operation_id,
+			source_account_id,
+			Some(account.revision),
+			None,
+			None,
+			RefreshPlan::route_source(supplied_refresh),
+		)
+		.await?;
+		Ok(())
+	}
+
+	/// Refresh, project, and select one account under one daemon-owned command receipt.
+	#[allow(clippy::too_many_arguments)] // Receipt, Route identity, two revision fences, resume state, and result builder are independent authority inputs.
+	pub(crate) async fn route_account_command<F>(
 		&self,
 		lease: AccountCommandReceiptLease,
+		operation_id: AccountOperationId,
 		account_id: &AccountId,
-		expected_revision: i64,
+		expected_account_revision: i64,
+		expected_routing_revision: i64,
+		resume_pending: bool,
 		build_response: F,
 	) -> Result<Value, AccountLifecycleError>
 	where
-		F: FnOnce(Result<(i64, String), AccountLifecycleError>) -> Result<Value, StoreError>
+		F: FnOnce(Result<AccountRouteResult, AccountRouteFailure>) -> Result<Value, StoreError>
 			+ Send
 			+ 'static,
 	{
+		let _routing_guard = self.routing_lock.lock().await;
+		let mut build_response = Some(build_response);
+		let routing = match self.store.read_account_routing_control().await {
+			Ok(routing) => routing,
+			Err(error) => {
+				return self
+					.complete_route_command_failure(
+						lease,
+						AccountRouteFailure::Lifecycle(error.into()),
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		if routing.revision != expected_routing_revision {
+			return self
+				.complete_route_command_failure(
+					lease,
+					AccountRouteFailure::Routing(RoutingControlOutcome::StaleRoutingControl {
+						revision: routing.revision,
+					}),
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
 		let lock = self.lock_for(account_id)?;
 		let _guard = lock.lock().await;
-		let result = use_in_codex_receipt_result(
-			self.use_account_in_codex_locked(account_id, expected_revision).await,
-		)?;
-		let response = build_response(result)?;
-		self.store.complete_account_command(lease, &response).await?;
+		let target_account = match self.load_account(account_id).await {
+			Ok(account) => account,
+			Err(error) => {
+				return self
+					.complete_route_command_failure(
+						lease,
+						AccountRouteFailure::Lifecycle(error),
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		let target_revision =
+			if !resume_pending || target_account.revision == expected_account_revision {
+				expected_account_revision
+			} else {
+				let derived = route_refresh_operation_id(&operation_id, account_id)?;
+				let operation = self.store.read_account_operation(&derived).await?;
+				let route_successor_is_exact = route_resume_revision_is_valid(
+					&target_account,
+					expected_account_revision,
+					&derived,
+					operation.as_ref(),
+				);
+				if !route_successor_is_exact {
+					return self
+						.complete_route_command_failure(
+							lease,
+							AccountRouteFailure::Lifecycle(AccountLifecycleError::StaleAccount),
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				}
+				target_account.revision
+			};
+		let target_binding = match projection_binding(&target_account, target_revision) {
+			Ok(binding) => binding.clone(),
+			Err(error) => {
+				return self
+					.complete_route_command_failure(
+						lease,
+						AccountRouteFailure::Lifecycle(error),
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		let stable = match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) => *snapshot,
+			StableSharedAuthRead::Waiting | StableSharedAuthRead::Unavailable => {
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		let shared_auth =
+			match self.shared_auth_route_source(account_id, &target_binding, stable).await {
+				Ok(source) => source,
+				Err(_) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+			};
+		let source_is_target =
+			shared_auth.source.as_ref().is_some_and(|source| &source.account_id == account_id);
+		if !source_is_target && self.shared_auth.liveness() != CodexLiveness::Quiescent {
+			return self
+				.defer_route_command(
+					lease,
+					operation_id,
+					account_id,
+					expected_routing_revision,
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
+		if let Some(source) = shared_auth.source.as_ref() {
+			let result = if source_is_target {
+				self.reconcile_shared_auth_route_source_while_locked(&operation_id, source).await
+			} else {
+				self.reconcile_shared_auth_route_source(&operation_id, source).await
+			};
+			if let Err(error) = result {
+				let _ = error;
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			}
+		}
+
+		if !source_is_target {
+			let target_operation_id = match route_refresh_operation_id(&operation_id, account_id) {
+				Ok(operation_id) => operation_id,
+				Err(error) => {
+					return self
+						.complete_route_command_failure(
+							lease,
+							AccountRouteFailure::Lifecycle(error),
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+			};
+			if let Err(error) = self
+				.refresh_while_locked(
+					target_operation_id,
+					account_id,
+					Some(expected_account_revision),
+					None,
+					None,
+					RefreshPlan::ROUTE_TARGET,
+				)
+				.await
+			{
+				return self
+					.complete_route_command_failure(
+						lease,
+						AccountRouteFailure::Lifecycle(error),
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			}
+		}
+		let routed_account = match self.load_account(account_id).await {
+			Ok(account) => account,
+			Err(error) => {
+				return self
+					.complete_route_command_failure(
+						lease,
+						AccountRouteFailure::Lifecycle(error),
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		if !source_is_target && self.shared_auth.liveness() != CodexLiveness::Quiescent {
+			return self
+				.defer_route_command(
+					lease,
+					operation_id,
+					account_id,
+					expected_routing_revision,
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
+		let final_source = match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) if snapshot.version() == &shared_auth.version => {
+				*snapshot
+			},
+			StableSharedAuthRead::Ready(_)
+			| StableSharedAuthRead::Waiting
+			| StableSharedAuthRead::Unavailable => {
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
+		let (projected_revision, projection_digest) = if source_is_target {
+			match self
+				.confirm_shared_auth_target_locked(
+					account_id,
+					routed_account.revision,
+					&final_source,
+				)
+				.await
+			{
+				Ok(Some(projection)) => projection,
+				Ok(None) | Err(AccountLifecycleError::CoordinatorUnavailable) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+				Err(error) => {
+					return self
+						.complete_route_command_failure(
+							lease,
+							AccountRouteFailure::Lifecycle(error),
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+			}
+		} else {
+			match self
+				.project_shared_auth_locked(account_id, routed_account.revision, &shared_auth.version)
+				.await
+			{
+				Ok(projection) => projection,
+				Err(SharedAuthProjectionError::OutcomeUnknown)
+				| Err(SharedAuthProjectionError::Rejected(
+					AccountLifecycleError::CoordinatorUnavailable,
+				)) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+				Err(SharedAuthProjectionError::Rejected(error)) => {
+					return self
+						.complete_route_command_failure(
+							lease,
+							AccountRouteFailure::Lifecycle(error),
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+			}
+		};
+		if projected_revision != routed_account.revision {
+			return self
+				.complete_route_command_failure(
+					lease,
+					AccountRouteFailure::Lifecycle(AccountLifecycleError::StaleAccount),
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
+
+		let event_projection_digest = projection_digest.clone();
+		let build_response = build_response.take().expect("Route builder is retained");
+		let response = self
+			.store
+			.route_account_command(
+				lease,
+				expected_routing_revision,
+				account_id,
+				projected_revision,
+				move |outcome, account| {
+					let result = match outcome {
+						RoutingControlOutcome::Updated { routing } => account
+							.cloned()
+							.map(|account| {
+								AccountRouteResult::Committed(Box::new(AccountRouteCommit {
+									account,
+									routing: routing.clone(),
+									projection_digest,
+								}))
+							})
+							.ok_or(AccountRouteFailure::Lifecycle(
+								AccountLifecycleError::AccountMissing,
+							)),
+						outcome => Err(AccountRouteFailure::Routing(outcome.clone())),
+					};
+					build_response(result)
+				},
+			)
+			.await?;
+		if resume_pending {
+			let account = self.load_account(account_id).await?;
+			let routing = self.store.read_account_routing_control().await?;
+			let _ = self.route_events.send(AccountRouteCompletion {
+				operation_id,
+				commit: AccountRouteCommit {
+					account,
+					routing,
+					projection_digest: event_projection_digest,
+				},
+			});
+		}
 		Ok(response)
 	}
 
-	async fn use_account_in_codex_locked(
+	async fn confirm_shared_auth_target_locked(
 		&self,
 		account_id: &AccountId,
 		expected_revision: i64,
-	) -> Result<(i64, String), UseInCodexProjectionError> {
+		snapshot: &SharedCodexAuthSnapshot,
+	) -> Result<Option<(i64, String)>, AccountLifecycleError> {
+		let SharedCodexAuthSnapshot::Managed { credential, .. } = snapshot else {
+			return Ok(None);
+		};
+		let account = self.load_account(account_id).await?;
+		let binding = projection_binding(&account, expected_revision)?;
+		if binding.provider != credential.provider {
+			return Ok(None);
+		}
+		let stored = self.credentials.read_exact(account_id, binding)?;
+		if !same_refresh_bundle(stored.bundle(), &credential.bundle) {
+			return Ok(None);
+		}
+		Ok(Some((account.revision, codex_auth_projection_digest(&account, binding))))
+	}
+
+	async fn project_shared_auth_locked(
+		&self,
+		account_id: &AccountId,
+		expected_revision: i64,
+		expected_source: &SharedCodexAuthVersion,
+	) -> Result<(i64, String), SharedAuthProjectionError> {
 		let account =
-			self.load_account(account_id).await.map_err(UseInCodexProjectionError::Rejected)?;
+			self.load_account(account_id).await.map_err(SharedAuthProjectionError::Rejected)?;
 		let binding = projection_binding(&account, expected_revision)
-			.map_err(UseInCodexProjectionError::Rejected)?
+			.map_err(SharedAuthProjectionError::Rejected)?
 			.clone();
 		let stored = self
 			.credentials
 			.read_exact(account_id, &binding)
 			.map_err(AccountLifecycleError::from)
-			.map_err(UseInCodexProjectionError::Rejected)?;
+			.map_err(SharedAuthProjectionError::Rejected)?;
 		let id_token = stored
 			.bundle()
 			.id_token()
 			.ok_or(AccountLifecycleError::CredentialAbsent)
-			.map_err(UseInCodexProjectionError::Rejected)?;
+			.map_err(SharedAuthProjectionError::Rejected)?;
 		let identity = decode_chatgpt_identity(id_token)
 			.map_err(AccountLifecycleError::from)
-			.map_err(UseInCodexProjectionError::Rejected)?;
+			.map_err(SharedAuthProjectionError::Rejected)?;
 		if identity.provider != binding.provider {
-			return Err(UseInCodexProjectionError::Rejected(
+			return Err(SharedAuthProjectionError::Rejected(
 				AccountLifecycleError::ProviderMismatch,
 			));
 		}
 		let latest =
-			self.load_account(account_id).await.map_err(UseInCodexProjectionError::Rejected)?;
+			self.load_account(account_id).await.map_err(SharedAuthProjectionError::Rejected)?;
 		if latest.revision != account.revision
 			|| latest.enabled != account.enabled
 			|| latest.lifecycle_readiness != account.lifecycle_readiness
 			|| latest.tombstoned != account.tombstoned
 			|| latest.credential.as_ref() != Some(&binding)
 		{
-			return Err(UseInCodexProjectionError::Rejected(AccountLifecycleError::StaleAccount));
+			return Err(SharedAuthProjectionError::Rejected(AccountLifecycleError::StaleAccount));
 		}
-		match project_shared_codex_auth(stored.bundle(), binding.provider.account_id()) {
+		match self.shared_auth.project_if_quiescent(
+			stored.bundle(),
+			binding.provider.account_id(),
+			expected_source,
+		) {
 			Ok(()) => {},
 			Err(CodexAuthProjectionError::OutcomeUnknown) => {
-				return Err(UseInCodexProjectionError::OutcomeUnknown);
+				return Err(SharedAuthProjectionError::OutcomeUnknown);
 			},
-			Err(error) => return Err(UseInCodexProjectionError::Rejected(projection_error(error))),
+			Err(error) => return Err(SharedAuthProjectionError::Rejected(projection_error(error))),
 		}
 		Ok((account.revision, codex_auth_projection_digest(&account, &binding)))
 	}
@@ -766,19 +1450,19 @@ impl AccountService {
 		let resolution = self.store.resolve_account_enrollment(&account_id, &provider).await?;
 		let (resolved_account_id, expected_account_revision, previous_credential) =
 			match &resolution {
-				AccountEnrollmentResolution::Fresh { account_id } =>
-					(account_id.clone(), None, None),
+				AccountEnrollmentResolution::Fresh { account_id } => {
+					(account_id.clone(), None, None)
+				},
 				AccountEnrollmentResolution::Restore {
 					account_id,
 					account_revision,
 					previous_credential,
-				} => (
-					account_id.clone(),
-					Some(*account_revision),
-					Some(previous_credential.clone()),
-				),
-				AccountEnrollmentResolution::AlreadyEnrolled { .. } =>
-					(account_id.clone(), None, None),
+				} => {
+					(account_id.clone(), Some(*account_revision), Some(previous_credential.clone()))
+				},
+				AccountEnrollmentResolution::AlreadyEnrolled { .. } => {
+					(account_id.clone(), None, None)
+				},
 			};
 		let lock = self.lock_for(&resolved_account_id)?;
 		let _guard = lock.lock().await;
@@ -792,19 +1476,15 @@ impl AccountService {
 				.await;
 		}
 		let target_version = match previous_credential.as_ref() {
-			Some(previous) => previous
-				.version
-				.successor()
-				.map_err(|_| AccountLifecycleError::InvalidOperation)?,
-			None =>
-				CredentialVersion::new(1).map_err(|_| AccountLifecycleError::InvalidOperation)?,
+			Some(previous) => {
+				previous.version.successor().map_err(|_| AccountLifecycleError::InvalidOperation)?
+			},
+			None => {
+				CredentialVersion::new(1).map_err(|_| AccountLifecycleError::InvalidOperation)?
+			},
 		};
-		let target = bundle.binding_for(
-			&resolved_account_id,
-			&operation_id,
-			target_version,
-			&provider,
-		)?;
+		let target =
+			bundle.binding_for(&resolved_account_id, &operation_id, target_version, &provider)?;
 		let preparation = AccountOperationPreparation {
 			operation_id: operation_id.clone(),
 			account_id: resolved_account_id,
@@ -879,7 +1559,7 @@ impl AccountService {
 		match phase {
 			AccountOperationPhase::Prepared
 			| AccountOperationPhase::StoreApplied
-			| AccountOperationPhase::Committed =>
+			| AccountOperationPhase::Committed => {
 				self.complete_account_operation_success(
 					lease,
 					&operation_id,
@@ -887,8 +1567,9 @@ impl AccountService {
 					AccountOperationPhase::Committed,
 					build_response,
 				)
-				.await,
-			AccountOperationPhase::Cancelled =>
+				.await
+			},
+			AccountOperationPhase::Cancelled => {
 				self.complete_account_operation_error(
 					lease,
 					&operation_id,
@@ -898,9 +1579,10 @@ impl AccountService {
 					AccountLifecycleError::InvalidOperation,
 					build_response,
 				)
-				.await,
+				.await
+			},
 			AccountOperationPhase::RecoveryRequired
-			| AccountOperationPhase::ProviderEffectPending =>
+			| AccountOperationPhase::ProviderEffectPending => {
 				self.complete_account_operation_error(
 					lease,
 					&operation_id,
@@ -910,7 +1592,8 @@ impl AccountService {
 					AccountLifecycleError::NotReady(AccountLifecycleReadiness::OperationUnsettled),
 					build_response,
 				)
-				.await,
+				.await
+			},
 		}
 	}
 
@@ -931,7 +1614,7 @@ impl AccountService {
 			expected_account_revision,
 			callback_generation,
 			previous_provider_account_id,
-			false,
+			RefreshPlan::ADMISSION,
 		)
 		.await
 	}
@@ -940,9 +1623,21 @@ impl AccountService {
 		&self,
 		current: &CredentialBinding,
 		stored: StoredCredential,
+		shared_family: SharedFamilyRefreshPolicy,
 	) -> Result<CredentialRefreshResult, CredentialRefreshError> {
-		if let Some(shared) = matching_shared_refresh_now(current, stored.bundle()) {
+		let now_unix_micros =
+			current_unix_micros().map_err(|_| CredentialRefreshError::Unavailable)?;
+		if let StableSharedAuthRead::Ready(snapshot) = self.shared_auth.read_current_stable()
+			&& let SharedCodexAuthSnapshot::Managed { credential, .. } = *snapshot
+			&& let Some(shared) =
+				matching_shared_refresh(current, stored.bundle(), now_unix_micros, Ok(credential))
+		{
 			return Ok(shared);
+		}
+		if matches!(shared_family, SharedFamilyRefreshPolicy::Guard)
+			&& self.shared_auth.liveness() == CodexLiveness::MayBeRunning
+		{
+			return Err(CredentialRefreshError::OwnerBusy);
 		}
 
 		let refresher = Arc::clone(&self.refresher);
@@ -954,9 +1649,26 @@ impl AccountService {
 		.map_err(|_| CredentialRefreshError::Ambiguous)?;
 
 		match result {
-			Err(CredentialRefreshError::Rejected) =>
-				recover_rejected_refresh_from_shared_now(current, stored.bundle()),
+			Err(CredentialRefreshError::Rejected) => recover_rejected_refresh_from_shared(
+				current,
+				stored.bundle(),
+				current_unix_micros().map_err(|_| CredentialRefreshError::Rejected)?,
+				self.stable_shared_auth_credential(),
+			),
 			result => result,
+		}
+	}
+
+	fn stable_shared_auth_credential(&self) -> Result<ImportedCredential, CredentialImportError> {
+		match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) => match *snapshot {
+				SharedCodexAuthSnapshot::Managed { credential, .. } => Ok(credential),
+				SharedCodexAuthSnapshot::Unmanaged { .. } => {
+					Err(CredentialImportError::Unavailable)
+				},
+			},
+			StableSharedAuthRead::Waiting
+			| StableSharedAuthRead::Unavailable => Err(CredentialImportError::Unavailable),
 		}
 	}
 
@@ -968,8 +1680,9 @@ impl AccountService {
 		expected_account_revision: Option<i64>,
 		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
 		previous_provider_account_id: Option<&str>,
-		allow_disabled: bool,
+		plan: RefreshPlan,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		let RefreshPlan { allow_disabled, shared_family, supplied_refresh } = plan;
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
@@ -1003,8 +1716,9 @@ impl AccountService {
 					)
 					.await
 				},
-				ReconciliationDisposition::Cancelled =>
-					Err(AccountLifecycleError::InvalidOperation),
+				ReconciliationDisposition::Cancelled => {
+					Err(AccountLifecycleError::InvalidOperation)
+				},
 				ReconciliationDisposition::Manual => Err(AccountLifecycleError::NotReady(
 					AccountLifecycleReadiness::OperationUnsettled,
 				)),
@@ -1054,7 +1768,10 @@ impl AccountService {
 					.await?,
 			)?;
 		}
-		let refreshed = self.refresh_or_reconcile_shared(current, stored).await;
+		let refreshed = match supplied_refresh {
+			Some(refreshed) => Ok(refreshed),
+			None => self.refresh_or_reconcile_shared(current, stored, shared_family).await,
+		};
 		let refreshed = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(CredentialRefreshError::Rejected) => {
@@ -1066,6 +1783,16 @@ impl AccountService {
 				)
 				.await?;
 				return Err(AccountLifecycleError::Refresh(CredentialRefreshError::Rejected));
+			},
+			Err(CredentialRefreshError::OwnerBusy) => {
+				self.recover_or_cancel(
+					&operation_id,
+					AccountOperationPhase::ProviderEffectPending,
+					"shared_auth_owner_busy",
+					false,
+				)
+				.await?;
+				return Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy));
 			},
 			Err(error) => {
 				self.recover_or_cancel(
@@ -1116,12 +1843,7 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		self.commit_and_project_refresh_result(
-			&operation_id,
-			account_id,
-			callback_generation,
-		)
-		.await
+		self.commit_and_project_refresh_result(&operation_id, account_id, callback_generation).await
 	}
 
 	/// Replace one exact account credential from a private Codex auth file.
@@ -1226,7 +1948,7 @@ impl AccountService {
 				)
 				.await
 			},
-			ReauthenticationReplayDisposition::Cancel =>
+			ReauthenticationReplayDisposition::Cancel => {
 				self.complete_account_operation_error(
 					lease,
 					operation_id,
@@ -1236,8 +1958,9 @@ impl AccountService {
 					AccountLifecycleError::InvalidOperation,
 					build_response,
 				)
-				.await,
-			ReauthenticationReplayDisposition::Recover =>
+				.await
+			},
+			ReauthenticationReplayDisposition::Recover => {
 				self.complete_account_operation_error(
 					lease,
 					operation_id,
@@ -1247,7 +1970,8 @@ impl AccountService {
 					AccountLifecycleError::NotReady(AccountLifecycleReadiness::OperationUnsettled),
 					build_response,
 				)
-				.await,
+				.await
+			},
 		}
 	}
 
@@ -1318,10 +2042,11 @@ impl AccountService {
 			provider: imported.provider.clone(),
 		};
 		let preparation_outcome = match recovery_operation_id {
-			Some(recovery_operation_id) =>
+			Some(recovery_operation_id) => {
 				self.store
 					.prepare_account_reauthentication_takeover(&preparation, recovery_operation_id)
-					.await?,
+					.await?
+			},
 			None => self.store.prepare_account_operation(&preparation).await?,
 		};
 		let phase = match preparation_outcome {
@@ -1467,8 +2192,7 @@ impl AccountService {
 			}
 			match operation.phase {
 				AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied => {
-					self.commit_and_project_refresh_result(&operation_id, account_id, None)
-						.await?;
+					self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -1561,8 +2285,7 @@ impl AccountService {
 							)
 							.await?,
 					)?;
-					self.commit_and_project_refresh_result(&operation_id, account_id, None)
-						.await?;
+					self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -1640,10 +2363,25 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		let refreshed = self.refresh_or_reconcile_shared(&current, stored).await;
+		let refreshed = self
+			.refresh_or_reconcile_shared(&current, stored, SharedFamilyRefreshPolicy::Guard)
+			.await;
 		let refreshed = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(error @ CredentialRefreshError::Rejected) => {
+				return self
+					.complete_account_operation_error(
+						lease,
+						&operation_id,
+						AccountOperationPhase::ProviderEffectPending,
+						AccountOperationPhase::Cancelled,
+						None,
+						AccountLifecycleError::Refresh(error),
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+			Err(error @ CredentialRefreshError::OwnerBusy) => {
 				return self
 					.complete_account_operation_error(
 						lease,
@@ -1717,8 +2455,7 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		self.commit_and_project_refresh_result(&operation_id, account_id, None)
-			.await?;
+		self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
 		self.complete_account_operation_success(
 			lease,
 			&operation_id,
@@ -1736,13 +2473,7 @@ impl AccountService {
 		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
 		let stored = self.credentials.read_exact(account_id, binding)?;
-		// Credential rotation and its receipt stay authoritative even when the replaceable shared
-		// Codex projection cannot be written. Route owns the explicit retryable projection command
-		// and cannot advance fixed routing until that separate command succeeds.
-		let _shared_auth_projection = (self.shared_auth_reprojector)(binding, stored.bundle());
-		// A later refresh of the same binding retries this conditional projection. Explicit Route
-		// always follows with UseAccountInCodex, whose exact writer and receipt provide the immediate
-		// retry-convergence boundary without misclassifying the provider effect.
+		// Ordinary refresh never writes shared auth. Route owns the only quiescent CAS projection.
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
@@ -1798,8 +2529,9 @@ impl AccountService {
 			self.require_operation_identity(&operation, account_id, AccountOperationKind::Logout)?;
 			return match self.reconcile_operation(&operation).await? {
 				ReconciliationDisposition::Committed => self.load_account(account_id).await,
-				ReconciliationDisposition::Cancelled =>
-					Err(AccountLifecycleError::InvalidOperation),
+				ReconciliationDisposition::Cancelled => {
+					Err(AccountLifecycleError::InvalidOperation)
+				},
 				ReconciliationDisposition::Manual => Err(AccountLifecycleError::NotReady(
 					AccountLifecycleReadiness::OperationUnsettled,
 				)),
@@ -2059,55 +2791,6 @@ impl AccountService {
 			.await?)
 	}
 
-	/// Select one fixed account under independent routing and account revision guards.
-	pub async fn set_fixed_selection(
-		&self,
-		expected_routing_revision: i64,
-		account_id: &AccountId,
-		expected_account_revision: i64,
-	) -> Result<RoutingControlOutcome, AccountLifecycleError> {
-		Ok(self
-			.store
-			.set_fixed_account_selection(
-				expected_routing_revision,
-				account_id,
-				expected_account_revision,
-			)
-			.await?)
-	}
-
-	/// Apply one fixed-selection command and its durable public result in one PG transaction.
-	pub async fn set_fixed_selection_command<F>(
-		&self,
-		lease: AccountCommandReceiptLease,
-		expected_routing_revision: i64,
-		account_id: &AccountId,
-		expected_account_revision: i64,
-		build_response: F,
-	) -> Result<Value, AccountLifecycleError>
-	where
-		F: FnOnce(&RoutingControlOutcome) -> Result<Value, StoreError> + Send + 'static,
-	{
-		Ok(self
-			.store
-			.set_fixed_account_selection_command(
-				lease,
-				expected_routing_revision,
-				account_id,
-				expected_account_revision,
-				build_response,
-			)
-			.await?)
-	}
-
-	/// Select balanced routing while preserving the complete account order.
-	pub async fn set_balanced_selection(
-		&self,
-		expected_routing_revision: i64,
-	) -> Result<RoutingControlOutcome, AccountLifecycleError> {
-		Ok(self.store.set_balanced_account_selection(expected_routing_revision).await?)
-	}
-
 	/// Apply one balanced-selection command and its durable result in one PG transaction.
 	pub async fn set_balanced_selection_command<F>(
 		&self,
@@ -2118,6 +2801,7 @@ impl AccountService {
 	where
 		F: FnOnce(&RoutingControlOutcome) -> Result<Value, StoreError> + Send + 'static,
 	{
+		let _routing_guard = self.routing_lock.lock().await;
 		Ok(self
 			.store
 			.set_balanced_account_selection_command(
@@ -2126,15 +2810,6 @@ impl AccountService {
 				build_response,
 			)
 			.await?)
-	}
-
-	/// Replace the complete order while preserving selection mode and fixed target.
-	pub async fn set_account_order(
-		&self,
-		expected_routing_revision: i64,
-		order: &[AccountId],
-	) -> Result<RoutingControlOutcome, AccountLifecycleError> {
-		Ok(self.store.set_account_order(expected_routing_revision, order).await?)
 	}
 
 	/// Apply one account-order command and its durable result in one PG transaction.
@@ -2148,6 +2823,7 @@ impl AccountService {
 	where
 		F: FnOnce(&RoutingControlOutcome) -> Result<Value, StoreError> + Send + 'static,
 	{
+		let _routing_guard = self.routing_lock.lock().await;
 		Ok(self
 			.store
 			.set_account_order_command(lease, expected_routing_revision, order, build_response)
@@ -2167,6 +2843,44 @@ impl AccountService {
 	{
 		let response = build_response(Err(error))?;
 		self.store.complete_account_command(lease, &response).await?;
+		Ok(response)
+	}
+
+	async fn complete_route_command_failure<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		failure: AccountRouteFailure,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<AccountRouteResult, AccountRouteFailure>) -> Result<Value, StoreError>
+			+ Send
+			+ 'static,
+	{
+		let response = build_response(Err(failure))?;
+		self.store.complete_account_command(lease, &response).await?;
+		Ok(response)
+	}
+
+	async fn defer_route_command<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		operation_id: AccountOperationId,
+		account_id: &AccountId,
+		routing_revision: i64,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<AccountRouteResult, AccountRouteFailure>) -> Result<Value, StoreError>
+			+ Send
+			+ 'static,
+	{
+		let response = build_response(Ok(AccountRouteResult::Pending(AccountRoutePending {
+			operation_id,
+			account_id: account_id.clone(),
+			routing_revision,
+		})))?;
+		self.store.defer_account_route_command(lease, &response).await?;
 		Ok(response)
 	}
 
@@ -2196,9 +2910,12 @@ impl AccountService {
 						AccountLifecycleMutationOutcome::Applied(mutation)
 						| AccountLifecycleMutationOutcome::Replayed(mutation)
 							if mutation.phase == target =>
-							account.ok_or(AccountLifecycleError::AccountMissing),
-						AccountLifecycleMutationOutcome::Rejected { rejection, .. } =>
-							Err(AccountLifecycleError::OperationRejected(*rejection)),
+						{
+							account.ok_or(AccountLifecycleError::AccountMissing)
+						},
+						AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
+							Err(AccountLifecycleError::OperationRejected(*rejection))
+						},
 						_ => Err(AccountLifecycleError::InvalidOperation),
 					};
 					build_response(result)
@@ -2236,9 +2953,12 @@ impl AccountService {
 						AccountLifecycleMutationOutcome::Applied(mutation)
 						| AccountLifecycleMutationOutcome::Replayed(mutation)
 							if mutation.phase == target =>
-							error,
-						AccountLifecycleMutationOutcome::Rejected { rejection, .. } =>
-							AccountLifecycleError::OperationRejected(*rejection),
+						{
+							error
+						},
+						AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
+							AccountLifecycleError::OperationRejected(*rejection)
+						},
 						_ => AccountLifecycleError::InvalidOperation,
 					};
 					build_response(Err(error))
@@ -2296,11 +3016,14 @@ impl AccountService {
 						AccountLifecycleMutationOutcome::Applied(mutation)
 						| AccountLifecycleMutationOutcome::Replayed(mutation)
 							if mutation.phase == target =>
+						{
 							account
 								.ok_or(AccountLifecycleError::AccountMissing)
-								.map(|account| (result, account)),
-						AccountLifecycleMutationOutcome::Rejected { rejection, .. } =>
-							Err(AccountLifecycleError::OperationRejected(*rejection)),
+								.map(|account| (result, account))
+						},
+						AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
+							Err(AccountLifecycleError::OperationRejected(*rejection))
+						},
 						_ => Err(AccountLifecycleError::InvalidOperation),
 					};
 					build_response(value)
@@ -2467,8 +3190,9 @@ impl AccountService {
 				AccountOperationPhase::Committed,
 				AccountManualRecoveryAction::ReconcileExactStoreState,
 			) => Some(AccountManualRecoveryOutcome::Committed),
-			(AccountOperationPhase::Cancelled, AccountManualRecoveryAction::CancelBeforeEffect) =>
-				Some(AccountManualRecoveryOutcome::Cancelled),
+			(AccountOperationPhase::Cancelled, AccountManualRecoveryAction::CancelBeforeEffect) => {
+				Some(AccountManualRecoveryOutcome::Cancelled)
+			},
 			(AccountOperationPhase::Committed | AccountOperationPhase::Cancelled, _) => {
 				return Err(AccountLifecycleError::InvalidOperation);
 			},
@@ -2482,10 +3206,12 @@ impl AccountService {
 			return Err(AccountLifecycleError::StaleAccount);
 		}
 		let outcome = match action {
-			AccountManualRecoveryAction::ReconcileExactStoreState =>
-				self.recover_from_exact_store(&operation).await?,
-			AccountManualRecoveryAction::CancelBeforeEffect =>
-				self.cancel_proven_before_effect(&operation).await?,
+			AccountManualRecoveryAction::ReconcileExactStoreState => {
+				self.recover_from_exact_store(&operation).await?
+			},
+			AccountManualRecoveryAction::CancelBeforeEffect => {
+				self.cancel_proven_before_effect(&operation).await?
+			},
 		};
 		let account = self.load_account(&operation.account_id).await?;
 		Ok((outcome, account))
@@ -2543,8 +3269,9 @@ impl AccountService {
 				AccountOperationPhase::Committed,
 				AccountManualRecoveryAction::ReconcileExactStoreState,
 			) => Some(AccountManualRecoveryOutcome::Committed),
-			(AccountOperationPhase::Cancelled, AccountManualRecoveryAction::CancelBeforeEffect) =>
-				Some(AccountManualRecoveryOutcome::Cancelled),
+			(AccountOperationPhase::Cancelled, AccountManualRecoveryAction::CancelBeforeEffect) => {
+				Some(AccountManualRecoveryOutcome::Cancelled)
+			},
 			(AccountOperationPhase::Committed | AccountOperationPhase::Cancelled, _) => {
 				return self
 					.complete_recovery_command_error(
@@ -2600,15 +3327,18 @@ impl AccountService {
 				) => operation.expected.as_ref().is_some_and(|expected| {
 					self.credentials.read_exact(&operation.account_id, expected).is_ok()
 				}),
-				(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) =>
+				(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) => {
 					operation.expected.as_ref().is_some_and(|expected| {
 						self.credentials.read_exact(&operation.account_id, expected).is_ok()
-					}),
+					})
+				},
 				(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Refresh)
 					if operation.recovery_operation_id.is_some() =>
+				{
 					operation.expected.as_ref().is_some_and(|expected| {
 						self.credentials.read_exact(&operation.account_id, expected).is_ok()
-					}),
+					})
+				},
 				_ => false,
 			};
 			let (target, outcome) = if proven {
@@ -2734,10 +3464,12 @@ impl AccountService {
 				.await;
 		}
 		let recovery_code = match operation.kind {
-			AccountOperationKind::Enroll | AccountOperationKind::Import =>
-				"credential_import_reconciliation",
-			AccountOperationKind::Refresh if operation.target.is_none() =>
-				PROVIDER_REFRESH_OUTCOME_UNKNOWN,
+			AccountOperationKind::Enroll | AccountOperationKind::Import => {
+				"credential_import_reconciliation"
+			},
+			AccountOperationKind::Refresh if operation.target.is_none() => {
+				PROVIDER_REFRESH_OUTCOME_UNKNOWN
+			},
 			AccountOperationKind::Refresh => "credential_refresh_reconciliation",
 			AccountOperationKind::Logout => "credential_logout_reconciliation",
 		};
@@ -2824,7 +3556,7 @@ impl AccountService {
 				Some(account.revision),
 				None,
 				None,
-				true,
+				RefreshPlan::EXISTING_WORK,
 			)
 			.await?;
 			account = self.load_account(account_id).await?;
@@ -3052,8 +3784,9 @@ impl AccountService {
 			return Ok(match self.reconcile_operation(operation).await? {
 				ReconciliationDisposition::Committed => AccountManualRecoveryOutcome::Committed,
 				ReconciliationDisposition::Cancelled => AccountManualRecoveryOutcome::Cancelled,
-				ReconciliationDisposition::Manual =>
-					AccountManualRecoveryOutcome::StillRequiresRecovery,
+				ReconciliationDisposition::Manual => {
+					AccountManualRecoveryOutcome::StillRequiresRecovery
+				},
 			});
 		}
 		let proven_applied = match operation.kind {
@@ -3127,15 +3860,18 @@ impl AccountService {
 					Err(CredentialStoreError::NotFound)
 				)
 			}),
-			(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) =>
+			(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Logout) => {
 				operation.expected.as_ref().is_some_and(|expected| {
 					self.credentials.read_exact(&operation.account_id, expected).is_ok()
-				}),
+				})
+			},
 			(AccountOperationPhase::RecoveryRequired, AccountOperationKind::Refresh)
 				if operation.recovery_operation_id.is_some() =>
+			{
 				operation.expected.as_ref().is_some_and(|expected| {
 					self.credentials.read_exact(&operation.account_id, expected).is_ok()
-				}),
+				})
+			},
 			_ => false,
 		};
 		if !proven {
@@ -3162,8 +3898,9 @@ impl AccountService {
 			return Ok(disposition);
 		}
 		match operation.kind {
-			AccountOperationKind::Enroll | AccountOperationKind::Import =>
-				self.reconcile_import_operation(operation).await,
+			AccountOperationKind::Enroll | AccountOperationKind::Import => {
+				self.reconcile_import_operation(operation).await
+			},
 			AccountOperationKind::Refresh => self.reconcile_refresh_operation(operation).await,
 			AccountOperationKind::Logout => self.reconcile_logout_operation(operation).await,
 		}
@@ -3186,8 +3923,9 @@ impl AccountService {
 				self.commit_store_applied(&operation.operation_id).await?;
 				Ok(Some(ReconciliationDisposition::Committed))
 			},
-			AccountOperationPhase::Prepared | AccountOperationPhase::ProviderEffectPending =>
-				Ok(None),
+			AccountOperationPhase::Prepared | AccountOperationPhase::ProviderEffectPending => {
+				Ok(None)
+			},
 		}
 	}
 
@@ -3268,7 +4006,9 @@ impl AccountService {
 			Ok(_) => self.commit_reconciled_operation(operation).await,
 			Err(CredentialStoreError::NotFound)
 				if operation.phase == AccountOperationPhase::Prepared =>
-				self.cancel_reconciled_operation(operation).await,
+			{
+				self.cancel_reconciled_operation(operation).await
+			},
 			Err(_) => self.mark_manual(operation, "credential_import_reconciliation").await,
 		}
 	}
@@ -3283,12 +4023,15 @@ impl AccountService {
 				operation.target.as_ref(),
 				|binding| self.credentials.read_exact(&operation.account_id, binding).map(|_| ()),
 			) {
-				PreparedRefreshReconciliation::StoreApplied =>
-					self.commit_reconciled_operation(operation).await,
-				PreparedRefreshReconciliation::NotApplied =>
-					self.cancel_reconciled_operation(operation).await,
-				PreparedRefreshReconciliation::RecoveryRequired =>
-					self.mark_manual(operation, "credential_reauthentication_reconciliation").await,
+				PreparedRefreshReconciliation::StoreApplied => {
+					self.commit_reconciled_operation(operation).await
+				},
+				PreparedRefreshReconciliation::NotApplied => {
+					self.cancel_reconciled_operation(operation).await
+				},
+				PreparedRefreshReconciliation::RecoveryRequired => {
+					self.mark_manual(operation, "credential_reauthentication_reconciliation").await
+				},
 			};
 		}
 		let Some(target) = operation.target.as_ref() else {
@@ -3307,8 +4050,9 @@ impl AccountService {
 		let expected =
 			operation.expected.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
 		match self.credentials.delete(&operation.account_id, expected) {
-			Ok(()) | Err(CredentialStoreError::NotFound) =>
-				self.commit_reconciled_operation(operation).await,
+			Ok(()) | Err(CredentialStoreError::NotFound) => {
+				self.commit_reconciled_operation(operation).await
+			},
 			Err(_) => self.mark_manual(operation, "credential_logout_reconciliation").await,
 		}
 	}
@@ -3560,28 +4304,16 @@ fn matching_shared_refresh(
 			if imported.provider == current.provider
 				&& imported.bundle.access_token_expires_at_unix_micros() > now_unix_micros
 				&& imported.bundle.access_token_expires_at_unix_micros()
-					> current_bundle.access_token_expires_at_unix_micros()
+					>= current_bundle.access_token_expires_at_unix_micros()
 				&& !same_refresh_bundle(current_bundle, &imported.bundle) =>
+		{
 			Some(CredentialRefreshResult {
 				returned_provider: imported.provider,
 				bundle: imported.bundle,
-			}),
+			})
+		},
 		Ok(_) | Err(_) => None,
 	}
-}
-
-fn matching_shared_refresh_now(
-	current: &CredentialBinding,
-	current_bundle: &CredentialSecretBundle,
-) -> Option<CredentialRefreshResult> {
-	current_unix_micros().ok().and_then(|now_unix_micros| {
-		matching_shared_refresh(
-			current,
-			current_bundle,
-			now_unix_micros,
-			read_shared_codex_credential(),
-		)
-	})
 }
 
 fn recover_rejected_refresh_from_shared(
@@ -3592,51 +4324,6 @@ fn recover_rejected_refresh_from_shared(
 ) -> Result<CredentialRefreshResult, CredentialRefreshError> {
 	matching_shared_refresh(current, current_bundle, now_unix_micros, shared)
 		.ok_or(CredentialRefreshError::Rejected)
-}
-
-fn recover_rejected_refresh_from_shared_now(
-	current: &CredentialBinding,
-	current_bundle: &CredentialSecretBundle,
-) -> Result<CredentialRefreshResult, CredentialRefreshError> {
-	let now_unix_micros = current_unix_micros().map_err(|_| CredentialRefreshError::Rejected)?;
-	recover_rejected_refresh_from_shared(
-		current,
-		current_bundle,
-		now_unix_micros,
-		read_shared_codex_credential(),
-	)
-}
-
-fn reproject_shared_codex_auth_if_current(
-	binding: &CredentialBinding,
-	bundle: &CredentialSecretBundle,
-) -> Result<(), AccountLifecycleError> {
-	reproject_shared_codex_auth_if_current_with(
-		binding,
-		bundle,
-		read_shared_codex_auth_identity,
-		project_shared_codex_auth,
-	)
-}
-
-fn reproject_shared_codex_auth_if_current_with<ReadIdentity, Project>(
-	binding: &CredentialBinding,
-	bundle: &CredentialSecretBundle,
-	read_identity: ReadIdentity,
-	project: Project,
-) -> Result<(), AccountLifecycleError>
-where
-	ReadIdentity: FnOnce() -> Result<SharedCodexAuthIdentity, CodexAuthProjectionError>,
-	Project: FnOnce(&CredentialSecretBundle, &str) -> Result<(), CodexAuthProjectionError>,
-{
-	match read_identity() {
-		Ok(SharedCodexAuthIdentity::Chatgpt { provider_account_id })
-			if binding.provider.provider() == AccountProvider::Chatgpt
-				&& provider_account_id == binding.provider.account_id() =>
-			project(bundle, binding.provider.account_id()).map_err(projection_error),
-		Ok(SharedCodexAuthIdentity::Chatgpt { .. } | SharedCodexAuthIdentity::Unmanaged)
-		| Err(_) => Ok(()),
-	}
 }
 
 fn same_refresh_bundle(first: &CredentialSecretBundle, second: &CredentialSecretBundle) -> bool {
@@ -3681,8 +4368,9 @@ where
 		Ok(()) => PreparedRefreshReconciliation::StoreApplied,
 		Err(CredentialStoreError::Unavailable) => PreparedRefreshReconciliation::RecoveryRequired,
 		Err(_) => match expected {
-			Some(expected) if read_exact(expected).is_ok() =>
-				PreparedRefreshReconciliation::NotApplied,
+			Some(expected) if read_exact(expected).is_ok() => {
+				PreparedRefreshReconciliation::NotApplied
+			},
 			Some(_) | None => PreparedRefreshReconciliation::RecoveryRequired,
 		},
 	}
@@ -3698,25 +4386,30 @@ where
 	F: FnMut(&CredentialBinding) -> Result<(), CredentialStoreError>,
 {
 	match phase {
-		AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied =>
-			ReauthenticationReplayDisposition::Complete,
+		AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied => {
+			ReauthenticationReplayDisposition::Complete
+		},
 		AccountOperationPhase::Cancelled => ReauthenticationReplayDisposition::Cancel,
 		AccountOperationPhase::Prepared => {
 			match classify_prepared_refresh_reconciliation(expected, target, read_exact) {
-				PreparedRefreshReconciliation::StoreApplied =>
-					ReauthenticationReplayDisposition::Complete,
-				PreparedRefreshReconciliation::NotApplied =>
-					ReauthenticationReplayDisposition::Cancel,
-				PreparedRefreshReconciliation::RecoveryRequired =>
-					ReauthenticationReplayDisposition::Recover,
+				PreparedRefreshReconciliation::StoreApplied => {
+					ReauthenticationReplayDisposition::Complete
+				},
+				PreparedRefreshReconciliation::NotApplied => {
+					ReauthenticationReplayDisposition::Cancel
+				},
+				PreparedRefreshReconciliation::RecoveryRequired => {
+					ReauthenticationReplayDisposition::Recover
+				},
 			}
 		},
-		AccountOperationPhase::ProviderEffectPending | AccountOperationPhase::RecoveryRequired =>
+		AccountOperationPhase::ProviderEffectPending | AccountOperationPhase::RecoveryRequired => {
 			if target.is_some_and(|target| read_exact(target).is_ok()) {
 				ReauthenticationReplayDisposition::Complete
 			} else {
 				ReauthenticationReplayDisposition::Recover
-			},
+			}
+		},
 	}
 }
 
@@ -3742,29 +4435,41 @@ fn projection_binding(
 	account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)
 }
 
-enum UseInCodexProjectionError {
+fn route_resume_revision_is_valid(
+	account: &AccountRecord,
+	expected_revision: i64,
+	derived_operation_id: &AccountOperationId,
+	operation: Option<&AccountOperation>,
+) -> bool {
+	if account.revision == expected_revision {
+		return true;
+	}
+	account.credential.as_ref().is_some_and(|binding| {
+		binding.writer_operation_id == *derived_operation_id
+			&& operation.is_some_and(|operation| {
+				operation.account_id == account.account_id
+					&& operation.kind == AccountOperationKind::Refresh
+					&& operation.expected_account_revision == Some(expected_revision)
+					&& operation.phase == AccountOperationPhase::Committed
+					&& operation.target.as_ref() == Some(binding)
+			})
+	})
+}
+
+enum SharedAuthProjectionError {
 	Rejected(AccountLifecycleError),
 	OutcomeUnknown,
 }
 
-fn use_in_codex_receipt_result<T>(
-	result: Result<T, UseInCodexProjectionError>,
-) -> Result<Result<T, AccountLifecycleError>, AccountLifecycleError> {
-	match result {
-		Ok(value) => Ok(Ok(value)),
-		Err(UseInCodexProjectionError::Rejected(error)) => Ok(Err(error)),
-		Err(UseInCodexProjectionError::OutcomeUnknown) =>
-			Err(AccountLifecycleError::CoordinatorUnavailable),
-	}
-}
-
 const fn projection_error(error: CodexAuthProjectionError) -> AccountLifecycleError {
 	match error {
-		CodexAuthProjectionError::UnsafePath | CodexAuthProjectionError::InvalidCredential =>
-			AccountLifecycleError::CredentialImport,
+		CodexAuthProjectionError::UnsafePath | CodexAuthProjectionError::InvalidCredential => {
+			AccountLifecycleError::CredentialImport
+		},
 		CodexAuthProjectionError::MissingIdentityToken => AccountLifecycleError::CredentialAbsent,
-		CodexAuthProjectionError::Unavailable | CodexAuthProjectionError::OutcomeUnknown =>
-			AccountLifecycleError::CoordinatorUnavailable,
+		CodexAuthProjectionError::Unavailable
+		| CodexAuthProjectionError::OutcomeUnknown
+		| CodexAuthProjectionError::SourceChanged => AccountLifecycleError::CoordinatorUnavailable,
 	}
 }
 
@@ -3774,8 +4479,9 @@ fn accepted_phase(
 	match outcome {
 		AccountLifecycleMutationOutcome::Applied(mutation)
 		| AccountLifecycleMutationOutcome::Replayed(mutation) => Ok(mutation.phase),
-		AccountLifecycleMutationOutcome::Rejected { rejection, .. } =>
-			Err(AccountLifecycleError::OperationRejected(rejection)),
+		AccountLifecycleMutationOutcome::Rejected { rejection, .. } => {
+			Err(AccountLifecycleError::OperationRejected(rejection))
+		},
 	}
 }
 
@@ -3787,12 +4493,15 @@ const fn store_error_observation(
 	error: CredentialStoreError,
 ) -> (AccountStoreObservation, AccountLifecycleReadiness) {
 	match error {
-		CredentialStoreError::Unavailable =>
-			(AccountStoreObservation::Unavailable, AccountLifecycleReadiness::StoreUnavailable),
-		CredentialStoreError::ProviderMismatch =>
-			(AccountStoreObservation::ProviderMismatch, AccountLifecycleReadiness::ProviderMismatch),
-		CredentialStoreError::NotFound =>
-			(AccountStoreObservation::Missing, AccountLifecycleReadiness::StoreMismatch),
+		CredentialStoreError::Unavailable => {
+			(AccountStoreObservation::Unavailable, AccountLifecycleReadiness::StoreUnavailable)
+		},
+		CredentialStoreError::ProviderMismatch => {
+			(AccountStoreObservation::ProviderMismatch, AccountLifecycleReadiness::ProviderMismatch)
+		},
+		CredentialStoreError::NotFound => {
+			(AccountStoreObservation::Missing, AccountLifecycleReadiness::StoreMismatch)
+		},
 		_ => (AccountStoreObservation::Mismatch, AccountLifecycleReadiness::StoreMismatch),
 	}
 }
@@ -3875,46 +4584,55 @@ mod tests {
 	use decodex_core::{
 		AccountId, AccountLifecycleReadiness, AccountOperationId, AccountOperationKind,
 		AccountOperationPhase, AccountProvider, AccountQuotaWindow, AccountQuotaWindowObservation,
-		AccountRecord, AccountState, CredentialBinding, CredentialFingerprint,
-		CredentialStoreSchemaVersion, CredentialVersion, DecodexRoot, ProviderIdentity,
+		AccountRecord, AccountSelectionMode, AccountState, CredentialBinding,
+		CredentialFingerprint, CredentialStoreSchemaVersion, CredentialVersion, DecodexRoot,
+		ProviderIdentity,
 	};
 	use decodex_database::{
 		AccountCommandKind, AccountCommandReceiptClaim, AccountLifecycleMutationOutcome,
-		AccountOperationPreparation, CommandIdentity, SqliteStore,
+		AccountOperationPreparation, CodexAccountCapabilityAttestation, CommandIdentity,
+		RoutingControlOutcome, SqliteStore,
 	};
 	use serde_json::json;
 
 	use super::{
-		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, AccountService, CredentialImportError,
-		CredentialRefreshError, CredentialRefreshPort, CredentialRefreshResult,
-		CredentialSecretBundle, CredentialStoreError, HostCredentialStore, ImportedCredential,
+		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, AccountRouteFailure, AccountRouteResult,
+		AccountService, CodexAuthProjectionError, CredentialImportError, CredentialRefreshError,
+		CredentialRefreshPort, CredentialRefreshResult, CredentialSecretBundle,
+		CredentialStoreError, HostCredentialStore, ImportedCredential,
 		PROVIDER_REFRESH_OUTCOME_UNKNOWN, PreparedRefreshReconciliation,
-		ReauthenticationReplayDisposition, RefreshResponse, UseInCodexProjectionError,
-		accepted_phase, access_token_needs_refresh, account_lock_for,
-		classify_prepared_refresh_reconciliation,
+		ReauthenticationReplayDisposition, RefreshResponse, accepted_phase,
+		access_token_needs_refresh, account_lock_for, classify_prepared_refresh_reconciliation,
 		classify_reauthentication_replay, codex_auth_projection_digest, credential_refresh_result,
-		matching_shared_refresh, projection_binding, reauthentication_current,
-		reauthentication_target, refreshed_credential_target,
-		recover_rejected_refresh_from_shared,
-		reproject_shared_codex_auth_if_current_with,
-		require_refreshed_access_token_for_observation, resolve_reauthentication_store_effect,
-		stable_account_alias, use_in_codex_receipt_result,
+		decode_chatgpt_identity, matching_shared_refresh, projection_binding,
+		reauthentication_current, reauthentication_target, recover_rejected_refresh_from_shared,
+		refreshed_credential_target, require_refreshed_access_token_for_observation,
+		resolve_reauthentication_store_effect, route_resume_revision_is_valid,
+		stable_account_alias,
 	};
 	use std::{
-		cell::Cell,
 		collections::{HashMap, HashSet},
 		fs,
 		os::unix::fs::PermissionsExt as _,
 		sync::{
 			Arc, Mutex,
-			atomic::{AtomicUsize, Ordering},
+			atomic::{AtomicBool, AtomicUsize, Ordering},
 		},
 		time::Duration,
 	};
 	use tempfile::tempdir;
 	use tokio::time;
 
-	use crate::host_credentials::SqliteCredentialStore;
+	use crate::{
+		auth_projection::{
+			SharedCodexAuthFileStamp, SharedCodexAuthSnapshot, SharedCodexAuthVersion,
+		},
+		host_credentials::SqliteCredentialStore,
+		shared_auth_coordinator::{
+			CodexLiveness, CodexLivenessPort, SharedAuthCoordinator, SharedAuthFilePort,
+			StableSharedAuthPoll,
+		},
+	};
 
 	const OBSERVED_AT_MICROS: i64 = 1_000_000;
 
@@ -3928,14 +4646,250 @@ mod tests {
 		}
 	}
 
-	static FAILED_SHARED_REPROJECTIONS: AtomicUsize = AtomicUsize::new(0);
+	struct FixedLiveness(CodexLiveness);
+	impl CodexLivenessPort for FixedLiveness {
+		fn observe(&self) -> CodexLiveness {
+			self.0
+		}
+	}
 
-	fn fail_shared_auth_reprojection(
-		_binding: &CredentialBinding,
-		_bundle: &CredentialSecretBundle,
-	) -> Result<(), AccountLifecycleError> {
-		FAILED_SHARED_REPROJECTIONS.fetch_add(1, Ordering::Relaxed);
-		Err(AccountLifecycleError::CoordinatorUnavailable)
+	struct MutableLiveness(Arc<AtomicBool>);
+	impl CodexLivenessPort for MutableLiveness {
+		fn observe(&self) -> CodexLiveness {
+			if self.0.load(Ordering::Relaxed) {
+				CodexLiveness::MayBeRunning
+			} else {
+				CodexLiveness::Quiescent
+			}
+		}
+	}
+
+	struct RouteSharedAuthFile {
+		source_provider: &'static str,
+		source_access: &'static str,
+		source_expiry: i64,
+		target_provider: &'static str,
+		target_access: &'static str,
+		projections: AtomicUsize,
+	}
+
+	impl RouteSharedAuthFile {
+		fn version() -> SharedCodexAuthVersion {
+			SharedCodexAuthVersion {
+				stamp: SharedCodexAuthFileStamp::Present {
+					device: 1,
+					inode: 2,
+					length: 3,
+					modified_seconds: 4,
+					modified_nanoseconds: 5,
+				},
+				sha256: Some([6; 32]),
+			}
+		}
+	}
+
+	impl SharedAuthFilePort for RouteSharedAuthFile {
+		fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+			Ok(Self::version().stamp)
+		}
+
+		fn read(
+			&self,
+			_expected: &SharedCodexAuthFileStamp,
+		) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+			Ok(SharedCodexAuthSnapshot::Managed {
+				version: Self::version(),
+				credential: imported(self.source_provider, self.source_access, self.source_expiry),
+			})
+		}
+
+		fn project(
+			&self,
+			bundle: &CredentialSecretBundle,
+			provider_account_id: &str,
+			expected: &SharedCodexAuthVersion,
+		) -> Result<(), CodexAuthProjectionError> {
+			if provider_account_id != self.target_provider
+				|| bundle.access_token() != self.target_access
+				|| expected != &Self::version()
+			{
+				return Err(CodexAuthProjectionError::SourceChanged);
+			}
+			self.projections.fetch_add(1, Ordering::Relaxed);
+			Ok(())
+		}
+	}
+
+	fn test_coordinator(
+		file: Arc<dyn SharedAuthFilePort>,
+		liveness: CodexLiveness,
+	) -> Arc<SharedAuthCoordinator> {
+		test_coordinator_with_liveness(file, Arc::new(FixedLiveness(liveness)))
+	}
+
+	fn test_coordinator_with_liveness(
+		file: Arc<dyn SharedAuthFilePort>,
+		liveness: Arc<dyn CodexLivenessPort>,
+	) -> Arc<SharedAuthCoordinator> {
+		let coordinator = Arc::new(SharedAuthCoordinator::with_ports(liveness, file));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
+		coordinator
+	}
+
+	fn route_test_coordinator(file: Arc<RouteSharedAuthFile>) -> Arc<SharedAuthCoordinator> {
+		test_coordinator(file, CodexLiveness::Quiescent)
+	}
+
+	struct UnmanagedSharedAuthFile {
+		projections: AtomicUsize,
+	}
+
+	impl SharedAuthFilePort for UnmanagedSharedAuthFile {
+		fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+			Ok(SharedCodexAuthFileStamp::Absent)
+		}
+
+		fn read(
+			&self,
+			_expected: &SharedCodexAuthFileStamp,
+		) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+			Ok(SharedCodexAuthSnapshot::Unmanaged {
+				version: SharedCodexAuthVersion {
+					stamp: SharedCodexAuthFileStamp::Absent,
+					sha256: None,
+				},
+			})
+		}
+
+		fn project(
+			&self,
+			_bundle: &CredentialSecretBundle,
+			_provider_account_id: &str,
+			_expected: &SharedCodexAuthVersion,
+		) -> Result<(), CodexAuthProjectionError> {
+			self.projections.fetch_add(1, Ordering::Relaxed);
+			Ok(())
+		}
+	}
+
+	struct CountingCredentialRefresher(Arc<AtomicUsize>);
+	impl CredentialRefreshPort for CountingCredentialRefresher {
+		fn refresh(
+			&self,
+			_current: &CredentialSecretBundle,
+		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+			self.0.fetch_add(1, Ordering::Relaxed);
+			Err(CredentialRefreshError::Rejected)
+		}
+	}
+
+	struct RouteCredentialRefresher;
+	impl CredentialRefreshPort for RouteCredentialRefresher {
+		fn refresh(
+			&self,
+			current: &CredentialSecretBundle,
+		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+			let identity = decode_chatgpt_identity(
+				current.id_token().ok_or(CredentialRefreshError::Rejected)?,
+			)
+			.map_err(|_| CredentialRefreshError::Rejected)?;
+			Ok(CredentialRefreshResult {
+				bundle: shared_bundle(
+					identity.provider.account_id(),
+					"target-refreshed-access",
+					i64::MAX / 2,
+				),
+				returned_provider: identity.provider,
+			})
+		}
+	}
+
+	async fn enroll_route_test_account(
+		store: &SqliteStore,
+		credentials: &Arc<dyn HostCredentialStore>,
+		account_id: &str,
+		operation_id: &str,
+		provider_account_id: &str,
+		access_token: &str,
+	) -> AccountId {
+		enroll_route_test_account_with_expiry(
+			store,
+			credentials,
+			account_id,
+			operation_id,
+			provider_account_id,
+			access_token,
+			2_000_000,
+		)
+		.await
+	}
+
+	async fn enroll_route_test_account_with_expiry(
+		store: &SqliteStore,
+		credentials: &Arc<dyn HostCredentialStore>,
+		account_id: &str,
+		operation_id: &str,
+		provider_account_id: &str,
+		access_token: &str,
+		expiry: i64,
+	) -> AccountId {
+		let account_id = AccountId::new(account_id).expect("account identity");
+		let operation_id = AccountOperationId::new(operation_id).expect("enrollment operation");
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, provider_account_id)
+			.expect("provider identity");
+		let bundle = shared_bundle(provider.account_id(), access_token, expiry);
+		let binding = bundle
+			.binding_for(
+				&account_id,
+				&operation_id,
+				CredentialVersion::new(1).expect("credential version"),
+				&provider,
+			)
+			.expect("credential binding");
+		accepted_phase(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: operation_id.clone(),
+					account_id: account_id.clone(),
+					kind: AccountOperationKind::Enroll,
+					display_label: Some(stable_account_alias(&provider)),
+					enabled: Some(true),
+					expected_account_revision: None,
+					expected: None,
+					target: Some(binding.clone()),
+					provider,
+				})
+				.await
+				.expect("prepare enrollment"),
+		)
+		.expect("accept enrollment");
+		credentials.create(&account_id, &binding, bundle).expect("create credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&operation_id,
+					AccountOperationPhase::Prepared,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await
+				.expect("record credential"),
+		)
+		.expect("accept credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&operation_id,
+					AccountOperationPhase::StoreApplied,
+					AccountOperationPhase::Committed,
+					None,
+				)
+				.await
+				.expect("commit enrollment"),
+		)
+		.expect("accept enrollment commit");
+		account_id
 	}
 
 	#[test]
@@ -3982,9 +4936,939 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn live_codex_blocks_provider_refresh_for_managed_and_absent_shared_auth() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let account_id = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000061",
+			"22000000-0000-4000-8000-000000000061",
+			"live-provider",
+			"live-access",
+		)
+		.await;
+		let provider_calls = Arc::new(AtomicUsize::new(0));
+		let managed_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "live-provider",
+			source_access: "live-access",
+			source_expiry: 2_000_000,
+			target_provider: "live-provider",
+			target_access: "unused",
+			projections: AtomicUsize::new(0),
+		});
+		let managed = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(CountingCredentialRefresher(Arc::clone(&provider_calls))),
+		)
+		.with_shared_auth_coordinator(test_coordinator(
+			Arc::clone(&managed_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
+		));
+		assert!(
+			managed
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "owner-busy-managed".to_owned(),
+					executable_sha256: "1".repeat(64),
+					schema_sha256: "2".repeat(64),
+					callback_profile_sha256: "3".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback")
+		);
+		assert!(matches!(
+			managed
+				.refresh(
+					AccountOperationId::new("22000000-0000-4000-8000-000000000062")
+						.expect("refresh operation"),
+					&account_id,
+					Some(1),
+					None,
+					None,
+				)
+				.await,
+			Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy))
+		));
+
+		let unmanaged_file = Arc::new(UnmanagedSharedAuthFile { projections: AtomicUsize::new(0) });
+		let unmanaged = AccountService::new(
+			store,
+			Arc::clone(&credentials),
+			Arc::new(CountingCredentialRefresher(Arc::clone(&provider_calls))),
+		)
+		.with_shared_auth_coordinator(test_coordinator(
+			Arc::clone(&unmanaged_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
+		));
+		assert!(
+			unmanaged
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "owner-busy-unmanaged".to_owned(),
+					executable_sha256: "4".repeat(64),
+					schema_sha256: "5".repeat(64),
+					callback_profile_sha256: "6".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback")
+		);
+		assert!(matches!(
+			unmanaged
+				.refresh(
+					AccountOperationId::new("22000000-0000-4000-8000-000000000063")
+						.expect("refresh operation"),
+					&account_id,
+					Some(1),
+					None,
+					None,
+				)
+				.await,
+			Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy))
+		));
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 0);
+		assert_eq!(managed_file.projections.load(Ordering::Relaxed), 0);
+		assert_eq!(unmanaged_file.projections.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test]
+	async fn stable_known_account_same_expiry_rotation_imports_once_without_provider_work() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let expiry = i64::MAX / 2;
+		let account_id = enroll_route_test_account_with_expiry(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000081",
+			"22000000-0000-4000-8000-000000000081",
+			"rotation-provider",
+			"initial-access",
+			expiry,
+		)
+		.await;
+		let file = Arc::new(RouteSharedAuthFile {
+			source_provider: "rotation-provider",
+			source_access: "rotated-access",
+			source_expiry: expiry,
+			target_provider: "rotation-provider",
+			target_access: "rotated-access",
+			projections: AtomicUsize::new(0),
+		});
+		let coordinator = Arc::new(SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::MayBeRunning)),
+			Arc::clone(&file) as Arc<dyn SharedAuthFilePort>,
+		));
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(UnusedCredentialRefresher),
+		)
+		.with_shared_auth_coordinator(coordinator);
+
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "rotation-import-build".to_owned(),
+					executable_sha256: "a".repeat(64),
+					schema_sha256: "b".repeat(64),
+					callback_profile_sha256: "c".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback")
+		);
+		assert!(service.follow_shared_auth_once().await.unwrap().is_none());
+		let imported =
+			service.follow_shared_auth_once().await.unwrap().expect("known rotation imports");
+		assert_eq!(imported.account_id, account_id);
+		assert_eq!(imported.revision, 2);
+		let binding = imported.credential.expect("imported binding");
+		let stored = credentials.read_exact(&account_id, &binding).expect("read imported bundle");
+		assert_eq!(stored.bundle().access_token(), "rotated-access");
+		assert_eq!(stored.bundle().access_token_expires_at_unix_micros(), expiry);
+		assert!(service.follow_shared_auth_once().await.unwrap().is_none());
+		assert_eq!(file.projections.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test]
+	async fn route_command_confirms_an_already_current_shared_target_without_rewriting_it() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, "route-provider")
+			.expect("provider identity");
+		let account_id =
+			AccountId::new("21000000-0000-4000-8000-000000000041").expect("account identity");
+		let enrollment_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000041")
+			.expect("enrollment operation");
+		let bundle = shared_bundle(provider.account_id(), "route-access", 3_000_000);
+		let binding = bundle
+			.binding_for(
+				&account_id,
+				&enrollment_operation,
+				CredentialVersion::new(1).expect("credential version"),
+				&provider,
+			)
+			.expect("credential binding");
+		accepted_phase(
+			store
+				.prepare_account_operation(&AccountOperationPreparation {
+					operation_id: enrollment_operation.clone(),
+					account_id: account_id.clone(),
+					kind: AccountOperationKind::Enroll,
+					display_label: Some(stable_account_alias(&provider)),
+					enabled: Some(true),
+					expected_account_revision: None,
+					expected: None,
+					target: Some(binding.clone()),
+					provider: provider.clone(),
+				})
+				.await
+				.expect("prepare enrollment"),
+		)
+		.expect("accept enrollment");
+		credentials.create(&account_id, &binding, bundle).expect("create credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&enrollment_operation,
+					AccountOperationPhase::Prepared,
+					AccountOperationPhase::StoreApplied,
+					None,
+				)
+				.await
+				.expect("record credential"),
+		)
+		.expect("accept credential");
+		accepted_phase(
+			store
+				.advance_account_operation(
+					&enrollment_operation,
+					AccountOperationPhase::StoreApplied,
+					AccountOperationPhase::Committed,
+					None,
+				)
+				.await
+				.expect("commit enrollment"),
+		)
+		.expect("accept enrollment commit");
+		let routing = store.read_account_routing_control().await.expect("read routing");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000042","account_id":"{}","expected_account_revision":1}}}}"#,
+			account_id.as_str(),
+		);
+		let command = CommandIdentity::new("route-command", request.as_bytes())
+			.expect("Route command identity");
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.expect("reserve Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "route-provider",
+			source_access: "route-access",
+			source_expiry: 3_000_000,
+			target_provider: "route-provider",
+			target_access: "route-access",
+			projections: AtomicUsize::new(0),
+		});
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(UnusedCredentialRefresher),
+		)
+		.with_shared_auth_coordinator(test_coordinator(
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
+		));
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "route-test-build".to_owned(),
+					executable_sha256: "a".repeat(64),
+					schema_sha256: "b".repeat(64),
+					callback_profile_sha256: "c".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest Route callback capability")
+		);
+		let response = service
+			.route_account_command(
+				lease,
+				AccountOperationId::new("22000000-0000-4000-8000-000000000042")
+					.expect("Route operation"),
+				&account_id,
+				1,
+				routing.revision,
+				false,
+				|result| {
+					Ok(match result {
+						Ok(AccountRouteResult::Committed(commit)) => json!({
+							"account_revision": commit.account.revision,
+							"routing_revision": commit.routing.revision,
+							"projection_digest": commit.projection_digest,
+						}),
+						Ok(AccountRouteResult::Pending(_)) | Err(_) => {
+							json!({"outcome": "unexpected"})
+						},
+					})
+				},
+			)
+			.await
+			.expect("complete Route");
+
+		assert_eq!(response["account_revision"], 1);
+		assert_eq!(response["routing_revision"], routing.revision + 1);
+		assert_eq!(response["projection_digest"].as_str().map(str::len), Some(64));
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+		let routed = store.read_account_routing_control().await.expect("read routed policy");
+		assert_eq!(routed.mode, AccountSelectionMode::Fixed(account_id.clone()));
+
+		let stale_request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000043","account_id":"{}","expected_account_revision":1}}}}"#,
+			account_id.as_str(),
+		);
+		let stale_command = CommandIdentity::new("stale-route-command", stale_request.as_bytes())
+			.expect("stale Route command identity");
+		let stale_lease = match store
+			.reserve_account_route_command(&stale_command, routing.revision, &stale_request)
+			.await
+			.expect("reserve stale Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new stale Route replayed")
+			},
+		};
+		let stale_response = service
+			.route_account_command(
+				stale_lease,
+				AccountOperationId::new("22000000-0000-4000-8000-000000000043")
+					.expect("stale Route operation"),
+				&account_id,
+				1,
+				routing.revision,
+				false,
+				|result| {
+					Ok(match result {
+						Err(AccountRouteFailure::Routing(
+							RoutingControlOutcome::StaleRoutingControl { revision },
+						)) => json!({"outcome": "stale_routing", "revision": revision}),
+						_ => json!({"outcome": "unexpected"}),
+					})
+				},
+			)
+			.await
+			.expect("complete stale Route");
+		assert_eq!(stale_response["outcome"], "stale_routing");
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+		assert!(
+			store
+				.read_pending_account_route_commands(8)
+				.await
+				.expect("read pending Routes")
+				.is_empty()
+		);
+	}
+
+	#[tokio::test]
+	async fn cross_account_route_preserves_the_exact_shared_source_before_projection() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let source_account_id = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000051",
+			"22000000-0000-4000-8000-000000000051",
+			"source-provider",
+			"source-access",
+		)
+		.await;
+		let target_account_id = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000052",
+			"22000000-0000-4000-8000-000000000052",
+			"target-provider",
+			"target-access",
+		)
+		.await;
+		let routing = store.read_account_routing_control().await.expect("read routing");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000053","account_id":"{}","expected_account_revision":1}}}}"#,
+			target_account_id.as_str(),
+		);
+		let command = CommandIdentity::new("cross-account-route", request.as_bytes())
+			.expect("cross-account Route identity");
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.expect("reserve cross-account Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "source-provider",
+			source_access: "source-rotated-access",
+			source_expiry: i64::MAX / 2,
+			target_provider: "target-provider",
+			target_access: "target-refreshed-access",
+			projections: AtomicUsize::new(0),
+		});
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(RouteCredentialRefresher),
+		)
+		.with_shared_auth_coordinator(route_test_coordinator(Arc::clone(&shared_auth_file)));
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "cross-route-test-build".to_owned(),
+					executable_sha256: "d".repeat(64),
+					schema_sha256: "e".repeat(64),
+					callback_profile_sha256: "f".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest cross-Route callback capability")
+		);
+
+		let response = service
+			.route_account_command(
+				lease,
+				AccountOperationId::new("22000000-0000-4000-8000-000000000053")
+					.expect("Route operation"),
+				&target_account_id,
+				1,
+				routing.revision,
+				false,
+				|result| {
+					Ok(match result {
+						Ok(AccountRouteResult::Committed(commit)) => json!({
+							"account_revision": commit.account.revision,
+							"routing_revision": commit.routing.revision,
+						}),
+						Ok(AccountRouteResult::Pending(_)) | Err(_) => {
+							json!({"outcome": "unexpected"})
+						},
+					})
+				},
+			)
+			.await
+			.expect("complete cross-account Route");
+
+		assert_eq!(response["account_revision"], 2);
+		assert_eq!(response["routing_revision"], routing.revision + 1);
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 1);
+		let source = store
+			.read_account_registry(Some(&source_account_id), 1)
+			.await
+			.expect("read source account")
+			.pop()
+			.expect("source account");
+		let source_binding = source.credential.expect("source binding");
+		let source_stored = credentials
+			.read_exact(&source_account_id, &source_binding)
+			.expect("read preserved source credential");
+		assert_eq!(source.revision, 2);
+		assert_eq!(source_stored.bundle().access_token(), "source-rotated-access");
+	}
+
+	#[tokio::test]
+	async fn pending_route_waits_for_natural_quiescence_then_commits_from_the_same_receipt() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let _source_account_id = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000071",
+			"22000000-0000-4000-8000-000000000071",
+			"pending-source-provider",
+			"pending-source-access",
+		)
+		.await;
+		let account_id = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000073",
+			"22000000-0000-4000-8000-000000000073",
+			"pending-target-provider",
+			"pending-target-access",
+		)
+		.await;
+		let routing = store.read_account_routing_control().await.expect("read routing");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000072","account_id":"{}","expected_account_revision":1}}}}"#,
+			account_id.as_str(),
+		);
+		let command = CommandIdentity::new("pending-route", request.as_bytes())
+			.expect("Route command identity");
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.expect("reserve Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "pending-source-provider",
+			source_access: "pending-source-access",
+			source_expiry: 2_000_000,
+			target_provider: "pending-target-provider",
+			target_access: "target-refreshed-access",
+			projections: AtomicUsize::new(0),
+		});
+		let running = Arc::new(AtomicBool::new(true));
+		let coordinator = test_coordinator_with_liveness(
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			Arc::new(MutableLiveness(Arc::clone(&running))),
+		);
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(RouteCredentialRefresher),
+		)
+		.with_shared_auth_coordinator(coordinator);
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "pending-route-build".to_owned(),
+					executable_sha256: "7".repeat(64),
+					schema_sha256: "8".repeat(64),
+					callback_profile_sha256: "9".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback")
+		);
+		let operation_id = AccountOperationId::new("22000000-0000-4000-8000-000000000072")
+			.expect("Route operation");
+		let response_builder = |result| {
+			Ok(match result {
+				Ok(AccountRouteResult::Pending(pending)) => json!({
+					"outcome": "pending",
+					"operation_id": pending.operation_id.as_str(),
+					"account_id": pending.account_id.as_str(),
+					"routing_revision": pending.routing_revision,
+				}),
+				Ok(AccountRouteResult::Committed(commit)) => json!({
+					"outcome": "routed",
+					"routing_revision": commit.routing.revision,
+				}),
+				Err(_) => json!({"outcome": "unexpected"}),
+			})
+		};
+		let pending_response = service
+			.route_account_command(
+				lease,
+				operation_id.clone(),
+				&account_id,
+				1,
+				routing.revision,
+				false,
+				response_builder,
+			)
+			.await
+			.expect("defer Route");
+		assert_eq!(pending_response["outcome"], "pending");
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+		assert!(matches!(
+			store
+				.reserve_account_route_command(&command, routing.revision, &request)
+				.await
+				.expect("replay pending Route"),
+			AccountCommandReceiptClaim::Pending(value) if value == pending_response
+		));
+
+		running.store(false, Ordering::Relaxed);
+		time::sleep(Duration::from_millis(2)).await;
+		let pending = store
+			.read_pending_account_route_commands(1)
+			.await
+			.expect("read pending Route")
+			.pop()
+			.expect("pending Route");
+		let lease = match store
+			.reclaim_account_route_command(&pending)
+			.await
+			.expect("reclaim pending Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("pending Route did not reclaim")
+			},
+		};
+		let routed = service
+			.route_account_command(
+				lease,
+				operation_id,
+				&account_id,
+				1,
+				routing.revision,
+				true,
+				response_builder,
+			)
+			.await
+			.expect("complete Route");
+		assert_eq!(routed["outcome"], "routed");
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 1);
+		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
+		assert_eq!(
+			store.read_account_routing_control().await.unwrap().mode,
+			AccountSelectionMode::Fixed(account_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn restarted_pending_route_waits_for_callback_readiness_then_converges_if_auth_is_current() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let target = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000c1",
+			"22000000-0000-4000-8000-0000000000c1",
+			"restart-current-provider",
+			"restart-current-access",
+		)
+		.await;
+		let routing = store.read_account_routing_control().await.unwrap();
+		let operation = "22000000-0000-4000-8000-0000000000c2";
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{operation}","account_id":"{}","expected_account_revision":1}}}}"#,
+			target.as_str(),
+		);
+		let command = CommandIdentity::new("restart-pending-route", request.as_bytes()).unwrap();
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		store.defer_account_route_command(lease, &json!({"outcome": "pending"})).await.unwrap();
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "restart-current-provider",
+			source_access: "restart-current-access",
+			source_expiry: 2_000_000,
+			target_provider: "restart-current-provider",
+			target_access: "restart-current-access",
+			projections: AtomicUsize::new(0),
+		});
+		let service = Arc::new(
+			AccountService::new(
+				store.clone(),
+				Arc::clone(&credentials),
+				Arc::new(UnusedCredentialRefresher),
+			)
+			.with_shared_auth_coordinator(test_coordinator(
+				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+				CodexLiveness::MayBeRunning,
+			)),
+		);
+		time::sleep(Duration::from_millis(2)).await;
+		crate::application::recover_pending_account_routes_once(
+			Arc::clone(&service),
+			&store,
+			None,
+		)
+		.await;
+		assert_eq!(store.read_pending_account_route_commands(1).await.unwrap().len(), 1);
+
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "restart-route-build".to_owned(),
+					executable_sha256: "a".repeat(64),
+					schema_sha256: "b".repeat(64),
+					callback_profile_sha256: "c".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.unwrap()
+		);
+		crate::application::recover_pending_account_routes_once(service, &store, None).await;
+		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
+		assert_eq!(
+			store.read_account_routing_control().await.unwrap().mode,
+			AccountSelectionMode::Fixed(target)
+		);
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test]
+	async fn newer_pending_route_replaces_the_target_without_a_shared_auth_write() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let _source = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000d1",
+			"22000000-0000-4000-8000-0000000000d1",
+			"replace-source-provider",
+			"replace-source-access",
+		)
+		.await;
+		let first_target = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000d2",
+			"22000000-0000-4000-8000-0000000000d2",
+			"replace-first-provider",
+			"replace-first-access",
+		)
+		.await;
+		let second_target = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000d3",
+			"22000000-0000-4000-8000-0000000000d3",
+			"replace-second-provider",
+			"replace-second-access",
+		)
+		.await;
+		let routing = store.read_account_routing_control().await.unwrap();
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "replace-source-provider",
+			source_access: "replace-source-access",
+			source_expiry: 2_000_000,
+			target_provider: "replace-second-provider",
+			target_access: "target-refreshed-access",
+			projections: AtomicUsize::new(0),
+		});
+		let service = AccountService::new(
+			store.clone(),
+			Arc::clone(&credentials),
+			Arc::new(RouteCredentialRefresher),
+		)
+		.with_shared_auth_coordinator(test_coordinator(
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
+		));
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "replace-route-build".to_owned(),
+					executable_sha256: "d".repeat(64),
+					schema_sha256: "e".repeat(64),
+					callback_profile_sha256: "f".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.unwrap()
+		);
+		let pending_response = |result| {
+			Ok(match result {
+				Ok(AccountRouteResult::Pending(pending)) => json!({
+					"outcome": "pending",
+					"account_id": pending.account_id.as_str(),
+				}),
+				_ => json!({"outcome": "unexpected"}),
+			})
+		};
+		let first_operation = "22000000-0000-4000-8000-0000000000d4";
+		let first_request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{first_operation}","account_id":"{}","expected_account_revision":1}}}}"#,
+			first_target.as_str(),
+		);
+		let first_command = CommandIdentity::new("replace-first-route", first_request.as_bytes()).unwrap();
+		let first_lease = match store
+			.reserve_account_route_command(&first_command, routing.revision, &first_request)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			_ => panic!("first Route replayed"),
+		};
+		let first_result = service
+			.route_account_command(
+				first_lease,
+				AccountOperationId::new(first_operation).unwrap(),
+				&first_target,
+				1,
+				routing.revision,
+				false,
+				pending_response,
+			)
+			.await
+			.unwrap();
+		assert_eq!(first_result["account_id"], first_target.as_str());
+
+		let second_operation = "22000000-0000-4000-8000-0000000000d5";
+		let second_request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{second_operation}","account_id":"{}","expected_account_revision":1}}}}"#,
+			second_target.as_str(),
+		);
+		let second_command =
+			CommandIdentity::new("replace-second-route", second_request.as_bytes()).unwrap();
+		let superseded = json!({"outcome": "rejected", "reason": "route_superseded"});
+		let second_lease = match store
+			.reserve_replacing_account_route_command(
+				&second_command,
+				routing.revision,
+				&second_request,
+				&superseded,
+			)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			_ => panic!("second Route replayed"),
+		};
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+		let second_result = service
+			.route_account_command(
+				second_lease,
+				AccountOperationId::new(second_operation).unwrap(),
+				&second_target,
+				1,
+				routing.revision,
+				false,
+				pending_response,
+			)
+			.await
+			.unwrap();
+		assert_eq!(second_result["account_id"], second_target.as_str());
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+		assert!(matches!(
+			store
+				.reserve_account_route_command(&first_command, routing.revision, &first_request)
+				.await
+				.unwrap(),
+			AccountCommandReceiptClaim::Replayed(value) if value == superseded
+		));
+		let pending = store.read_pending_account_route_commands(8).await.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].idempotency_key, "replace-second-route");
+	}
+
+	#[tokio::test]
+	async fn live_codex_does_not_delay_terminal_pending_route_routing_drift() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let target = enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000b1",
+			"22000000-0000-4000-8000-0000000000b1",
+			"drift-target-provider",
+			"drift-target-access",
+		)
+		.await;
+		let routing = store.read_account_routing_control().await.unwrap();
+		let operation = "22000000-0000-4000-8000-0000000000b2";
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{operation}","account_id":"{}","expected_account_revision":1}}}}"#,
+			target.as_str(),
+		);
+		let command = CommandIdentity::new("drifted-pending-route", request.as_bytes()).unwrap();
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		store.defer_account_route_command(lease, &json!({"outcome": "pending"})).await.unwrap();
+		enroll_route_test_account(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000b3",
+			"22000000-0000-4000-8000-0000000000b3",
+			"drift-other-provider",
+			"drift-other-access",
+		)
+		.await;
+		assert_ne!(store.read_account_routing_control().await.unwrap().revision, routing.revision);
+
+		let shared_auth_file = Arc::new(RouteSharedAuthFile {
+			source_provider: "drift-target-provider",
+			source_access: "drift-target-access",
+			source_expiry: 2_000_000,
+			target_provider: "drift-target-provider",
+			target_access: "drift-target-access",
+			projections: AtomicUsize::new(0),
+		});
+		let service = Arc::new(
+			AccountService::new(
+				store.clone(),
+				Arc::clone(&credentials),
+				Arc::new(UnusedCredentialRefresher),
+			)
+			.with_shared_auth_coordinator(test_coordinator(
+				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+				CodexLiveness::MayBeRunning,
+			)),
+		);
+		time::sleep(Duration::from_millis(2)).await;
+		crate::application::recover_pending_account_routes_once(service, &store, None).await;
+
+		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test]
 	#[allow(clippy::too_many_lines)] // The precommitted refresh fixture and receipt readback form one crash-window proof.
-	async fn committed_refresh_finishes_its_receipt_when_shared_reprojection_fails() {
-		FAILED_SHARED_REPROJECTIONS.store(0, Ordering::Relaxed);
+	async fn committed_refresh_finishes_its_receipt_without_a_shared_auth_write() {
 		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
@@ -3995,9 +5879,8 @@ mod tests {
 			.expect("provider identity");
 		let account_id =
 			AccountId::new("21000000-0000-4000-8000-000000000031").expect("account identity");
-		let enrollment_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000031")
-				.expect("enrollment operation");
+		let enrollment_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000031")
+			.expect("enrollment operation");
 		let initial_bundle = shared_bundle(provider.account_id(), "initial-access", 2_000_000);
 		let initial_binding = initial_bundle
 			.binding_for(
@@ -4052,9 +5935,8 @@ mod tests {
 		)
 		.expect("accept enrollment commit");
 
-		let refresh_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000032")
-				.expect("refresh operation");
+		let refresh_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000032")
+			.expect("refresh operation");
 		let refreshed_bundle = shared_bundle(provider.account_id(), "refreshed-access", 3_000_000);
 		let refreshed_binding = refreshed_bundle
 			.binding_for(
@@ -4124,19 +6006,25 @@ mod tests {
 		let command = CommandIdentity::new("refresh-reprojection-receipt", b"exact refresh replay")
 			.expect("command identity");
 		let lease = match store
-			.reserve_account_command(&command, AccountCommandKind::Refresh, account_id.as_str(), Some(1))
+			.reserve_account_command(
+				&command,
+				AccountCommandKind::Refresh,
+				account_id.as_str(),
+				Some(1),
+			)
 			.await
 			.expect("reserve refresh command")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("new refresh command replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new refresh command replayed")
+			},
 		};
 		let service = AccountService::new(
 			store.clone(),
 			Arc::clone(&credentials),
 			Arc::new(UnusedCredentialRefresher),
-		)
-		.with_shared_auth_reprojector(fail_shared_auth_reprojection);
+		);
 		let response = service
 			.refresh_command(lease, refresh_operation.clone(), &account_id, 1, |result| {
 				Ok(match result {
@@ -4151,7 +6039,6 @@ mod tests {
 			.expect("complete committed refresh command");
 
 		assert_eq!(response, json!({"outcome": "succeeded", "account_revision": 2}));
-		assert_eq!(FAILED_SHARED_REPROJECTIONS.load(Ordering::Relaxed), 1);
 		let refreshed = service.inspect(&account_id).await.expect("read refreshed account").account;
 		assert_eq!(refreshed.revision, 2);
 		assert_eq!(refreshed.credential.as_ref(), Some(&refreshed_binding));
@@ -4162,12 +6049,19 @@ mod tests {
 			.expect("refresh operation exists");
 		assert_eq!(operation.phase, AccountOperationPhase::Committed);
 		match store
-			.reserve_account_command(&command, AccountCommandKind::Refresh, account_id.as_str(), Some(1))
+			.reserve_account_command(
+				&command,
+				AccountCommandKind::Refresh,
+				account_id.as_str(),
+				Some(1),
+			)
 			.await
 			.expect("replay refresh command")
 		{
 			AccountCommandReceiptClaim::Replayed(replayed) => assert_eq!(replayed, response),
-			AccountCommandReceiptClaim::Owned(_) => panic!("committed refresh receipt was not terminal"),
+			AccountCommandReceiptClaim::Owned(_) | AccountCommandReceiptClaim::Pending(_) => {
+				panic!("committed refresh receipt was not terminal")
+			},
 		}
 	}
 
@@ -4215,7 +6109,8 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn device_login_enrollment_commits_one_credential_bound_account_and_replays_its_receipt() {
+	async fn device_login_enrollment_commits_one_credential_bound_account_and_replays_its_receipt()
+	{
 		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
@@ -4244,12 +6139,12 @@ mod tests {
 			.expect("reserve enrollment command")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("new enrollment command replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new enrollment command replayed")
+			},
 		};
-		let (_source_directory, source_descriptor) = owner_private_shared_codex_auth(
-			"device-login-provider",
-			"device-login@example.test",
-		);
+		let (_source_directory, source_descriptor) =
+			owner_private_shared_codex_auth("device-login-provider", "device-login@example.test");
 		let response = service
 			.enroll_from_credential_file_command(
 				lease,
@@ -4302,7 +6197,9 @@ mod tests {
 			.expect("replay enrollment command")
 		{
 			AccountCommandReceiptClaim::Replayed(replayed) => assert_eq!(replayed, response),
-			AccountCommandReceiptClaim::Owned(_) => panic!("completed enrollment did not replay"),
+			AccountCommandReceiptClaim::Owned(_) | AccountCommandReceiptClaim::Pending(_) => {
+				panic!("completed enrollment did not replay")
+			},
 		}
 	}
 
@@ -4327,9 +6224,8 @@ mod tests {
 				.expect("provider identity");
 		let existing_account =
 			AccountId::new("21000000-0000-4000-8000-000000000010").expect("existing account");
-		let existing_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000010")
-				.expect("existing operation");
+		let existing_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000010")
+			.expect("existing operation");
 		let existing_bundle = shared_bundle(provider.account_id(), "existing-access", 3_000_000);
 		let existing_binding = existing_bundle
 			.binding_for(
@@ -4380,8 +6276,8 @@ mod tests {
 
 		let account_id =
 			AccountId::new("21000000-0000-4000-8000-000000000011").expect("new account");
-		let operation_id = AccountOperationId::new("22000000-0000-4000-8000-000000000011")
-			.expect("new operation");
+		let operation_id =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000011").expect("new operation");
 		let command = CommandIdentity::new("duplicate-provider-enroll", b"exact duplicate request")
 			.expect("command identity");
 		let lease = match store
@@ -4395,12 +6291,12 @@ mod tests {
 			.expect("reserve enrollment command")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("new enrollment command replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new enrollment command replayed")
+			},
 		};
-		let (_source_directory, source_descriptor) = owner_private_shared_codex_auth(
-			provider.account_id(),
-			"duplicate@example.test",
-		);
+		let (_source_directory, source_descriptor) =
+			owner_private_shared_codex_auth(provider.account_id(), "duplicate@example.test");
 		let response = service
 			.enroll_from_credential_file_command(
 				lease,
@@ -4448,7 +6344,9 @@ mod tests {
 			.expect("replay enrollment command")
 		{
 			AccountCommandReceiptClaim::Replayed(replayed) => assert_eq!(replayed, response),
-			AccountCommandReceiptClaim::Owned(_) => panic!("completed enrollment did not replay"),
+			AccountCommandReceiptClaim::Owned(_) | AccountCommandReceiptClaim::Pending(_) => {
+				panic!("completed enrollment did not replay")
+			},
 		}
 		credentials
 			.read_exact(&existing_account, &existing_binding)
@@ -4472,14 +6370,12 @@ mod tests {
 			Arc::clone(&credentials),
 			Arc::new(UnusedCredentialRefresher),
 		);
-		let provider =
-			ProviderIdentity::new(AccountProvider::Chatgpt, "restored-provider-account")
-				.expect("provider identity");
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, "restored-provider-account")
+			.expect("provider identity");
 		let original_account =
 			AccountId::new("21000000-0000-4000-8000-000000000020").expect("original account");
-		let enrollment_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000020")
-				.expect("enrollment operation");
+		let enrollment_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000020")
+			.expect("enrollment operation");
 		let enrollment_command =
 			CommandIdentity::new("restore-provider-enroll", b"initial enrollment")
 				.expect("enrollment command");
@@ -4494,12 +6390,12 @@ mod tests {
 			.expect("reserve initial enrollment")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("initial enrollment replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("initial enrollment replayed")
+			},
 		};
-		let (_initial_source, initial_descriptor) = owner_private_shared_codex_auth(
-			provider.account_id(),
-			"initial@example.test",
-		);
+		let (_initial_source, initial_descriptor) =
+			owner_private_shared_codex_auth(provider.account_id(), "initial@example.test");
 		let initial = service
 			.enroll_from_credential_file_command(
 				enrollment_lease,
@@ -4529,9 +6425,8 @@ mod tests {
 			})
 		);
 
-		let logout_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000021")
-				.expect("logout operation");
+		let logout_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000021")
+			.expect("logout operation");
 		let tombstone = service
 			.logout(logout_operation, &original_account, 1)
 			.await
@@ -4542,9 +6437,8 @@ mod tests {
 
 		let legacy_account =
 			AccountId::new("21000000-0000-4000-8000-000000000022").expect("legacy account");
-		let legacy_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000022")
-				.expect("legacy operation");
+		let legacy_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000022")
+			.expect("legacy operation");
 		let legacy_bundle = shared_bundle(provider.account_id(), "legacy-access", 3_000_000);
 		let legacy_target = legacy_bundle
 			.binding_for(
@@ -4600,9 +6494,8 @@ mod tests {
 
 		let requested_account =
 			AccountId::new("21000000-0000-4000-8000-000000000023").expect("requested account");
-		let restore_operation =
-			AccountOperationId::new("22000000-0000-4000-8000-000000000023")
-				.expect("restore operation");
+		let restore_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000023")
+			.expect("restore operation");
 		let restore_command =
 			CommandIdentity::new("restore-provider-reenroll", b"restore enrollment")
 				.expect("restore command");
@@ -4617,12 +6510,12 @@ mod tests {
 			.expect("reserve restore enrollment")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("restore enrollment replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("restore enrollment replayed")
+			},
 		};
-		let (_restore_source, restore_descriptor) = owner_private_shared_codex_auth(
-			provider.account_id(),
-			"restored@example.test",
-		);
+		let (_restore_source, restore_descriptor) =
+			owner_private_shared_codex_auth(provider.account_id(), "restored@example.test");
 		let restored = service
 			.enroll_from_credential_file_command(
 				restore_lease,
@@ -4668,11 +6561,7 @@ mod tests {
 		let accounts = service.list().await.expect("list restored account");
 		assert_eq!(accounts.len(), 1);
 		assert_eq!(accounts[0].account.account_id, original_account);
-		let binding = accounts[0]
-			.account
-			.credential
-			.as_ref()
-			.expect("restored credential binding");
+		let binding = accounts[0].account.credential.as_ref().expect("restored credential binding");
 		assert_eq!(binding.version.get(), 2);
 		assert_eq!(binding.writer_operation_id, restore_operation);
 		credentials
@@ -4857,7 +6746,9 @@ mod tests {
 			.expect("reserve takeover command")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("new takeover command replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new takeover command replayed")
+			},
 		};
 		let response = service
 			.reauthenticate_from_credential_file_command(
@@ -5054,20 +6945,6 @@ mod tests {
 	}
 
 	#[test]
-	fn post_rename_unknown_escapes_before_receipt_completion() {
-		assert!(matches!(
-			use_in_codex_receipt_result::<()>(Err(UseInCodexProjectionError::OutcomeUnknown,)),
-			Err(AccountLifecycleError::CoordinatorUnavailable),
-		));
-		assert!(matches!(
-			use_in_codex_receipt_result::<()>(Err(UseInCodexProjectionError::Rejected(
-				AccountLifecycleError::CredentialAbsent,
-			))),
-			Ok(Err(AccountLifecycleError::CredentialAbsent)),
-		));
-	}
-
-	#[test]
 	fn codex_projection_digest_changes_with_only_credential_negative_binding_state() {
 		let first = projection_account(Some(binding("projection-provider", 3)));
 		let first_binding = first.credential.as_ref().unwrap();
@@ -5083,6 +6960,19 @@ mod tests {
 		assert_eq!(first_digest.len(), 64);
 		assert_ne!(first_digest, revised_digest);
 		assert_ne!(first_digest, versioned_digest);
+	}
+
+	#[test]
+	fn pending_route_rejects_unrelated_account_revision_drift() {
+		let mut account = projection_account(Some(binding("revision-drift-provider", 3)));
+		let expected_revision = account.revision;
+		account.revision += 2;
+		let route_operation =
+			AccountOperationId::new("22000000-0000-4000-8000-000000000091").unwrap();
+		let derived = super::route_refresh_operation_id(&route_operation, &account.account_id)
+			.expect("derived Route refresh operation");
+
+		assert!(!route_resume_revision_is_valid(&account, expected_revision, &derived, None,));
 	}
 
 	fn identity_token(account_id: &str, email: &str, plan_type: &str) -> String {
@@ -5104,8 +6994,8 @@ mod tests {
 		let directory = tempdir().expect("temporary device-login home");
 		let root = fs::canonicalize(directory.path()).expect("canonical device-login home");
 		let path = root.join("auth.json");
-		let access_payload = URL_SAFE_NO_PAD
-			.encode(serde_json::to_vec(&json!({"exp": 2_000_000_000_i64})).unwrap());
+		let access_payload =
+			URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json!({"exp": 2_000_000_000_i64})).unwrap());
 		let access_token = format!("header.{access_payload}.signature");
 		let value = json!({
 			"auth_mode": "chatgpt",
@@ -5261,65 +7151,7 @@ mod tests {
 	}
 
 	#[test]
-	fn matching_shared_identity_reprojects_the_exact_persisted_refresh_bundle() {
-		let binding = binding("projected-provider-account", 8);
-		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
-		let projected = Cell::new(false);
-
-		reproject_shared_codex_auth_if_current_with(
-			&binding,
-			&persisted,
-			|| {
-				Ok(super::SharedCodexAuthIdentity::Chatgpt {
-					provider_account_id: binding.provider.account_id().to_owned(),
-				})
-			},
-			|bundle, provider_account_id| {
-				assert_eq!(provider_account_id, binding.provider.account_id());
-				assert!(super::same_refresh_bundle(bundle, &persisted));
-				projected.set(true);
-				Ok(())
-			},
-		)
-		.unwrap();
-
-		assert!(projected.get());
-	}
-
-	#[test]
-	fn mismatched_shared_identity_cannot_trigger_refresh_reprojection() {
-		let binding = binding("expected-provider-account", 8);
-		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
-
-		reproject_shared_codex_auth_if_current_with(
-			&binding,
-			&persisted,
-			|| {
-				Ok(super::SharedCodexAuthIdentity::Chatgpt {
-					provider_account_id: "different-provider-account".to_owned(),
-				})
-			},
-			|_, _| panic!("mismatched shared auth must not be overwritten"),
-		)
-		.unwrap();
-	}
-
-	#[test]
-	fn shared_identity_read_failure_does_not_authorize_refresh_reprojection() {
-		let binding = binding("expected-provider-account", 8);
-		let persisted = shared_bundle(binding.provider.account_id(), "persisted-access", 4_000_000);
-
-		reproject_shared_codex_auth_if_current_with(
-			&binding,
-			&persisted,
-			|| Err(super::CodexAuthProjectionError::Unavailable),
-			|_, _| panic!("unreadable shared auth must not be overwritten"),
-		)
-		.unwrap();
-	}
-
-	#[test]
-	fn rejected_provider_refresh_recovers_only_from_a_newer_matching_shared_bundle() {
+	fn rejected_provider_refresh_recovers_only_from_a_non_older_matching_shared_bundle() {
 		let provider_account_id = "expected-provider-account";
 		let current = binding(provider_account_id, 7);
 		let current_bundle = shared_bundle(provider_account_id, "current-access", 2_000_000);
@@ -5330,7 +7162,7 @@ mod tests {
 			OBSERVED_AT_MICROS,
 			Ok(imported(provider_account_id, "newer-access", 3_000_000)),
 		)
-		.expect("newer exact-identity shared auth must recover provider rejection");
+		.expect("non-older exact-identity shared auth must recover provider rejection");
 		assert_eq!(recovered.returned_provider, current.provider);
 
 		assert!(matches!(
@@ -5384,7 +7216,7 @@ mod tests {
 	}
 
 	#[test]
-	fn unchanged_not_newer_or_expired_shared_credential_preserves_provider_refresh_fallback() {
+	fn unchanged_older_or_expired_shared_credential_preserves_provider_refresh_fallback() {
 		let provider_account_id = "expected-provider-account";
 		let current = binding(provider_account_id, 7);
 		let current_bundle = shared_bundle(provider_account_id, "same-access", 3_000_000);
@@ -5398,6 +7230,14 @@ mod tests {
 			)
 			.is_none()
 		);
+		let same_expiry_rotation = matching_shared_refresh(
+			&current,
+			&current_bundle,
+			OBSERVED_AT_MICROS,
+			Ok(imported(provider_account_id, "rotated-access", 3_000_000)),
+		)
+		.expect("same-expiry token rotation must preserve the live shared writer");
+		assert_eq!(same_expiry_rotation.bundle.access_token(), "rotated-access");
 		assert!(
 			matching_shared_refresh(
 				&current,

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -5,7 +5,7 @@ use std::{
 	future::{self, Future},
 	pin::Pin,
 	sync::Arc,
-	time::{SystemTime, UNIX_EPOCH},
+	time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use decodex_codex::CodexAdapter;
@@ -31,12 +31,12 @@ use decodex_database::{
 };
 use decodex_protocol::{
 	AccountCommandRejectionDto, AccountCredentialBindingDto, AccountDto,
-	AccountLoginRequest, AccountLoginStatus,
 	AccountInitialSelectionResult, AccountInspectResult, AccountLifecycleReadinessDto,
-	AccountManualRecoveryActionDto, AccountManualRecoveryOutcomeDto, AccountObservedStateDto,
-	AccountOperationKindDto, AccountOperationPhaseDto, AccountProfileDailyUsageDto,
-	AccountProfileDto, AccountProfileEmailDto, AccountProfileErrorDto, AccountProfileResult,
-	AccountProviderDto, AccountQuotaErrorDto, AccountQuotaStateDto, AccountQuotaWindowDto,
+	AccountLoginRequest, AccountLoginStatus, AccountManualRecoveryActionDto,
+	AccountManualRecoveryOutcomeDto, AccountObservedStateDto, AccountOperationKindDto,
+	AccountOperationPhaseDto, AccountProfileDailyUsageDto, AccountProfileDto,
+	AccountProfileEmailDto, AccountProfileErrorDto, AccountProfileResult, AccountProviderDto,
+	AccountQuotaErrorDto, AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutePendingDto,
 	AccountRoutingControlDto, AccountSelectionModeDto, AccountSelectionRecoveryDto,
 	AccountUnsettledOperationDto, AccountsResult, CausationId, Channel, CodexAuthProjectionResult,
 	CommandEnvelope, CommandError, CommandPayload, ConversationHistoryPage,
@@ -59,7 +59,10 @@ use decodex_protocol::{
 	WorkItemBoardResult, WorkItemBoardWorkItemId,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::watch;
+use tokio::{
+	sync::{Mutex as AsyncMutex, broadcast, watch},
+	time,
+};
 
 use crate::{
 	CredentialStoreError, ProcessGenerationControl, ProviderAttemptControl,
@@ -74,7 +77,8 @@ use crate::{
 	},
 	account_service::{
 		AccountLifecycleError, AccountManualRecoveryAction, AccountManualRecoveryOutcome,
-		AccountService, CodexAuthProjectionInspection, stable_account_alias,
+		AccountRouteCommit, AccountRouteCompletion, AccountRouteFailure, AccountRoutePending,
+		AccountRouteResult, AccountService, CodexAuthProjectionInspection, stable_account_alias,
 	},
 	domain_packs::{self, DomainPackError, QUICK_TASK_CAPABILITY},
 	managed_repository_runtime::ManagedRepositoryCapability,
@@ -289,6 +293,8 @@ pub(crate) struct ServiceApplication {
 	_codex: CodexAdapter,
 	blob_store: Option<BlobStore>,
 	accounts: Option<Arc<AccountService>>,
+	account_route_events: Option<AsyncMutex<broadcast::Receiver<AccountRouteCompletion>>>,
+	publication_stop: watch::Sender<bool>,
 	reset_cards: Option<ApiResetCardRuntime>,
 	account_observations: Option<AccountObservationService>,
 	account_login: Option<Arc<crate::account_login::AccountLoginManager>>,
@@ -307,6 +313,7 @@ impl ServiceApplication {
 		quick_tasks: QuickTaskCapability,
 		doctor: DoctorReport,
 	) -> Self {
+		let (publication_stop, _) = watch::channel(false);
 		Self {
 			store,
 			_managed_repositories: managed_repositories,
@@ -315,6 +322,8 @@ impl ServiceApplication {
 			_codex: codex,
 			blob_store,
 			accounts: None,
+			account_route_events: None,
+			publication_stop,
 			reset_cards: None,
 			account_observations: None,
 			account_login: None,
@@ -324,6 +333,8 @@ impl ServiceApplication {
 	}
 
 	pub(crate) fn with_accounts(mut self, accounts: Option<Arc<AccountService>>) -> Self {
+		self.account_route_events =
+			accounts.as_ref().map(|accounts| AsyncMutex::new(accounts.subscribe_route_events()));
 		self.accounts = accounts;
 
 		self
@@ -394,6 +405,122 @@ impl ServiceApplication {
 	}
 }
 
+pub(crate) async fn recover_pending_account_routes_once(
+	accounts: Arc<AccountService>,
+	store: &SqliteStore,
+	observations: Option<&AccountObservationService>,
+) {
+	if let Ok(Some(account)) = accounts.follow_shared_auth_once().await
+		&& let Some(observations) = observations
+	{
+		observations.invalidate_account(&account.account_id).await;
+		observations.request_refresh();
+	}
+	if let Ok(pending) = store.read_pending_account_route_commands(64).await {
+		let codex_may_be_running = accounts.shared_auth_may_be_running();
+		for pending_command in pending {
+			let _route_guard = accounts.lock_route_command().await;
+			let routing_is_stale =
+				store.read_account_routing_control().await.ok().is_some_and(|routing| {
+					routing.revision != pending_command.expected_routing_revision
+				});
+			let Ok(CommandPayload::RouteAccount {
+				operation_id,
+				account_id,
+				expected_account_revision,
+			}) = serde_json::from_str::<CommandPayload>(&pending_command.request_json)
+			else {
+				continue;
+			};
+			let (Ok(operation_id), Ok(account_id), Ok(expected_account_revision)) = (
+				AccountOperationId::new(operation_id.as_str()),
+				AccountId::new(account_id.as_str()),
+				i64::try_from(expected_account_revision.0),
+			) else {
+				continue;
+			};
+			if !routing_is_stale
+				&& accounts.inspect(&account_id).await.ok().is_some_and(|inspection| {
+					matches!(
+						inspection.readiness,
+						AccountLifecycleReadiness::CallbackCapabilityUnready
+							| AccountLifecycleReadiness::StoreUnavailable
+							| AccountLifecycleReadiness::StoreMismatch
+							| AccountLifecycleReadiness::OperationUnsettled
+					)
+				})
+			{
+				continue;
+			}
+			if codex_may_be_running
+				&& !routing_is_stale
+				&& !accounts.shared_auth_is_current_for(&account_id).await
+			{
+				continue;
+			}
+			let lease = match store.reclaim_account_route_command(&pending_command).await {
+				Ok(AccountCommandReceiptClaim::Owned(lease)) => lease,
+				Ok(
+					AccountCommandReceiptClaim::Pending(_)
+					| AccountCommandReceiptClaim::Replayed(_),
+				)
+				| Err(_) => continue,
+			};
+			let result = accounts
+				.route_account_command(
+					lease,
+					operation_id,
+					&account_id,
+					expected_account_revision,
+					pending_command.expected_routing_revision,
+					true,
+					|result| encode_account_command_receipt(&account_route_result(result)),
+				)
+				.await;
+			let committed = account_route_receipt_committed(result);
+			if committed && let Some(observations) = observations {
+				observations.invalidate_account(&account_id).await;
+				observations.request_refresh();
+			}
+		}
+	}
+}
+
+fn account_route_receipt_committed(
+	result: Result<serde_json::Value, AccountLifecycleError>,
+) -> bool {
+	result.ok().is_some_and(|value| {
+		decode_account_command_receipt(value).ok().and_then(Result::ok).is_some_and(|publication| {
+			matches!(publication.result, ResultPayload::AccountRouted { .. })
+		})
+	})
+}
+
+async fn recover_pending_account_routes(
+	accounts: Arc<AccountService>,
+	store: SqliteStore,
+	observations: Option<AccountObservationService>,
+	mut stop: watch::Receiver<bool>,
+) {
+	loop {
+		if *stop.borrow() {
+			return;
+		}
+		recover_pending_account_routes_once(Arc::clone(&accounts), &store, observations.as_ref())
+			.await;
+
+		tokio::select! {
+			biased;
+			changed = stop.changed() => {
+				if changed.is_err() || *stop.borrow() {
+					return;
+				}
+			},
+			() = time::sleep(Duration::from_secs(1)) => {},
+		}
+	}
+}
+
 impl ServiceApplication {
 	async fn account_list(&self) -> AccountsResult {
 		let Some(service) = &self.accounts else {
@@ -411,8 +538,19 @@ impl ServiceApplication {
 			.collect::<Result<Vec<_>, _>>();
 		let routing =
 			service.routing_control().await.ok().and_then(|routing| routing_dto(routing).ok());
+		let pending_route = match &self.store {
+			ProductStore::Available(store) => match store
+				.read_pending_account_route_commands(2)
+				.await
+			{
+				Ok(pending) if pending.is_empty() => None,
+				Ok(pending) if pending.len() == 1 => pending_account_route_dto(&pending[0]).ok(),
+				Ok(_) | Err(_) => return AccountsResult::Unavailable,
+			},
+			ProductStore::Unavailable(_) => None,
+		};
 		match accounts {
-			Ok(accounts) => AccountsResult::Available { accounts, routing },
+			Ok(accounts) => AccountsResult::Available { accounts, routing, pending_route },
 			Err(_) => AccountsResult::Unavailable,
 		}
 	}
@@ -545,10 +683,15 @@ impl ServiceApplication {
 		command: &CommandEnvelope,
 	) -> Result<ApplicationPublication, CommandError> {
 		validate_account_command_envelope(command)?;
-		if self.accounts.is_none() {
+		let Some(service) = self.accounts.as_ref() else {
 			return Err(application_unavailable("account service is unavailable"));
-		}
+		};
 		let (kind, entity_id, expected_revision) = account_command_descriptor(command)?;
+		let _route_guard = if kind == AccountCommandKind::Route {
+			Some(service.lock_route_command().await)
+		} else {
+			None
+		};
 		let ProductStore::Available(store) = &self.store else {
 			return Err(application_unavailable("account product state is unavailable"));
 		};
@@ -556,17 +699,35 @@ impl ServiceApplication {
 			.map_err(|_| account_rejection(AccountCommandRejectionDto::InvalidRequest, None))?;
 		let identity = CommandIdentity::new(command.idempotency_key.as_str(), &request)
 			.map_err(map_account_store_command_error)?;
-		let reserved = match store
-			.reserve_account_command(&identity, kind, &entity_id, expected_revision)
-			.await
-			.map_err(map_account_store_command_error)?
-		{
+		let claim = if kind == AccountCommandKind::Route {
+			let request_json = std::str::from_utf8(&request)
+				.map_err(|_| account_rejection(AccountCommandRejectionDto::InvalidRequest, None))?;
+			let superseded_response = encode_account_command_receipt(&Err(account_rejection(
+				AccountCommandRejectionDto::RouteSuperseded,
+				None,
+			)))
+			.map_err(map_account_store_command_error)?;
+			store
+				.reserve_replacing_account_route_command(
+					&identity,
+					expected_revision.ok_or_else(|| {
+						account_rejection(AccountCommandRejectionDto::InvalidRequest, None)
+					})?,
+					request_json,
+					&superseded_response,
+				)
+				.await
+		} else {
+			store.reserve_account_command(&identity, kind, &entity_id, expected_revision).await
+		};
+		let reserved = match claim.map_err(map_account_store_command_error)? {
 			AccountCommandReceiptClaim::Owned(lease) => ReservedAccountCommand::Owned(lease),
-			AccountCommandReceiptClaim::Replayed(value) => ReservedAccountCommand::Replayed(
-				Box::new(decode_account_command_receipt(value).map_err(|_| {
+			AccountCommandReceiptClaim::Pending(value)
+			| AccountCommandReceiptClaim::Replayed(value) => ReservedAccountCommand::Replayed(Box::new(
+				decode_account_command_receipt(value).map_err(|_| {
 					application_unavailable("account command receipt is incompatible")
-				})?),
-			),
+				})?,
+			)),
 		};
 		let lease = match reserved {
 			ReservedAccountCommand::Owned(lease) => lease,
@@ -669,6 +830,30 @@ impl ServiceApplication {
 					})
 					.await
 			},
+			CommandPayload::RouteAccount {
+				operation_id,
+				account_id,
+				expected_account_revision,
+			} => {
+				let operation_id = operation_id_from_wire(operation_id)?;
+				let account_id = account_id_from_wire(account_id)?;
+				let expected_routing_revision = required_expected_revision(command)?;
+				let expected_account_revision = i64::try_from(expected_account_revision.0)
+					.map_err(|_| {
+						account_rejection(AccountCommandRejectionDto::InvalidRequest, None)
+					})?;
+				service
+					.route_account_command(
+						lease,
+						operation_id,
+						&account_id,
+						expected_account_revision,
+						expected_routing_revision,
+						false,
+						|result| encode_account_command_receipt(&account_route_result(result)),
+					)
+					.await
+			},
 			CommandPayload::RecoverAccountOperation { operation_id, action } => {
 				let operation_id = operation_id_from_wire(operation_id)?;
 				let expected = required_expected_revision(command)?;
@@ -728,43 +913,6 @@ impl ServiceApplication {
 							};
 							encode_account_command_receipt(&result)
 						},
-					)
-					.await
-			},
-			CommandPayload::UseAccountInCodex { account_id } => {
-				let account_id = account_id_from_wire(account_id)?;
-				let publication_account_id = account_id.clone();
-				let expected = required_expected_revision(command)?;
-				service
-					.use_account_in_codex_command(lease, &account_id, expected, move |result| {
-						encode_account_command_receipt(
-							&result.map_err(account_lifecycle_command_error).and_then(
-								|(revision, digest)| {
-									codex_auth_projection_publication(
-										publication_account_id,
-										revision,
-										digest,
-									)
-								},
-							),
-						)
-					})
-					.await
-			},
-			CommandPayload::SetFixedAccountSelection { account_id, expected_account_revision } => {
-				let expected_routing_revision = required_expected_revision(command)?;
-				let account_id = account_id_from_wire(account_id)?;
-				let expected_account_revision = i64::try_from(expected_account_revision.0)
-					.map_err(|_| {
-						account_rejection(AccountCommandRejectionDto::InvalidRequest, None)
-					})?;
-				service
-					.set_fixed_selection_command(
-						lease,
-						expected_routing_revision,
-						&account_id,
-						expected_account_revision,
-						|outcome| encode_account_command_receipt(&routing_command_result(outcome)),
 					)
 					.await
 			},
@@ -1707,10 +1855,11 @@ async fn authorize_program_capability(
 
 impl Application for ServiceApplication {
 	fn has_publication_source(&self) -> bool {
-		self.quick_tasks.runtime().is_some()
+		self.quick_tasks.runtime().is_some() || self.account_route_events.is_some()
 	}
 
 	fn begin_shutdown(&self) {
+		self.publication_stop.send_replace(true);
 		if let Some(manager) = &self.account_login {
 			manager.begin_shutdown();
 		}
@@ -1744,6 +1893,14 @@ impl Application for ServiceApplication {
 		}
 		if let Some(control) = &self.provider_attempts {
 			tasks.push(Box::pin(control.reconciliation_task(stop.clone())));
+		}
+		if let (Some(accounts), ProductStore::Available(store)) = (&self.accounts, &self.store) {
+			tasks.push(Box::pin(recover_pending_account_routes(
+				Arc::clone(accounts),
+				store.clone(),
+				self.account_observations.clone(),
+				stop.clone(),
+			)));
 		}
 
 		if let Some(runtime) = &self.reset_cards {
@@ -1802,12 +1959,11 @@ impl Application for ServiceApplication {
 			| CommandPayload::ImportAccountCredentialFile { .. }
 			| CommandPayload::SetAccountEnabled { .. }
 			| CommandPayload::LogoutAccount { .. }
-			| CommandPayload::SetFixedAccountSelection { .. }
+			| CommandPayload::RouteAccount { .. }
 			| CommandPayload::SetBalancedAccountSelection
 			| CommandPayload::SetAccountOrder { .. }
 			| CommandPayload::RefreshAccount { .. }
-			| CommandPayload::RecoverAccountOperation { .. }
-			| CommandPayload::UseAccountInCodex { .. } => {
+			| CommandPayload::RecoverAccountOperation { .. } => {
 				let publication = self.execute_account_command(command).await?;
 				self.invalidate_account_observation(&publication.entity_id).await;
 				self.request_account_observation_refresh();
@@ -1943,12 +2099,67 @@ impl Application for ServiceApplication {
 	}
 
 	async fn next_publication(&self) -> Option<ApplicationEventPublication> {
-		let runtime = self.quick_tasks.runtime()?;
+		match (self.quick_tasks.runtime(), self.account_route_events.as_ref()) {
+			(None, None) => None,
+			(Some(runtime), None) => loop {
+				let outcome = runtime.next_event().await?;
+				if let Some(publication) = self.quick_task_event_publication(outcome).await {
+					return Some(publication);
+				}
+			},
+			(None, Some(_)) => self.next_account_route_publication().await,
+			(Some(runtime), Some(_)) => loop {
+				tokio::select! {
+					outcome = runtime.next_event() => {
+						let Some(outcome) = outcome else {
+							return self.next_account_route_publication().await;
+						};
+						if let Some(publication) = self.quick_task_event_publication(outcome).await {
+							return Some(publication);
+						}
+					},
+					publication = self.next_account_route_publication() => {
+						return publication;
+					},
+				}
+			},
+		}
+	}
+}
+
+impl ServiceApplication {
+	async fn next_account_route_publication(&self) -> Option<ApplicationEventPublication> {
+		let receiver = self.account_route_events.as_ref()?;
+		let mut receiver = receiver.lock().await;
+		let mut stop = self.publication_stop.subscribe();
+		if *stop.borrow() {
+			return None;
+		}
 		loop {
-			let outcome = runtime.next_event().await?;
-			if let Some(publication) = self.quick_task_event_publication(outcome).await {
-				return Some(publication);
-			}
+			let completion = tokio::select! {
+				result = receiver.recv() => match result {
+					Ok(completion) => completion,
+					Err(broadcast::error::RecvError::Lagged(_)) => continue,
+					Err(broadcast::error::RecvError::Closed) => return None,
+				},
+				changed = stop.changed() => {
+					if changed.is_err() || *stop.borrow() {
+						return None;
+					}
+					continue;
+				},
+			};
+			let publication = account_routed_publication(completion.commit).ok()?;
+			let correlation_id =
+				CorrelationId::new(completion.operation_id.as_str().to_owned()).ok()?;
+			return Some(ApplicationEventPublication {
+				correlation_id,
+				causation_id: None,
+				channel: publication.channel,
+				entity_id: publication.entity_id,
+				entity_revision: publication.entity_revision,
+				event: publication.event,
+			});
 		}
 	}
 }
@@ -3394,15 +3605,10 @@ fn account_command_descriptor(
 		CommandPayload::SetAccountEnabled { account_id, .. } => {
 			(AccountCommandKind::SetEnabled, account_id.as_str())
 		},
-		CommandPayload::UseAccountInCodex { account_id } => {
-			(AccountCommandKind::UseInCodex, account_id.as_str())
-		},
 		CommandPayload::LogoutAccount { account_id, .. } => {
 			(AccountCommandKind::Logout, account_id.as_str())
 		},
-		CommandPayload::SetFixedAccountSelection { .. } => {
-			(AccountCommandKind::SetFixedSelection, "account-routing")
-		},
+		CommandPayload::RouteAccount { .. } => (AccountCommandKind::Route, "account-routing"),
 		CommandPayload::SetBalancedAccountSelection => {
 			(AccountCommandKind::SetBalancedSelection, "account-routing")
 		},
@@ -3439,8 +3645,7 @@ fn validate_account_command_envelope(command: &CommandEnvelope) -> Result<(), Co
 				return Err(account_rejection(AccountCommandRejectionDto::InvalidRequest, None));
 			}
 		},
-		CommandPayload::SetAccountEnabled { account_id, .. }
-		| CommandPayload::UseAccountInCodex { account_id } => {
+		CommandPayload::SetAccountEnabled { account_id, .. } => {
 			let _ = account_id_from_wire(account_id)?;
 			let _ = required_expected_revision(command)?;
 		},
@@ -3450,7 +3655,8 @@ fn validate_account_command_envelope(command: &CommandEnvelope) -> Result<(), Co
 			let _ = account_id_from_wire(account_id)?;
 			let _ = required_expected_revision(command)?;
 		},
-		CommandPayload::SetFixedAccountSelection { account_id, expected_account_revision } => {
+		CommandPayload::RouteAccount { operation_id, account_id, expected_account_revision } => {
+			let _ = operation_id_from_wire(operation_id)?;
 			let _ = account_id_from_wire(account_id)?;
 			let _ = required_expected_revision(command)?;
 			if expected_account_revision.0 == 0 {
@@ -3530,34 +3736,6 @@ pub(crate) fn account_enrollment_publication(
 	})
 }
 
-fn codex_auth_projection_publication(
-	account_id: AccountId,
-	account_revision: i64,
-	projection_digest: String,
-) -> Result<ApplicationPublication, CommandError> {
-	let account_revision = u64::try_from(account_revision)
-		.ok()
-		.filter(|revision| *revision > 0)
-		.map(EntityRevision)
-		.ok_or_else(|| application_unavailable("account result is incompatible"))?;
-	let account_id = EntityId::new(account_id.as_str().to_owned())
-		.map_err(|_| application_unavailable("account result is incompatible"))?;
-	let projection_digest = Sha256Digest::new(projection_digest)
-		.map_err(|_| application_unavailable("account result is incompatible"))?;
-
-	Ok(ApplicationPublication {
-		channel: Channel::AccountsHealth,
-		entity_id: account_id.clone(),
-		entity_revision: account_revision,
-		result: ResultPayload::CodexAuthProjected {
-			account_id: account_id.clone(),
-			account_revision,
-			projection_digest: projection_digest.clone(),
-		},
-		event: EventPayload::CodexAuthProjected { account_id, account_revision, projection_digest },
-	})
-}
-
 fn account_logout_publication(
 	account: AccountRecord,
 ) -> Result<ApplicationPublication, CommandError> {
@@ -3592,6 +3770,91 @@ fn account_routing_publication(
 		entity_revision: routing.revision,
 		result: ResultPayload::AccountRoutingChanged { routing: routing.clone() },
 		event: EventPayload::AccountRoutingChanged { routing },
+	})
+}
+
+fn account_routed_publication(
+	commit: AccountRouteCommit,
+) -> Result<ApplicationPublication, CommandError> {
+	let account = account_dto(commit.account)
+		.map_err(|_| application_unavailable("account Route result is incompatible"))?;
+	let routing = routing_dto(commit.routing)
+		.map_err(|_| application_unavailable("account Route result is incompatible"))?;
+	if routing.mode != decodex_protocol::AccountSelectionModeDto::Fixed(account.account_id.clone())
+	{
+		return Err(application_unavailable("account Route result is incompatible"));
+	}
+	let projection_digest = Sha256Digest::new(commit.projection_digest)
+		.map_err(|_| application_unavailable("account Route result is incompatible"))?;
+	let entity_id = EntityId::new("account-routing").expect("account routing entity is bounded");
+	Ok(ApplicationPublication {
+		channel: Channel::AccountsHealth,
+		entity_id,
+		entity_revision: routing.revision,
+		result: ResultPayload::AccountRouted {
+			account: Box::new(account.clone()),
+			routing: routing.clone(),
+			projection_digest: projection_digest.clone(),
+		},
+		event: EventPayload::AccountRouted {
+			account: Box::new(account),
+			routing,
+			projection_digest,
+		},
+	})
+}
+
+fn account_route_pending_publication(
+	pending: AccountRoutePending,
+) -> Result<ApplicationPublication, CommandError> {
+	let pending = AccountRoutePendingDto {
+		operation_id: EntityId::new(pending.operation_id.as_str().to_owned())
+			.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		account_id: EntityId::new(pending.account_id.as_str().to_owned())
+			.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		routing_revision: EntityRevision(
+			u64::try_from(pending.routing_revision)
+				.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		),
+	};
+	let entity_id = EntityId::new("account-routing").expect("account routing entity is bounded");
+	Ok(ApplicationPublication {
+		channel: Channel::AccountsHealth,
+		entity_id,
+		entity_revision: pending.routing_revision,
+		result: ResultPayload::AccountRoutePending { pending: pending.clone() },
+		event: EventPayload::AccountRoutePending { pending },
+	})
+}
+
+fn account_route_result(
+	result: Result<AccountRouteResult, AccountRouteFailure>,
+) -> Result<ApplicationPublication, CommandError> {
+	match result {
+		Ok(AccountRouteResult::Pending(pending)) => account_route_pending_publication(pending),
+		Ok(AccountRouteResult::Committed(commit)) => account_routed_publication(*commit),
+		Err(AccountRouteFailure::Lifecycle(error)) => Err(account_lifecycle_command_error(error)),
+		Err(AccountRouteFailure::Routing(outcome)) => match routing_command_result(&outcome) {
+			Err(error) => Err(error),
+			Ok(_) => Err(application_unavailable("account Route result is incompatible")),
+		},
+	}
+}
+
+fn pending_account_route_dto(
+	pending: &decodex_database::PendingAccountRouteCommand,
+) -> Result<AccountRoutePendingDto, ()> {
+	let CommandPayload::RouteAccount { operation_id, account_id, .. } =
+		serde_json::from_str::<CommandPayload>(&pending.request_json).map_err(|_| ())?
+	else {
+		return Err(());
+	};
+	Ok(AccountRoutePendingDto {
+		operation_id,
+		account_id,
+		routing_revision: EntityRevision(
+			u64::try_from(pending.expected_routing_revision).map_err(|_| ())?,
+		),
 	})
 }
 
@@ -3726,6 +3989,9 @@ pub(crate) fn account_lifecycle_command_error(error: AccountLifecycleError) -> C
 		},
 		AccountLifecycleError::CredentialImport => {
 			account_rejection(AccountCommandRejectionDto::InvalidRequest, None)
+		},
+		AccountLifecycleError::Refresh(crate::CredentialRefreshError::OwnerBusy) => {
+			account_rejection(AccountCommandRejectionDto::SharedAuthOwnerBusy, None)
 		},
 		AccountLifecycleError::Refresh(_) => {
 			account_rejection(AccountCommandRejectionDto::LifecycleUnready, None)
@@ -4047,11 +4313,13 @@ mod tests {
 		ACCOUNT_COMMAND_RECEIPT_SCHEMA, AccountLifecycleError, AccountProfileClaimsView,
 		AccountProfileRuntimeError, AccountProfileView, ProductStore, ResetCardServiceError,
 		StoredAccountCommandOutcome, account_dto, account_lifecycle_command_error,
-		account_profile_dto, account_profile_unavailable_dto, authorize_program_capability,
+		account_profile_dto, account_profile_unavailable_dto, account_route_pending_publication,
+		account_route_receipt_committed, authorize_program_capability,
 		decode_account_command_receipt, encode_account_command_receipt, lifecycle_rejection,
 		operation_query_result, program_cycle_dto, protocol_reset_error,
 		quick_task_summary_from_row, quota_dto,
 	};
+	use crate::account_service::AccountRoutePending;
 	use crate::domain_packs::{QUICK_TASK_CAPABILITY, resolve_identity};
 
 	fn program_preflight_fixture(
@@ -4715,6 +4983,19 @@ mod tests {
 				error: ResetCardError::InventoryChanged,
 			},
 		);
+	}
+
+	#[test]
+	fn pending_route_receipt_does_not_trigger_committed_account_observation_work() {
+		let pending = AccountRoutePending {
+			operation_id: AccountOperationId::new("22000000-0000-4000-8000-0000000000a1").unwrap(),
+			account_id: AccountId::new("21000000-0000-4000-8000-0000000000a1").unwrap(),
+			routing_revision: 7,
+		};
+		let publication = account_route_pending_publication(pending).unwrap();
+		let encoded = encode_account_command_receipt(&Ok(publication)).unwrap();
+
+		assert!(!account_route_receipt_committed(Ok(encoded)));
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/auth_projection.rs
+++ b/crates/decodex-runtime/src/auth_projection.rs
@@ -18,9 +18,13 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize, de::IgnoredAny};
+use sha2::{Digest as _, Sha256};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
-use crate::host_credentials::CredentialSecretBundle;
+use crate::{
+	account_import::{ImportedCredential, parse_shared_codex},
+	host_credentials::CredentialSecretBundle,
+};
 
 const AUTH_FILE_NAME: &CStr = c"auth.json";
 const CODEX_DIRECTORY_NAME: &CStr = c".codex";
@@ -30,25 +34,173 @@ const TEMP_CREATE_ATTEMPTS: u64 = 8;
 static PROJECTION_LOCK: Mutex<()> = Mutex::new(());
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
-/// Project one exact ChatGPT bundle into the normal Codex shared auth file.
-pub(crate) fn project_shared_codex_auth(
-	bundle: &CredentialSecretBundle,
-	provider_account_id: &str,
-) -> Result<(), CodexAuthProjectionError> {
-	let home = codex_home()?;
-	project_shared_codex_auth_at(&home, bundle, provider_account_id, ProjectionFault::None)
+/// Credential-negative metadata used to coalesce stable shared-auth reads.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SharedCodexAuthFileStamp {
+	Absent,
+	Present {
+		device: u64,
+		inode: u64,
+		length: u64,
+		modified_seconds: i64,
+		modified_nanoseconds: i64,
+	},
 }
 
+/// Exact credential-negative source version required by the final Route CAS.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SharedCodexAuthVersion {
+	pub(crate) stamp: SharedCodexAuthFileStamp,
+	pub(crate) sha256: Option<[u8; 32]>,
+}
+
+/// One stable, bounded read of the normal shared Codex auth source.
+pub(crate) enum SharedCodexAuthSnapshot {
+	Managed { version: SharedCodexAuthVersion, credential: ImportedCredential },
+	Unmanaged { version: SharedCodexAuthVersion },
+}
+
+impl SharedCodexAuthSnapshot {
+	pub(crate) const fn version(&self) -> &SharedCodexAuthVersion {
+		match self {
+			Self::Managed { version, .. } | Self::Unmanaged { version } => version,
+		}
+	}
+}
+
+/// Read only the exact metadata needed by the daemon's stable-read coalescer.
+pub(crate) fn read_shared_codex_auth_stamp()
+-> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+	let home = codex_home()?;
+	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	let directory = open_codex_directory(&home)?;
+	let identity = directory_identity(&directory)?;
+	let stamp = read_file_stamp(&directory)?;
+	let current = open_codex_directory(&home)?;
+	if directory_identity(&current)? != identity {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	Ok(stamp)
+}
+
+/// Read one source only while its metadata remains equal to two prior poll observations.
+pub(crate) fn read_shared_codex_auth_snapshot(
+	expected: &SharedCodexAuthFileStamp,
+) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+	let home = codex_home()?;
+	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	let directory = open_codex_directory(&home)?;
+	let identity = directory_identity(&directory)?;
+	let snapshot = read_snapshot_from_directory(&directory, expected)?;
+	let current = open_codex_directory(&home)?;
+	if directory_identity(&current)? != identity {
+		return Err(CodexAuthProjectionError::UnsafePath);
+	}
+	Ok(snapshot)
+}
+
+/// Project one exact target only while the complete stable source version remains current.
+pub(crate) fn project_shared_codex_auth_cas(
+	bundle: &CredentialSecretBundle,
+	provider_account_id: &str,
+	expected_source: &SharedCodexAuthVersion,
+) -> Result<(), CodexAuthProjectionError> {
+	let home = codex_home()?;
+	project_shared_codex_auth_cas_at(
+		&home,
+		bundle,
+		provider_account_id,
+		expected_source,
+		ProjectionFault::None,
+	)
+}
+
+fn project_shared_codex_auth_cas_at(
+	home: &Path,
+	bundle: &CredentialSecretBundle,
+	provider_account_id: &str,
+	expected_source: &SharedCodexAuthVersion,
+	fault: ProjectionFault,
+) -> Result<(), CodexAuthProjectionError> {
+	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	let directory = open_codex_directory(home)?;
+	let identity = directory_identity(&directory)?;
+	if read_file_version(&directory)? != *expected_source {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	let mutation = project_to_directory_inner(
+		&directory,
+		bundle,
+		provider_account_id,
+		None,
+		Some(expected_source),
+		fault,
+	)?;
+	let current =
+		open_codex_directory(home).map_err(|error| after_projection_error(mutation, error))?;
+	let current_identity =
+		directory_identity(&current).map_err(|error| after_projection_error(mutation, error))?;
+	if current_identity != identity {
+		return Err(after_projection_error(mutation, CodexAuthProjectionError::UnsafePath));
+	}
+	Ok(())
+}
+
+#[cfg(test)]
 fn project_shared_codex_auth_at(
 	home: &Path,
 	bundle: &CredentialSecretBundle,
 	provider_account_id: &str,
 	fault: ProjectionFault,
 ) -> Result<(), CodexAuthProjectionError> {
+	project_shared_codex_auth_with_precondition_at(home, bundle, provider_account_id, None, fault)
+}
+
+#[cfg(test)]
+fn project_shared_codex_auth_with_precondition_at(
+	home: &Path,
+	bundle: &CredentialSecretBundle,
+	provider_account_id: &str,
+	expected_source: Option<(&CredentialSecretBundle, &str)>,
+	fault: ProjectionFault,
+) -> Result<(), CodexAuthProjectionError> {
 	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
 	let directory = open_codex_directory(home)?;
 	let identity = directory_identity(&directory)?;
-	let mutation = project_to_directory_inner(&directory, bundle, provider_account_id, fault)?;
+	let expected_target = if let Some((expected_bundle, expected_provider_account_id)) =
+		expected_source
+	{
+		let before = inspect_target(&directory)?;
+		let id_token = bundle.id_token().ok_or(CodexAuthProjectionError::MissingIdentityToken)?;
+		let target_is_current =
+			current_auth_matches(&directory, bundle, id_token, provider_account_id)?;
+		let source_is_current = if target_is_current {
+			true
+		} else {
+			let expected_id_token =
+				expected_bundle.id_token().ok_or(CodexAuthProjectionError::MissingIdentityToken)?;
+			current_auth_matches(
+				&directory,
+				expected_bundle,
+				expected_id_token,
+				expected_provider_account_id,
+			)?
+		};
+		if !source_is_current || inspect_target(&directory)? != before {
+			return Err(CodexAuthProjectionError::SourceChanged);
+		}
+		Some(before)
+	} else {
+		None
+	};
+	let mutation = project_to_directory_inner(
+		&directory,
+		bundle,
+		provider_account_id,
+		expected_target,
+		None,
+		fault,
+	)?;
 	#[cfg(test)]
 	if fault == ProjectionFault::AfterRenamePathRevalidation {
 		return Err(after_projection_error(mutation, CodexAuthProjectionError::Unavailable));
@@ -62,41 +214,6 @@ fn project_shared_codex_auth_at(
 	}
 
 	Ok(())
-}
-
-/// Read only the non-secret provider identity from the exact safe shared Codex auth file.
-pub(crate) fn read_shared_codex_auth_identity()
--> Result<SharedCodexAuthIdentity, CodexAuthProjectionError> {
-	let home = codex_home()?;
-	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
-	let directory = open_codex_directory(&home)?;
-	let identity = directory_identity(&directory)?;
-	let result = read_identity_from_directory(&directory)?;
-	let current = open_codex_directory(&home)?;
-	if directory_identity(&current)? != identity {
-		return Err(CodexAuthProjectionError::UnsafePath);
-	}
-	Ok(result)
-}
-
-/// Compare the complete safe shared Codex token projection with one exact host-store bundle.
-pub(crate) fn shared_codex_auth_matches(
-	bundle: &CredentialSecretBundle,
-	provider_account_id: &str,
-) -> Result<bool, CodexAuthProjectionError> {
-	let Some(id_token) = bundle.id_token() else {
-		return Ok(false);
-	};
-	let home = codex_home()?;
-	let _guard = PROJECTION_LOCK.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
-	let directory = open_codex_directory(&home)?;
-	let identity = directory_identity(&directory)?;
-	let matches = current_auth_matches(&directory, bundle, id_token, provider_account_id)?;
-	let current = open_codex_directory(&home)?;
-	if directory_identity(&current)? != identity {
-		return Err(CodexAuthProjectionError::UnsafePath);
-	}
-	Ok(matches)
 }
 
 fn codex_home() -> Result<PathBuf, CodexAuthProjectionError> {
@@ -115,14 +232,23 @@ fn project_to_directory(
 	bundle: &CredentialSecretBundle,
 	provider_account_id: &str,
 ) -> Result<(), CodexAuthProjectionError> {
-	project_to_directory_inner(directory, bundle, provider_account_id, ProjectionFault::None)
-		.map(|_| ())
+	project_to_directory_inner(
+		directory,
+		bundle,
+		provider_account_id,
+		None,
+		None,
+		ProjectionFault::None,
+	)
+	.map(|_| ())
 }
 
 fn project_to_directory_inner(
 	directory: &File,
 	bundle: &CredentialSecretBundle,
 	provider_account_id: &str,
+	expected_target: Option<Option<TargetIdentity>>,
+	expected_version: Option<&SharedCodexAuthVersion>,
 	fault: ProjectionFault,
 ) -> Result<ProjectionMutation, CodexAuthProjectionError> {
 	#[cfg(not(test))]
@@ -133,12 +259,20 @@ fn project_to_directory_inner(
 	{
 		return Err(CodexAuthProjectionError::InvalidCredential);
 	}
+	if let Some(expected_version) = expected_version
+		&& read_file_version(directory)? != *expected_version
+	{
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
 	let id_token = bundle.id_token().ok_or(CodexAuthProjectionError::MissingIdentityToken)?;
 	if current_auth_matches(directory, bundle, id_token, provider_account_id)? {
 		return Ok(ProjectionMutation::AlreadyCurrent);
 	}
 	let encoded = encode_auth(bundle, id_token, provider_account_id)?;
 	let original = inspect_target(directory)?;
+	if expected_target.is_some_and(|expected| expected != original) {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
 	let (mut temporary, temporary_name) = create_temporary(directory)?;
 	temporary
 		.write_all(&encoded)
@@ -149,7 +283,16 @@ fn project_to_directory_inner(
 		TemporaryEntry { directory: directory.as_raw_fd(), name: temporary_name, renamed: false };
 
 	if inspect_target(directory)? != original {
-		return Err(CodexAuthProjectionError::UnsafePath);
+		return Err(if expected_target.is_some() {
+			CodexAuthProjectionError::SourceChanged
+		} else {
+			CodexAuthProjectionError::UnsafePath
+		});
+	}
+	if let Some(expected_version) = expected_version
+		&& read_file_version(directory)? != *expected_version
+	{
+		return Err(CodexAuthProjectionError::SourceChanged);
 	}
 	#[cfg(test)]
 	if fault == ProjectionFault::BeforeRename {
@@ -324,8 +467,8 @@ struct IdentityOnlyAuth {
 	auth_mode: String,
 	#[serde(rename = "OPENAI_API_KEY", default)]
 	_api_key: Option<IgnoredAny>,
-	#[serde(default)]
-	tokens: Option<IdentityOnlyTokens>,
+	#[serde(default, rename = "tokens")]
+	_tokens: Option<IdentityOnlyTokens>,
 	#[serde(rename = "last_refresh", default)]
 	_last_refresh: Option<IgnoredAny>,
 }
@@ -339,9 +482,11 @@ struct IdentityOnlyTokens {
 	_access_token: Option<IgnoredAny>,
 	#[serde(rename = "refresh_token", default)]
 	_refresh_token: Option<IgnoredAny>,
-	account_id: String,
+	#[serde(rename = "account_id")]
+	_account_id: String,
 }
 
+#[cfg(test)]
 fn read_identity_from_directory(
 	directory: &File,
 ) -> Result<SharedCodexAuthIdentity, CodexAuthProjectionError> {
@@ -360,8 +505,8 @@ fn read_identity_from_directory(
 		return Ok(SharedCodexAuthIdentity::Unmanaged);
 	}
 	let account_id = auth
-		.tokens
-		.map(|tokens| tokens.account_id)
+		._tokens
+		.map(|tokens| tokens._account_id)
 		.filter(|account_id| {
 			!account_id.is_empty()
 				&& account_id.len() <= 512
@@ -369,6 +514,82 @@ fn read_identity_from_directory(
 		})
 		.ok_or(CodexAuthProjectionError::Unavailable)?;
 	Ok(SharedCodexAuthIdentity::Chatgpt { provider_account_id: account_id })
+}
+
+fn read_snapshot_from_directory(
+	directory: &File,
+	expected: &SharedCodexAuthFileStamp,
+) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+	let actual = read_file_stamp(directory)?;
+	if &actual != expected {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	if matches!(actual, SharedCodexAuthFileStamp::Absent) {
+		return Ok(SharedCodexAuthSnapshot::Unmanaged {
+			version: SharedCodexAuthVersion { stamp: actual, sha256: None },
+		});
+	}
+
+	let mut target = open_target_readonly(directory)?;
+	validate_target_file(&target)?;
+	if file_stamp(&target)? != actual {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	let bytes = read_bounded(&mut target)?;
+	if file_stamp(&target)? != actual || read_file_stamp(directory)? != actual {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	let version =
+		SharedCodexAuthVersion { stamp: actual, sha256: Some(Sha256::digest(&bytes).into()) };
+	let auth = serde_json::from_slice::<IdentityOnlyAuth>(&bytes)
+		.map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	if auth.auth_mode != "chatgpt" {
+		return Ok(SharedCodexAuthSnapshot::Unmanaged { version });
+	}
+	let credential =
+		parse_shared_codex(&bytes).map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	Ok(SharedCodexAuthSnapshot::Managed { version, credential })
+}
+
+fn read_file_version(directory: &File) -> Result<SharedCodexAuthVersion, CodexAuthProjectionError> {
+	let stamp = read_file_stamp(directory)?;
+	if matches!(stamp, SharedCodexAuthFileStamp::Absent) {
+		return Ok(SharedCodexAuthVersion { stamp, sha256: None });
+	}
+	let mut target = open_target_readonly(directory)?;
+	validate_target_file(&target)?;
+	if file_stamp(&target)? != stamp {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	let bytes = read_bounded(&mut target)?;
+	if file_stamp(&target)? != stamp || read_file_stamp(directory)? != stamp {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	Ok(SharedCodexAuthVersion { stamp, sha256: Some(Sha256::digest(&bytes).into()) })
+}
+
+fn read_file_stamp(directory: &File) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+	if inspect_target(directory)?.is_none() {
+		return Ok(SharedCodexAuthFileStamp::Absent);
+	}
+	let target = open_target_readonly(directory)?;
+	validate_target_file(&target)?;
+	let stamp = file_stamp(&target)?;
+	if inspect_target(directory)? != Some(file_identity(&target)?) {
+		return Err(CodexAuthProjectionError::SourceChanged);
+	}
+	Ok(stamp)
+}
+
+fn file_stamp(file: &File) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+	let metadata = file.metadata().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+	Ok(SharedCodexAuthFileStamp::Present {
+		device: metadata.dev(),
+		inode: metadata.ino(),
+		length: metadata.size(),
+		modified_seconds: metadata.mtime(),
+		modified_nanoseconds: metadata.mtime_nsec(),
+	})
 }
 
 fn read_bounded(file: &mut File) -> Result<Zeroizing<Vec<u8>>, CodexAuthProjectionError> {
@@ -792,11 +1013,13 @@ pub(crate) enum CodexAuthProjectionError {
 	UnsafePath,
 	Unavailable,
 	OutcomeUnknown,
+	SourceChanged,
 	MissingIdentityToken,
 	InvalidCredential,
 }
 
 /// Credential-negative identity read from the normal shared Codex auth file.
+#[cfg(test)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum SharedCodexAuthIdentity {
 	Chatgpt {
@@ -821,8 +1044,10 @@ mod tests {
 		CodexAuthProjectionError, PinnedSandboxFixtureHome, ProjectionFault,
 		SharedCodexAuthIdentity, current_auth_matches, open_codex_directory,
 		open_exact_sandbox_root, open_exact_sandbox_root_after_metadata,
-		open_pinned_sandbox_codex_directory, project_shared_codex_auth_at, project_to_directory,
-		read_identity_from_directory,
+		open_pinned_sandbox_codex_directory, project_shared_codex_auth_at,
+		project_shared_codex_auth_cas_at, project_shared_codex_auth_with_precondition_at,
+		project_to_directory, read_file_stamp, read_identity_from_directory,
+		read_snapshot_from_directory,
 	};
 	use crate::host_credentials::CredentialSecretBundle;
 
@@ -1011,6 +1236,90 @@ mod tests {
 		let auth = read_auth(home.path());
 		assert_eq!(auth["tokens"]["account_id"], "provider-two");
 		assert_eq!(auth["tokens"]["id_token"], "id-two");
+	}
+
+	#[test]
+	fn conditional_projection_preserves_a_source_that_changed_before_replace() {
+		let home = fixture_home();
+		let directory = open_codex_directory(home.path()).unwrap();
+		let first = bundle(Some("id-one"), "one");
+		let second = bundle(Some("id-two"), "two");
+		let concurrent = bundle(Some("id-three"), "three");
+		project_to_directory(&directory, &first, "provider-one").unwrap();
+
+		project_shared_codex_auth_with_precondition_at(
+			home.path(),
+			&second,
+			"provider-two",
+			Some((&first, "provider-one")),
+			ProjectionFault::None,
+		)
+		.unwrap();
+		assert_eq!(read_auth(home.path())["tokens"]["account_id"], "provider-two");
+
+		project_to_directory(&directory, &concurrent, "provider-three").unwrap();
+		assert_eq!(
+			project_shared_codex_auth_with_precondition_at(
+				home.path(),
+				&second,
+				"provider-two",
+				Some((&first, "provider-one")),
+				ProjectionFault::None,
+			),
+			Err(CodexAuthProjectionError::SourceChanged),
+		);
+		assert_eq!(read_auth(home.path())["tokens"]["account_id"], "provider-three");
+	}
+
+	#[test]
+	fn exact_version_cas_preserves_changed_unmanaged_and_absent_sources() {
+		let home = fixture_home();
+		let directory = open_codex_directory(home.path()).unwrap();
+		let target = home.path().join(".codex/auth.json");
+		let absent_stamp = read_file_stamp(&directory).unwrap();
+		let absent = read_snapshot_from_directory(&directory, &absent_stamp).unwrap();
+		fs::write(&target, br#"{"auth_mode":"apikey","OPENAI_API_KEY":null}"#).unwrap();
+		fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+		assert_eq!(
+			project_shared_codex_auth_cas_at(
+				home.path(),
+				&bundle(Some("id-target"), "target"),
+				"provider-target",
+				absent.version(),
+				ProjectionFault::None,
+			),
+			Err(CodexAuthProjectionError::SourceChanged),
+		);
+
+		let unmanaged_stamp = read_file_stamp(&directory).unwrap();
+		let unmanaged = read_snapshot_from_directory(&directory, &unmanaged_stamp).unwrap();
+		fs::write(&target, br#"{"auth_mode":"apikey","OPENAI_API_KEY":"changed"}"#).unwrap();
+		assert_eq!(
+			project_shared_codex_auth_cas_at(
+				home.path(),
+				&bundle(Some("id-target"), "target"),
+				"provider-target",
+				unmanaged.version(),
+				ProjectionFault::None,
+			),
+			Err(CodexAuthProjectionError::SourceChanged),
+		);
+		assert_eq!(read_auth(home.path())["OPENAI_API_KEY"], "changed");
+	}
+
+	#[test]
+	fn partial_shared_auth_is_unavailable_and_is_never_interpreted_as_absent() {
+		let home = fixture_home();
+		let directory = open_codex_directory(home.path()).unwrap();
+		let target = home.path().join(".codex/auth.json");
+		fs::write(&target, b"{").unwrap();
+		fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+		let stamp = read_file_stamp(&directory).unwrap();
+		assert!(matches!(
+			read_snapshot_from_directory(&directory, &stamp),
+			Err(CodexAuthProjectionError::Unavailable)
+		));
+		assert_eq!(fs::read(&target).unwrap(), b"{");
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/bootstrap.rs
+++ b/crates/decodex-runtime/src/bootstrap.rs
@@ -10,7 +10,8 @@ use std::{
 	time::Duration,
 };
 
-#[cfg(target_os = "macos")] use crate::host_credentials::SqliteCredentialStore;
+#[cfg(target_os = "macos")]
+use crate::host_credentials::SqliteCredentialStore;
 use crate::{
 	BoundServer, ProtocolServer, ServerConfig, ServerError,
 	account_api::AccountApiRuntime,
@@ -18,7 +19,10 @@ use crate::{
 	account_observation::AccountObservationService,
 	account_profile::AccountProfileRuntime,
 	account_service::{AccountService, OpenAiCredentialRefresher},
-	application::{ProductStore, ProductStoreUnavailableReason, ServiceApplication},
+	application::{
+		ProductStore, ProductStoreUnavailableReason, ServiceApplication,
+		recover_pending_account_routes_once,
+	},
 	managed_repository_runtime::{
 		ManagedRepositoryCapability, ManagedRepositoryReadiness, ManagedRepositoryUnavailableReason,
 	},
@@ -160,22 +164,33 @@ impl ServiceBootstrap {
 		let account_observations = match (&accounts, &account_api) {
 			(Some(accounts), Some(account_api))
 				if account_profiles.is_some() || reset_cards.is_some() =>
+			{
 				Some(AccountObservationService::new(
 					Arc::clone(accounts),
 					Some(Arc::clone(account_api)),
 					account_profiles.clone(),
 					reset_cards.clone(),
-				)),
+				))
+			},
 			_ => None,
 		};
+		if let (ProductStore::Available(store), Some(accounts)) = (&store, &accounts) {
+			let _ = store.release_interrupted_account_route_claims().await;
+			recover_pending_account_routes_once(
+				Arc::clone(accounts),
+				store,
+				account_observations.as_ref(),
+			)
+			.await;
+		}
 		let account_login = match (&store, &accounts) {
-			(ProductStore::Available(store), Some(accounts)) => Some(Arc::new(
-				crate::account_login::AccountLoginManager::new(
+			(ProductStore::Available(store), Some(accounts)) => {
+				Some(Arc::new(crate::account_login::AccountLoginManager::new(
 					store.clone(),
 					Arc::clone(accounts),
 					account_observations.clone(),
-				),
-			)),
+				)))
+			},
 			_ => None,
 		};
 		let server = ProtocolServer::new(
@@ -303,20 +318,27 @@ fn compose_quick_tasks(composition: QuickTaskComposition) -> QuickTaskCapability
 		execution_authorization,
 		launch_profile,
 	) {
-		(None, _, _, _, _, _, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProductState),
-		(_, None, _, _, _, _, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::BlobStore),
-		(_, _, None, _, _, _, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::AccountService),
-		(_, _, _, None, _, _, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProcessGeneration),
-		(_, _, _, _, None, _, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProviderAttempt),
-		(_, _, _, _, _, None, _) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ExecutionAuthorization),
-		(_, _, _, _, _, _, None) =>
-			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::AppServerProfile),
+		(None, _, _, _, _, _, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProductState)
+		},
+		(_, None, _, _, _, _, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::BlobStore)
+		},
+		(_, _, None, _, _, _, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::AccountService)
+		},
+		(_, _, _, None, _, _, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProcessGeneration)
+		},
+		(_, _, _, _, None, _, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ProviderAttempt)
+		},
+		(_, _, _, _, _, None, _) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::ExecutionAuthorization)
+		},
+		(_, _, _, _, _, _, None) => {
+			QuickTaskCapability::Unavailable(QuickTaskUnavailableReason::AppServerProfile)
+		},
 		(
 			Some(store),
 			Some(blob_store),
@@ -368,8 +390,9 @@ async fn bootstrap_with_authority(
 	let (process_generations, process_generation_readiness) = match sqlite.clone() {
 		Some(store) => match ProcessGenerationControl::start(store).await {
 			Ok(control) => (Some(control), ProcessGenerationReadiness::Ready),
-			Err(ProcessSupervisorError::Platform) =>
-				(None, ProcessGenerationReadiness::PlatformUnavailable),
+			Err(ProcessSupervisorError::Platform) => {
+				(None, ProcessGenerationReadiness::PlatformUnavailable)
+			},
 			Err(_) => (None, ProcessGenerationReadiness::ProductStateUnavailable),
 		},
 		None => (None, ProcessGenerationReadiness::ProductStateUnavailable),
@@ -628,14 +651,16 @@ fn managed_repository_doctor(capability: &ManagedRepositoryCapability) -> Doctor
 fn quick_task_doctor(capability: &QuickTaskCapability) -> DoctorStatus {
 	match capability.readiness() {
 		QuickTaskReadiness::Ready => DoctorStatus::Ready,
-		QuickTaskReadiness::Unavailable(QuickTaskUnavailableReason::ProductState) =>
-			DoctorStatus::Unavailable(DoctorIssue::DatabaseNotConfigured),
+		QuickTaskReadiness::Unavailable(QuickTaskUnavailableReason::ProductState) => {
+			DoctorStatus::Unavailable(DoctorIssue::DatabaseNotConfigured)
+		},
 		QuickTaskReadiness::Unavailable(
 			QuickTaskUnavailableReason::AccountService
 			| QuickTaskUnavailableReason::ExecutionAuthorization,
 		) => DoctorStatus::Unavailable(DoctorIssue::Authentication),
-		QuickTaskReadiness::Unavailable(QuickTaskUnavailableReason::UnsupportedPlatform) =>
-			DoctorStatus::Unavailable(DoctorIssue::Disabled),
+		QuickTaskReadiness::Unavailable(QuickTaskUnavailableReason::UnsupportedPlatform) => {
+			DoctorStatus::Unavailable(DoctorIssue::Disabled)
+		},
 		QuickTaskReadiness::Unavailable(
 			QuickTaskUnavailableReason::BlobStore
 			| QuickTaskUnavailableReason::ProcessGeneration
@@ -730,8 +755,9 @@ fn host_directory(path: &Path) -> Result<(), HostDirectoryError> {
 fn config_issue(error: ConfigError) -> DoctorIssue {
 	match error {
 		ConfigError::UnsupportedVersion => DoctorIssue::ConfigurationVersion,
-		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) =>
-			DoctorIssue::ConfigurationMissing,
+		ConfigError::Path(PathError::Io { kind: ErrorKind::NotFound, .. }) => {
+			DoctorIssue::ConfigurationMissing
+		},
 		ConfigError::Path(
 			PathError::UnsafeRoot
 			| PathError::CodexOwnedRoot
@@ -771,11 +797,13 @@ pub(crate) async fn validate_local_database(root: DecodexRoot) -> Result<(), Loc
 
 const fn local_database_error(error: decodex_database::DatabaseError) -> LocalDatabaseError {
 	match sqlite_bootstrap_failure(error) {
-		BootstrapFailure::UnsafeHostPath | BootstrapFailure::UnsafeAuthority =>
-			LocalDatabaseError::UnsafeHostPath,
+		BootstrapFailure::UnsafeHostPath | BootstrapFailure::UnsafeAuthority => {
+			LocalDatabaseError::UnsafeHostPath
+		},
 		BootstrapFailure::Incompatible => LocalDatabaseError::Incompatible,
-		BootstrapFailure::Unreachable | BootstrapFailure::Authentication =>
-			LocalDatabaseError::Unavailable,
+		BootstrapFailure::Unreachable | BootstrapFailure::Authentication => {
+			LocalDatabaseError::Unavailable
+		},
 	}
 }
 
@@ -785,8 +813,9 @@ fn connect_database(paths: &DecodexPaths) -> (ProductStore, DoctorStatus, Doctor
 		Ok(store) => (ProductStore::Available(store), DoctorStatus::Ready, vault),
 		Err(error) => {
 			let (reason, issue, vault) = match sqlite_bootstrap_failure(error) {
-				BootstrapFailure::Authentication =>
-					unreachable!("SQLite has no database authentication"),
+				BootstrapFailure::Authentication => {
+					unreachable!("SQLite has no database authentication")
+				},
 				BootstrapFailure::Unreachable => (
 					ProductStoreUnavailableReason::Unreachable,
 					DoctorIssue::DatabaseUnreachable,

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,13 +1,13 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.6 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.9 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Quick Task owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.
 
 mod account_api;
 mod account_import;
-mod account_login;
 #[expect(dead_code, reason = "dormant until a later explicit product authority enables routing")]
 mod account_launch;
+mod account_login;
 mod account_observation;
 mod account_profile;
 mod account_service;
@@ -18,12 +18,14 @@ mod domain_packs;
 #[expect(dead_code, reason = "sealed until the accepted GitHub-effect composition owner")]
 pub(crate) mod github_effects;
 mod host_credentials;
-#[path = "managed_repository_disabled.rs"] mod managed_repository_runtime;
+#[path = "managed_repository_disabled.rs"]
+mod managed_repository_runtime;
 mod process_platform;
 mod process_supervisor;
 mod provider_attempt_service;
 mod quick_task;
 mod routing_orchestration;
+mod shared_auth_coordinator;
 mod supervised_validation;
 mod websocket;
 
@@ -63,7 +65,8 @@ pub use websocket::{
 	ServerConfig, ServerError, SpawnId, TerminationPrimary, TerminationReceipt,
 };
 
-#[cfg(test)] use {tempfile as _, tokio_tungstenite as _};
+#[cfg(test)]
+use {tempfile as _, tokio_tungstenite as _};
 
 /// The vNext service assembly selected by the `decodexd` composition root.
 #[derive(Clone, Copy, Debug)]

--- a/crates/decodex-runtime/src/shared_auth_coordinator.rs
+++ b/crates/decodex-runtime/src/shared_auth_coordinator.rs
@@ -1,0 +1,689 @@
+//! Single daemon-owned coordinator for stable shared Codex auth observation and cutover.
+
+use std::{
+	sync::{Arc, Mutex},
+};
+
+#[cfg(target_os = "macos")]
+use std::{
+	collections::{HashMap, HashSet},
+	ffi::{OsStr, OsString, c_void},
+	mem::MaybeUninit,
+	os::unix::ffi::OsStringExt as _,
+	path::{Path, PathBuf},
+};
+
+use crate::{
+	auth_projection::{
+		CodexAuthProjectionError, SharedCodexAuthFileStamp, SharedCodexAuthSnapshot,
+		SharedCodexAuthVersion, project_shared_codex_auth_cas, read_shared_codex_auth_snapshot,
+		read_shared_codex_auth_stamp,
+	},
+	host_credentials::CredentialSecretBundle,
+};
+
+const REQUIRED_STABLE_POLLS: u8 = 2;
+
+/// Conservative process observation. Any uncertainty keeps the shared writer handoff closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CodexLiveness {
+	Quiescent,
+	MayBeRunning,
+}
+
+pub(crate) trait CodexLivenessPort: Send + Sync {
+	fn observe(&self) -> CodexLiveness;
+}
+
+pub(crate) trait SharedAuthFilePort: Send + Sync {
+	fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError>;
+
+	fn read(
+		&self,
+		expected: &SharedCodexAuthFileStamp,
+	) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError>;
+
+	fn project(
+		&self,
+		bundle: &CredentialSecretBundle,
+		provider_account_id: &str,
+		expected: &SharedCodexAuthVersion,
+	) -> Result<(), CodexAuthProjectionError>;
+}
+
+struct ProductionSharedAuthFile;
+impl SharedAuthFilePort for ProductionSharedAuthFile {
+	fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+		read_shared_codex_auth_stamp()
+	}
+
+	fn read(
+		&self,
+		expected: &SharedCodexAuthFileStamp,
+	) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+		read_shared_codex_auth_snapshot(expected)
+	}
+
+	fn project(
+		&self,
+		bundle: &CredentialSecretBundle,
+		provider_account_id: &str,
+		expected: &SharedCodexAuthVersion,
+	) -> Result<(), CodexAuthProjectionError> {
+		project_shared_codex_auth_cas(bundle, provider_account_id, expected)
+	}
+}
+
+#[derive(Default)]
+struct StableReadState {
+	candidate: Option<SharedCodexAuthFileStamp>,
+	consecutive: u8,
+	handled: Option<SharedCodexAuthFileStamp>,
+}
+
+pub(crate) enum StableSharedAuthPoll {
+	Changed(Box<SharedCodexAuthSnapshot>),
+	Unchanged,
+	Waiting,
+	Unavailable,
+}
+
+pub(crate) enum StableSharedAuthRead {
+	Ready(Box<SharedCodexAuthSnapshot>),
+	Waiting,
+	Unavailable,
+}
+
+/// One coordinator instance owns all shared-auth polling and projection decisions in `decodexd`.
+pub(crate) struct SharedAuthCoordinator {
+	liveness: Arc<dyn CodexLivenessPort>,
+	file: Arc<dyn SharedAuthFilePort>,
+	state: Mutex<StableReadState>,
+}
+
+impl SharedAuthCoordinator {
+	pub(crate) fn production() -> Self {
+		Self {
+			liveness: Arc::new(ProductionCodexLiveness),
+			file: Arc::new(ProductionSharedAuthFile),
+			state: Mutex::new(StableReadState::default()),
+		}
+	}
+
+	#[cfg(test)]
+	pub(crate) fn with_ports(
+		liveness: Arc<dyn CodexLivenessPort>,
+		file: Arc<dyn SharedAuthFilePort>,
+	) -> Self {
+		Self { liveness, file, state: Mutex::new(StableReadState::default()) }
+	}
+
+	pub(crate) fn liveness(&self) -> CodexLiveness {
+		self.liveness.observe()
+	}
+
+	pub(crate) fn poll_stable_change(&self) -> StableSharedAuthPoll {
+		let stamp = match self.file.stamp() {
+			Ok(stamp) => stamp,
+			Err(_) => return StableSharedAuthPoll::Unavailable,
+		};
+		let mut state = match self.state.lock() {
+			Ok(state) => state,
+			Err(_) => return StableSharedAuthPoll::Unavailable,
+		};
+		if state.candidate.as_ref() != Some(&stamp) {
+			state.candidate = Some(stamp);
+			state.consecutive = 1;
+			state.handled = None;
+			return StableSharedAuthPoll::Waiting;
+		}
+		state.consecutive = state.consecutive.saturating_add(1);
+		if state.consecutive < REQUIRED_STABLE_POLLS {
+			return StableSharedAuthPoll::Waiting;
+		}
+		if state.handled.as_ref() == Some(&stamp) {
+			return StableSharedAuthPoll::Unchanged;
+		}
+		drop(state);
+		match self.file.read(&stamp) {
+			Ok(snapshot) => {
+				if let Ok(mut state) = self.state.lock()
+					&& state.candidate.as_ref() == Some(&stamp)
+				{
+					state.handled = Some(stamp);
+				}
+				StableSharedAuthPoll::Changed(Box::new(snapshot))
+			},
+			Err(_) => StableSharedAuthPoll::Unavailable,
+		}
+	}
+
+	pub(crate) fn read_current_stable(&self) -> StableSharedAuthRead {
+		let stamp = match self.file.stamp() {
+			Ok(stamp) => stamp,
+			Err(_) => return StableSharedAuthRead::Unavailable,
+		};
+		let mut state = match self.state.lock() {
+			Ok(state) => state,
+			Err(_) => return StableSharedAuthRead::Unavailable,
+		};
+		if state.candidate.as_ref() != Some(&stamp) {
+			state.candidate = Some(stamp);
+			state.consecutive = 1;
+			state.handled = None;
+			return StableSharedAuthRead::Waiting;
+		}
+		state.consecutive = state.consecutive.saturating_add(1);
+		if state.consecutive < REQUIRED_STABLE_POLLS {
+			return StableSharedAuthRead::Waiting;
+		}
+		drop(state);
+		match self.file.read(&stamp) {
+			Ok(snapshot) => StableSharedAuthRead::Ready(Box::new(snapshot)),
+			Err(_) => StableSharedAuthRead::Unavailable,
+		}
+	}
+
+	pub(crate) fn project_if_quiescent(
+		&self,
+		bundle: &CredentialSecretBundle,
+		provider_account_id: &str,
+		expected: &SharedCodexAuthVersion,
+	) -> Result<(), CodexAuthProjectionError> {
+		if self.liveness() != CodexLiveness::Quiescent {
+			return Err(CodexAuthProjectionError::SourceChanged);
+		}
+		self.file.project(bundle, provider_account_id, expected)
+	}
+}
+
+struct ProductionCodexLiveness;
+
+#[cfg(target_os = "macos")]
+impl CodexLivenessPort for ProductionCodexLiveness {
+	fn observe(&self) -> CodexLiveness {
+		observe_macos_codex_liveness()
+	}
+}
+
+#[cfg(not(target_os = "macos"))]
+impl CodexLivenessPort for ProductionCodexLiveness {
+	fn observe(&self) -> CodexLiveness {
+		CodexLiveness::MayBeRunning
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_codex_liveness() -> CodexLiveness {
+	// Apple SDK `sys/proc_info.h` defines `PROC_ALL_PIDS` as 1. libc exposes the
+	// functions but not this selector, so keep the one SDK-named value local.
+	const PROC_ALL_PIDS: u32 = 1;
+	let required = unsafe { libc::proc_listpids(PROC_ALL_PIDS, 0, std::ptr::null_mut(), 0) };
+	let pid_size = std::mem::size_of::<libc::pid_t>();
+	let Ok(required) = usize::try_from(required) else {
+		return CodexLiveness::MayBeRunning;
+	};
+	if required == 0 || pid_size == 0 {
+		return CodexLiveness::MayBeRunning;
+	}
+	let capacity = required / pid_size + 64;
+	let mut pids = vec![0 as libc::pid_t; capacity];
+	let Ok(buffer_bytes) = i32::try_from(pids.len().saturating_mul(pid_size)) else {
+		return CodexLiveness::MayBeRunning;
+	};
+	let returned = unsafe {
+		libc::proc_listpids(PROC_ALL_PIDS, 0, pids.as_mut_ptr().cast::<c_void>(), buffer_bytes)
+	};
+	let Ok(returned) = usize::try_from(returned) else {
+		return CodexLiveness::MayBeRunning;
+	};
+	if returned == 0 || returned >= pids.len().saturating_mul(pid_size) {
+		return CodexLiveness::MayBeRunning;
+	}
+	pids.truncate(returned / pid_size);
+	let observations = pids
+		.into_iter()
+		.filter(|pid| *pid > 0)
+		.map(observe_macos_process)
+		.collect::<Vec<_>>();
+	let Ok(own_pid) = libc::pid_t::try_from(std::process::id()) else {
+		return CodexLiveness::MayBeRunning;
+	};
+	classify_macos_codex_liveness(own_pid, &observations)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum MacosProcessField<T> {
+	Value(T),
+	Unavailable,
+	Vanished,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MacosProcessObservation {
+	pid: libc::pid_t,
+	parent_pid: MacosProcessField<libc::pid_t>,
+	name: MacosProcessField<OsString>,
+	path: MacosProcessField<PathBuf>,
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process(pid: libc::pid_t) -> MacosProcessObservation {
+	let name = observe_macos_process_name(pid);
+	let path = match &name {
+		MacosProcessField::Value(name) if !process_name_looks_like_codex(name) => {
+			MacosProcessField::Unavailable
+		},
+		MacosProcessField::Vanished => MacosProcessField::Vanished,
+		MacosProcessField::Value(_) | MacosProcessField::Unavailable => {
+			observe_macos_process_path(pid)
+		},
+	};
+	MacosProcessObservation { pid, parent_pid: observe_macos_parent_pid(pid), name, path }
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process_name(pid: libc::pid_t) -> MacosProcessField<OsString> {
+	let mut bytes = vec![0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+	let length = unsafe {
+		libc::proc_name(
+			pid,
+			bytes.as_mut_ptr().cast::<c_void>(),
+			libc::PROC_PIDPATHINFO_MAXSIZE as u32,
+		)
+	};
+	if length == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	let Ok(length) = usize::try_from(length) else {
+		return MacosProcessField::Unavailable;
+	};
+	if length > bytes.len() {
+		return MacosProcessField::Unavailable;
+	}
+	let length = bytes[..length].iter().position(|byte| *byte == 0).unwrap_or(length);
+	if length == 0 {
+		return MacosProcessField::Unavailable;
+	}
+	bytes.truncate(length);
+	MacosProcessField::Value(OsString::from_vec(bytes))
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process_path(pid: libc::pid_t) -> MacosProcessField<PathBuf> {
+	let mut bytes = vec![0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+	let length = unsafe {
+		libc::proc_pidpath(
+			pid,
+			bytes.as_mut_ptr().cast::<c_void>(),
+			libc::PROC_PIDPATHINFO_MAXSIZE as u32,
+		)
+	};
+	if length == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	let Ok(length) = usize::try_from(length) else {
+		return MacosProcessField::Unavailable;
+	};
+	if length > bytes.len() {
+		return MacosProcessField::Unavailable;
+	}
+	let length = bytes[..length].iter().position(|byte| *byte == 0).unwrap_or(length);
+	if length == 0 {
+		return MacosProcessField::Unavailable;
+	}
+	bytes.truncate(length);
+	MacosProcessField::Value(PathBuf::from(OsString::from_vec(bytes)))
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_parent_pid(pid: libc::pid_t) -> MacosProcessField<libc::pid_t> {
+	let mut info = MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+	let Ok(size) = i32::try_from(std::mem::size_of::<libc::proc_bsdinfo>()) else {
+		return MacosProcessField::Unavailable;
+	};
+	let returned = unsafe {
+		libc::proc_pidinfo(
+			pid,
+			libc::PROC_PIDTBSDINFO,
+			0,
+			info.as_mut_ptr().cast::<c_void>(),
+			size,
+		)
+	};
+	if returned == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	if returned != size {
+		return MacosProcessField::Unavailable;
+	}
+	let info = unsafe { info.assume_init() };
+	libc::pid_t::try_from(info.pbi_ppid)
+		.map(MacosProcessField::Value)
+		.unwrap_or(MacosProcessField::Unavailable)
+}
+
+#[cfg(target_os = "macos")]
+fn classify_macos_codex_liveness(
+	own_pid: libc::pid_t,
+	observations: &[MacosProcessObservation],
+) -> CodexLiveness {
+	let parents = observations
+		.iter()
+		.filter_map(|observation| match observation.parent_pid {
+			MacosProcessField::Value(parent) => Some((observation.pid, parent)),
+			MacosProcessField::Unavailable | MacosProcessField::Vanished => None,
+		})
+		.collect::<HashMap<_, _>>();
+	for observation in observations {
+		if observation.pid == own_pid || !macos_process_looks_like_external_codex(observation) {
+			continue;
+		}
+		// Decodex-owned app-server children use the daemon's attested external-token
+		// path and cannot own the normal shared auth writer. Counting them would make
+		// the coordinator permanently wait on itself.
+		if process_descends_from(observation.pid, own_pid, &parents) {
+			continue;
+		}
+		return CodexLiveness::MayBeRunning;
+	}
+	CodexLiveness::Quiescent
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_looks_like_external_codex(observation: &MacosProcessObservation) -> bool {
+	match &observation.path {
+		MacosProcessField::Value(path) => path_looks_like_codex(path),
+		MacosProcessField::Vanished => false,
+		MacosProcessField::Unavailable => match &observation.name {
+			MacosProcessField::Value(name) => process_name_looks_like_codex(name),
+			MacosProcessField::Unavailable | MacosProcessField::Vanished => false,
+		},
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn process_descends_from(
+	pid: libc::pid_t,
+	ancestor: libc::pid_t,
+	parents: &HashMap<libc::pid_t, libc::pid_t>,
+) -> bool {
+	let mut current = pid;
+	let mut visited = HashSet::new();
+	while current > 1 && visited.insert(current) {
+		let Some(parent) = parents.get(&current).copied() else {
+			return false;
+		};
+		if parent == ancestor {
+			return true;
+		}
+		current = parent;
+	}
+	false
+}
+
+#[cfg(target_os = "macos")]
+fn process_name_looks_like_codex(name: &OsStr) -> bool {
+	name == OsStr::new("ChatGPT")
+		|| name == OsStr::new("Codex")
+		|| name == OsStr::new("codex")
+		|| name == OsStr::new("verified-codex-image")
+}
+
+#[cfg(target_os = "macos")]
+fn path_looks_like_codex(path: &Path) -> bool {
+	let executable = path.file_name();
+	path.ends_with("ChatGPT.app/Contents/MacOS/ChatGPT")
+		|| path.ends_with("ChatGPT.app/Contents/Resources/codex")
+		|| path.ends_with("Codex.app/Contents/MacOS/Codex")
+		|| path.ends_with("Codex.app/Contents/Resources/codex")
+		|| executable == Some(OsStr::new("codex"))
+		|| executable == Some(OsStr::new("Codex"))
+		|| executable == Some(OsStr::new("verified-codex-image"))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		collections::VecDeque,
+		sync::atomic::{AtomicUsize, Ordering},
+	};
+
+	use super::*;
+
+	struct FixedLiveness(CodexLiveness);
+	impl CodexLivenessPort for FixedLiveness {
+		fn observe(&self) -> CodexLiveness {
+			self.0
+		}
+	}
+
+	struct ScriptedFile {
+		stamps: Mutex<VecDeque<Result<SharedCodexAuthFileStamp, CodexAuthProjectionError>>>,
+		reads: AtomicUsize,
+		failed_reads: AtomicUsize,
+	}
+
+	impl SharedAuthFilePort for ScriptedFile {
+		fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+			self.stamps
+				.lock()
+				.expect("script lock")
+				.pop_front()
+				.unwrap_or(Ok(SharedCodexAuthFileStamp::Absent))
+		}
+
+		fn read(
+			&self,
+			expected: &SharedCodexAuthFileStamp,
+		) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+			self.reads.fetch_add(1, Ordering::Relaxed);
+			if self
+				.failed_reads
+				.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+					remaining.checked_sub(1)
+				})
+				.is_ok()
+			{
+				return Err(CodexAuthProjectionError::Unavailable);
+			}
+			Ok(SharedCodexAuthSnapshot::Unmanaged {
+				version: SharedCodexAuthVersion { stamp: expected.clone(), sha256: None },
+			})
+		}
+
+		fn project(
+			&self,
+			_bundle: &CredentialSecretBundle,
+			_provider_account_id: &str,
+			_expected: &SharedCodexAuthVersion,
+		) -> Result<(), CodexAuthProjectionError> {
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn stable_poll_requires_two_equal_metadata_observations_and_coalesces_reads() {
+		let file = Arc::new(ScriptedFile {
+			stamps: Mutex::new(VecDeque::from([
+				Ok(SharedCodexAuthFileStamp::Absent),
+				Ok(SharedCodexAuthFileStamp::Absent),
+				Ok(SharedCodexAuthFileStamp::Absent),
+			])),
+			reads: AtomicUsize::new(0),
+			failed_reads: AtomicUsize::new(0),
+		});
+		let coordinator = SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::Quiescent)),
+			file.clone(),
+		);
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Unchanged));
+		assert_eq!(file.reads.load(Ordering::Relaxed), 1);
+	}
+
+	#[test]
+	fn unavailable_stable_read_is_retried_without_a_metadata_change() {
+		let file = Arc::new(ScriptedFile {
+			stamps: Mutex::new(VecDeque::from([
+				Ok(SharedCodexAuthFileStamp::Absent),
+				Ok(SharedCodexAuthFileStamp::Absent),
+				Ok(SharedCodexAuthFileStamp::Absent),
+			])),
+			reads: AtomicUsize::new(0),
+			failed_reads: AtomicUsize::new(1),
+		});
+		let coordinator = SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::Quiescent)),
+			file.clone(),
+		);
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Unavailable));
+		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
+		assert_eq!(file.reads.load(Ordering::Relaxed), 2);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn codex_path_matcher_covers_current_and_legacy_apps_without_generic_helpers() {
+		assert!(process_name_looks_like_codex(OsStr::new("ChatGPT")));
+		assert!(process_name_looks_like_codex(OsStr::new("codex")));
+		assert!(!process_name_looks_like_codex(OsStr::new("launchd")));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
+		)));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/Resources/codex",
+		)));
+		assert!(path_looks_like_codex(Path::new("/Applications/Codex.app/Contents/MacOS/Codex",)));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/Codex.app/Contents/Resources/codex",
+		)));
+		assert!(!path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper",
+		)));
+	}
+
+	#[cfg(target_os = "macos")]
+	fn process(
+		pid: libc::pid_t,
+		parent_pid: MacosProcessField<libc::pid_t>,
+		name: MacosProcessField<&str>,
+		path: MacosProcessField<&str>,
+	) -> MacosProcessObservation {
+		MacosProcessObservation {
+			pid,
+			parent_pid,
+			name: match name {
+				MacosProcessField::Value(name) => {
+					MacosProcessField::Value(OsString::from(name))
+				},
+				MacosProcessField::Unavailable => MacosProcessField::Unavailable,
+				MacosProcessField::Vanished => MacosProcessField::Vanished,
+			},
+			path: match path {
+				MacosProcessField::Value(path) => {
+					MacosProcessField::Value(PathBuf::from(path))
+				},
+				MacosProcessField::Unavailable => MacosProcessField::Unavailable,
+				MacosProcessField::Vanished => MacosProcessField::Vanished,
+			},
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn unrelated_inaccessible_process_does_not_prevent_quiescence() {
+		let observations = [process(
+			20,
+			MacosProcessField::Value(1),
+			MacosProcessField::Value("launchd"),
+			MacosProcessField::Unavailable,
+		)];
+		assert_eq!(classify_macos_codex_liveness(10, &observations), CodexLiveness::Quiescent);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn named_codex_with_inaccessible_path_fails_closed() {
+		let observations = [process(
+			20,
+			MacosProcessField::Value(1),
+			MacosProcessField::Value("codex"),
+			MacosProcessField::Unavailable,
+		)];
+		assert_eq!(classify_macos_codex_liveness(10, &observations), CodexLiveness::MayBeRunning);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn no_candidate_or_vanished_candidate_is_quiescent() {
+		let observations = [process(
+			20,
+			MacosProcessField::Vanished,
+			MacosProcessField::Value("codex"),
+			MacosProcessField::Vanished,
+		)];
+		assert_eq!(classify_macos_codex_liveness(10, &[]), CodexLiveness::Quiescent);
+		assert_eq!(classify_macos_codex_liveness(10, &observations), CodexLiveness::Quiescent);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn matching_chatgpt_parent_or_codex_child_blocks_cutover() {
+		let observations = [
+			process(
+				20,
+				MacosProcessField::Value(1),
+				MacosProcessField::Value("ChatGPT"),
+				MacosProcessField::Value("/Applications/ChatGPT.app/Contents/MacOS/ChatGPT"),
+			),
+			process(
+				21,
+				MacosProcessField::Value(20),
+				MacosProcessField::Value("codex"),
+				MacosProcessField::Value(
+					"/Applications/ChatGPT.app/Contents/Resources/codex",
+				),
+			),
+		];
+		assert_eq!(classify_macos_codex_liveness(10, &observations), CodexLiveness::MayBeRunning);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn daemon_owned_codex_descendant_does_not_block_its_coordinator() {
+		let observations = [
+			process(
+				11,
+				MacosProcessField::Value(10),
+				MacosProcessField::Value("helper"),
+				MacosProcessField::Unavailable,
+			),
+			process(
+				12,
+				MacosProcessField::Value(11),
+				MacosProcessField::Value("codex"),
+				MacosProcessField::Value(
+					"/Applications/ChatGPT.app/Contents/Resources/codex",
+				),
+			),
+		];
+		assert_eq!(classify_macos_codex_liveness(10, &observations), CodexLiveness::Quiescent);
+	}
+}

--- a/crates/decodex-runtime/src/websocket.rs
+++ b/crates/decodex-runtime/src/websocket.rs
@@ -41,11 +41,11 @@ use crate::{Application, ApplicationEventPublication, ApplicationPublication};
 use decodex_core::ServerIdentity;
 use decodex_protocol::{
 	self, AccountLoginRequestEnvelope, AccountLoginResponseEnvelope, CausationId, ClientCommandId,
-	ClientHello, ClientMessage, CommandEnvelope, CommandError,
-	CommandOutcome, CommandReceipt, CommandResultEnvelope, CorrelationId, Cursor, EventEnvelope,
-	IdempotencyKey, LocalTransportAuthority, LocalTransportListener, LocalTransportRefusal,
-	LocalTransportStream, ProtocolVersion, QueryEnvelope, QueryResultEnvelope, ReceiptDisposition,
-	ReconnectMode, Refusal, RefusalEnvelope, ResumeCursor, ServerId, ServerInstanceId,
+	ClientHello, ClientMessage, CommandEnvelope, CommandError, CommandOutcome, CommandReceipt,
+	CommandResultEnvelope, CorrelationId, Cursor, EventEnvelope, IdempotencyKey,
+	LocalTransportAuthority, LocalTransportListener, LocalTransportRefusal, LocalTransportStream,
+	ProtocolVersion, QueryEnvelope, QueryResultEnvelope, ReceiptDisposition, ReconnectMode,
+	Refusal, RefusalEnvelope, ResultPayload, ResumeCursor, ServerId, ServerInstanceId,
 	ServerMessage, ServerWelcome, SnapshotEnvelope, SnapshotItem, SupportedVersions, WireText,
 };
 
@@ -793,7 +793,10 @@ where
 				.enqueue(
 					actor_sender,
 					connection_id,
-					protocol_refusal(&self.inner.server_id, "account login returned invalid status"),
+					protocol_refusal(
+						&self.inner.server_id,
+						"account login returned invalid status",
+					),
 				)
 				.await;
 		}
@@ -847,11 +850,7 @@ where
 	) -> bool {
 		let (reply, result) = oneshot::channel();
 		if actor_sender
-			.send(PublicationRequest::Enqueue {
-				connection_id,
-				message: Box::new(message),
-				reply,
-			})
+			.send(PublicationRequest::Enqueue { connection_id, message: Box::new(message), reply })
 			.await
 			.is_err()
 		{
@@ -1131,19 +1130,22 @@ where
 			frozen_reader.map(SessionReaderCompletion::requested_seal),
 		);
 		let close_sent = match (seal_reason, frozen_reader) {
-			(SessionSealReason::OutboundFull, _) =>
+			(SessionSealReason::OutboundFull, _) => {
 				Self::send_close(
 					socket_writer,
 					write_timeout,
 					1_013,
 					"bounded outbound queue exceeded",
 				)
-				.await,
+				.await
+			},
 			(_, Some(SessionReaderCompletion::PeerClose)) if peer_close_reply_flushed => true,
-			(_, Some(SessionReaderCompletion::PeerClose)) =>
-				Self::flush_peer_close_reply(socket_writer, write_timeout).await,
-			(_, Some(SessionReaderCompletion::Reason(_)) | None) =>
-				Self::send_close(socket_writer, write_timeout, 1_000, "server session sealed").await,
+			(_, Some(SessionReaderCompletion::PeerClose)) => {
+				Self::flush_peer_close_reply(socket_writer, write_timeout).await
+			},
+			(_, Some(SessionReaderCompletion::Reason(_)) | None) => {
+				Self::send_close(socket_writer, write_timeout, 1_000, "server session sealed").await
+			},
 		};
 		let transport = if close_sent {
 			SessionTransportDisposition::drained(locally_written)
@@ -1310,8 +1312,9 @@ where
 				.filter(|reason| reason.canonicalizes_outbound_closed())
 				.unwrap_or(SessionSealReason::OutboundClosed),
 			Ok(reason) => reason,
-			Err(oneshot::error::TryRecvError::Empty) =>
-				requested.unwrap_or(SessionSealReason::ActorUnavailable),
+			Err(oneshot::error::TryRecvError::Empty) => {
+				requested.unwrap_or(SessionSealReason::ActorUnavailable)
+			},
 			Err(oneshot::error::TryRecvError::Closed) => SessionSealReason::ActorUnavailable,
 		}
 	}
@@ -1476,15 +1479,17 @@ where
 
 	fn directive_for_acceptance(acceptance: SessionAcceptance) -> OwnerDirective {
 		match acceptance {
-			SessionAcceptance::Sealed(SessionSealReason::OrdinalExhausted) =>
-				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity),
+			SessionAcceptance::Sealed(SessionSealReason::OrdinalExhausted) => {
+				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity)
+			},
 			SessionAcceptance::Accepted(_)
 			| SessionAcceptance::Unavailable
 			| SessionAcceptance::Sealed(
 				SessionSealReason::OutboundClosed | SessionSealReason::OutboundFull,
 			) => OwnerDirective::Continue,
-			SessionAcceptance::Sealed(_) =>
-				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity),
+			SessionAcceptance::Sealed(_) => {
+				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity)
+			},
 		}
 	}
 
@@ -1695,8 +1700,9 @@ where
 		self.tasks.abort_classified_sessions();
 		self.command_shutdown = match self.command_shutdown {
 			CommandShutdownState::Retained => CommandShutdownState::DeadlineElapsed,
-			CommandShutdownState::IntegrityRecorded =>
-				CommandShutdownState::IntegrityRecordedAfterDeadline,
+			CommandShutdownState::IntegrityRecorded => {
+				CommandShutdownState::IntegrityRecordedAfterDeadline
+			},
 			state => state,
 		};
 	}
@@ -1711,8 +1717,9 @@ where
 
 		self.command_shutdown = match self.command_shutdown {
 			CommandShutdownState::Retained => CommandShutdownState::IntegrityRecorded,
-			CommandShutdownState::DeadlineElapsed =>
-				CommandShutdownState::IntegrityRecordedAfterDeadline,
+			CommandShutdownState::DeadlineElapsed => {
+				CommandShutdownState::IntegrityRecordedAfterDeadline
+			},
 			CommandShutdownState::IntegrityRecorded
 			| CommandShutdownState::IntegrityRecordedAfterDeadline => {
 				return OwnerDirective::Continue;
@@ -1816,11 +1823,13 @@ where
 		};
 
 		match wake {
-			AcceptingWake::RequestedShutdown =>
-				OwnerDirective::BeginStopping(StopCause::RequestedShutdown),
+			AcceptingWake::RequestedShutdown => {
+				OwnerDirective::BeginStopping(StopCause::RequestedShutdown)
+			},
 			AcceptingWake::OwnedTask(Some(joined)) => self.harvest_task(joined),
-			AcceptingWake::OwnedTask(None) =>
-				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity),
+			AcceptingWake::OwnedTask(None) => {
+				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity)
+			},
 			AcceptingWake::Operation(completion) => self.finish_operation(completion),
 			AcceptingWake::Ordinary(ordinary) => self.handle_ordinary(*ordinary),
 		}
@@ -1871,8 +1880,9 @@ where
 				OwnerDirective::Continue
 			},
 			StoppingWake::OwnedTask(Some(joined)) => self.harvest_task(joined),
-			StoppingWake::OwnedTask(None) =>
-				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity),
+			StoppingWake::OwnedTask(None) => {
+				OwnerDirective::BeginStopping(StopCause::OwnerIntegrity)
+			},
 			StoppingWake::Operation(completion) => self.finish_operation(completion),
 			StoppingWake::ApplicationSettled => {
 				self.application_settled = true;
@@ -1888,8 +1898,9 @@ where
 				OwnerDirective::Continue
 			},
 			StoppingWake::FlushDeferred => self.flush_deferred_events(),
-			StoppingWake::ApplicationEvent(publication) =>
-				self.handle_application_event(publication),
+			StoppingWake::ApplicationEvent(publication) => {
+				self.handle_application_event(publication)
+			},
 		}
 	}
 
@@ -1897,10 +1908,12 @@ where
 		match ordinary {
 			AcceptingOrdinaryWake::Accepted(accepted) => self.handle_accepted(accepted),
 			AcceptingOrdinaryWake::Request(Some(request)) => self.handle_request(request),
-			AcceptingOrdinaryWake::Request(None) =>
-				OwnerDirective::BeginStopping(StopCause::ActorIngressClosed),
-			AcceptingOrdinaryWake::ApplicationEvent(publication) =>
-				self.handle_application_event(publication),
+			AcceptingOrdinaryWake::Request(None) => {
+				OwnerDirective::BeginStopping(StopCause::ActorIngressClosed)
+			},
+			AcceptingOrdinaryWake::ApplicationEvent(publication) => {
+				self.handle_application_event(publication)
+			},
 		}
 	}
 
@@ -1935,8 +1948,9 @@ where
 					OwnerDirective::Continue
 				}
 			},
-			Err(refusal) if refusal.invalidates_listener() =>
-				OwnerDirective::BeginStopping(StopCause::EndpointRefusal(refusal)),
+			Err(refusal) if refusal.invalidates_listener() => {
+				OwnerDirective::BeginStopping(StopCause::EndpointRefusal(refusal))
+			},
 			Err(_) => OwnerDirective::Continue,
 		}
 	}
@@ -2093,8 +2107,9 @@ where
 
 				directive
 			},
-			PublicationRequest::Command { connection_id, command, version, reply } =>
-				self.handle_command_request(connection_id, command, version, reply),
+			PublicationRequest::Command { connection_id, command, version, reply } => {
+				self.handle_command_request(connection_id, command, version, reply)
+			},
 		}
 	}
 
@@ -2222,8 +2237,9 @@ where
 		};
 		match operation {
 			ActiveActorOperation::Command(command) => match completion {
-				ActiveActorOperationCompletion::Command(execution) =>
-					self.finish_active_command(command, *execution),
+				ActiveActorOperationCompletion::Command(execution) => {
+					self.finish_active_command(command, *execution)
+				},
 				ActiveActorOperationCompletion::RegistrationSnapshot(_) => {
 					self.operation = Some(ActiveActorOperation::Command(command));
 
@@ -2231,8 +2247,9 @@ where
 				},
 			},
 			ActiveActorOperation::RegistrationSnapshot(snapshot) => match completion {
-				ActiveActorOperationCompletion::RegistrationSnapshot(result) =>
-					self.finish_registration_snapshot(snapshot, result),
+				ActiveActorOperationCompletion::RegistrationSnapshot(result) => {
+					self.finish_registration_snapshot(snapshot, result)
+				},
 				ActiveActorOperationCompletion::Command(_) => {
 					self.operation = Some(ActiveActorOperation::RegistrationSnapshot(snapshot));
 
@@ -2341,7 +2358,9 @@ where
 			active.version,
 			execution,
 		);
-		if result.outcome != CommandOutcome::AcceptanceUnknown {
+		if result.outcome != CommandOutcome::AcceptanceUnknown
+			&& !result.payload.as_ref().is_some_and(ResultPayload::is_evolving_receipt)
+		{
 			self.state.receipts.insert(
 				receipt_key,
 				StoredCommand {
@@ -2809,10 +2828,12 @@ async fn poll_active_operation(
 	operation: &mut Option<ActiveActorOperation>,
 ) -> ActiveActorOperationCompletion {
 	match operation.as_mut().expect("guarded active operation exists") {
-		ActiveActorOperation::Command(command) =>
-			ActiveActorOperationCompletion::Command(Box::new(command.future.as_mut().await)),
-		ActiveActorOperation::RegistrationSnapshot(snapshot) =>
-			ActiveActorOperationCompletion::RegistrationSnapshot(snapshot.future.as_mut().await),
+		ActiveActorOperation::Command(command) => {
+			ActiveActorOperationCompletion::Command(Box::new(command.future.as_mut().await))
+		},
+		ActiveActorOperation::RegistrationSnapshot(snapshot) => {
+			ActiveActorOperationCompletion::RegistrationSnapshot(snapshot.future.as_mut().await)
+		},
 	}
 }
 
@@ -2871,14 +2892,16 @@ struct SealedSession {
 impl SealedSession {
 	fn reconcile(&self, transport: SessionTransportDisposition) -> SessionCompletionClassification {
 		let progress_matches = match transport {
-			SessionTransportDisposition::DrainedThrough(locally_written) =>
-				locally_written == self.accepted_through,
+			SessionTransportDisposition::DrainedThrough(locally_written) => {
+				locally_written == self.accepted_through
+			},
 			SessionTransportDisposition::TransportFailed {
 				locally_written,
 				cause: SessionTransportFailure::CloseWrite,
 			} => locally_written == self.accepted_through,
-			SessionTransportDisposition::TransportFailed { locally_written, .. } =>
-				locally_written <= self.accepted_through,
+			SessionTransportDisposition::TransportFailed { locally_written, .. } => {
+				locally_written <= self.accepted_through
+			},
 		};
 		if !progress_matches {
 			return SessionCompletionClassification::Invalid;
@@ -2913,8 +2936,9 @@ impl SealedSession {
 		}
 		match transport {
 			SessionTransportDisposition::DrainedThrough(_) => match self.reason {
-				SessionSealReason::ActorUnavailable =>
-					SessionCompletionClassification::TransportFailed,
+				SessionSealReason::ActorUnavailable => {
+					SessionCompletionClassification::TransportFailed
+				},
 				SessionSealReason::Deadline
 				| SessionSealReason::InitialPrefixFailed
 				| SessionSealReason::OutboundClosed
@@ -2934,8 +2958,9 @@ impl SealedSession {
 				| SessionSealReason::ServerDrained
 				| SessionSealReason::ServerShutdown
 				| SessionSealReason::WriterFailed => SessionCompletionClassification::SessionLocal,
-				SessionSealReason::ActorUnavailable | SessionSealReason::OrdinalExhausted =>
-					SessionCompletionClassification::TransportFailed,
+				SessionSealReason::ActorUnavailable | SessionSealReason::OrdinalExhausted => {
+					SessionCompletionClassification::TransportFailed
+				},
 				SessionSealReason::Deadline
 				| SessionSealReason::OutboundClosed
 				| SessionSealReason::RegistrationAbandoned

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -1,7 +1,8 @@
 //! SQLite bootstrap and authoritative doctor protocol fixtures.
 #![allow(unused_crate_dependencies)]
 
-#[cfg(unix)] use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::{fs, fs::OpenOptions, io::Write as _};
 
 use futures_util::{SinkExt as _, StreamExt as _};
@@ -363,7 +364,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 7 },
+			version: ProtocolVersion { major: 2, minor: 10 },
 			artifact_cohort: Some(decodex_protocol::CURRENT_ARTIFACT_COHORT),
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
@@ -371,7 +372,7 @@ async fn assert_exact_current_doctor_queries(
 	)
 	.await;
 	let ServerMessage::Refusal(refusal) = receive(&mut future).await else {
-		panic!("expected V2.7 minor-version refusal");
+		panic!("expected V2.10 minor-version refusal");
 	};
 	assert!(matches!(
 		refusal.refusal,
@@ -417,7 +418,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 7 },
+			ProtocolVersion { major: 2, minor: 10 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -23,14 +23,13 @@ use decodex_core::{DecodexRoot, LocalTrustPolicy};
 use decodex_protocol::{
 	AccountLoginInstallMode, AccountLoginMethod, AccountLoginRequest, AccountLoginRequestEnvelope,
 	AccountLoginStart, AccountLoginState, AccountLoginStatus, AccountsResult, CURRENT_VERSION,
-	CausationId, Channel, ClientCommandId, ClientHello, ClientMessage, CommandEnvelope, CommandError,
-	CommandPayload, CorrelationId, Cursor,
-	DoctorCheck, DoctorComponent, DoctorIssue, DoctorReport, DoctorStatus, EntityId,
-	EntityRevision, EventPayload, IdempotencyKey, LocalTransportAuthority, LocalTransportRefusal,
-	LocalTransportStream, ProtocolVersion, QueryEnvelope, QueryId, QueryPayload,
-	QueryResultPayload, ReceiptDisposition, ReconnectMode, Refusal, ResetCardDescriptorDto,
-	ResetCardOperationResult, ResultPayload, ResumeCursor, ServerId, ServerInstanceId,
-	ServerMessage, SnapshotItem, VersionRefusal, WireText,
+	CausationId, Channel, ClientCommandId, ClientHello, ClientMessage, CommandEnvelope,
+	CommandError, CommandPayload, CorrelationId, Cursor, DoctorCheck, DoctorComponent, DoctorIssue,
+	DoctorReport, DoctorStatus, EntityId, EntityRevision, EventPayload, IdempotencyKey,
+	LocalTransportAuthority, LocalTransportRefusal, LocalTransportStream, ProtocolVersion,
+	QueryEnvelope, QueryId, QueryPayload, QueryResultPayload, ReceiptDisposition, ReconnectMode,
+	Refusal, ResetCardDescriptorDto, ResetCardOperationResult, ResultPayload, ResumeCursor,
+	ServerId, ServerInstanceId, ServerMessage, SnapshotItem, VersionRefusal, WireText,
 };
 use decodex_runtime::{
 	ActorCommandDeadlineClass, Application, ApplicationPublication, ProtocolServer, ServerConfig,
@@ -234,10 +233,7 @@ impl Application for FixtureApplication {
 		future::ready(result)
 	}
 
-	async fn account_login<'a>(
-		&'a self,
-		request: &'a AccountLoginRequest,
-	) -> AccountLoginStatus {
+	async fn account_login<'a>(&'a self, request: &'a AccountLoginRequest) -> AccountLoginStatus {
 		self.state.lock().expect("test state mutex poisoned").login_requests += 1;
 		let state = match request {
 			AccountLoginRequest::Start { start } => match start.method {
@@ -556,8 +552,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 6);
-	assert_eq!(welcome.supported.maximum_minor, 6);
+	assert_eq!(welcome.supported.minimum_minor, 9);
+	assert_eq!(welcome.supported.maximum_minor, 9);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;
@@ -638,9 +634,11 @@ async fn account_login_exchange_does_not_advance_or_enter_retained_state() {
 	};
 	assert_eq!(after.cursor, before.cursor);
 	assert_eq!(after.items, before.items);
-	assert!(!serde_json::to_string(&after)
-		.expect("serialize credential-negative snapshot")
-		.contains(response.status.session_id.as_str()));
+	assert!(
+		!serde_json::to_string(&after)
+			.expect("serialize credential-negative snapshot")
+			.contains(response.status.session_id.as_str())
+	);
 
 	drop(second);
 	bound.shutdown().await.expect("shutdown ephemeral account-login server");

--- a/database/migrations/0009_durable_account_route.sql
+++ b/database/migrations/0009_durable_account_route.sql
@@ -1,0 +1,19 @@
+ALTER TABLE command_receipts ADD COLUMN request_json TEXT;
+
+CREATE INDEX pending_account_route_commands
+  ON command_receipts(operation, state, claim_expires_at_micros)
+  WHERE operation = 'route_account' AND state = 'reserved';
+
+CREATE TRIGGER route_command_request_required_insert
+BEFORE INSERT ON command_receipts
+WHEN NEW.operation = 'route_account' AND NEW.request_json IS NULL
+BEGIN
+  SELECT RAISE(ABORT, 'route command request is required');
+END;
+
+CREATE TRIGGER route_command_request_required_update
+BEFORE UPDATE OF operation, request_json ON command_receipts
+WHEN NEW.operation = 'route_account' AND NEW.request_json IS NULL
+BEGIN
+  SELECT RAISE(ABORT, 'route command request is required');
+END;

--- a/database/migrations/0010_pending_account_route_progress.sql
+++ b/database/migrations/0010_pending_account_route_progress.sql
@@ -1,0 +1,21 @@
+ALTER TABLE command_receipts ADD COLUMN progress_json TEXT;
+
+CREATE UNIQUE INDEX one_pending_account_route
+  ON command_receipts(operation)
+  WHERE operation = 'route_account' AND state = 'reserved';
+
+CREATE TRIGGER route_command_progress_shape_insert
+BEFORE INSERT ON command_receipts
+WHEN NEW.progress_json IS NOT NULL
+ AND (NEW.operation <> 'route_account' OR NEW.state <> 'reserved')
+BEGIN
+  SELECT RAISE(ABORT, 'route command progress is invalid');
+END;
+
+CREATE TRIGGER route_command_progress_shape_update
+BEFORE UPDATE OF operation, state, progress_json ON command_receipts
+WHEN NEW.progress_json IS NOT NULL
+ AND (NEW.operation <> 'route_account' OR NEW.state <> 'reserved')
+BEGIN
+  SELECT RAISE(ABORT, 'route command progress is invalid');
+END;

--- a/database/src/account_lifecycle.rs
+++ b/database/src/account_lifecycle.rs
@@ -62,11 +62,7 @@ pub enum AccountLifecycleMutationOutcome {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AccountEnrollmentResolution {
 	Fresh { account_id: AccountId },
-	Restore {
-		account_id: AccountId,
-		account_revision: i64,
-		previous_credential: CredentialBinding,
-	},
+	Restore { account_id: AccountId, account_revision: i64, previous_credential: CredentialBinding },
 	AlreadyEnrolled { account_id: AccountId, account_revision: i64 },
 }
 
@@ -110,9 +106,8 @@ pub enum AccountCommandKind {
 	Enroll,
 	Import,
 	SetEnabled,
-	UseInCodex,
+	Route,
 	Logout,
-	SetFixedSelection,
 	SetBalancedSelection,
 	SetAccountOrder,
 	Refresh,
@@ -125,9 +120,8 @@ impl AccountCommandKind {
 			Self::Enroll => "enroll_account",
 			Self::Import => "import_account_credential_file",
 			Self::SetEnabled => "set_account_enabled",
-			Self::UseInCodex => "use_account_in_codex",
+			Self::Route => "route_account",
 			Self::Logout => "logout_account",
-			Self::SetFixedSelection => "set_fixed_account_selection",
 			Self::SetBalancedSelection => "set_balanced_account_selection",
 			Self::SetAccountOrder => "set_account_order",
 			Self::Refresh => "refresh_account",
@@ -138,8 +132,18 @@ impl AccountCommandKind {
 
 pub struct AccountCommandReceiptLease(CommandReservation);
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAccountRouteCommand {
+	pub idempotency_key: String,
+	pub request_sha256: String,
+	pub request_json: String,
+	pub expected_routing_revision: i64,
+	pub progress: Option<Value>,
+}
+
 pub enum AccountCommandReceiptClaim {
 	Owned(AccountCommandReceiptLease),
+	Pending(Value),
 	Replayed(Value),
 }
 
@@ -208,7 +212,204 @@ impl SqliteStore {
 		let command = command.clone();
 		let entity_id = entity_id.to_owned();
 		self.run(move |connection| {
-			reserve_command_sync(connection, command, kind, entity_id, expected_revision)
+			reserve_command_sync(
+				connection,
+				command,
+				kind,
+				entity_id,
+				expected_revision,
+				None,
+				false,
+				None,
+			)
+		})
+		.await
+	}
+
+	pub async fn reserve_account_route_command(
+		&self,
+		command: &CommandIdentity,
+		expected_routing_revision: i64,
+		request_json: &str,
+	) -> Result<AccountCommandReceiptClaim, StoreError> {
+		self.reserve_account_route_command_inner(
+			command,
+			expected_routing_revision,
+			request_json,
+			None,
+		)
+		.await
+	}
+
+	pub async fn reserve_replacing_account_route_command(
+		&self,
+		command: &CommandIdentity,
+		expected_routing_revision: i64,
+		request_json: &str,
+		superseded_response: &Value,
+	) -> Result<AccountCommandReceiptClaim, StoreError> {
+		validate_account_command_response(superseded_response)?;
+		self.reserve_account_route_command_inner(
+			command,
+			expected_routing_revision,
+			request_json,
+			Some(superseded_response.clone()),
+		)
+		.await
+	}
+
+	async fn reserve_account_route_command_inner(
+		&self,
+		command: &CommandIdentity,
+		expected_routing_revision: i64,
+		request_json: &str,
+		superseded_response: Option<Value>,
+	) -> Result<AccountCommandReceiptClaim, StoreError> {
+		validate_routing_revision(expected_routing_revision)?;
+		let request_value: Value = serde_json::from_str(request_json)
+			.map_err(|_| StoreError::InvalidInput("account Route request is invalid"))?;
+		if request_json.len() > 64 * 1024 {
+			return Err(StoreError::InvalidInput("account Route request is invalid"));
+		}
+		ensure_credential_negative_json(&request_value)?;
+		let command = command.clone();
+		let request_json = request_json.to_owned();
+		let superseded_response = superseded_response
+			.map(|response| serde_json::to_string(&response))
+			.transpose()
+			.map_err(|_| StoreError::InvalidInput("account Route result is invalid"))?;
+		self.run(move |connection| {
+			reserve_command_sync(
+				connection,
+				command,
+				AccountCommandKind::Route,
+				"account-routing".to_owned(),
+				Some(expected_routing_revision),
+				Some(request_json),
+				false,
+				superseded_response,
+			)
+		})
+		.await
+	}
+
+	pub async fn read_pending_account_route_commands(
+		&self,
+		limit: u16,
+	) -> Result<Vec<PendingAccountRouteCommand>, StoreError> {
+		validate_limit(limit, "pending account Route limit must be between 1 and 512")?;
+		self.run(move |connection| {
+			let mut statement = connection
+				.prepare(
+					"SELECT idempotency_key, request_sha256, request_json, expected_revision,
+					        progress_json
+					 FROM command_receipts
+					 WHERE protocol = ?1 AND operation = 'route_account' AND state = 'reserved'
+					 ORDER BY reserved_at_micros, idempotency_key LIMIT ?2",
+				)
+				.map_err(sql_error)?;
+			let rows = statement
+				.query_map(params![ACCOUNT_COMMAND_PROTOCOL, limit], |row| {
+					Ok(PendingAccountRouteCommand {
+						idempotency_key: row.get(0)?,
+						request_sha256: row.get(1)?,
+						request_json: row.get(2)?,
+						expected_routing_revision: row.get(3)?,
+						progress: row
+							.get::<_, Option<String>>(4)?
+							.map(|value| serde_json::from_str(&value))
+							.transpose()
+							.map_err(|error| {
+								rusqlite::Error::FromSqlConversionFailure(
+									4,
+									rusqlite::types::Type::Text,
+									Box::new(error),
+								)
+							})?,
+					})
+				})
+				.map_err(sql_error)?;
+			rows.collect::<Result<Vec<_>, _>>().map_err(sql_error)
+		})
+		.await
+	}
+
+	/// Expire Route leases left by the previous daemon before the listener accepts commands.
+	pub async fn release_interrupted_account_route_claims(&self) -> Result<u64, StoreError> {
+		self.run(move |connection| {
+			let changed = connection
+				.execute(
+					"UPDATE command_receipts
+					 SET claim_expires_at_micros = reserved_at_micros + 1
+					 WHERE protocol = ?1 AND operation = 'route_account' AND state = 'reserved'",
+					params![ACCOUNT_COMMAND_PROTOCOL],
+				)
+				.map_err(sql_error)?;
+			u64::try_from(changed)
+				.map_err(|_| StoreError::InvalidInput("account Route claim count is invalid"))
+		})
+		.await
+	}
+
+	pub async fn reclaim_account_route_command(
+		&self,
+		pending: &PendingAccountRouteCommand,
+	) -> Result<AccountCommandReceiptClaim, StoreError> {
+		let command = CommandIdentity {
+			key: pending.idempotency_key.clone(),
+			request_hash: pending.request_sha256.clone(),
+		};
+		let expected = pending.expected_routing_revision;
+		let request_json = pending.request_json.clone();
+		self.run(move |connection| {
+			reserve_command_sync(
+				connection,
+				command,
+				AccountCommandKind::Route,
+				"account-routing".to_owned(),
+				Some(expected),
+				Some(request_json),
+				true,
+				None,
+			)
+		})
+		.await
+	}
+
+	/// Retain one replayable pending result while releasing the Route lease to the daemon worker.
+	pub async fn defer_account_route_command(
+		&self,
+		lease: AccountCommandReceiptLease,
+		progress: &Value,
+	) -> Result<(), StoreError> {
+		validate_account_command_response(progress)?;
+		let progress = serde_json::to_string(progress)
+			.map_err(|_| StoreError::InvalidInput("account Route progress is invalid"))?;
+		self.run(move |connection| {
+			let now = unix_micros().map_err(StoreError::from)?;
+			let changed = connection
+				.execute(
+					"UPDATE command_receipts
+					 SET progress_json = ?1,
+					     claim_expires_at_micros = MAX(?2, reserved_at_micros + 1)
+					 WHERE protocol = ?3 AND idempotency_key = ?4 AND request_sha256 = ?5
+					   AND operation = 'route_account' AND state = 'reserved'
+					   AND claim_token = ?6 AND claim_expires_at_micros > ?2",
+					params![
+						progress,
+						now,
+						lease.0.protocol,
+						lease.0.key,
+						lease.0.request_hash,
+						lease.0.claim_token,
+					],
+				)
+				.map_err(sql_error)?;
+			if changed == 1 {
+				Ok(())
+			} else {
+				Err(StoreError::OwnershipLost("account Route command lease"))
+			}
 		})
 		.await
 	}
@@ -526,7 +727,8 @@ impl SqliteStore {
 		.await
 	}
 
-	pub async fn set_fixed_account_selection_command<F>(
+	/// Commit one fixed Route and its complete public result in one transaction.
+	pub async fn route_account_command<F>(
 		&self,
 		lease: AccountCommandReceiptLease,
 		expected_routing_revision: i64,
@@ -535,7 +737,9 @@ impl SqliteStore {
 		build_response: F,
 	) -> Result<Value, StoreError>
 	where
-		F: FnOnce(&RoutingControlOutcome) -> Result<Value, StoreError> + Send + 'static,
+		F: FnOnce(&RoutingControlOutcome, Option<&AccountRecord>) -> Result<Value, StoreError>
+			+ Send
+			+ 'static,
 	{
 		validate_routing_revision(expected_routing_revision)?;
 		validate_account_revision(expected_account_revision)?;
@@ -544,13 +748,20 @@ impl SqliteStore {
 			let transaction = connection
 				.transaction_with_behavior(TransactionBehavior::Immediate)
 				.map_err(sql_error)?;
-			let outcome = set_fixed_routing_sync(
+			let outcome = route_fixed_routing_sync(
 				&transaction,
 				expected_routing_revision,
 				&account_id,
 				expected_account_revision,
 			)?;
-			let response = build_response(&outcome)?;
+			let account = if matches!(outcome, RoutingControlOutcome::Updated { .. }) {
+				read_account_registry_sync(&transaction, Some(account_id.as_str()), 1)?
+					.into_iter()
+					.next()
+			} else {
+				None
+			};
+			let response = build_response(&outcome, account.as_ref())?;
 			validate_account_command_response(&response)?;
 			finish_command_sync(&transaction, &lease.0, &response)?;
 			transaction.commit().map_err(sql_error)?;
@@ -822,12 +1033,16 @@ impl SqliteStore {
 	}
 }
 
+#[allow(clippy::too_many_arguments)] // One transaction needs the exact command identity, descriptor, reclaim mode, and optional supersession result.
 fn reserve_command_sync(
 	connection: &mut Connection,
 	command: CommandIdentity,
 	kind: AccountCommandKind,
 	entity_id: String,
 	expected_revision: Option<i64>,
+	request_json: Option<String>,
+	reclaim_pending_route: bool,
+	superseded_response: Option<String>,
 ) -> Result<AccountCommandReceiptClaim, StoreError> {
 	let transaction =
 		connection.transaction_with_behavior(TransactionBehavior::Immediate).map_err(sql_error)?;
@@ -835,7 +1050,7 @@ fn reserve_command_sync(
 	let existing = transaction
 		.query_row(
 			"SELECT request_sha256, operation, entity_id, expected_revision, state,
-			        response_json, claim_expires_at_micros
+			        response_json, claim_expires_at_micros, request_json, progress_json
 			 FROM command_receipts WHERE protocol = ?1 AND idempotency_key = ?2",
 			params![ACCOUNT_COMMAND_PROTOCOL, command.key],
 			|row| {
@@ -847,18 +1062,32 @@ fn reserve_command_sync(
 					row.get::<_, String>(4)?,
 					row.get::<_, Option<String>>(5)?,
 					row.get::<_, Option<i64>>(6)?,
+					row.get::<_, Option<String>>(7)?,
+					row.get::<_, Option<String>>(8)?,
 				))
 			},
 		)
 		.optional()
 		.map_err(sql_error)?;
 	let receipt_exists = existing.is_some();
-	if let Some((request, operation, stored_entity, revision, state, response, expires)) = existing
+	if let Some((
+		request,
+		operation,
+		stored_entity,
+		revision,
+		state,
+		response,
+		expires,
+		stored_json,
+		progress,
+	)) = existing
 	{
 		if request != command.request_hash
 			|| operation != kind.as_str()
 			|| stored_entity != entity_id
 			|| revision != expected_revision
+			|| (kind == AccountCommandKind::Route
+				&& stored_json.as_deref() != request_json.as_deref())
 		{
 			return Err(StoreError::IdempotencyConflict);
 		}
@@ -869,8 +1098,47 @@ fn reserve_command_sync(
 			transaction.commit().map_err(sql_error)?;
 			return Ok(AccountCommandReceiptClaim::Replayed(response));
 		}
+		if !reclaim_pending_route && let Some(progress) = progress {
+			let progress = serde_json::from_str(&progress)
+				.map_err(|_| incompatible("account Route progress"))?;
+			transaction.commit().map_err(sql_error)?;
+			return Ok(AccountCommandReceiptClaim::Pending(progress));
+		}
 		if expires.is_some_and(|expires| expires > now) {
 			return Err(StoreError::OwnershipLost("command receipt claim is active"));
+		}
+	}
+	if !receipt_exists
+		&& kind == AccountCommandKind::Route
+		&& !reclaim_pending_route
+		&& let Some(superseded_response) = superseded_response.as_ref()
+		&& let Some((pending_key, claim_expires_at)) = transaction
+			.query_row(
+				"SELECT idempotency_key, claim_expires_at_micros
+				 FROM command_receipts
+				 WHERE protocol = ?1 AND operation = 'route_account' AND state = 'reserved'",
+				params![ACCOUNT_COMMAND_PROTOCOL],
+				|row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+			)
+			.optional()
+			.map_err(sql_error)?
+	{
+		if claim_expires_at.is_some_and(|expires| expires > now) {
+			return Err(StoreError::OwnershipLost("pending account Route is active"));
+		}
+		let changed = transaction
+			.execute(
+				"UPDATE command_receipts
+				 SET state = 'completed_success', response_json = ?1, claim_token = NULL,
+				     claim_expires_at_micros = NULL, completed_at_micros = ?2,
+				     progress_json = NULL
+				 WHERE protocol = ?3 AND idempotency_key = ?4
+				   AND operation = 'route_account' AND state = 'reserved'",
+				params![superseded_response, now, ACCOUNT_COMMAND_PROTOCOL, pending_key],
+			)
+			.map_err(sql_error)?;
+		if changed != 1 {
+			return Err(StoreError::OwnershipLost("pending account Route supersession"));
 		}
 	}
 
@@ -892,8 +1160,9 @@ fn reserve_command_sync(
 				"INSERT INTO command_receipts (
 				   protocol, idempotency_key, request_sha256, operation, entity_id,
 				   expected_revision, state, response_json, claim_token,
-				   claim_expires_at_micros, reserved_at_micros, completed_at_micros
-				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'reserved', NULL, ?7, ?8, ?9, NULL)",
+					   claim_expires_at_micros, reserved_at_micros, completed_at_micros,
+				   request_json, progress_json
+				 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'reserved', NULL, ?7, ?8, ?9, NULL, ?10, NULL)",
 				params![
 					ACCOUNT_COMMAND_PROTOCOL,
 					command.key,
@@ -904,6 +1173,7 @@ fn reserve_command_sync(
 					claim_token,
 					expires,
 					now,
+					request_json,
 				],
 			)
 			.map_err(sql_error)?;
@@ -928,7 +1198,8 @@ fn finish_command_sync(
 		.execute(
 			"UPDATE command_receipts
 			 SET state = 'completed_success', response_json = ?1, claim_token = NULL,
-			     claim_expires_at_micros = NULL, completed_at_micros = ?2
+			     claim_expires_at_micros = NULL, completed_at_micros = ?2,
+			     progress_json = NULL
 			 WHERE protocol = ?3 AND idempotency_key = ?4 AND request_sha256 = ?5
 			   AND state = 'reserved' AND claim_token = ?6 AND claim_expires_at_micros > ?2",
 			params![
@@ -996,19 +1267,25 @@ fn prepare_operation_sync(
 
 	let account = account_base_sync(connection, &preparation.account_id)?;
 	let rejection = match preparation.kind {
-		AccountOperationKind::Enroll | AccountOperationKind::Import =>
-			enrollment_rejection_sync(connection, preparation, account.as_ref())?,
+		AccountOperationKind::Enroll | AccountOperationKind::Import => {
+			enrollment_rejection_sync(connection, preparation, account.as_ref())?
+		},
 		AccountOperationKind::Refresh | AccountOperationKind::Logout => match account {
 			None => Some(AccountLifecycleRejection::AccountMissing),
-			Some(ref account) if account.tombstoned =>
-				Some(AccountLifecycleRejection::AccountMissing),
+			Some(ref account) if account.tombstoned => {
+				Some(AccountLifecycleRejection::AccountMissing)
+			},
 			Some(ref account)
 				if preparation.expected_account_revision != Some(account.revision) =>
-				Some(AccountLifecycleRejection::StaleAccount),
+			{
+				Some(AccountLifecycleRejection::StaleAccount)
+			},
 			Some(_)
 				if credential_binding_sync(connection, &preparation.account_id)?
 					!= preparation.expected =>
-				Some(AccountLifecycleRejection::StaleAccount),
+			{
+				Some(AccountLifecycleRejection::StaleAccount)
+			},
 			Some(_) => None,
 		},
 	};
@@ -1711,12 +1988,9 @@ fn resolve_account_enrollment_sync(
 		.optional()
 		.map_err(sql_error)?;
 	let Some(existing) = existing else {
-		return Ok(AccountEnrollmentResolution::Fresh {
-			account_id: requested_account_id.clone(),
-		});
+		return Ok(AccountEnrollmentResolution::Fresh { account_id: requested_account_id.clone() });
 	};
-	let account_id =
-		AccountId::new(existing).map_err(|_| incompatible("account identity"))?;
+	let account_id = AccountId::new(existing).map_err(|_| incompatible("account identity"))?;
 	let account = account_base_sync(connection, &account_id)?
 		.ok_or_else(|| incompatible("account enrollment resolution"))?;
 	if !account.tombstoned {
@@ -1737,12 +2011,8 @@ fn resolve_account_enrollment_sync(
 			return Err(incompatible("tombstoned account enrollment state"));
 		}
 	}
-	let previous_credential = tombstone_predecessor_credential_sync(
-		connection,
-		&account_id,
-		account.revision,
-		provider,
-	)?;
+	let previous_credential =
+		tombstone_predecessor_credential_sync(connection, &account_id, account.revision, provider)?;
 	Ok(AccountEnrollmentResolution::Restore {
 		account_id,
 		account_revision: account.revision,
@@ -1759,9 +2029,8 @@ fn is_legacy_tombstone_enrollment_collision_sync(
 		|| !matches!(
 			operation.phase,
 			AccountOperationPhase::StoreApplied | AccountOperationPhase::RecoveryRequired
-		)
-		|| (operation.phase == AccountOperationPhase::RecoveryRequired
-			&& operation.recovery_code.as_deref() != Some(RECOVERY_CODE))
+		) || (operation.phase == AccountOperationPhase::RecoveryRequired
+		&& operation.recovery_code.as_deref() != Some(RECOVERY_CODE))
 		|| operation.expected_account_revision.is_some()
 		|| operation.expected.is_some()
 		|| operation.requested_display_label.is_none()
@@ -1770,8 +2039,7 @@ fn is_legacy_tombstone_enrollment_collision_sync(
 		return Ok(false);
 	}
 	let Some(target) = operation.target.as_ref() else { return Ok(false) };
-	if target.version.get() != 1
-		|| account_base_sync(connection, &operation.account_id)?.is_some()
+	if target.version.get() != 1 || account_base_sync(connection, &operation.account_id)?.is_some()
 	{
 		return Ok(false);
 	}
@@ -1786,10 +2054,7 @@ fn is_legacy_tombstone_enrollment_collision_sync(
 			"SELECT account_id, revision FROM accounts
 			 WHERE provider = ?1 AND provider_account_id = ?2
 			   AND tombstoned_at_micros IS NOT NULL",
-			params![
-				provider_text(target.provider.provider()),
-				target.provider.account_id(),
-			],
+			params![provider_text(target.provider.provider()), target.provider.account_id(),],
 			|row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
 		)
 		.optional()
@@ -1840,8 +2105,8 @@ fn tombstone_predecessor_credential_sync(
 	let (binding, predecessor_revision) = predecessor;
 	let binding = parse_binding_json(binding.as_deref())?
 		.ok_or_else(|| incompatible("tombstoned account credential history"))?;
-	let predecessor_revision = predecessor_revision
-		.ok_or_else(|| incompatible("tombstoned account revision history"))?;
+	let predecessor_revision =
+		predecessor_revision.ok_or_else(|| incompatible("tombstoned account revision history"))?;
 	if predecessor_revision.checked_add(1) != Some(account_revision)
 		|| binding.provider != *provider
 	{
@@ -2081,6 +2346,36 @@ fn set_fixed_routing_sync(
 	Ok(RoutingControlOutcome::Updated { routing: read_routing_control_sync(connection)? })
 }
 
+fn route_fixed_routing_sync(
+	connection: &Connection,
+	expected_routing_revision: i64,
+	account_id: &AccountId,
+	expected_account_revision: i64,
+) -> Result<RoutingControlOutcome, StoreError> {
+	let routing = read_routing_control_sync(connection)?;
+	if routing.revision != expected_routing_revision {
+		return Ok(RoutingControlOutcome::StaleRoutingControl { revision: routing.revision });
+	}
+	let Some(account) = account_base_sync(connection, account_id)? else {
+		return Ok(RoutingControlOutcome::AccountMissing);
+	};
+	if account.tombstoned {
+		return Ok(RoutingControlOutcome::AccountMissing);
+	}
+	if account.revision != expected_account_revision {
+		return Ok(RoutingControlOutcome::StaleAccount { revision: account.revision });
+	}
+	if routing.mode == AccountSelectionMode::Fixed(account_id.clone()) {
+		return Ok(RoutingControlOutcome::Updated { routing });
+	}
+	set_fixed_routing_sync(
+		connection,
+		expected_routing_revision,
+		account_id,
+		expected_account_revision,
+	)
+}
+
 fn set_balanced_routing_sync(
 	connection: &Connection,
 	expected_routing_revision: i64,
@@ -2088,6 +2383,9 @@ fn set_balanced_routing_sync(
 	let routing = read_routing_control_sync(connection)?;
 	if routing.revision != expected_routing_revision {
 		return Ok(RoutingControlOutcome::StaleRoutingControl { revision: routing.revision });
+	}
+	if pending_account_route_exists_sync(connection)? {
+		return Ok(RoutingControlOutcome::InvalidRequest);
 	}
 	let revision =
 		routing.revision.checked_add(1).ok_or(StoreError::CapacityExhausted("routing revision"))?;
@@ -2109,6 +2407,9 @@ fn set_account_order_sync(
 	let routing = read_routing_control_sync(connection)?;
 	if routing.revision != expected_routing_revision {
 		return Ok(RoutingControlOutcome::StaleRoutingControl { revision: routing.revision });
+	}
+	if pending_account_route_exists_sync(connection)? {
+		return Ok(RoutingControlOutcome::InvalidRequest);
 	}
 	let visible = routing.order.iter().cloned().collect::<BTreeSet<_>>();
 	let proposed = order.iter().cloned().collect::<BTreeSet<_>>();
@@ -2133,6 +2434,19 @@ fn set_account_order_sync(
 	}
 	bump_routing_revision(connection, now)?;
 	Ok(RoutingControlOutcome::Updated { routing: read_routing_control_sync(connection)? })
+}
+
+fn pending_account_route_exists_sync(connection: &Connection) -> Result<bool, StoreError> {
+	connection
+		.query_row(
+			"SELECT EXISTS (
+			   SELECT 1 FROM command_receipts
+			   WHERE protocol = ?1 AND operation = 'route_account' AND state = 'reserved'
+			 )",
+			params![ACCOUNT_COMMAND_PROTOCOL],
+			|row| row.get(0),
+		)
+		.map_err(sql_error)
 }
 
 fn compact_routing_order(connection: &Connection, now: i64) -> Result<(), StoreError> {
@@ -2479,17 +2793,19 @@ fn validate_account_command_response(value: &Value) -> Result<(), StoreError> {
 
 fn ensure_credential_negative_json(value: &Value) -> Result<(), StoreError> {
 	match value {
-		Value::Object(entries) =>
+		Value::Object(entries) => {
 			for (key, value) in entries {
 				if decodex_core::is_credential_metadata_key(key) {
 					return Err(StoreError::CredentialRejected);
 				}
 				ensure_credential_negative_json(value)?;
-			},
-		Value::Array(entries) =>
+			}
+		},
+		Value::Array(entries) => {
 			for value in entries {
 				ensure_credential_negative_json(value)?;
-			},
+			}
+		},
 		Value::String(value) if decodex_core::contains_credential_material(value) => {
 			return Err(StoreError::CredentialRejected);
 		},

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -23,7 +23,8 @@ pub use self::{
 		AccountAdministrationOutcome, AccountCommandKind, AccountCommandReceiptClaim,
 		AccountCommandReceiptLease, AccountEnrollmentResolution, AccountLifecycleMutation,
 		AccountLifecycleMutationOutcome, AccountLifecycleRejection, AccountOperationPreparation,
-		AccountStoreObservation, CodexAccountCapabilityAttestation, RoutingControlOutcome,
+		AccountStoreObservation, CodexAccountCapabilityAttestation, PendingAccountRouteCommand,
+		RoutingControlOutcome,
 	},
 	account_profiles::{
 		AccountProfileDailyUsage, AccountProfileObservation, AccountProfileObservationOutcome,
@@ -61,8 +62,8 @@ pub use self::{
 		BindProgramDomainPack, ContinueProgram, CreateProgramCycle, DomainPackIdentity,
 		ProgramCharterRecord, ProgramClaimRecord, ProgramCycleRecord, ProgramDomainPackBinding,
 		ProgramEvidenceInput, ProgramEvidenceRecord, ProgramObjectiveRecord, ProgramProposalRecord,
-		ProgramReviewRecord, ProgramSignalRecord, ProgramSummaryRecord, ProgramWorkItemRecord,
-		ProgramWorkItemDomainPack, RecordProgramReview,
+		ProgramReviewRecord, ProgramSignalRecord, ProgramSummaryRecord, ProgramWorkItemDomainPack,
+		ProgramWorkItemRecord, RecordProgramReview,
 	},
 	provider_attempts::{
 		AuthorizeProviderDispatchOutcome, FreshPreparedProviderAttempt, FreshProviderDispatchFence,
@@ -93,7 +94,8 @@ pub use self::{
 	},
 };
 
-#[cfg(unix)] use std::os::unix::fs::MetadataExt as _;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt as _;
 use std::{
 	fs::File,
 	path::{Path, PathBuf},
@@ -231,7 +233,8 @@ impl SqliteStore {
 	#[cfg(test)]
 	fn open_test(path: &Path) -> Result<Self, DatabaseError> {
 		use std::fs::OpenOptions;
-		#[cfg(unix)] use std::os::unix::fs::OpenOptionsExt as _;
+		#[cfg(unix)]
+		use std::os::unix::fs::OpenOptionsExt as _;
 
 		let mut options = OpenOptions::new();
 		options.read(true).write(true).create(true);
@@ -279,7 +282,8 @@ pub(crate) fn unix_micros() -> Result<i64, DatabaseError> {
 #[cfg(test)]
 mod tests {
 	use std::fs;
-	#[cfg(unix)] use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _, symlink};
+	#[cfg(unix)]
+	use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _, symlink};
 
 	use rusqlite::Connection;
 	use serde_json::json;
@@ -296,8 +300,8 @@ mod tests {
 	use super::{
 		AccountCommandKind, AccountCommandReceiptClaim, AccountLifecycleMutationOutcome,
 		AccountOperationPreparation, CodexAccountCapabilityAttestation, CommandIdentity,
-		CredentialKey, CredentialRecord, DatabaseError, SqliteStore, StoreError, migrations,
-		unix_micros,
+		CredentialKey, CredentialRecord, DatabaseError, RoutingControlOutcome, SqliteStore,
+		StoreError, migrations, unix_micros,
 	};
 
 	const ACCOUNT: &str = "10000000-0000-4000-8000-000000000001";
@@ -727,7 +731,9 @@ mod tests {
 			.expect("reserve command")
 		{
 			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Replayed(_) => panic!("new command replayed"),
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new command replayed")
+			},
 		};
 		let response = json!({ "status": "ok", "revision": 1 });
 		store.complete_account_command(lease, &response).await.expect("complete command");
@@ -742,7 +748,9 @@ mod tests {
 			.expect("replay command")
 		{
 			AccountCommandReceiptClaim::Replayed(actual) => assert_eq!(actual, response),
-			AccountCommandReceiptClaim::Owned(_) => panic!("completed command was reclaimed"),
+			AccountCommandReceiptClaim::Owned(_) | AccountCommandReceiptClaim::Pending(_) => {
+				panic!("completed command was reclaimed")
+			},
 		}
 		let conflicting = CommandIdentity::new("account-command-one", b"disable primary")
 			.expect("conflicting command identity");
@@ -769,6 +777,175 @@ mod tests {
 			AccountQuotaDisposition::Current(fact) if fact.used_percent == 25
 		));
 		assert_eq!(routing.mode, AccountSelectionMode::Fixed(account_id));
+	}
+
+	#[tokio::test]
+	async fn durable_route_receipt_retains_its_request_and_reclaims_after_restart() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("decodex.sqlite3");
+		let store = SqliteStore::open_test(&path).expect("initialize store");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{OPERATION_ONE}","account_id":"{ACCOUNT}","expected_account_revision":7}}}}"#,
+		);
+		let command = CommandIdentity::new("durable-route", request.as_bytes())
+			.expect("Route command identity");
+		let lease = match store
+			.reserve_account_route_command(&command, 9, &request)
+			.await
+			.expect("reserve Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		let progress = json!({
+			"status": "pending",
+			"account_id": ACCOUNT,
+			"operation_id": OPERATION_ONE,
+		});
+		store.defer_account_route_command(lease, &progress).await.expect("defer Route");
+		let pending =
+			store.read_pending_account_route_commands(8).await.expect("read pending Route");
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].request_json, request);
+		assert_eq!(pending[0].expected_routing_revision, 9);
+		assert_eq!(pending[0].progress.as_ref(), Some(&progress));
+		drop(store);
+
+		let reopened = SqliteStore::open_test(&path).expect("reopen store");
+		assert_eq!(
+			reopened
+				.release_interrupted_account_route_claims()
+				.await
+				.expect("release interrupted Route claim"),
+			1
+		);
+		let pending =
+			reopened.read_pending_account_route_commands(8).await.expect("read restarted Route");
+		assert!(matches!(
+			reopened
+				.reserve_account_route_command(&command, 9, &request)
+				.await
+				.expect("replay deferred Route"),
+			AccountCommandReceiptClaim::Pending(value) if value == progress
+		));
+		let lease = match reopened
+			.reclaim_account_route_command(&pending[0])
+			.await
+			.expect("reclaim interrupted Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("pending Route was already completed")
+			},
+		};
+		reopened
+			.complete_account_command(lease, &json!({"status": "routed"}))
+			.await
+			.expect("complete reclaimed Route");
+		assert!(
+			reopened
+				.read_pending_account_route_commands(8)
+				.await
+				.expect("read completed Routes")
+				.is_empty()
+		);
+	}
+
+	#[tokio::test]
+	async fn newer_route_atomically_supersedes_the_deferred_receipt() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("decodex.sqlite3");
+		let store = SqliteStore::open_test(&path).expect("initialize store");
+		let routing = store.read_account_routing_control().await.expect("read routing");
+		let first_request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{OPERATION_ONE}","account_id":"{ACCOUNT}","expected_account_revision":1}}}}"#,
+		);
+		let first = CommandIdentity::new("first-pending-route", first_request.as_bytes()).unwrap();
+		let first_lease = match store
+			.reserve_account_route_command(&first, routing.revision, &first_request)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("first Route replayed")
+			},
+		};
+		store
+			.defer_account_route_command(first_lease, &json!({"status": "pending-first"}))
+			.await
+			.unwrap();
+
+		let second_account = "10000000-0000-4000-8000-000000000002";
+		let second_request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{OPERATION_TWO}","account_id":"{second_account}","expected_account_revision":1}}}}"#,
+		);
+		let second = CommandIdentity::new("second-pending-route", second_request.as_bytes()).unwrap();
+		let superseded = json!({"outcome": "rejected", "reason": "route_superseded"});
+		assert!(matches!(
+			store
+				.reserve_replacing_account_route_command(
+					&second,
+					routing.revision,
+					&second_request,
+					&superseded,
+				)
+				.await
+				.unwrap(),
+			AccountCommandReceiptClaim::Owned(_)
+		));
+		assert!(matches!(
+			store
+				.reserve_account_route_command(&first, routing.revision, &first_request)
+				.await
+				.unwrap(),
+			AccountCommandReceiptClaim::Replayed(value) if value == superseded
+		));
+		let pending = store.read_pending_account_route_commands(8).await.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].idempotency_key, "second-pending-route");
+		assert_eq!(pending[0].request_json, second_request);
+
+		drop(store);
+		let reopened = SqliteStore::open_test(&path).expect("reopen store");
+		let pending = reopened.read_pending_account_route_commands(8).await.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].idempotency_key, "second-pending-route");
+	}
+
+	#[tokio::test]
+	async fn pending_route_fences_balanced_and_order_revision_changes() {
+		let directory = tempdir().expect("temporary directory");
+		let store = SqliteStore::open_test(&directory.path().join("decodex.sqlite3"))
+			.expect("initialize store");
+		let routing = store.read_account_routing_control().await.expect("read routing");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{OPERATION_ONE}","account_id":"{ACCOUNT}","expected_account_revision":1}}}}"#,
+		);
+		let command = CommandIdentity::new("routing-fence", request.as_bytes()).unwrap();
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.unwrap()
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route replayed")
+			},
+		};
+		store.defer_account_route_command(lease, &json!({"status": "pending"})).await.unwrap();
+
+		assert_eq!(
+			store.set_balanced_account_selection(routing.revision).await.unwrap(),
+			RoutingControlOutcome::InvalidRequest,
+		);
+		assert_eq!(
+			store.set_account_order(routing.revision, &[]).await.unwrap(),
+			RoutingControlOutcome::InvalidRequest,
+		);
+		assert_eq!(store.read_account_routing_control().await.unwrap(), routing);
 	}
 
 	#[tokio::test]

--- a/database/src/migrations.rs
+++ b/database/src/migrations.rs
@@ -6,7 +6,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{DatabaseError, error::sqlite_error};
 
 pub(crate) const APPLICATION_ID: i64 = 0x4443_5831;
-const CURRENT_SCHEMA_VERSION: i64 = 8;
+const CURRENT_SCHEMA_VERSION: i64 = 10;
 
 struct Migration {
 	version: i64,
@@ -54,6 +54,16 @@ const MIGRATIONS: &[Migration] = &[
 		version: 8,
 		name: "account_reauthentication_takeover",
 		sql: include_str!("../migrations/0008_account_reauthentication_takeover.sql"),
+	},
+	Migration {
+		version: 9,
+		name: "durable_account_route",
+		sql: include_str!("../migrations/0009_durable_account_route.sql"),
+	},
+	Migration {
+		version: 10,
+		name: "pending_account_route_progress",
+		sql: include_str!("../migrations/0010_pending_account_route_progress.sql"),
 	},
 ];
 

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -175,7 +175,7 @@ the pre-existing malformed-cycle tests pass together. After this correction, the
 complete GPUI package passed 120 tests with two live tests ignored.
 
 The client does not activate the deferred general WorkItem and Project query surface.
-Protocol 2.6 is exact-current. The Adaptive Program controller uses only its bounded
+Protocol 2.7 is exact-current. The Adaptive Program controller uses only its bounded
 Program and built-in Domain Pack commands and queries. The unrelated WorkItem board
 controller stays dormant. This keeps deferred Factory surfaces from affecting
 Conversation history or the Workbench connection.
@@ -260,7 +260,7 @@ remain outside this lifecycle-refresh milestone because
 or tool effects. Only one positively client-ID-correlated Decodex Turn may repair its own
 terminal state and assistant suffix.
 
-Protocol 2.6 carries the controls, archive event, bounded Program aggregate, built-in
+Protocol 2.7 carries the controls, archive event, bounded Program aggregate, built-in
 Domain Pack projection, and the optional exact recovery-operation identity for official
 device-login takeover. It carries no credential value. SQLite
 schema version 3 adds the original Quick Task execution settings. Schema version 4 adds
@@ -328,42 +328,42 @@ has supplied a current value. An absent, unknown, unsupported, or failed five-ho
 does not create a synthetic `5 HOUR` row. It remains a typed protocol fact for routing and
 diagnostics.
 
-### Menu-bar Route preparation evidence
+### Daemon-owned Route evidence
 
-The 2026-08-21 focused repair restores credential preparation before the Swift menu-bar
-Route changes fixed routing. Deterministic store tests prove `RefreshAccount`, exact latest
-projection, and fixed selection in that order. They also prove Account and credential-version
-advancement, no projection or routing after refresh rejection, no fixed routing after
-projection failure, exact projection-receipt reuse, fixed-only retry after later partial
-success, and serialized cross-account Route actions.
+The 2026-08-23 Route repair replaces the Swift three-command workflow with one exact
+`RouteAccount` command and one `AccountRouted` result. Protocol, FFI, CLI, GPUI, and Swift use
+the same command. The former public projection and fixed-selection commands are absent.
 
-Account Service tests prove that only a valid newer same-identity shared bundle is absorbed,
-including the one bounded read after provider rejection. Different identity, unreadable auth,
-unchanged data, older data, and expired data remain fail-closed. A committed-refresh fixture
-starts at `StoreApplied`, forces conditional shared projection failure, and proves that the
-Account operation commits and its refresh command receipt remains terminal and replayable.
-The safe projection writer also proves that a later bundle replaces stale shared auth for the
-same provider identity.
+Account Service tests construct two enrolled accounts and a newer shared source bundle. They
+prove that cross-account Route stores the source successor before target refresh, suppresses
+intermediate Route writes, passes the exact persisted source bundle to the final projector, and
+commits the target Account and fixed routing under one receipt. The same fixture proves that a
+stale routing revision completes without another projection effect.
 
-The focused Swift Route presentation test gates `UseAccountInCodex` after a successful credential
-refresh. It proves that the Account revision and credential version advance before projection,
-the last-known inventory and both quota windows remain visible, the profile and its degradation
-facts remain available, and the aggregate profile Total stays equal. The retained inventory is
-not current for the successor revision, so its Reset Card targets remain fenced. Fixed routing
-stays unchanged until projection succeeds, and the control sequence remains credential refresh,
-Codex projection, then fixed routing. The existing refresh-rejection test continues to prove
-fail-closed behavior.
+The auth projection test starts from source A, conditionally replaces it with target B, then
+installs concurrent source C. Repeating the A-to-B conditional write returns `SourceChanged` and
+leaves C intact. Existing projection tests continue to prove mode-0600 temporary creation,
+atomic rename, exact readback, parent synchronization, idempotent target replay, unsafe-path
+rejection, and post-rename outcome-unknown classification.
 
-Focused validation passed 30 Account Service tests, the exact later-projection Rust test, the
-native FFI refresh-request test, 17 Swift native-client tests, and 34 Swift account-control
-store tests. The affected-package gate then passed all 22 FFI tests, 212 runtime unit tests
-with one intentional installed-Codex skip, every runtime integration and doc test, strict
-Clippy with warnings denied, and all 226 Swift tests. Both account-login and vNext architecture
-gates passed, and the SwiftPM production build completed with the same Xcode toolchain. The
-first Swift attempt under the active Command Line Tools directory failed
-before source compilation because `SwiftUIMacros` was unavailable. The supported rerun used
-`/Applications/Xcode-beta.app` with Swift 6.4 and passed; the initial toolchain failure is not
-product evidence.
+The SQLite restart test retains the credential-negative Route payload in migration-9 command
+receipts, reopens the database, releases the prior daemon lease, reclaims the exact command, and
+completes it once. Bootstrap performs this release and one recovery pass before it constructs the
+protocol server. The retained websocket disconnect test proves that an admitted command continues
+after its presentation connection closes.
+
+Swift tests prove one request with both Account and routing revisions, one authoritative result,
+serialized Route presentation, no-op behavior only when routing and exact projection are current,
+and unchanged state after a rejected Route. Source architecture tests reject the removed Route
+preparation structure, refresh/projection/fixed client calls, and the old Total-preservation
+helper. The complete Swift suite passed all 222 tests with Xcode beta.
+
+Final validation included the complete Rust workspace, the final 216-test runtime package with
+its integration targets, the 73-test protocol library and six local-transport tests, strict
+workspace Clippy with warnings denied, the schema-9 local database gate, 16 vNext and account-login
+architecture tests, the explicit disconnected-command continuation test, all 222 Swift tests, and
+the Swift production build. Existing live daemon and installed-Codex tests remained intentionally
+ignored.
 
 The staged nested bundle passed strict deep code-signature verification. A direct call through
 its embedded FFI negotiated the running daemon, returned `available`, and read six accounts.

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -1,3 +1,9 @@
+---
+type: "Reference"
+title: "Local Database Operations"
+openwiki_generated: true
+---
+
 # Local Database Operations
 
 Status: current operator and validation workflow.
@@ -37,8 +43,20 @@ operation indexes atomically. A binary rollback across this schema boundary must
 matching pre-upgrade private database backup; an older daemon does not accept a newer
 migration ledger.
 
-The account-login restoration repair adds no schema migration. Artifact cohort 2 changes the
-strict local result/FFI shape. On startup, the daemon can compensate only the exact pre-repair
+Schema version 9 adds one nullable, credential-negative `request_json` column to command
+receipts. Only a reserved `route_account` receipt must contain this value. The partial index
+supports bounded startup recovery. On daemon startup, the runtime releases only interrupted
+Route leases and completes one recovery pass before it accepts protocol commands.
+
+Schema version 10 adds the nullable `progress_json` column to the existing command receipt,
+retaining schema 9 request authority while recording credential-negative pending Route progress.
+A unique partial index permits at most one reserved `route_account` receipt, and triggers keep
+progress restricted to that pending Route state. The migration is additive and preserves
+existing receipt rows.
+
+The account-login restoration repair adds no schema migration. The current protocol uses exact
+artifact cohort 5; older cohort notes below are historical evidence for the prior repair and not
+current compatibility guidance. Artifact cohort 3 changes the strict local result/FFI shape. On startup, the daemon can compensate only the exact pre-repair
 `StoreApplied` enrollment collision described by the account-lifecycle contract; it deletes the
 proved orphan credential and cancels that operation. Installation therefore upgrades the signed
 daemon, CLI, App executable, and App FFI as one cohort while retaining the pre-install database
@@ -69,7 +87,7 @@ The macOS installer:
    `~/.decodex` as its stable working directory;
 5. starts the daemon; and
 6. runs doctor and account-list readback through the installed CLI, which proves the
-   running daemon uses the same protocol 2.6 and artifact cohort 2.
+   running daemon uses the same protocol 2.9 and artifact cohort 5.
 
 It does not install former server store, create roles or databases, manage a socket directory, or
 resolve a database password.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -87,6 +87,22 @@ ProviderAttempt state, and exact command receipts. Missing or stale quota data m
 unknown capacity; it is not fabricated exhaustion. A current known depleted fact still
 blocks that account.
 
+Account Route is one daemon-owned command coordinated by `decodexd`'s
+`SharedAuthCoordinator`. While Codex runs, the coordinator performs read-only stable-auth
+following: it observes stable metadata and imports known source rotations without writing the
+shared auth file. A Route that cannot safely cut over returns `AccountRoutePending`, a confirmed
+typed success backed by one durable receipt that can later become terminal; restart-transient
+account readiness keeps it pending. A newer explicit Route atomically supersedes an older pending
+target, and replay of the old command returns `route_superseded`. Swift and GPUI keep other ready
+targets selectable; the current routed target becomes a `Keep` action while another target is
+pending. After natural external Codex quiescence, `decodexd` rechecks the exact source
+auth version, refreshes the target as needed, and performs the shared-auth write with an exact-source
+CAS before committing fixed routing and its Route receipt. If shared auth already names the target,
+`decodexd` may reconcile credentials and routing without rewriting `auth.json` even while Codex
+runs. Cross-account `auth.json` writes still require natural external Codex quiescence because
+running Codex caches account auth. The menu-bar app has no Route workflow state. `decodexd` never
+controls the Codex process.
+
 The runtime keeps the mature Codex app-server protocol and safety harness. It does not
 replace Codex with a new agent kernel. It preserves exact account binding, pre-spawn
 fencing, one dispatch authorization, positive-only terminal evidence, and restart-safe

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -1,3 +1,18 @@
+---
+type: "Reference"
+title: "Account Lifecycle Authority"
+description: "Daemon-owned account lifecycle contract, including Route coordination and shared Codex authentication authority."
+tags: [accounts, routing, shared-auth, daemon]
+openwiki:
+  roles: [architecture, domain, integration, workflow]
+  change_kinds: [lifecycle, public-api, persistence]
+  source_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/application.rs, database/migrations/0010_pending_account_route_progress.sql]
+  symbols: [SharedAuthCoordinator, AccountService::route_account_command, AccountService::follow_shared_auth_once, recover_pending_account_routes_once]
+  test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs]
+  invariants: ["One SharedAuthCoordinator owns stable shared-auth reads, Codex liveness observation, and conditional projection decisions in decodexd.", "A Route projection write is allowed only after natural Codex quiescence and an exact-source compare-and-swap check.", "UI clients submit Route intents and render authoritative results; they do not control Codex processes."]
+  validation_commands: ["cargo test -p decodex-runtime account_service::tests::pending_route_waits_for_natural_quiescence_then_commits_from_the_same_receipt", "cargo test -p decodex-runtime shared_auth_coordinator::tests"]
+---
+
 # Account Lifecycle Authority
 
 Status: historical account-domain contract. Its durable lifecycle and exact-binding
@@ -159,14 +174,15 @@ The commands are deterministic:
 | --- | --- |
 | `enable_account` | If the expected account revision is current, set `enabled=true`. Change only the account revision when the value changes. |
 | `disable_account` | If the expected account revision is current, set `enabled=false`. Block new admission immediately. Do not terminate or rebind existing work. |
-| `set_fixed_selection` | If the expected routing revision and target account revision are current, set mode `fixed` and the exact target Account UUID. Preserve account order. |
+| `route_account` | Under current routing and target Account revisions, preserve a valid changed known shared source credential whose expiry is not earlier, refresh the target, and either commit fixed mode plus the Route receipt or retain one schema-10 pending receipt until natural Codex quiescence permits the exact-source CAS cutover. Preserve account order. |
 | `set_balanced_selection` | If the expected routing revision is current, set mode `balanced` and clear the fixed target. Preserve account order. |
 | `set_account_order` | If the expected routing revision is current, replace the order with one complete duplicate-free permutation of all non-tombstoned Account UUIDs. Preserve mode and a valid fixed target. |
 
-A fresh command whose desired value already matches returns a terminal no-change
-receipt at the same revision. Any real change increments exactly one owning revision.
-No command changes observed health, quota, credentials, ProcessGeneration, or
-ProviderAttempt state as a side effect.
+A fresh policy command whose desired value already matches returns a terminal no-change
+receipt at the same revision. Any real policy change increments exactly one owning revision.
+Policy commands do not change observed health, quota, credentials, ProcessGeneration, or
+ProviderAttempt state. `route_account` is the explicit compound exception: its journaled
+credential work can advance source or target Account revisions before it commits routing.
 
 For a new task, `fixed` considers only its target. An ineligible fixed target returns a
 typed no-route result. `balanced` selects the first fully eligible account in canonical
@@ -180,31 +196,65 @@ for an explicit retry. Routing Snapshot remains the complete policy/evidence own
 Routing Decision remains the sole selection owner. Their broader automatic-routing
 behavior is accepted later.
 
-## Explicit Use in Codex
+## Daemon-owned Route and shared Codex auth
 
-`UseAccountInCodex` projects one exact ready account to the normal shared
-`~/.codex/auth.json`. It is independent from routing: projection does not change routing,
-and routing does not project auth. The command checks the current Account revision and
-the exact HostCredentialStore version, fingerprint, and provider binding. Tokens remain
-inside the daemon.
+`RouteAccount` is the only public fixed-account action. It is coordinated by one daemon-wide
+`SharedAuthCoordinator`, installed in `AccountService`; no second coordinator or client-side
+Route state machine exists. The coordinator owns Codex liveness observation, two-equal-metadata
+stable reads, and the conditional shared-auth projection seam. It checks the routing revision,
+the target Account revision, and exact HostCredentialStore bindings. On macOS, liveness ignores
+inaccessible unrelated PIDs and Decodex-owned, attested app-server descendants, but blocks an
+external ChatGPT process or Codex writer; a named candidate with inaccessible identity remains
+fail-closed. Non-macOS production liveness remains conservative and does not authorize projection. It can use the existing
+refresh journal for both the current shared source Account and the target Account. Tokens
+remain inside the daemon. Balanced selection and account order remain separate policy commands.
 
-The host write rejects an ambiguous `CODEX_HOME`, symbolic links, path drift, wrong
-ownership, wrong link count, and group- or other-writable ancestors. It creates one
-same-directory mode-`0600` temporary file, synchronizes it, atomically renames it over
-the exact target, reads back the exact account binding, and synchronizes the parent.
-Same-binding replay is successful without rewriting the file. The read-only result is
-`current`, `unmanaged`, or `unavailable` and exposes only Account UUID, Account revision,
-and a credential-negative projection digest.
+While Codex may be running, the coordinator is read-only with respect to the stable shared auth:
+it may observe stable metadata and import a known newer managed source rotation into the daemon
+credential store, but it does not write `~/.codex/auth.json`. An ordinary Decodex refresh first
+attempts that stable read. If Codex may be running and no valid newer rotation was absorbed,
+`CredentialRefreshError::OwnerBusy` is returned before any provider call. This includes absent or
+unmanaged shared auth; those states are not an unsettled refresh-owner condition. Uncertain
+liveness, unstable metadata, or an unavailable stable read therefore fails closed through the
+same pre-provider guard.
 
-The projection affects future Codex launches and new app-server processes. It does not
-claim to hot-switch an already running Codex process. There is no watcher, backup,
-per-account Codex home, token environment projection, legacy helper, or fallback.
+A blocked Route returns `AccountRoutePending`, a confirmed typed success rather than an error.
+The result is backed by one durable schema-10 `route_account` receipt retaining the
+credential-negative request and optional progress. The receipt is replayable by the same command
+identity and can later become terminal when recovery completes; pending work is not a second
+command and does not authorize a client to retry its own workflow. A stale routing revision can
+settle it without writing shared auth, while restart-transient account readiness, liveness, or
+stable-read prerequisites keep the receipt pending until recovery can prove the next step.
 
-The commands remain independent protocol authorities, but the Swift menu-bar `Route`
-control composes them with credential refresh. Route must receive the committed successor
-Account revision, project that exact latest credential, and only then set fixed routing.
-Projection failure leaves fixed routing unchanged. Retry state retains the exact refresh
-receipt or the proved prepared revision so a completed credential effect is not repeated.
+A newer explicit Route target atomically supersedes the older pending target under the routing
+lock. The newer target remains the authoritative pending target; replaying the old command returns
+the typed `route_superseded` rejection. This does not make other eligible accounts unavailable:
+Swift and GPUI keep other ready targets selectable while a pending Route exists, and submit a new
+explicit Route when the operator changes target. If the operator wants to retain the current fixed
+target, that current row remains actionable as `Keep` and supersedes the other pending target.
+
+After natural Codex exit, `decodexd` rechecks the exact stable source stamp and snapshot, repeats
+the source/target revision and provider-binding fences, and refreshes the target under its
+`ProvedInactive` Route policy before projecting it with an exact-source compare-and-swap. When
+shared auth already names the target and its exact credential bundle is already stored, the daemon
+may reconcile credentials and routing without rewriting `auth.json`, even while Codex runs. This
+same-target exception does not permit a cross-account write: changing `auth.json` to another
+account still requires natural external Codex quiescence because running Codex caches account auth. The
+host write rejects an ambiguous `CODEX_HOME`, symbolic links, path drift, wrong ownership, wrong
+link count, and group- or other-writable ancestors. It creates one same-directory mode-`0600`
+temporary file, synchronizes it, atomically renames it over the exact target, reads back the
+exact account binding, and synchronizes the parent. Same-binding replay is successful without
+rewriting the file. Fixed routing is committed only after the target refresh and exact-source
+cutover succeed; `OwnerBusy` is not a normal post-quiescence Route outcome.
+
+The projection affects future Codex launches and new app-server processes. It does not claim to
+hot-switch an already running Codex process. The Swift menu-bar, GPUI, and CLI are UI/protocol-only
+clients: they submit one Route intent and apply one authoritative result. They do not read
+credentials, write shared auth, refresh providers, own retry state, or control Codex processes.
+`decodexd` never starts, stops, signals, rebinds, or otherwise controls the Codex process. There
+is no watcher, backup, per-account Codex home, token environment projection, legacy helper, or
+fallback. Startup recovery replays the same derived account operation and converges before the
+listener accepts new commands.
 
 ## Account operations
 
@@ -230,7 +280,9 @@ source descriptor, not credential bytes in the public protocol.
 
 Refresh reads one exact credential version and records `provider_effect_pending` before
 the provider call. Immediately before provider work, it can absorb only a valid shared
-Codex bundle with the exact provider identity and a later expiry than the stored bundle.
+Codex bundle with the exact provider identity and an expiry that is not earlier than the stored
+bundle. Equal-expiry token rotation is valid because Codex can rotate the refresh token without
+changing the access-token expiry.
 It validates the returned or reconciled provider identity and writes the complete rotated
 bundle with one compare-and-swap. Concurrent callers serialize on that operation. After
 provider rejection, one bounded shared-auth read can still supply that exact newer bundle;
@@ -239,12 +291,12 @@ an exact store write can be committed. A provider request with no proved store w
 not replayed unless the provider has an accepted idempotent result-readback contract.
 Otherwise, the account becomes `reauth_required`.
 
-Every committed refresh reads the exact persisted successor bundle. When the current
-shared-auth identity still names the same provider account, Account Service attempts to
-re-project that bundle. An unreadable identity is not overwrite authority. Projection
-failure does not undo or make the provider effect ambiguous, and the terminal refresh
-receipt still completes. Explicit `UseAccountInCodex` owns retryable fail-closed projection
-for menu-bar Route.
+Every ordinary committed refresh reads the exact persisted successor bundle. Route-internal
+refreshes suppress any intermediate shared-auth write: the single `SharedAuthCoordinator` owns
+stable readback and the compound Route owns one final fail-closed conditional projection after
+natural Codex quiescence. An unreadable or changed identity is not overwrite authority. Projection
+failure does not undo or make the provider effect ambiguous, but a Route projection failure keeps
+the Route receipt pending rather than committing fixed routing.
 
 Logout disables new launch admission and rejects with `account_in_use` while an active
 ProcessGeneration or unsettled ProviderAttempt is bound to the account. It then deletes
@@ -371,6 +423,7 @@ reconciliation also remain readable after a gate changes. They cannot start a ne
 ## Daemon account observation
 
 `decodexd` owns the provider-observation cadence through the lifecycle composition described
+<!-- openwiki: broken internal link [../architecture/runtime-architecture.md#account-lifecycle-and-credential-authority] heading anchor "account-lifecycle-and-credential-authority" does not exist in "../architecture/runtime-architecture.md". Fix the href or restore the target, then delete this comment. -->
 in [Runtime architecture](../architecture/runtime-architecture.md#account-lifecycle-and-credential-authority).
 Its account observer starts immediately, repeats every 15 seconds, and wakes after a
 successful account command or when a durable Reset Card worker claim settles. Each round

--- a/openwiki/specs/account-login-authority.md
+++ b/openwiki/specs/account-login-authority.md
@@ -9,7 +9,7 @@ openwiki:
   source_paths: [crates/decodex-account-login/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-runtime/src/bootstrap.rs, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/lib.rs, crates/decodex-protocol/src/client.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-app-client-ffi/src/lib.rs, apps/decodex-gpui/src/account_login.rs]
   symbols: [AccountLoginManager, AccountLoginInstallAuthority, AccountService, AccountLoginClient, AccountLoginController, CURRENT_VERSION, CURRENT_ARTIFACT_COHORT, LoginHome]
   test_paths: [tests/scripts/test_account_login_architecture.py, crates/decodex-account-login/src/lib.rs, crates/decodex-protocol/src/account_login.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-runtime/tests/websocket_protocol.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift]
-  invariants: ["decodexd is the only runtime owner of provider authorization and credential installation.", "The login exchange is transient and memory-only; login status is not retained in database snapshots, events, or command payloads.", "Clients must negotiate exact protocol 2.6 and artifact cohort 2.", "Cancellation waits for provider cleanup and the worker join before returning terminal status."]
+  invariants: ["decodexd is the only runtime owner of provider authorization and credential installation.", "The login exchange is transient and memory-only; login status is not retained in database snapshots, events, or command payloads.", "Clients must negotiate exact protocol 2.9 and artifact cohort 5.", "Cancellation waits for provider cleanup and the worker join before returning terminal status."]
   validation_commands: ["python3 tests/scripts/test_account_login_architecture.py", "cargo test -p decodex-account-login", "cargo test -p decodex-protocol", "cargo test -p decodex-runtime", "cargo test -p decodex-app-client-ffi"]
 ---
 
@@ -65,14 +65,14 @@ The client implementation is `AccountLoginClient` in `crates/decodex-protocol/sr
 
 ## Protocol negotiation
 
-The current wire contract is protocol `2.6` exactly:
+The current wire contract is protocol `2.9` exactly:
 
-- `CURRENT_VERSION` is `{ major: 2, minor: 6 }`.
-- `CURRENT_ARTIFACT_COHORT` remains `2` and must match between daemon and every local consumer.
+- `CURRENT_VERSION` is `{ major: 2, minor: 9 }`.
+- `CURRENT_ARTIFACT_COHORT` is `5` and must match between daemon and every local consumer.
 - Negotiation accepts only the exact current version. A major mismatch and an unsupported minor are distinct refusals; the nominal `PREVIOUS_MINOR_VERSION` is intentionally equal to the current version for the clean break.
-- A welcome with a missing or different artifact cohort is refused. Do not reintroduce pre-2.6 compatibility when documenting or changing the current protocol.
+- A welcome with a missing or different artifact cohort is refused. Do not reintroduce pre-2.9 compatibility when documenting or changing the current protocol.
 
-The version and cohort definitions live in `crates/decodex-protocol/src/lib.rs`; handshake and cohort checks are exercised by `crates/decodex-protocol/src/client.rs`, `retained_session.rs`, and `wire.rs` tests. Account-login additions must preserve both the exact negotiation rule and unchanged cohort 2.
+The version and cohort definitions live in `crates/decodex-protocol/src/lib.rs`; handshake and cohort checks are exercised by `crates/decodex-protocol/src/client.rs`, `retained_session.rs`, and `wire.rs` tests. Account-login additions must preserve both the exact negotiation rule and cohort 5.
 
 ## AccountService installation
 
@@ -101,7 +101,7 @@ These are protocol-only FFI and GPUI seams. They must not depend on `decodex-acc
 
 **Changing provider behavior:** edit `crates/decodex-account-login/src/lib.rs` and its focused tests. Preserve bounded response/callback parsing, no process execution, no logging, cancellation checks, and private-home cleanup. Then validate the runtime consumer and architecture gate; do not add provider dependencies to FFI or GPUI.
 
-**Changing the wire contract:** edit `crates/decodex-protocol/src/account_login.rs`, `client.rs`, and `wire.rs` together. Preserve exact 2.6 negotiation, cohort 2, 8 KiB URL bounds, `deny_unknown_fields`, canonical UUID validation, and exclusion from durable wire types. Run protocol account-login tests and the architecture gate before any broader package check.
+**Changing the wire contract:** edit `crates/decodex-protocol/src/account_login.rs`, `client.rs`, and `wire.rs` together. Preserve exact 2.9 negotiation, cohort 5, 8 KiB URL bounds, `deny_unknown_fields`, canonical UUID validation, and exclusion from durable wire types. Run protocol account-login tests and the architecture gate before any broader package check.
 
 **Changing installation or lifecycle:** start at `AccountLoginManager`, `AccountLoginInstallAuthority`, and `AccountService`. Update focused runtime tests for initial, completed, failed, same-session, busy, cancellation, replacement, shutdown, revision mismatch, and exact UUID restoration behavior. Escalate to runtime bootstrap and websocket tests only when composition or transport wiring changes.
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -6,11 +6,11 @@ tags: [local-product, sqlite, quick-task, adaptive-factory, domain-pack, app-ser
 openwiki:
   roles: [architecture, domain, workflow]
   change_kinds: [lifecycle, public-api, runtime]
-  source_paths: [crates/decodex-app-client-ffi/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
-  symbols: [QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
-  test_paths: [tests/scripts/test_account_login_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-app-client-ffi/src/lib.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
-  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
-  validation_commands: [cargo test --workspace --all-targets]
+  source_paths: [crates/decodex-app-client-ffi/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, database/migrations/0009_durable_account_route.sql, database/migrations/0010_pending_account_route_progress.sql, apps/decodex-app/Sources/DecodexApp/AccountControlCLIClient.swift, apps/decodex-app/Sources/DecodexApp/ResetCardStore.swift, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/shell.rs]
+  symbols: [SharedAuthCoordinator, AccountService::route_account_command, recover_pending_account_routes_once, AccountRoutePendingDto, QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
+  test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, database/src/account_lifecycle.rs, crates/decodex-protocol/src/wire.rs, tests/scripts/test_account_login_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-app-client-ffi/src/lib.rs, apps/decodex-app/Tests/DecodexAppTests/AccountControlCLIClientTests.swift, apps/decodex-app/Tests/DecodexAppTests/AccountControlStoreTests.swift, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
+  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; SharedAuthCoordinator requires two equal metadata observations before stable readback and never projects while Codex may be running.; A pending Route preserves one command identity and routing revision until recovery can resume it.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
+  validation_commands: [cargo test -p decodex-runtime shared_auth_coordinator::tests, cargo test -p decodex-runtime account_service::tests::pending_route_waits_for_natural_quiescence_then_commits_from_the_same_receipt, cargo test -p decodex-protocol account_route_pending, cargo test -p database pending_route_fences_balanced_and_order_revision_changes, cargo test --workspace --all-targets]
 ---
 
 # Local Product V1 Contract
@@ -166,15 +166,15 @@ bounded inline value or a digest and length.
 
 ## Repeatable Program Loop V1
 
-The current protocol accepts only exact 2.6 clients. It retains the bounded, manually repeated
+The current protocol accepts only exact 2.9 clients. It retains the bounded, manually repeated
 Program aggregate above the existing Quick Task execution path. The initial command
 creates one Program charter, one sourced Signal, one Claim, one non-executable Proposal,
 one finite Objective, and one ready WorkItem in one SQLite transaction.
 
-Every local 2.6 hello and welcome also carries the exact artifact cohort. The daemon,
-CLI, retained clients, and App FFI fail before application work when the cohort is absent
-or differs. This is one compatibility fence inside the existing protocol. It does not add
-a second version service or runtime authority.
+Every local 2.9 hello and welcome also carries artifact cohort `5`. The daemon, CLI,
+retained clients, and App FFI fail before application work when the cohort is absent or
+differs. This is one compatibility fence inside the existing protocol. It does not add a
+second version service or runtime authority.
 
 After one cycle has an exact terminal Review, `ContinueProgram` can append one next
 Signal, Claim, non-executable Proposal, finite Objective, and ready WorkItem. The command
@@ -401,7 +401,7 @@ one tombstoned Account, the operation restores the original Account UUID at the 
 revision and the immediate successor credential version, then appends that UUID to routing order.
 The provisional client UUID is retained only in the strict `AccountRestored` command result.
 FFI completion returns the daemon-resolved UUID, and Swift refreshes that row before reporting
-success. A live provider owner remains `provider_already_enrolled`. Artifact cohort 2 fences the
+success. A live provider owner remains `provider_already_enrolled`. Artifact cohort `5` fences the
 new result and FFI completion shape from older local clients.
 
 Startup also compensates the one exact pre-repair collision in which a version-one enrollment
@@ -424,37 +424,76 @@ The SQLite file is plaintext owner-private storage, consistent with the source C
 authentication file and the explicit local-device threat model. No credential value can
 appear in Debug output, protocol data, logs, migration output, or transfer reports.
 
-## Menu-bar Route preparation
+## Daemon-owned account Route
 
-The Swift menu-bar `Route` action composes three existing typed commands in this order:
+The menu-bar sends one `RouteAccount` command with one Route operation UUID, the target
+Account UUID and revision, the routing revision, and one idempotency key. Swift does not run
+a refresh, projection, or fixed-selection workflow. It applies the daemon's authoritative `AccountRouted` or `AccountRoutePending` result,
+including the target Account, routing control, credential-negative projection digest, and pending
+Route when present.
 
-1. `RefreshAccount` reconciles and persists the target account credential.
-2. `UseAccountInCodex` projects the exact persisted latest bundle to shared
-   `~/.codex/auth.json` with the returned Account revision.
-3. `SetFixedAccountSelection` uses that same Account revision and the captured routing
-   revision.
+`AccountService` holds one routing lock across Route, balanced selection, and order changes.
+One daemon-wide `SharedAuthCoordinator` owns Codex liveness observation, stable shared-auth reads,
+and the conditional projection seam; there is no client-side or second coordinator. A stable read
+requires two equal file-metadata observations. `SharedAuthCoordinator` owns the poll state,
+including the candidate stamp, consecutive observation count, and already-handled stamp; it
+returns `Waiting`, `Unavailable`, `Unchanged`, or `Changed` rather than exposing a partial
+snapshot as current. A partial or unavailable read is retryable without inventing a new metadata
+change. While Codex may be running, the coordinator may absorb a valid newer same-identity managed
+bundle into SQLite, but never writes shared auth. Ordinary refresh returns `OwnerBusy` before
+provider work when no such bundle was absorbed. Route's target refresh uses the `ProvedInactive`
+policy after natural Codex exit instead. Its production liveness port is conservative: uncertainty
+is `MayBeRunning`, so projection fails closed; on macOS, inaccessible unrelated PIDs and Decodex-owned
+attested app-server descendants are ignored, while external ChatGPT/Codex writers block cutover.
+Test ports cover these liveness and file boundaries.
 
-Before a provider refresh, Account Service performs one bounded shared-auth read. It can
-absorb that bundle only when the decoded provider identity is exact, the bundle is valid,
-and its access-token expiry is later than both the current time and the stored bundle. If
-the provider rejects refresh, the service performs one more bounded shared-auth read. A
-newer exact-identity bundle can complete the existing journal and credential CAS. Any
-unreadable, unchanged, older, expired, or different-identity bundle leaves the rejection
-terminal. Swift does not project auth or change fixed routing after that rejection.
+Route coordinates the normal shared `~/.codex/auth.json`. If the file is absent or unmanaged, the
+Route can continue with the target. A managed identity naming another enrolled Account is first
+reconciled into that source Account using a stable account-scoped operation derived from the Route
+operation UUID. Unknown, unreadable, unsafe, or inconsistent managed identity fails closed. After
+natural exit, Route rechecks the exact stable source stamp and snapshot, refreshes the target, and
+projects the target only with an exact-source compare-and-swap. The writer uses one same-directory
+mode-0600 temporary file, synchronization, atomic rename, exact readback, and parent synchronization;
+source drift fails before rename, while an already-current target is idempotent.
 
-After a successful credential CAS, SQLite commits the Account operation and revision.
-Account Service then reads the exact persisted successor bundle and conditionally re-projects
-it only when the current shared-auth identity still matches. A shared-identity read failure
-does not authorize an overwrite. A conditional projection write failure also cannot relabel
-the committed provider effect or strand its refresh receipt. The separate
-`UseAccountInCodex` command is the mandatory fail-closed projection boundary for Route, so
-fixed routing cannot advance until the safe writer succeeds.
+If Codex may be running, Route does not pretend a cross-account switch is complete. Migrations
+`0009_durable_account_route.sql` and `0010_pending_account_route_progress.sql` retain one
+credential-negative, replayable pending `route_account` receipt with optional progress, protected
+by one pending Route invariant. `AccountService::route_account_command` first fences account and
+routing revisions under the routing lock, then returns `AccountRoutePending` as a confirmed typed
+success before any projection write when liveness or stable-read prerequisites are not satisfied.
+The durable receipt can later become terminal; restart-transient account readiness keeps it pending.
+A newer explicit Route target atomically supersedes the older pending target, and replay of the old
+command returns `route_superseded`. Swift and GPUI retain other ready accounts as selectable and
+can submit a new target. The current fixed target remains a `Keep` action so it can cancel a
+different pending target. The daemon reclaims pending work at startup and through
+`recover_pending_account_routes_once`, then resumes from the same operation identity after natural
+exit; recovery can settle a stale routing revision without writing shared auth. Fixed routing commits
+only after target refresh and exact-source cutover succeed. If shared auth is already the target,
+`decodexd` may reconcile credentials and routing without rewriting `auth.json`, even while Codex
+runs. Cross-account auth projection still requires natural external Codex quiescence because a
+running Codex caches account auth. The protocol's `AccountRoutePendingDto` carries only the
+operation ID, target account ID, and fenced routing revision, so clients render authoritative
+Pending state without owning workflow state.
+Client disconnect or menu-bar exit does not cancel admitted daemon work.
 
-Swift validates that the refresh result advances both the Account revision and credential
-version by one without changing provider identity. It retains the exact refresh operation,
-refresh idempotency key, prepared revision, and projection idempotency key across uncertain
-or partial outcomes. A retry resumes at the first incomplete step instead of repeating a
-proved refresh or selecting a fixed route over stale auth.
+Focused implementation checks are in `crates/decodex-runtime/src/shared_auth_coordinator.rs`
+for stable-read and liveness behavior, `crates/decodex-runtime/src/account_service.rs` for
+same-receipt pending recovery, `database/src/account_lifecycle.rs` for revision fencing, and
+`crates/decodex-protocol/src/wire.rs` for pending-result validation. Run the focused tests before
+the workspace suite; generated indexes and client projections are not hand-edited as part of this
+contract.
+
+The app has one Route button and projects the daemon's authoritative Pending state; it does not
+maintain a separate preparation workflow. Account, profile, inventory, quota, and aggregate values
+follow authoritative revisions. Any displayed reset-card `Total` is derived from the registry-backed
+account observation, not preserved as a client-owned value across partial reads. Retryable partial
+account reads retain safe prior projections and retry using bounded delays.
+
+Route does not terminate, restart, signal, inject into, or otherwise control Codex Desktop or an
+app-server process. It uses no private Codex IPC, unstable app-server injection, watcher, backup,
+per-account home, or token environment projection. The file projection is authoritative for future
+Codex launches and new app-server processes, not a live cross-account hot switch.
 
 ## Deferred capabilities
 
@@ -481,7 +520,7 @@ Acceptance requires:
 - a daemon restart followed by a later response on the same Conversation and Codex
   thread, with no duplicate ProviderAttempt dispatch;
 - protocol-only GPUI and CLI operation;
-- one matching artifact cohort across the running daemon, CLI, and App FFI;
+- protocol 2.9 with matching artifact cohort 5 across the running daemon, CLI, and App FFI;
 - local-history-first Conversation opening, immediate queued-prompt projection, and
   Turn-level adjacent assistant-fragment coalescing;
 - exact selected-thread refresh, verified archive, and request-scoped execution controls;

--- a/scripts/macos/install_decodex_local_service.py
+++ b/scripts/macos/install_decodex_local_service.py
@@ -1147,10 +1147,15 @@ def account_ids_from_result(document: dict[str, Any]) -> Optional[list[str]]:
     ):
         return None
     data = result.get("data")
-    if not isinstance(data, dict) or set(data) != {"accounts", "routing"}:
+    if not isinstance(data, dict) or set(data) != {
+        "accounts",
+        "routing",
+        "pending_route",
+    }:
         return None
     accounts = data.get("accounts")
     routing = data.get("routing")
+    pending_route = data.get("pending_route")
     if not isinstance(accounts, list) or not isinstance(routing, dict):
         return None
     account_ids: list[str] = []
@@ -1178,6 +1183,17 @@ def account_ids_from_result(document: dict[str, Any]) -> Optional[list[str]]:
             return None
     elif set(mode) != {"mode", "account_id"} or mode.get("account_id") not in account_ids:
         return None
+    if pending_route is not None:
+        if (
+            not isinstance(pending_route, dict)
+            or set(pending_route)
+            != {"operation_id", "account_id", "routing_revision"}
+            or not isinstance(pending_route.get("operation_id"), str)
+            or not UUID_PATTERN.fullmatch(pending_route["operation_id"])
+            or pending_route.get("account_id") not in account_ids
+            or pending_route.get("routing_revision") != revision
+        ):
+            return None
     return account_ids
 
 

--- a/scripts/vnext/local_database_gate.py
+++ b/scripts/vnext/local_database_gate.py
@@ -53,6 +53,16 @@ MIGRATIONS = (
         "account_reauthentication_takeover",
         ROOT / "database/migrations/0008_account_reauthentication_takeover.sql",
     ),
+    (
+        9,
+        "durable_account_route",
+        ROOT / "database/migrations/0009_durable_account_route.sql",
+    ),
+    (
+        10,
+        "pending_account_route_progress",
+        ROOT / "database/migrations/0010_pending_account_route_progress.sql",
+    ),
 )
 DATABASE_RELATIVE_PATH = Path("server/decodex.sqlite3")
 APPLICATION_ID = 0x4443_5831

--- a/tests/scripts/test_install_decodex_local_service.py
+++ b/tests/scripts/test_install_decodex_local_service.py
@@ -83,6 +83,7 @@ class LocalServiceInstallerTests(unittest.TestCase):
                 "outcome": "available",
                 "data": {
                     "accounts": accounts,
+                    "pending_route": None,
                     "routing": {
                         "revision": 1,
                         "mode": {"mode": "balanced"},
@@ -278,6 +279,21 @@ class LocalServiceInstallerTests(unittest.TestCase):
         document = self.account_document([first, second])
         self.assertEqual(self.module.account_ids_from_result(document), [first, second])
         document["result"]["data"]["routing"]["order"] = [second, first]
+        self.assertIsNone(self.module.account_ids_from_result(document))
+
+    def test_account_list_parser_accepts_only_exact_pending_route_projection(self) -> None:
+        first = "10000000-0000-4000-8000-000000000001"
+        second = "10000000-0000-4000-8000-000000000002"
+        operation = "20000000-0000-4000-8000-000000000001"
+        document = self.account_document([first, second])
+        document["result"]["data"]["pending_route"] = {
+            "operation_id": operation,
+            "account_id": second,
+            "routing_revision": 1,
+        }
+        self.assertEqual(self.module.account_ids_from_result(document), [first, second])
+
+        document["result"]["data"]["pending_route"]["routing_revision"] = 2
         self.assertIsNone(self.module.account_ids_from_result(document))
 
     def test_retired_snapshot_is_captured_only_before_sqlite_exists(self) -> None:

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -94,6 +94,29 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
                 self.assertNotIn("rusqlite", dependencies)
                 self.assertNotIn("redb", dependencies)
 
+    def test_shared_auth_coordinator_is_read_only_until_quiescent_cutover(self) -> None:
+        coordinator = read(
+            "crates/decodex-runtime/src/shared_auth_coordinator.rs"
+        )
+        application = read("crates/decodex-runtime/src/application.rs")
+        account_service = read("crates/decodex-runtime/src/account_service.rs")
+        self.assertIn("proc_listpids", coordinator)
+        self.assertIn("proc_pidpath", coordinator)
+        self.assertIn("CodexLiveness::MayBeRunning", coordinator)
+        self.assertIn("project_shared_codex_auth_cas", coordinator)
+        for forbidden in (
+            "std::process::Command",
+            "libc::kill",
+            "SIGTERM",
+            "SIGKILL",
+        ):
+            self.assertNotIn(forbidden, coordinator)
+        self.assertLess(
+            application.index("shared_auth_may_be_running"),
+            application.index("reclaim_account_route_command"),
+        )
+        self.assertNotIn("reproject_shared", account_service)
+
     def test_credentials_are_narrow_and_daemon_private(self) -> None:
         credentials = read("database/src/credentials.rs")
         adapter = read("crates/decodex-runtime/src/host_credentials/sqlite_store.rs")


### PR DESCRIPTION
## Summary

- move shared auth.json coordination and durable pending routes into decodexd
- allow a pending account switch to be superseded safely, including keeping the current account
- keep the menu bar app alive independently and surface typed pending state without false failure UX
- preserve atomic auth projection, external Codex liveness checks, and restart recovery

## Verification

- Swift package: 227 passed
- GPUI: 129 passed, 3 ignored
- Runtime: 229 passed, 1 ignored
- Protocol, database, CLI, and FFI suites passed
- Rust Clippy passed with warnings denied
- Python installer and architecture suites: 29 passed
- SQLite local database gate passed at schema 10
- staged diff check and secret-pattern scan passed

## Scope

LiteLLM auth synchronization is intentionally out of scope.