### PR TITLE
Restore Decodex after a quiet login launch

### DIFF
--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -115,6 +115,9 @@ fn main() {
 			.is_ok_and(|shell| shell.read(cx).was_launched_as_login_item(cx));
 		main_window.borrow_mut().replace(window);
 		if launched_as_login_item {
+			#[cfg(target_os = "macos")]
+			order_out_native_windows();
+			#[cfg(not(target_os = "macos"))]
 			cx.hide();
 		} else {
 			activate_main_window(&window, cx);
@@ -139,6 +142,18 @@ fn activate_native_application() {
 
 	let main_thread = MainThreadMarker::new().expect("GPUI application callback runs on main thread");
 	NSApplication::sharedApplication(main_thread).activate();
+}
+
+#[cfg(target_os = "macos")]
+fn order_out_native_windows() {
+	use objc2::MainThreadMarker;
+	use objc2_app_kit::NSApplication;
+
+	let main_thread = MainThreadMarker::new().expect("GPUI application callback runs on main thread");
+	let application = NSApplication::sharedApplication(main_thread);
+	for window in application.windows().iter() {
+		window.orderOut(None);
+	}
 }
 
 fn compose_lifecycle(

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -133,6 +133,8 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
         self.assertIn("keyAELaunchedAsLogInItem", launch_at_login)
         self.assertIn("on_window_should_close", main)
         self.assertIn("on_reopen", main)
+        self.assertIn("order_out_native_windows();", main)
+        self.assertIn("window.orderOut(None);", main)
         for daemon_owned_path in (
             "database/migrations/0011_desktop_settings.sql",
             "database/src/desktop_settings.rs",


### PR DESCRIPTION
## Summary
- keep login-item launches quiet by ordering native windows out instead of hiding the entire application
- preserve GPUI reopen delivery so Dock or Finder activation restores the retained main window
- add an architecture guard for the native order-out path

## Validation
- 233 Swift tests
- 18 Python architecture tests
- schema 11 / 41-table database gate
- Rust stable workspace test, check, and Clippy with all targets and features
- signed one-app staging gate
- real keyAELaunchedAsLogInItem launch: zero on-screen windows, one app-owned bundled daemon
- same-process reopen: retained window restored with login item still enabled