### PR TITLE
Align OpenWiki with immediate account routing

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,7 +1,7 @@
 {
-  "updatedAt": "2026-08-25T14:28:13.813Z",
+  "updatedAt": "2026-08-25T15:53:47.509Z",
   "command": "update",
-  "gitHead": "d0647907f8e99bddf8a83298cfd2df6623c9221e",
+  "gitHead": "f6432a3c5fb9d698ba93479c8c955886228eae3f",
   "model": "gpt-5.6-luna-nosystem",
   "status": "complete",
   "language": "en"

--- a/openwiki/architecture/runtime-architecture.md
+++ b/openwiki/architecture/runtime-architecture.md
@@ -37,7 +37,7 @@ The app embeds presentation and local-service payloads, while `decodexd` remains
 
 - the owner-only local protocol listener;
 - the bundled SQLite product database;
-- account credentials, routing, quota observations, and login installation;
+- account credentials, synchronous exact-source routing, quota observations, and login installation;
 - conversations, history, runtime sessions, process generations, and provider attempts;
 - Program state and domain projections;
 - Codex app-server child lifecycles; and

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -45,14 +45,11 @@ migration ledger.
 
 Schema version 9 adds one nullable, credential-negative `request_json` column to command
 receipts. Only a reserved `route_account` receipt must contain this value. The partial index
-supports bounded startup recovery. On daemon startup, the runtime releases only interrupted
-Route leases and completes one recovery pass before it accepts protocol commands.
-
-Schema version 10 adds the nullable `progress_json` column to the existing command receipt,
-retaining schema 9 request authority while recording credential-negative pending Route progress.
-A unique partial index permits at most one reserved `route_account` receipt, and triggers keep
-progress restricted to that pending Route state. The migration is additive and preserves
-existing receipt rows.
+supports bounded startup recovery. Schema version 10 adds nullable `progress_json` for decoding
+legacy pending Route progress and a unique partial index for at most one reserved receipt. These
+columns and constraints are compatibility storage: current Route is synchronous and does not
+normally create Pending state. On daemon startup, the runtime performs the one bounded legacy
+Route recovery pass before accepting protocol commands.
 
 Schema version 11 adds the singleton `desktop_settings` table. `decodexd` is its only
 reader and writer. The positive revision guards the **Show Decodex in the menu bar**

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -87,21 +87,15 @@ ProviderAttempt state, and exact command receipts. Missing or stale quota data m
 unknown capacity; it is not fabricated exhaustion. A current known depleted fact still
 blocks that account.
 
-Account Route is one daemon-owned command coordinated by `decodexd`'s
-`SharedAuthCoordinator`. While Codex runs, the coordinator performs read-only stable-auth
-following: it observes stable metadata and imports known source rotations without writing the
-shared auth file. A Route that cannot safely cut over returns `AccountRoutePending`, a confirmed
-typed success backed by one durable receipt that can later become terminal; restart-transient
-account readiness keeps it pending. A newer explicit Route atomically supersedes an older pending
-target, and replay of the old command returns `route_superseded`. GPUI keeps other ready
-targets selectable; the current routed target becomes a `Keep` action while another target is
-pending. After natural external Codex quiescence, `decodexd` rechecks the exact source
-auth version, refreshes the target as needed, and performs the shared-auth write with an exact-source
-CAS before committing fixed routing and its Route receipt. If shared auth already names the target,
-`decodexd` may reconcile credentials and routing without rewriting `auth.json` even while Codex
-runs. Cross-account `auth.json` writes still require natural external Codex quiescence because
-running Codex caches account auth. The optional in-process menu-bar item has no Route workflow
-state. `decodexd` never controls the Codex process.
+Account Route is one daemon-owned synchronous command coordinated by `decodexd`'s
+`SharedAuthCoordinator`. The command reads the exact shared-auth source, reconciles a known source
+rotation, refreshes the target when required, performs exact-source CAS/write/readback, and commits
+fixed routing only after those checks succeed. Route has no Codex process/liveness wait and no
+normal `AccountRoutePending`. Passive shared-auth following uses stable metadata observations to
+import only same-account non-older rotations into daemon credentials; it never writes `auth.json`.
+`AccountRoutePending` remains only for legacy receipt decoding and one-time startup recovery. The
+optional in-process menu-bar item has no Route workflow state. `decodexd` never controls the Codex
+process.
 
 The runtime keeps the mature Codex app-server protocol and safety harness. It does not
 replace Codex with a new agent kernel. It preserves exact account binding, pre-spawn

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -9,8 +9,8 @@ openwiki:
   source_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/application.rs, database/migrations/0010_pending_account_route_progress.sql]
   symbols: [SharedAuthCoordinator, AccountService::route_account_command, AccountService::follow_shared_auth_once, recover_pending_account_routes_once]
   test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs]
-  invariants: ["One SharedAuthCoordinator owns stable shared-auth reads, Codex liveness observation, and conditional projection decisions in decodexd.", "A Route projection write is allowed only after natural Codex quiescence and an exact-source compare-and-swap check.", "UI clients submit Route intents and render authoritative results; they do not control Codex processes."]
-  validation_commands: ["cargo test -p decodex-runtime account_service::tests::pending_route_waits_for_natural_quiescence_then_commits_from_the_same_receipt", "cargo test -p decodex-runtime shared_auth_coordinator::tests"]
+  invariants: ["Route is one synchronous daemon command with exact shared-auth source read, exact-source compare-and-swap projection, and exact readback before routing commit.", "Passive shared-auth following imports only a same-account non-older managed rotation and never writes auth.json.", "AccountRoutePending is compatibility state for legacy decode and one-time startup recovery, not normal Route execution.", "UI clients submit Route intents and render authoritative results; they do not control Codex processes."]
+  validation_commands: ["cargo test -p decodex-runtime account_service::tests::cross_account_route_is_synchronous_even_when_codex_may_be_running", "cargo test -p decodex-runtime account_service::tests::stable_known_account_same_expiry_rotation_imports_once_without_provider_work", "cargo test -p decodex-runtime shared_auth_coordinator::tests"]
 ---
 
 # Account Lifecycle Authority
@@ -175,7 +175,7 @@ The commands are deterministic:
 | --- | --- |
 | `enable_account` | If the expected account revision is current, set `enabled=true`. Change only the account revision when the value changes. |
 | `disable_account` | If the expected account revision is current, set `enabled=false`. Block new admission immediately. Do not terminate or rebind existing work. |
-| `route_account` | Under current routing and target Account revisions, preserve a valid changed known shared source credential whose expiry is not earlier, refresh the target, and either commit fixed mode plus the Route receipt or retain one schema-10 pending receipt until natural Codex quiescence permits the exact-source CAS cutover. Preserve account order. |
+| `route_account` | Under current routing and target Account revisions, synchronously read the exact shared-auth source, reconcile a known source rotation, refresh the target when required, perform exact-source CAS/readback, and then commit fixed mode plus the Route receipt. Preserve account order. Legacy pending receipts are compatibility input for startup recovery only. |
 | `set_balanced_selection` | If the expected routing revision is current, set mode `balanced` and clear the fixed target. Preserve account order. |
 | `set_account_order` | If the expected routing revision is current, replace the order with one complete duplicate-free permutation of all non-tombstoned Account UUIDs. Preserve mode and a valid fixed target. |
 
@@ -201,62 +201,44 @@ behavior is accepted later.
 
 `RouteAccount` is the only public fixed-account action. It is coordinated by one daemon-wide
 `SharedAuthCoordinator`, installed in `AccountService`; no second coordinator or client-side
-Route state machine exists. The coordinator owns Codex liveness observation, two-equal-metadata
-stable reads, and the conditional shared-auth projection seam. It checks the routing revision,
-the target Account revision, and exact HostCredentialStore bindings. On macOS, liveness ignores
-inaccessible unrelated PIDs and Decodex-owned, attested app-server descendants, but blocks an
-external ChatGPT process or Codex writer; a named candidate with inaccessible identity remains
-fail-closed. Non-macOS production liveness remains conservative and does not authorize projection. It can use the existing
-refresh journal for both the current shared source Account and the target Account. Tokens
-remain inside the daemon. Balanced selection and account order remain separate policy commands.
+Route state machine exists. `AccountService::route_account_command` is synchronous at the
+command boundary: it takes the routing lock, checks routing and target revisions, performs an
+exact shared-auth source read, reconciles a known source rotation, refreshes the target when
+needed, performs the exact-source CAS projection, reads the result back, and only then commits
+fixed routing and the Route receipt. Tokens remain inside the daemon. Balanced selection and
+account order remain separate policy commands.
 
-While Codex may be running, the coordinator is read-only with respect to the stable shared auth:
-it may observe stable metadata and import a known newer managed source rotation into the daemon
-credential store, but it does not write `~/.codex/auth.json`. An ordinary Decodex refresh first
-attempts that stable read. If Codex may be running and no valid newer rotation was absorbed,
-`CredentialRefreshError::OwnerBusy` is returned before any provider call. This includes absent or
-unmanaged shared auth; those states are not an unsettled refresh-owner condition. Uncertain
-liveness, unstable metadata, or an unavailable stable read therefore fails closed through the
-same pre-provider guard.
+Passive shared-auth following is a different loop. `follow_shared_auth_once` uses the
+coordinator's stable two-equal-metadata observation and imports only a known, same-account managed
+rotation whose credential is not older than the stored bundle. It updates daemon credentials
+through the normal account journal but never writes `~/.codex/auth.json`; absent, unmanaged,
+ambiguous, unstable, or unavailable sources are not treated as logout or Route completion.
 
-A blocked Route returns `AccountRoutePending`, a confirmed typed success rather than an error.
-The result is backed by one durable schema-10 `route_account` receipt retaining the
-credential-negative request and optional progress. The receipt is replayable by the same command
-identity and can later become terminal when recovery completes; pending work is not a second
-command and does not authorize a client to retry its own workflow. A stale routing revision can
-settle it without writing shared auth, while restart-transient account readiness, liveness, or
-stable-read prerequisites keep the receipt pending until recovery can prove the next step.
-
-A newer explicit Route target atomically supersedes the older pending target under the routing
-lock. The newer target remains the authoritative pending target; replaying the old command returns
-the typed `route_superseded` rejection. This does not make other eligible accounts unavailable:
-GPUI keeps other ready targets selectable while a pending Route exists, and submits a new
-explicit Route when the operator changes target. If the operator wants to retain the current fixed
-target, that current row remains actionable as `Keep` and supersedes the other pending target.
-
-After natural Codex exit, `decodexd` rechecks the exact stable source stamp and snapshot, repeats
-the source/target revision and provider-binding fences, and refreshes the target under its
-`ProvedInactive` Route policy before projecting it with an exact-source compare-and-swap. When
+Normal Route has no Codex process/liveness wait and does not return `AccountRoutePending`. If
 shared auth already names the target and its exact credential bundle is already stored, the daemon
-may reconcile credentials and routing without rewriting `auth.json`, even while Codex runs. This
-same-target exception does not permit a cross-account write: changing `auth.json` to another
-account still requires natural external Codex quiescence because running Codex caches account auth. The
-host write rejects an ambiguous `CODEX_HOME`, symbolic links, path drift, wrong ownership, wrong
-link count, and group- or other-writable ancestors. It creates one same-directory mode-`0600`
-temporary file, synchronizes it, atomically renames it over the exact target, reads back the
-exact account binding, and synchronizes the parent. Same-binding replay is successful without
-rewriting the file. Fixed routing is committed only after the target refresh and exact-source
-cutover succeed; `OwnerBusy` is not a normal post-quiescence Route outcome.
+can reconcile credentials and routing without rewriting `auth.json`. A cross-account projection
+still uses the exact-source CAS writer and its source/readback safety checks. A source change or
+failed readback fails the command before fixed routing is committed.
 
-The projection affects future Codex launches and new app-server processes. It does not claim to
-hot-switch an already running Codex process. The GPUI main-window and menu-bar presentations, and
-the CLI, are protocol-only
-clients: they submit one Route intent and apply one authoritative result. They do not read
-credentials, write shared auth, refresh providers, own retry state, or control Codex processes.
-`decodexd` never starts, stops, signals, rebinds, or otherwise controls the Codex process. There
-is no watcher, backup, per-account Codex home, token environment projection, legacy helper, or
-fallback. Startup recovery replays the same derived account operation and converges before the
-listener accepts new commands.
+`AccountRoutePending` and `AccountRoutePendingDto` remain only for decoding older durable
+receipts and the one-time startup compatibility pass in `recover_pending_account_routes_once`.
+They are not a normal waiting state, a client retry workflow, or a Codex liveness mechanism. The
+legacy receipt can be reclaimed and completed when its exact command identity and fences are
+recoverable; a newer explicit target may still produce the compatibility `route_superseded`
+result. The protocol and schema retain these types and columns so older pending receipts can be
+decoded safely.
+
+The exact-source writer rejects an ambiguous `CODEX_HOME`, symbolic links, path drift, wrong
+ownership, wrong link count, and group- or other-writable ancestors. It creates one same-directory
+mode-`0600` temporary file, synchronizes it, atomically renames it over the exact target, reads
+back the exact account binding, and synchronizes the parent. Same-binding replay is successful
+without rewriting the file.
+
+The projection affects future Codex launches and new app-server processes; it does not hot-switch
+an already running Codex process. GPUI and CLI are protocol-only clients: they submit one Route
+intent and apply one authoritative result. They do not read credentials, write shared auth,
+refresh providers, own retry state, or control Codex processes. `decodexd` never starts, stops,
+signals, rebinds, or otherwise controls the Codex process.
 
 ## Account operations
 
@@ -294,11 +276,10 @@ not replayed unless the provider has an accepted idempotent result-readback cont
 Otherwise, the account becomes `reauth_required`.
 
 Every ordinary committed refresh reads the exact persisted successor bundle. Route-internal
-refreshes suppress any intermediate shared-auth write: the single `SharedAuthCoordinator` owns
-stable readback and the compound Route owns one final fail-closed conditional projection after
-natural Codex quiescence. An unreadable or changed identity is not overwrite authority. Projection
-failure does not undo or make the provider effect ambiguous, but a Route projection failure keeps
-the Route receipt pending rather than committing fixed routing.
+refreshes suppress intermediate shared-auth writes: the single `SharedAuthCoordinator` owns source
+readback and the compound Route owns one final fail-closed exact-source CAS projection. An
+unreadable or changed identity is not overwrite authority. Projection failure does not undo or make
+the provider effect ambiguous, but it prevents fixed routing from committing.
 
 Logout disables new launch admission and rejects with `account_in_use` while an active
 ProcessGeneration or unsettled ProviderAttempt is bound to the account. It then deletes

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -9,8 +9,8 @@ openwiki:
   source_paths: [crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, database/src/desktop_settings.rs, database/migrations/0009_durable_account_route.sql, database/migrations/0010_pending_account_route_progress.sql, database/migrations/0011_desktop_settings.sql, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/desktop_settings.rs, apps/decodex-gpui/src/settings_surface.rs, apps/decodex-gpui/src/shell.rs]
   symbols: [SharedAuthCoordinator, AccountService::route_account_command, recover_pending_account_routes_once, AccountRoutePendingDto, QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
   test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, database/src/account_lifecycle.rs, database/src/desktop_settings.rs, crates/decodex-protocol/src/wire.rs, tests/scripts/test_account_login_architecture.py, tests/scripts/test_vnext_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/auth_projection.rs, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/desktop_settings.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
-  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; SharedAuthCoordinator requires two equal metadata observations before stable readback and never projects while Codex may be running.; A pending Route preserves one command identity and routing revision until recovery can resume it.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
-  validation_commands: [cargo test -p decodex-runtime shared_auth_coordinator::tests, cargo test -p decodex-runtime account_service::tests::pending_route_waits_for_natural_quiescence_then_commits_from_the_same_receipt, cargo test -p decodex-protocol account_route_pending, cargo test -p database pending_route_fences_balanced_and_order_revision_changes, cargo test --workspace --all-targets]
+  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Route is synchronous exact-source CAS/readback with no Codex process/liveness wait.; Passive shared-auth following imports only same-account non-older rotations without writing auth.json.; AccountRoutePending is legacy-decode and one-time-startup-recovery compatibility state only.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
+  validation_commands: [cargo test -p decodex-runtime shared_auth_coordinator::tests, cargo test -p decodex-runtime account_service::tests::cross_account_route_is_synchronous_even_when_codex_may_be_running, cargo test -p decodex-runtime account_service::tests::stable_known_account_same_expiry_rotation_imports_once_without_provider_work, cargo test -p decodex-protocol account_route_pending, cargo test -p database pending_route_fences_balanced_and_order_revision_changes, cargo test --workspace --all-targets]
 ---
 
 # Local Product V1 Contract
@@ -427,64 +427,50 @@ appear in Debug output, protocol data, logs, migration output, or transfer repor
 
 GPUI sends one `RouteAccount` command with one Route operation UUID, the target Account UUID
 and revision, the routing revision, and one idempotency key. GPUI does not run a refresh,
-projection, or fixed-selection workflow. It applies the daemon's authoritative `AccountRouted` or `AccountRoutePending` result,
-including the target Account, routing control, credential-negative projection digest, and pending
-Route when present.
+projection, or fixed-selection workflow. It applies the daemon's authoritative `AccountRouted`
+result, including the target Account, routing control, and credential-negative projection digest.
+`AccountRoutePending` is retained only so older receipts can be decoded and recovered at startup.
 
 `AccountService` holds one routing lock across Route, balanced selection, and order changes.
-One daemon-wide `SharedAuthCoordinator` owns Codex liveness observation, stable shared-auth reads,
-and the conditional projection seam; there is no client-side or second coordinator. A stable read
-requires two equal file-metadata observations. `SharedAuthCoordinator` owns the poll state,
-including the candidate stamp, consecutive observation count, and already-handled stamp; it
-returns `Waiting`, `Unavailable`, `Unchanged`, or `Changed` rather than exposing a partial
-snapshot as current. A partial or unavailable read is retryable without inventing a new metadata
-change. While Codex may be running, the coordinator may absorb a valid newer same-identity managed
-bundle into SQLite, but never writes shared auth. Ordinary refresh returns `OwnerBusy` before
-provider work when no such bundle was absorbed. Route's target refresh uses the `ProvedInactive`
-policy after natural Codex exit instead. Its production liveness port is conservative: uncertainty
-is `MayBeRunning`, so projection fails closed; on macOS, inaccessible unrelated PIDs and Decodex-owned
-attested app-server descendants are ignored, while external ChatGPT/Codex writers block cutover.
-Test ports cover these liveness and file boundaries.
+One daemon-wide `SharedAuthCoordinator` owns exact source reads, stable passive-following polls,
+and the exact-source projection seam; there is no client-side or second coordinator. A stable
+passive read requires two equal file-metadata observations. While following shared auth, the
+coordinator may import only a valid newer same-account managed bundle into SQLite and never writes
+shared auth. Route itself is synchronous and performs its exact-source CAS/readback directly; it
+has no Codex process/liveness wait or normal Pending result.
 
 Route coordinates the normal shared `~/.codex/auth.json`. If the file is absent or unmanaged, the
 Route can continue with the target. A managed identity naming another enrolled Account is first
 reconciled into that source Account using a stable account-scoped operation derived from the Route
-operation UUID. Unknown, unreadable, unsafe, or inconsistent managed identity fails closed. After
-natural exit, Route rechecks the exact stable source stamp and snapshot, refreshes the target, and
-projects the target only with an exact-source compare-and-swap. The writer uses one same-directory
-mode-0600 temporary file, synchronization, atomic rename, exact readback, and parent synchronization;
-source drift fails before rename, while an already-current target is idempotent.
+operation UUID. Unknown, unreadable, unsafe, or inconsistent managed identity fails closed. Route rechecks the exact source stamp and snapshot as part of the same synchronous command,
+refreshes the target when needed, and projects the target only with an exact-source
+compare-and-swap. It does not wait for Codex Desktop or an app-server process to exit. The writer
+uses one same-directory mode-0600 temporary file, synchronization, atomic rename, exact readback,
+and parent synchronization; source drift fails before rename, while an already-current target is
+idempotent.
 
-If Codex may be running, Route does not pretend a cross-account switch is complete. Migrations
-`0009_durable_account_route.sql` and `0010_pending_account_route_progress.sql` retain one
-credential-negative, replayable pending `route_account` receipt with optional progress, protected
-by one pending Route invariant. `AccountService::route_account_command` first fences account and
-routing revisions under the routing lock, then returns `AccountRoutePending` as a confirmed typed
-success before any projection write when liveness or stable-read prerequisites are not satisfied.
-The durable receipt can later become terminal; restart-transient account readiness keeps it pending.
-A newer explicit Route target atomically supersedes the older pending target, and replay of the old
-command returns `route_superseded`. GPUI retains other ready accounts as selectable and
-can submit a new target. The current fixed target remains a `Keep` action so it can cancel a
-different pending target. The daemon reclaims pending work at startup and through
-`recover_pending_account_routes_once`, then resumes from the same operation identity after natural
-exit; recovery can settle a stale routing revision without writing shared auth. Fixed routing commits
-only after target refresh and exact-source cutover succeed. If shared auth is already the target,
-`decodexd` may reconcile credentials and routing without rewriting `auth.json`, even while Codex
-runs. Cross-account auth projection still requires natural external Codex quiescence because a
-running Codex caches account auth. The protocol's `AccountRoutePendingDto` carries only the
-operation ID, target account ID, and fenced routing revision, so clients render authoritative
-Pending state without owning workflow state.
+Route executes synchronously under the routing lock. `AccountService::route_account_command`
+reads the exact shared-auth source, performs any same-account source reconciliation, refreshes the
+target when needed, performs exact-source CAS/write/readback, and commits fixed routing and the
+receipt only after success. It does not wait for Codex liveness or return a normal Pending state.
+`AccountRoutePending` and `AccountRoutePendingDto`, plus migrations
+`0009_durable_account_route.sql` and `0010_pending_account_route_progress.sql`, remain only to
+decode legacy receipts and support the one-time `recover_pending_account_routes_once` startup
+recovery pass. They are not a client-owned retry workflow. Passive following imports only same-
+account non-older rotations into daemon credentials and never writes `auth.json`.
 Client disconnect or application exit does not cancel admitted daemon work.
 
 Focused implementation checks are in `crates/decodex-runtime/src/shared_auth_coordinator.rs`
-for stable-read and liveness behavior, `crates/decodex-runtime/src/account_service.rs` for
+for stable-read and exact-source coordination, `crates/decodex-runtime/src/account_service.rs` for
 same-receipt pending recovery, `database/src/account_lifecycle.rs` for revision fencing, and
 `crates/decodex-protocol/src/wire.rs` for pending-result validation. Run the focused tests before
 the workspace suite; generated indexes and client projections are not hand-edited as part of this
 contract.
 
-The app has one Route button and projects the daemon's authoritative Pending state; it does not
-maintain a separate preparation workflow. Account, profile, inventory, quota, and aggregate values
+The app has one Route button and applies the daemon's authoritative terminal Route result. It does
+not project a normal Pending state or maintain a separate preparation workflow. The retained
+`AccountRoutePending` UI/protocol shapes exist only to decode and recover older receipts during the
+one-time startup compatibility pass. Account, profile, inventory, quota, and aggregate values
 follow authoritative revisions. Any displayed reset-card `Total` is derived from the registry-backed
 account observation, not preserved as a client-owned value across partial reads. Retryable partial
 account reads retain safe prior projections and retry using bounded delays.


### PR DESCRIPTION
Summary:
- regenerate OpenWiki from merged f6432a3c authority
- document synchronous exact-source CAS/readback with no Route process or liveness wait and no normal Pending
- document passive same-account non-older import-only observation and legacy startup recovery compatibility
- repair the generated local-product acceptance document tail

Validation:
- complete OpenWiki update status targets f6432a3c
- full generated-file readback and Route semantic reverse scan
- duplicate, truncation, section-count, and end-of-file assertions
- git diff --check
- python3 -m unittest tests/scripts/test_vnext_architecture.py: 12 passed