### PR TITLE
Implement Program Graph Surface V1

### DIFF
--- a/apps/decodex-gpui/src/bin/factory_visual_capture.rs
+++ b/apps/decodex-gpui/src/bin/factory_visual_capture.rs
@@ -7,6 +7,9 @@ mod composer_input;
 #[path = "../factory_surface.rs"]
 mod factory_surface;
 #[allow(dead_code)]
+#[path = "../program_graph.rs"]
+mod program_graph;
+#[allow(dead_code)]
 #[path = "../programs.rs"]
 mod programs;
 #[allow(dead_code)]
@@ -23,10 +26,49 @@ use gpui::{AppContext as _, VisualTestAppContext, px, size};
 
 use crate::{factory_surface::FactorySurface, programs::Programs, work_items::WorkItems};
 
+#[derive(Clone, Copy)]
+enum VisualScenario {
+	Development,
+	PaperInvestment,
+}
+
+impl VisualScenario {
+	fn from_environment() -> gpui::Result<Self> {
+		match std::env::var("DECODEX_VISUAL_SCENARIO") {
+			Ok(value) if value == "development" => Ok(Self::Development),
+			Ok(value) if value == "paper-investment" => Ok(Self::PaperInvestment),
+			Err(std::env::VarError::NotPresent) => Ok(Self::Development),
+			Ok(value) => Err(std::io::Error::new(
+				std::io::ErrorKind::InvalidInput,
+				format!(
+					"unsupported DECODEX_VISUAL_SCENARIO {value:?}; expected development or paper-investment"
+				),
+			)
+			.into()),
+			Err(error) => Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, error).into()),
+		}
+	}
+
+	fn default_output(self) -> PathBuf {
+		PathBuf::from(match self {
+			Self::Development => "target/visual-tests/program-graph-development-three-cycle.png",
+			Self::PaperInvestment => "target/visual-tests/program-graph-paper-investment.png",
+		})
+	}
+
+	fn programs(self) -> Programs {
+		match self {
+			Self::Development => Programs::visual_development_three_cycle(),
+			Self::PaperInvestment => Programs::visual_paper_investment(),
+		}
+	}
+}
+
 fn main() -> gpui::Result<()> {
+	let scenario = VisualScenario::from_environment()?;
 	let output = std::env::var_os("DECODEX_VISUAL_OUTPUT")
 		.map(PathBuf::from)
-		.unwrap_or_else(|| PathBuf::from("target/visual-tests/factory-operate.png"));
+		.unwrap_or_else(|| scenario.default_output());
 	if let Some(parent) = output.parent() {
 		std::fs::create_dir_all(parent)?;
 	}
@@ -40,7 +82,7 @@ fn main() -> gpui::Result<()> {
 		cx.new(|cx| {
 			let mut surface = FactorySurface::new(cx);
 			surface.bind_work_items(WorkItems::visual_no_projects(), cx);
-			surface.bind_programs(Programs::visual_closed_cycle(), cx);
+			surface.bind_programs(scenario.programs(), cx);
 			surface
 		})
 	})?;

--- a/apps/decodex-gpui/src/bin/workbench_visual_capture.rs
+++ b/apps/decodex-gpui/src/bin/workbench_visual_capture.rs
@@ -34,6 +34,9 @@ mod history_pager;
 #[path = "../native_menu_bar.rs"]
 mod native_menu_bar;
 #[allow(dead_code)]
+#[path = "../program_graph.rs"]
+mod program_graph;
+#[allow(dead_code)]
 #[path = "../programs.rs"]
 mod programs;
 #[allow(dead_code)]

--- a/apps/decodex-gpui/src/factory_surface.rs
+++ b/apps/decodex-gpui/src/factory_surface.rs
@@ -6,9 +6,9 @@
 use std::path::PathBuf;
 
 use gpui::{
-	Animation, AnimationExt, AnyElement, App, Bounds, BoxShadow, Context, Entity, EventEmitter,
-	Focusable, FontWeight, Hsla, KeyBinding, PathBuilder, Pixels, Render, Role, SharedString,
-	Window, actions, canvas, div, ease_in_out, point, prelude::*, px, rgb, rgba,
+	AnyElement, App, Bounds, BoxShadow, Context, Entity, EventEmitter, Focusable, FontWeight, Hsla,
+	KeyBinding, PathBuilder, Pixels, Render, Role, SharedString, Window, actions, canvas, div,
+	point, prelude::*, px, rgb, rgba,
 };
 
 use decodex_protocol::{
@@ -21,6 +21,7 @@ use decodex_protocol::{
 
 use crate::{
 	composer_input::{ComposerEvent, ComposerInput, SubmitComposer},
+	program_graph::{self, ProgramGraphEvent, ProgramGraphSurface},
 	programs::{
 		ProgramCommandState, ProgramInputError, Programs, ProgramsLoadState, ProgramsSnapshot,
 		entity_id,
@@ -49,6 +50,7 @@ const AMBER: u32 = ui_theme::AMBER;
 actions!(factory_surface, [ToggleFactoryLauncher, CloseFactoryOverlay]);
 
 pub(crate) fn bind_keys(cx: &mut App) {
+	program_graph::bind_keys(cx);
 	cx.bind_keys([
 		KeyBinding::new("cmd-k", ToggleFactoryLauncher, None),
 		KeyBinding::new("escape", CloseFactoryOverlay, None),
@@ -330,6 +332,12 @@ struct ProgramContinuationInputs {
 	working_directory: Entity<ComposerInput>,
 }
 
+struct ProgramInspectorSelection<'a> {
+	node: Option<&'a ProgramNodeDto>,
+	domain: Option<&'a DomainEntityDto>,
+	program: bool,
+}
+
 impl ProgramContinuationInputs {
 	fn new(cx: &mut Context<FactorySurface>) -> Self {
 		let input = |index, placeholder, label, cx: &mut Context<FactorySurface>| {
@@ -390,7 +398,7 @@ pub(crate) struct FactorySurface {
 	work_item_status: Option<SharedString>,
 	programs: Option<Programs>,
 	programs_snapshot: Option<ProgramsSnapshot>,
-	program_selection: Option<EntityId>,
+	program_graph: Entity<ProgramGraphSurface>,
 	program_pack: ProgramPackChoice,
 	program_inputs: ProgramCreationInputs,
 	program_review_inputs: ProgramReviewInputs,
@@ -439,6 +447,16 @@ impl FactorySurface {
 		let program_inputs = ProgramCreationInputs::new(cx);
 		let program_review_inputs = ProgramReviewInputs::new(cx);
 		let program_continuation_inputs = ProgramContinuationInputs::new(cx);
+		let program_graph = cx.new(ProgramGraphSurface::new);
+		cx.subscribe(&program_graph, |_surface, _, event: &ProgramGraphEvent, cx| match event {
+			ProgramGraphEvent::SelectionChanged => cx.notify(),
+			ProgramGraphEvent::OpenConversation(conversation_id) => {
+				cx.emit(FactoryEvent::OpenWorkItemConversation {
+					conversation_id: conversation_id.clone(),
+				});
+			},
+		})
+		.detach();
 		for input in program_inputs
 			.all()
 			.into_iter()
@@ -470,7 +488,7 @@ impl FactorySurface {
 			work_item_status: None,
 			programs: None,
 			programs_snapshot: None,
-			program_selection: None,
+			program_graph,
 			program_pack: ProgramPackChoice::Development,
 			program_inputs,
 			program_review_inputs,
@@ -485,7 +503,7 @@ impl FactorySurface {
 	pub(crate) fn bind_programs(&mut self, programs: Programs, cx: &mut Context<Self>) {
 		self.programs = Some(programs.clone());
 		self.programs_snapshot = Some(programs.snapshot());
-		self.reconcile_program_selection();
+		self.synchronize_program_graph(cx);
 		cx.notify();
 	}
 
@@ -507,33 +525,14 @@ impl FactorySurface {
 				self.program_status = None;
 			}
 			self.programs_snapshot = Some(snapshot);
-			self.reconcile_program_selection();
+			self.synchronize_program_graph(cx);
 			cx.notify();
 		}
 	}
 
-	fn reconcile_program_selection(&mut self) {
-		let Some(cycle) =
-			self.programs_snapshot.as_ref().and_then(|snapshot| snapshot.cycle.as_ref())
-		else {
-			self.program_selection = None;
-			return;
-		};
-		if self.program_selection.as_ref().is_some_and(|selected| {
-			cycle.nodes.iter().any(|node| &node.id == selected)
-				|| cycle
-					.domain_pack
-					.as_ref()
-					.is_some_and(|pack| pack.entities.iter().any(|entity| &entity.id == selected))
-		}) {
-			return;
-		}
-		self.program_selection = cycle
-			.domain_pack
-			.as_ref()
-			.and_then(|pack| pack.entities.first())
-			.map(|entity| entity.id.clone())
-			.or_else(|| cycle.nodes.first().map(|node| node.id.clone()));
+	fn synchronize_program_graph(&mut self, cx: &mut Context<Self>) {
+		let cycle = self.programs_snapshot.as_ref().and_then(|snapshot| snapshot.cycle.clone());
+		self.program_graph.update(cx, |graph, cx| graph.set_cycle(cycle, cx));
 	}
 
 	pub(crate) fn bind_work_items(&mut self, work_items: WorkItems, cx: &mut Context<Self>) {
@@ -777,7 +776,7 @@ impl FactorySurface {
 		};
 		if programs.select(program_id) {
 			self.programs_snapshot = Some(programs.snapshot());
-			self.program_selection = None;
+			self.synchronize_program_graph(cx);
 			self.program_continuation_visible = false;
 			self.program_status = None;
 			cx.notify();
@@ -880,8 +879,9 @@ impl FactorySurface {
 	}
 
 	fn select_program_node(&mut self, node_id: EntityId, cx: &mut Context<Self>) {
-		self.program_selection = Some(node_id);
-		cx.notify();
+		self.program_graph.update(cx, |graph, cx| {
+			graph.select(node_id, cx);
+		});
 	}
 
 	fn start_program_work_item(&mut self, cx: &mut Context<Self>) {
@@ -1393,11 +1393,11 @@ impl FactorySurface {
 			return self.program_intake(snapshot, cx);
 		}
 		let cycle = snapshot.cycle.as_ref().expect("checked Program cycle");
-		let selected_node = self
-			.program_selection
+		let selected = self.program_graph.read(cx).selected().cloned();
+		let selected_node = selected
 			.as_ref()
 			.and_then(|selected| cycle.nodes.iter().find(|node| &node.id == selected));
-		let selected_domain = self.program_selection.as_ref().and_then(|selected| {
+		let selected_domain = selected.as_ref().and_then(|selected| {
 			cycle
 				.domain_pack
 				.as_ref()
@@ -1427,6 +1427,7 @@ impl FactorySurface {
 			.aria_label("Authoritative Program causal graph")
 			.flex_1()
 			.min_h_0()
+			.h_full()
 			.w_full()
 			.min_w(px(FACTORY_MIN_WIDTH))
 			.flex()
@@ -1477,12 +1478,14 @@ impl FactorySurface {
 									.child("SQLITE AUTHORITY · LIVE PROJECTION"),
 							),
 					)
-					.child(self.program_domain_graph(cycle, cx))
-					.child(self.program_graph(cycle, cx)),
+					.child(self.program_graph.clone()),
 			)
 			.child(self.program_inspector(
-				selected_node,
-				selected_domain,
+				ProgramInspectorSelection {
+					node: selected_node,
+					domain: selected_domain,
+					program: selected.as_ref() == Some(&cycle.program.program_id),
+				},
 				cycle,
 				can_review,
 				can_continue,
@@ -1737,178 +1740,9 @@ impl FactorySurface {
 			.into_any_element()
 	}
 
-	fn program_graph(
-		&self,
-		cycle: &decodex_protocol::ProgramCycleDto,
-		cx: &mut Context<Self>,
-	) -> AnyElement {
-		let selected = self.program_selection.clone();
-		let cycle_count =
-			cycle.nodes.iter().filter(|node| node.kind == ProgramNodeKind::Signal).count();
-		let mut current_cycle = 0;
-		let mut graph = div()
-			.id("program-graph-strip")
-			.flex_1()
-			.min_h_0()
-			.p_3()
-			.flex()
-			.items_center()
-			.overflow_x_scroll()
-			.border_1()
-			.border_color(rgba(0xffffff12))
-			.rounded(px(12.0))
-			.bg(rgba(ui_theme::SURFACE_MATERIAL));
-		for (index, node) in cycle.nodes.iter().enumerate() {
-			if index > 0 {
-				let relation = cycle
-					.edges
-					.iter()
-					.find(|edge| edge.to == node.id)
-					.map(|edge| relation_label(edge.kind))
-					.unwrap_or("relates");
-				graph = graph.child(program_edge(relation));
-			}
-			if node.kind == ProgramNodeKind::Signal {
-				current_cycle += 1;
-				graph = graph
-					.child(program_cycle_boundary(current_cycle, current_cycle == cycle_count));
-			}
-			graph = graph.child(program_node_card(node, selected.as_ref() == Some(&node.id), cx));
-		}
-		graph.into_any_element()
-	}
-
-	fn program_domain_graph(
-		&self,
-		cycle: &decodex_protocol::ProgramCycleDto,
-		cx: &mut Context<Self>,
-	) -> AnyElement {
-		let Some(pack) = cycle.domain_pack.as_ref() else {
-			return div()
-				.id("program-domain-unbound")
-				.h(px(86.0))
-				.min_h(px(86.0))
-				.px_4()
-				.flex()
-				.items_center()
-				.justify_between()
-				.border_1()
-				.border_color(rgba(0xf0a64a35))
-				.rounded(px(10.0))
-				.bg(rgba(0xf0a64a0a))
-				.child(
-					div()
-						.flex()
-						.flex_col()
-						.gap_1()
-						.child(
-							div()
-								.font_family("SF Mono")
-								.text_size(px(8.0))
-								.text_color(rgb(AMBER))
-								.child("LEGACY PROGRAM · DOMAIN PACK UNBOUND"),
-						)
-						.child(div().text_size(px(9.0)).text_color(rgb(TEXT_MUTED)).child(
-							"Bind one built-in Pack once to enable a domain projection and Program execution.",
-						)),
-				)
-				.into_any_element();
-		};
-		let selected = self.program_selection.clone();
-		let capability = pack
-			.descriptor
-			.capabilities
-			.first()
-			.map(|capability| {
-				format!(
-					"{} · {}",
-					capability.id.as_str(),
-					match capability.status {
-						DomainPackCapabilityStatus::Granted => "GRANTED",
-						DomainPackCapabilityStatus::Unavailable => "UNAVAILABLE",
-					}
-				)
-			})
-			.unwrap_or_else(|| "NO CAPABILITIES".to_owned());
-		let mut graph = div()
-			.id("program-domain-graph")
-			.h(px(206.0))
-			.min_h(px(206.0))
-			.p_3()
-			.flex()
-			.flex_col()
-			.gap_2()
-			.border_1()
-			.border_color(rgba(0xffffff16))
-			.rounded(px(12.0))
-			.bg(rgba(ui_theme::SURFACE_MATERIAL))
-			.child(
-				div()
-					.flex()
-					.items_center()
-					.justify_between()
-					.child(
-						div()
-							.flex()
-							.items_center()
-							.gap_2()
-							.child(
-								div()
-									.font_family("SF Mono")
-									.text_size(px(8.0))
-									.text_color(rgb(BLUE))
-									.child("DOMAIN LENS"),
-							)
-							.child(
-								div()
-									.text_size(px(10.0))
-									.font_weight(FontWeight::SEMIBOLD)
-									.child(pack.descriptor.name.as_str().to_owned()),
-							)
-							.child(
-								div()
-									.font_family("SF Mono")
-									.text_size(px(7.0))
-									.text_color(rgb(TEXT_FAINT))
-									.child(format!("v{}", pack.descriptor.version.as_str())),
-							),
-					)
-					.child(
-						div()
-							.font_family("SF Mono")
-							.text_size(px(7.0))
-							.text_color(rgb(GREEN))
-							.child(capability),
-					),
-			);
-		let mut strip = div()
-			.id("program-domain-entity-strip")
-			.flex_1()
-			.min_h_0()
-			.flex()
-			.items_center()
-			.overflow_x_scroll();
-		for (index, entity) in pack.entities.iter().enumerate() {
-			if index > 0 {
-				let relation = pack
-					.relations
-					.iter()
-					.find(|relation| relation.to == entity.id)
-					.map(|relation| domain_relation_label(relation.kind.as_str()))
-					.unwrap_or_else(|| "relates".to_owned());
-				strip = strip.child(program_edge(&relation));
-			}
-			strip =
-				strip.child(domain_entity_card(entity, selected.as_ref() == Some(&entity.id), cx));
-		}
-		graph = graph.child(strip);
-		graph.into_any_element()
-	}
-
 	fn program_inspector(
 		&self,
-		selected: Option<&ProgramNodeDto>,
-		selected_domain: Option<&DomainEntityDto>,
+		selection: ProgramInspectorSelection<'_>,
 		cycle: &decodex_protocol::ProgramCycleDto,
 		can_review: bool,
 		can_continue: bool,
@@ -1933,7 +1767,42 @@ impl FactorySurface {
 					.text_color(rgb(TEXT_FAINT))
 					.child("SEMANTIC INSPECTOR"),
 			);
-		if let Some(node) = selected {
+		if selection.program {
+			panel = panel
+				.child(
+					div()
+						.flex()
+						.items_center()
+						.gap_2()
+						.child(div().size(px(8.0)).rounded_full().bg(rgb(TEXT)))
+						.child(
+							div()
+								.text_size(px(13.0))
+								.font_weight(FontWeight::SEMIBOLD)
+								.child(cycle.program.name.as_str().to_owned()),
+						),
+				)
+				.child(
+					div()
+						.font_family("SF Mono")
+						.text_size(px(8.0))
+						.text_color(rgb(TEXT_MUTED))
+						.child(format!(
+							"PROGRAM · {} · REV {}",
+							cycle.program.state.as_str(),
+							cycle.program.revision.0
+						)),
+				)
+				.child(
+					div()
+						.text_size(px(10.0))
+						.text_color(rgb(TEXT_MUTED))
+						.child(cycle.program.purpose.as_str().to_owned()),
+				)
+				.child(program_pulse_section("IDENTITY", cycle.program.program_id.as_str()))
+				.child(program_pulse_section("REVIEW POLICY", cycle.review_policy.as_str()));
+		}
+		if let Some(node) = selection.node {
 			panel = panel
 				.child(
 					div()
@@ -1983,7 +1852,7 @@ impl FactorySurface {
 				));
 			}
 		}
-		if let Some(entity) = selected_domain {
+		if let Some(entity) = selection.domain {
 			let color = domain_entity_color(entity.kind.as_str());
 			panel = panel
 				.child(
@@ -3153,7 +3022,7 @@ impl FactorySurface {
 		else {
 			return div().into_any_element();
 		};
-		let selected = self.program_selection.clone();
+		let selected = self.program_graph.read(cx).selected().cloned();
 		let origin = cycle.nodes.iter().filter_map(|node| node.observed_at_micros).min();
 		let mut cycle_number = 0;
 		let moments = cycle.nodes.iter().enumerate().map(|(index, node)| {
@@ -3524,6 +3393,8 @@ impl Render for FactorySurface {
 					.id("factory-canvas-scroll")
 					.flex_1()
 					.min_h_0()
+					.flex()
+					.flex_col()
 					.overflow_x_scroll()
 					.child(self.factory_canvas(cx)),
 			)
@@ -3537,17 +3408,7 @@ impl Render for FactorySurface {
 							self.program_timeline(cx)
 						} else {
 							self.replay_panel(cx)
-						})
-						.with_animation(
-							"factory-timeline-reveal",
-							Animation::new(ui_theme::MOTION_PANEL).with_easing(ease_in_out),
-							|element, delta| {
-								element
-									.opacity(0.3 + delta * 0.7)
-									.relative()
-									.top(px((1.0 - delta) * 14.0))
-							},
-						),
+						}),
 				)
 			});
 
@@ -4051,120 +3912,6 @@ fn relative_timeline_time(delta_micros: i64) -> String {
 	}
 }
 
-fn program_edge(label: &str) -> AnyElement {
-	div()
-		.w(px(66.0))
-		.min_w(px(66.0))
-		.flex()
-		.flex_col()
-		.items_center()
-		.gap_1()
-		.child(
-			div()
-				.font_family("SF Mono")
-				.text_size(px(7.0))
-				.text_color(rgb(BLUE))
-				.child(label.to_owned()),
-		)
-		.child(div().w_full().border_t_1().border_color(rgb(BLUE)))
-		.child(div().font_family("SF Mono").text_size(px(8.0)).text_color(rgb(BLUE)).child("→"))
-		.into_any_element()
-}
-
-fn program_cycle_boundary(number: usize, current: bool) -> AnyElement {
-	div()
-		.w(px(54.0))
-		.min_w(px(54.0))
-		.flex()
-		.flex_col()
-		.items_center()
-		.gap_1()
-		.child(
-			div()
-				.font_family("SF Mono")
-				.text_size(px(8.0))
-				.font_weight(FontWeight::SEMIBOLD)
-				.text_color(rgb(if current { GREEN } else { TEXT_FAINT }))
-				.child(format!("C{number}")),
-		)
-		.child(
-			div()
-				.font_family("SF Mono")
-				.text_size(px(6.5))
-				.text_color(rgb(TEXT_FAINT))
-				.child(if current { "CURRENT" } else { "HISTORY" }),
-		)
-		.into_any_element()
-}
-
-fn program_node_card(
-	node: &ProgramNodeDto,
-	selected: bool,
-	cx: &mut Context<FactorySurface>,
-) -> AnyElement {
-	let node_id = node.id.clone();
-	let color = program_node_color(node.kind);
-	div()
-		.id(format!("program-node/{}", node.id.as_str()))
-		.role(Role::Button)
-		.aria_label(format!("Inspect {} {}", node_kind_label(node.kind), node.title.as_str()))
-		.w(px(178.0))
-		.min_w(px(178.0))
-		.min_h(px(148.0))
-		.p_3()
-		.flex()
-		.flex_col()
-		.gap_2()
-		.border_1()
-		.border_color(if selected { rgb(color) } else { rgba(0xffffff16) })
-		.rounded(px(10.0))
-		.bg(if selected {
-			rgba(ui_theme::SURFACE_RAISED_MATERIAL)
-		} else {
-			rgba(ui_theme::SURFACE_MATERIAL)
-		})
-		.cursor_pointer()
-		.hover(|style| style.border_color(rgba(0xffffff2c)))
-		.on_click(cx.listener(move |surface, _, _, cx| {
-			surface.select_program_node(node_id.clone(), cx);
-		}))
-		.child(
-			div()
-				.flex()
-				.items_center()
-				.justify_between()
-				.child(
-					div()
-						.font_family("SF Mono")
-						.text_size(px(7.5))
-						.text_color(rgb(color))
-						.child(node_kind_label(node.kind)),
-				)
-				.child(
-					div()
-						.font_family("SF Mono")
-						.text_size(px(7.0))
-						.text_color(rgb(TEXT_FAINT))
-						.child(node.state.as_str().to_owned()),
-				),
-		)
-		.child(
-			div()
-				.text_size(px(11.0))
-				.font_weight(FontWeight::SEMIBOLD)
-				.child(node.title.as_str().to_owned()),
-		)
-		.child(
-			div()
-				.max_h(px(64.0))
-				.overflow_hidden()
-				.text_size(px(9.0))
-				.text_color(rgb(TEXT_MUTED))
-				.child(node.summary.as_str().to_owned()),
-		)
-		.into_any_element()
-}
-
 fn program_pack_choice(
 	pack: ProgramPackChoice,
 	selected: bool,
@@ -4218,82 +3965,6 @@ fn program_pack_choice(
 		.into_any_element()
 }
 
-fn domain_entity_card(
-	entity: &DomainEntityDto,
-	selected: bool,
-	cx: &mut Context<FactorySurface>,
-) -> AnyElement {
-	let entity_id = entity.id.clone();
-	let color = domain_entity_color(entity.kind.as_str());
-	div()
-		.id(format!("domain-entity/{}", entity.id.as_str()))
-		.role(Role::Button)
-		.aria_label(format!("Inspect {} {}", entity.kind.as_str(), entity.title.as_str()))
-		.w(px(178.0))
-		.min_w(px(178.0))
-		.min_h(px(126.0))
-		.p_3()
-		.flex()
-		.flex_col()
-		.gap_2()
-		.border_1()
-		.border_color(if selected { rgb(color) } else { rgba(0xffffff16) })
-		.rounded(px(10.0))
-		.bg(if selected {
-			rgba(ui_theme::SURFACE_RAISED_MATERIAL)
-		} else {
-			rgba(ui_theme::SURFACE_MATERIAL)
-		})
-		.cursor_pointer()
-		.hover(|style| style.border_color(rgba(0xffffff34)))
-		.on_click(cx.listener(move |surface, _, _, cx| {
-			surface.select_program_node(entity_id.clone(), cx);
-		}))
-		.child(
-			div()
-				.flex()
-				.items_center()
-				.justify_between()
-				.child(
-					div()
-						.font_family("SF Mono")
-						.text_size(px(7.0))
-						.text_color(rgb(color))
-						.child(domain_kind_label(entity.kind.as_str())),
-				)
-				.child(
-					div()
-						.font_family("SF Mono")
-						.text_size(px(7.0))
-						.text_color(rgb(TEXT_FAINT))
-						.child(entity.state.as_str().to_owned()),
-				),
-		)
-		.child(
-			div()
-				.text_size(px(11.0))
-				.font_weight(FontWeight::SEMIBOLD)
-				.child(entity.title.as_str().to_owned()),
-		)
-		.child(
-			div()
-				.max_h(px(48.0))
-				.overflow_hidden()
-				.text_size(px(8.5))
-				.text_color(rgb(TEXT_MUTED))
-				.child(entity.summary.as_str().to_owned()),
-		)
-		.into_any_element()
-}
-
-fn domain_kind_label(kind: &str) -> String {
-	kind.rsplit('.').next().unwrap_or(kind).replace('_', " ").to_uppercase()
-}
-
-fn domain_relation_label(kind: &str) -> String {
-	kind.rsplit('.').next().unwrap_or(kind).replace('_', " ")
-}
-
 fn domain_entity_color(kind: &str) -> u32 {
 	if kind.starts_with("finance.") { GREEN } else { BLUE }
 }
@@ -4317,20 +3988,6 @@ const fn node_kind_label(kind: ProgramNodeKind) -> &'static str {
 		ProgramNodeKind::Run => "CODEX RUN",
 		ProgramNodeKind::Evidence => "EVIDENCE",
 		ProgramNodeKind::Review => "REVIEW",
-	}
-}
-
-const fn relation_label(kind: decodex_protocol::ProgramRelationKind) -> &'static str {
-	match kind {
-		decodex_protocol::ProgramRelationKind::Continues => "continues",
-		decodex_protocol::ProgramRelationKind::Observes => "observes",
-		decodex_protocol::ProgramRelationKind::Supports => "supports",
-		decodex_protocol::ProgramRelationKind::Justifies => "justifies",
-		decodex_protocol::ProgramRelationKind::Proposes => "proposes",
-		decodex_protocol::ProgramRelationKind::DecomposesTo => "decomposes",
-		decodex_protocol::ProgramRelationKind::Executes => "executes",
-		decodex_protocol::ProgramRelationKind::Produces => "produces",
-		decodex_protocol::ProgramRelationKind::Validates => "validates",
 	}
 }
 
@@ -4789,6 +4446,34 @@ mod tests {
 		assert!(instructions.contains("Do not use live data"));
 		assert!(working_directory.is_empty());
 		visual.update(|window, cx| window.draw(cx).clear());
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[gpui::test]
+	fn three_cycle_program_graph_keeps_one_selection_at_minimum_laptop_size(
+		cx: &mut TestAppContext,
+	) {
+		let (surface, visual) = open_factory(cx);
+		let programs = Programs::visual_development_three_cycle();
+		let cycle = programs.snapshot().cycle.expect("visual development cycle");
+		let run = cycle
+			.nodes
+			.iter()
+			.rev()
+			.find(|node| node.kind == ProgramNodeKind::Run)
+			.expect("latest visual Run")
+			.clone();
+		surface.update(visual, |surface, cx| {
+			surface.bind_programs(programs, cx);
+			surface.select_program_node(run.id.clone(), cx);
+		});
+		let selected = surface
+			.read_with(visual, |surface, cx| surface.program_graph.read(cx).selected().cloned());
+		assert_eq!(selected, Some(run.id));
+		visual.update(|window, cx| {
+			window.resize(size(px(1_180.0), px(720.0)));
+			window.draw(cx).clear();
+		});
 	}
 
 	#[test]

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -27,6 +27,7 @@ mod health_query;
 mod history_pager;
 mod programs;
 mod native_menu_bar;
+mod program_graph;
 mod quick_tasks;
 mod settings_surface;
 mod shell;

--- a/apps/decodex-gpui/src/program_graph.rs
+++ b/apps/decodex-gpui/src/program_graph.rs
@@ -1,0 +1,2152 @@
+//! Private host-owned Program and Domain Pack graph projection.
+
+use std::{
+	collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+	sync::Arc,
+};
+
+use gpui::{
+	AnyElement, App, Bounds, Context, CursorStyle, Element, ElementId, Entity, EventEmitter,
+	FocusHandle, FontWeight, GlobalElementId, InspectorElementId, KeyBinding, LayoutId,
+	MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathBuilder, Pixels, Point, Render,
+	Role, ScrollDelta, ScrollWheelEvent, Size, Style, Subscription, Window, actions, canvas, div,
+	point, prelude::*, px, relative, rgb, rgba, size,
+};
+
+use decodex_protocol::{
+	DomainEntityDto, DomainPackCapabilityStatus, EntityId, ProgramCycleDto, ProgramNodeDto,
+	ProgramNodeKind, ProgramRelationKind,
+};
+
+use crate::ui_theme;
+
+const NODE_WIDTH: f32 = 168.0;
+const NODE_HEIGHT: f32 = 104.0;
+const LAYER_GAP: f32 = 76.0;
+const ROW_GAP: f32 = 32.0;
+const WORLD_PADDING: f32 = 44.0;
+const VIEW_PADDING: f32 = 24.0;
+const MIN_ZOOM: f32 = 0.16;
+const MAX_ZOOM: f32 = 1.8;
+const ZOOM_STEP: f32 = 1.2;
+const MIN_VISIBLE_WORLD: f32 = 72.0;
+
+const TEXT: u32 = ui_theme::TEXT;
+const TEXT_MUTED: u32 = ui_theme::TEXT_MUTED;
+const TEXT_FAINT: u32 = ui_theme::TEXT_FAINT;
+const BLUE: u32 = ui_theme::BLUE;
+const GREEN: u32 = ui_theme::GREEN;
+const AMBER: u32 = ui_theme::AMBER;
+const LINE: u32 = ui_theme::LINE;
+
+actions!(
+	program_graph,
+	[
+		GraphMoveLeft,
+		GraphMoveRight,
+		GraphMoveUp,
+		GraphMoveDown,
+		GraphActivate,
+		GraphFit,
+		GraphZoomIn,
+		GraphZoomOut,
+		GraphReset,
+	]
+);
+
+pub(crate) fn bind_keys(cx: &mut App) {
+	cx.bind_keys([
+		KeyBinding::new("left", GraphMoveLeft, Some("ProgramGraphNode")),
+		KeyBinding::new("right", GraphMoveRight, Some("ProgramGraphNode")),
+		KeyBinding::new("up", GraphMoveUp, Some("ProgramGraphNode")),
+		KeyBinding::new("down", GraphMoveDown, Some("ProgramGraphNode")),
+		KeyBinding::new("enter", GraphActivate, Some("ProgramGraphNode")),
+		KeyBinding::new("space", GraphActivate, Some("ProgramGraphNode")),
+		KeyBinding::new("f", GraphFit, Some("ProgramGraphNode")),
+		KeyBinding::new("=", GraphZoomIn, Some("ProgramGraphNode")),
+		KeyBinding::new("-", GraphZoomOut, Some("ProgramGraphNode")),
+		KeyBinding::new("0", GraphReset, Some("ProgramGraphNode")),
+	]);
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ProgramGraphEvent {
+	SelectionChanged,
+	OpenConversation(EntityId),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum GraphLens {
+	Domain,
+	Program,
+}
+
+impl GraphLens {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::Domain => "Domain Pack",
+			Self::Program => "Program causal",
+		}
+	}
+
+	const fn element_id(self) -> &'static str {
+		match self {
+			Self::Domain => "domain",
+			Self::Program => "program",
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct EdgeIdentity {
+	from: String,
+	relation: String,
+	to: String,
+}
+
+#[derive(Clone, Debug)]
+struct GraphNode {
+	id: EntityId,
+	kind: String,
+	title: String,
+	summary: String,
+	state: String,
+	color: u32,
+	conversation_id: Option<EntityId>,
+}
+
+#[derive(Clone, Debug)]
+struct GraphEdge {
+	identity: EdgeIdentity,
+	label: String,
+	explicit_feedback: bool,
+}
+
+#[derive(Clone, Debug)]
+struct GraphInput {
+	nodes: Vec<GraphNode>,
+	edges: Vec<GraphEdge>,
+}
+
+impl GraphInput {
+	fn structure_key(&self) -> GraphStructureKey {
+		let mut nodes =
+			self.nodes.iter().map(|node| node.id.as_str().to_owned()).collect::<Vec<_>>();
+		nodes.sort();
+		let mut edges = self
+			.edges
+			.iter()
+			.map(|edge| (edge.identity.clone(), edge.explicit_feedback))
+			.collect::<Vec<_>>();
+		edges.sort();
+		GraphStructureKey { nodes, edges }
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GraphStructureKey {
+	nodes: Vec<String>,
+	edges: Vec<(EdgeIdentity, bool)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WorldPoint {
+	x: f32,
+	y: f32,
+}
+
+#[derive(Clone, Debug)]
+struct GraphLayout {
+	positions: BTreeMap<String, WorldPoint>,
+	#[cfg(test)]
+	ranks: BTreeMap<String, usize>,
+	feedback_edges: BTreeSet<EdgeIdentity>,
+	world_size: Size<f32>,
+}
+
+#[derive(Clone, Debug)]
+struct GraphScene {
+	nodes: Vec<GraphNode>,
+	edges: Vec<GraphEdge>,
+	layout: Arc<GraphLayout>,
+}
+
+impl GraphScene {
+	fn contains(&self, id: &EntityId) -> bool {
+		self.nodes.iter().any(|node| node.id == *id)
+	}
+
+	fn node(&self, id: &EntityId) -> Option<&GraphNode> {
+		self.nodes.iter().find(|node| node.id == *id)
+	}
+
+	fn node_by_key(&self, id: &str) -> Option<&GraphNode> {
+		self.nodes.iter().find(|node| node.id.as_str() == id)
+	}
+
+	fn relation_readout(&self, selected: Option<&EntityId>) -> Vec<String> {
+		let Some(selected) = selected.filter(|selected| self.contains(selected)) else {
+			return vec!["Select a node to read its incoming and outgoing relations.".to_owned()];
+		};
+		let mut readout = Vec::new();
+		for edge in &self.edges {
+			let feedback = self.layout.feedback_edges.contains(&edge.identity);
+			if edge.identity.from == selected.as_str() {
+				let target = self
+					.node_by_key(&edge.identity.to)
+					.map_or(edge.identity.to.as_str(), |node| node.title.as_str());
+				readout.push(format!(
+					"OUT{} · {} → {target}",
+					if feedback { " · FEEDBACK" } else { "" },
+					edge.label
+				));
+			}
+			if edge.identity.to == selected.as_str() {
+				let source = self
+					.node_by_key(&edge.identity.from)
+					.map_or(edge.identity.from.as_str(), |node| node.title.as_str());
+				readout.push(format!(
+					"IN{} · {source} → {}",
+					if feedback { " · FEEDBACK" } else { "" },
+					edge.label
+				));
+			}
+		}
+		if readout.is_empty() {
+			readout.push("No projected relations for this identity.".to_owned());
+		}
+		readout.sort();
+		readout
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GraphLayoutError {
+	Empty,
+	DuplicateNode,
+	DuplicateEdge,
+	DanglingEdge,
+	CycleBreakFailed,
+}
+
+#[derive(Default)]
+struct GraphCache {
+	key: Option<GraphStructureKey>,
+	layout: Option<Arc<GraphLayout>>,
+	scene: Option<Arc<GraphScene>>,
+	computations: usize,
+}
+
+impl GraphCache {
+	fn update(&mut self, input: GraphInput) -> Result<bool, GraphLayoutError> {
+		let key = input.structure_key();
+		let changed = self.key.as_ref() != Some(&key);
+		let layout = if changed {
+			self.computations = self.computations.saturating_add(1);
+			Arc::new(compute_layout(&input)?)
+		} else {
+			self.layout.clone().ok_or(GraphLayoutError::CycleBreakFailed)?
+		};
+		self.key = Some(key);
+		self.layout = Some(Arc::clone(&layout));
+		self.scene = Some(Arc::new(GraphScene { nodes: input.nodes, edges: input.edges, layout }));
+		Ok(changed)
+	}
+
+	fn clear(&mut self) {
+		self.key = None;
+		self.layout = None;
+		self.scene = None;
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ViewportMode {
+	Fit,
+	Manual { zoom: f32, pan: Point<f32> },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct GraphViewport {
+	mode: ViewportMode,
+	bounds: Option<Bounds<Pixels>>,
+	drag_anchor: Option<Point<Pixels>>,
+}
+
+impl Default for GraphViewport {
+	fn default() -> Self {
+		Self { mode: ViewportMode::Fit, bounds: None, drag_anchor: None }
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ViewTransform {
+	zoom: f32,
+	pan: Point<f32>,
+	view_size: Size<f32>,
+	world_size: Size<f32>,
+}
+
+impl ViewTransform {
+	fn for_viewport(
+		viewport: GraphViewport,
+		bounds: Bounds<Pixels>,
+		world_size: Size<f32>,
+	) -> Self {
+		let view_size = size(f32::from(bounds.size.width), f32::from(bounds.size.height));
+		let (zoom, pan) = match viewport.mode {
+			ViewportMode::Fit => {
+				let width = (view_size.width - VIEW_PADDING * 2.0).max(1.0) / world_size.width;
+				let height = (view_size.height - VIEW_PADDING * 2.0).max(1.0) / world_size.height;
+				(width.min(height).clamp(MIN_ZOOM, 1.0), point(0.0, 0.0))
+			},
+			ViewportMode::Manual { zoom, pan } => (zoom.clamp(MIN_ZOOM, MAX_ZOOM), pan),
+		};
+		let mut transform = Self { zoom, pan, view_size, world_size };
+		transform.pan = transform.clamp_pan(transform.pan);
+		transform
+	}
+
+	fn clamp_pan(self, pan: Point<f32>) -> Point<f32> {
+		let horizontal = (self.world_size.width * self.zoom / 2.0 + self.view_size.width / 2.0
+			- MIN_VISIBLE_WORLD)
+			.max(0.0);
+		let vertical = (self.world_size.height * self.zoom / 2.0 + self.view_size.height / 2.0
+			- MIN_VISIBLE_WORLD)
+			.max(0.0);
+		point(pan.x.clamp(-horizontal, horizontal), pan.y.clamp(-vertical, vertical))
+	}
+
+	fn world_to_screen(self, value: WorldPoint) -> Point<f32> {
+		point(
+			self.view_size.width / 2.0
+				+ (value.x - self.world_size.width / 2.0) * self.zoom
+				+ self.pan.x,
+			self.view_size.height / 2.0
+				+ (value.y - self.world_size.height / 2.0) * self.zoom
+				+ self.pan.y,
+		)
+	}
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct FocusKey {
+	lens: GraphLens,
+	id: String,
+}
+
+#[derive(Clone, Copy)]
+enum MoveDirection {
+	Left,
+	Right,
+	Up,
+	Down,
+}
+
+#[derive(Clone, Copy)]
+enum ViewportCommand {
+	Fit,
+	ZoomIn,
+	ZoomOut,
+	Reset,
+}
+
+pub(crate) struct ProgramGraphSurface {
+	program: GraphCache,
+	domain: GraphCache,
+	domain_title: Option<String>,
+	domain_status: Option<String>,
+	selected: Option<EntityId>,
+	active_lens: GraphLens,
+	focused: Option<FocusKey>,
+	program_viewport: GraphViewport,
+	domain_viewport: GraphViewport,
+	focus_handles: BTreeMap<FocusKey, FocusHandle>,
+	focus_subscriptions: Vec<Subscription>,
+	focus_bindings_dirty: bool,
+	projection_error: Option<String>,
+}
+
+impl EventEmitter<ProgramGraphEvent> for ProgramGraphSurface {}
+
+impl ProgramGraphSurface {
+	pub(crate) fn new(_: &mut Context<Self>) -> Self {
+		Self {
+			program: GraphCache::default(),
+			domain: GraphCache::default(),
+			domain_title: None,
+			domain_status: None,
+			selected: None,
+			active_lens: GraphLens::Program,
+			focused: None,
+			program_viewport: GraphViewport::default(),
+			domain_viewport: GraphViewport::default(),
+			focus_handles: BTreeMap::new(),
+			focus_subscriptions: Vec::new(),
+			focus_bindings_dirty: true,
+			projection_error: None,
+		}
+	}
+
+	pub(crate) fn selected(&self) -> Option<&EntityId> {
+		self.selected.as_ref()
+	}
+
+	fn selected_conversation_id(&self) -> Option<EntityId> {
+		let selected = self.selected.as_ref()?;
+		self.program
+			.scene
+			.as_ref()
+			.and_then(|scene| scene.node(selected))
+			.and_then(|node| node.conversation_id.clone())
+	}
+
+	pub(crate) fn set_cycle(&mut self, cycle: Option<ProgramCycleDto>, cx: &mut Context<Self>) {
+		let Some(cycle) = cycle else {
+			self.program.clear();
+			self.domain.clear();
+			self.domain_title = None;
+			self.domain_status = None;
+			self.selected = None;
+			self.projection_error = None;
+			self.sync_focus_handles(cx);
+			cx.notify();
+			return;
+		};
+
+		let program = program_input(&cycle);
+		let domain = cycle.domain_pack.as_ref().map(|pack| domain_input(&cycle, pack));
+		let program_changed = self.program.update(program);
+		let domain_changed = match domain {
+			Some(input) => self.domain.update(input),
+			None => {
+				self.domain.clear();
+				Ok(true)
+			},
+		};
+		self.projection_error = match (program_changed, domain_changed) {
+			(Ok(_), Ok(_)) => None,
+			(Err(error), _) | (_, Err(error)) =>
+				Some(format!("Invalid graph projection: {error:?}")),
+		};
+		if program_changed == Ok(true) {
+			self.program_viewport = GraphViewport::default();
+		}
+		if domain_changed == Ok(true) {
+			self.domain_viewport = GraphViewport::default();
+		}
+		self.domain_title =
+			cycle.domain_pack.as_ref().map(|pack| pack.descriptor.name.as_str().to_owned());
+		self.domain_status = cycle.domain_pack.as_ref().map(|pack| {
+			pack.descriptor
+				.capabilities
+				.iter()
+				.map(|capability| {
+					format!(
+						"{} · {}",
+						capability.id.as_str(),
+						match capability.status {
+							DomainPackCapabilityStatus::Granted => "GRANTED",
+							DomainPackCapabilityStatus::Unavailable => "UNAVAILABLE",
+						}
+					)
+				})
+				.collect::<Vec<_>>()
+				.join(" · ")
+		});
+
+		let selection_valid = self.selected.as_ref().is_some_and(|selected| {
+			self.program.scene.as_ref().is_some_and(|scene| scene.contains(selected))
+				|| self.domain.scene.as_ref().is_some_and(|scene| scene.contains(selected))
+		});
+		if !selection_valid {
+			self.selected = cycle.nodes.first().map(|node| node.id.clone()).or_else(|| {
+				self.program
+					.scene
+					.as_ref()
+					.and_then(|scene| scene.nodes.first())
+					.map(|node| node.id.clone())
+			});
+		}
+		self.sync_focus_handles(cx);
+		cx.notify();
+	}
+
+	pub(crate) fn select(&mut self, id: EntityId, cx: &mut Context<Self>) -> bool {
+		let lens = if self.program.scene.as_ref().is_some_and(|scene| scene.contains(&id)) {
+			Some(GraphLens::Program)
+		} else if self.domain.scene.as_ref().is_some_and(|scene| scene.contains(&id)) {
+			Some(GraphLens::Domain)
+		} else {
+			None
+		};
+		let Some(lens) = lens else { return false };
+		self.set_selection(lens, id, cx);
+		true
+	}
+
+	fn set_selection(&mut self, lens: GraphLens, id: EntityId, cx: &mut Context<Self>) {
+		self.active_lens = lens;
+		if self.selected.as_ref() == Some(&id) {
+			return;
+		}
+		self.selected = Some(id);
+		cx.emit(ProgramGraphEvent::SelectionChanged);
+		cx.notify();
+	}
+
+	fn sync_focus_handles(&mut self, cx: &mut Context<Self>) {
+		let mut keys = BTreeSet::new();
+		for (lens, scene) in [
+			(GraphLens::Domain, self.domain.scene.as_ref()),
+			(GraphLens::Program, self.program.scene.as_ref()),
+		] {
+			if let Some(scene) = scene {
+				for node in &scene.nodes {
+					keys.insert(FocusKey { lens, id: node.id.as_str().to_owned() });
+				}
+			}
+		}
+		if keys.len() == self.focus_handles.len()
+			&& keys.iter().all(|key| self.focus_handles.contains_key(key))
+		{
+			return;
+		}
+		self.focus_handles = keys
+			.into_iter()
+			.enumerate()
+			.map(|(index, key)| {
+				let handle = cx.focus_handle().tab_index(index as isize).tab_stop(true);
+				(key, handle)
+			})
+			.collect();
+		self.focus_subscriptions.clear();
+		self.focus_bindings_dirty = true;
+	}
+
+	fn bind_focus_updates(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+		if !self.focus_bindings_dirty {
+			return;
+		}
+		self.focus_subscriptions.clear();
+		for (key, handle) in &self.focus_handles {
+			let key = key.clone();
+			self.focus_subscriptions.push(cx.on_focus(handle, window, move |surface, _, cx| {
+				surface.focused = Some(key.clone());
+				if let Some(id) = surface.entity_id_for_key(&key) {
+					surface.set_selection(key.lens, id, cx);
+				}
+			}));
+		}
+		self.focus_bindings_dirty = false;
+	}
+
+	fn entity_id_for_key(&self, key: &FocusKey) -> Option<EntityId> {
+		self.scene(key.lens)
+			.and_then(|scene| scene.node_by_key(&key.id))
+			.map(|node| node.id.clone())
+	}
+
+	fn scene(&self, lens: GraphLens) -> Option<&Arc<GraphScene>> {
+		match lens {
+			GraphLens::Domain => self.domain.scene.as_ref(),
+			GraphLens::Program => self.program.scene.as_ref(),
+		}
+	}
+
+	fn viewport(&self, lens: GraphLens) -> GraphViewport {
+		match lens {
+			GraphLens::Domain => self.domain_viewport,
+			GraphLens::Program => self.program_viewport,
+		}
+	}
+
+	fn viewport_mut(&mut self, lens: GraphLens) -> &mut GraphViewport {
+		match lens {
+			GraphLens::Domain => &mut self.domain_viewport,
+			GraphLens::Program => &mut self.program_viewport,
+		}
+	}
+
+	fn update_bounds(&mut self, lens: GraphLens, bounds: Bounds<Pixels>) {
+		let viewport = self.viewport_mut(lens);
+		if viewport.bounds != Some(bounds) {
+			viewport.bounds = Some(bounds);
+		}
+	}
+
+	fn viewport_command(
+		&mut self,
+		lens: GraphLens,
+		command: ViewportCommand,
+		cx: &mut Context<Self>,
+	) {
+		let Some(scene) = self.scene(lens).cloned() else { return };
+		let viewport = self.viewport(lens);
+		let bounds = viewport
+			.bounds
+			.unwrap_or_else(|| Bounds::new(point(px(0.0), px(0.0)), size(px(640.0), px(280.0))));
+		let current = ViewTransform::for_viewport(viewport, bounds, scene.layout.world_size);
+		let mode = match command {
+			ViewportCommand::Fit => ViewportMode::Fit,
+			ViewportCommand::Reset => ViewportMode::Manual { zoom: 1.0, pan: point(0.0, 0.0) },
+			ViewportCommand::ZoomIn => ViewportMode::Manual {
+				zoom: (current.zoom * ZOOM_STEP).clamp(MIN_ZOOM, MAX_ZOOM),
+				pan: current.pan,
+			},
+			ViewportCommand::ZoomOut => ViewportMode::Manual {
+				zoom: (current.zoom / ZOOM_STEP).clamp(MIN_ZOOM, MAX_ZOOM),
+				pan: current.pan,
+			},
+		};
+		let viewport = self.viewport_mut(lens);
+		if viewport.mode != mode {
+			viewport.mode = mode;
+			viewport.drag_anchor = None;
+			cx.notify();
+		}
+	}
+
+	fn handle_scroll(
+		&mut self,
+		lens: GraphLens,
+		event: &ScrollWheelEvent,
+		bounds: Bounds<Pixels>,
+		cx: &mut Context<Self>,
+	) {
+		let Some(scene) = self.scene(lens).cloned() else { return };
+		self.active_lens = lens;
+		let viewport = self.viewport(lens);
+		let current = ViewTransform::for_viewport(viewport, bounds, scene.layout.world_size);
+		let pixel_delta = match event.delta {
+			ScrollDelta::Pixels(delta) => point(f32::from(delta.x), f32::from(delta.y)),
+			ScrollDelta::Lines(delta) => point(delta.x * 18.0, delta.y * 18.0),
+		};
+		let (zoom, pan) = if event.modifiers.control || event.modifiers.platform {
+			let factor = if pixel_delta.y > 0.0 {
+				1.0 + pixel_delta.y.abs() * 0.01
+			} else {
+				1.0 / (1.0 + pixel_delta.y.abs() * 0.01)
+			};
+			let zoom = (current.zoom * factor).clamp(MIN_ZOOM, MAX_ZOOM);
+			let center = point(
+				f32::from(event.position.x - bounds.origin.x) - current.view_size.width / 2.0,
+				f32::from(event.position.y - bounds.origin.y) - current.view_size.height / 2.0,
+			);
+			let ratio = zoom / current.zoom;
+			let pan = point(
+				current.pan.x + (center.x - current.pan.x) * (1.0 - ratio),
+				current.pan.y + (center.y - current.pan.y) * (1.0 - ratio),
+			);
+			(zoom, current.clamp_pan(pan))
+		} else {
+			(current.zoom, current.clamp_pan(current.pan + pixel_delta))
+		};
+		let mode = ViewportMode::Manual { zoom, pan };
+		if self.viewport(lens).mode != mode {
+			self.viewport_mut(lens).mode = mode;
+			cx.notify();
+		}
+	}
+
+	fn handle_mouse_down(
+		&mut self,
+		lens: GraphLens,
+		event: &MouseDownEvent,
+		cx: &mut Context<Self>,
+	) {
+		if matches!(event.button, MouseButton::Left | MouseButton::Middle) {
+			self.active_lens = lens;
+			let viewport = self.viewport_mut(lens);
+			if viewport.drag_anchor != Some(event.position) {
+				viewport.drag_anchor = Some(event.position);
+				cx.notify();
+			}
+		}
+	}
+
+	fn handle_mouse_move(
+		&mut self,
+		lens: GraphLens,
+		event: &MouseMoveEvent,
+		cx: &mut Context<Self>,
+	) {
+		let Some(anchor) = self.viewport(lens).drag_anchor else { return };
+		let delta = event.position - anchor;
+		if delta.x == px(0.0) && delta.y == px(0.0) {
+			return;
+		}
+		let Some(scene) = self.scene(lens).cloned() else { return };
+		let viewport = self.viewport(lens);
+		let bounds = viewport
+			.bounds
+			.unwrap_or_else(|| Bounds::new(point(px(0.0), px(0.0)), size(px(640.0), px(280.0))));
+		let current = ViewTransform::for_viewport(viewport, bounds, scene.layout.world_size);
+		let pan = current.clamp_pan(point(
+			current.pan.x + f32::from(delta.x),
+			current.pan.y + f32::from(delta.y),
+		));
+		let viewport = self.viewport_mut(lens);
+		viewport.mode = ViewportMode::Manual { zoom: current.zoom, pan };
+		viewport.drag_anchor = Some(event.position);
+		cx.notify();
+	}
+
+	fn handle_mouse_up(&mut self, lens: GraphLens, _: &MouseUpEvent, cx: &mut Context<Self>) {
+		let viewport = self.viewport_mut(lens);
+		if viewport.drag_anchor.take().is_some() {
+			cx.notify();
+		}
+	}
+
+	fn move_selection(
+		&mut self,
+		direction: MoveDirection,
+		window: &mut Window,
+		cx: &mut Context<Self>,
+	) {
+		let key = self.focused.clone().or_else(|| {
+			self.selected.as_ref().map(|selected| FocusKey {
+				lens: self.active_lens,
+				id: selected.as_str().to_owned(),
+			})
+		});
+		let Some(key) = key else { return };
+		let Some(scene) = self.scene(key.lens) else { return };
+		let Some(origin) = scene.layout.positions.get(&key.id).copied() else { return };
+		let candidate = scene
+			.layout
+			.positions
+			.iter()
+			.filter(|(id, _)| id.as_str() != key.id)
+			.filter_map(|(id, position)| {
+				let dx = position.x - origin.x;
+				let dy = position.y - origin.y;
+				let (primary, secondary) = match direction {
+					MoveDirection::Left if dx < 0.0 => (-dx, dy.abs()),
+					MoveDirection::Right if dx > 0.0 => (dx, dy.abs()),
+					MoveDirection::Up if dy < 0.0 => (-dy, dx.abs()),
+					MoveDirection::Down if dy > 0.0 => (dy, dx.abs()),
+					_ => return None,
+				};
+				Some((primary * 1_000.0 + secondary, id.clone()))
+			})
+			.min_by(|left, right| left.0.total_cmp(&right.0).then_with(|| left.1.cmp(&right.1)))
+			.map(|(_, id)| id);
+		let Some(id) = candidate else { return };
+		let target = FocusKey { lens: key.lens, id };
+		if let Some(handle) = self.focus_handles.get(&target).cloned()
+			&& let Some(entity_id) = self.entity_id_for_key(&target)
+		{
+			self.focused = Some(target);
+			self.set_selection(key.lens, entity_id, cx);
+			window.focus(&handle, cx);
+		}
+	}
+
+	fn activate_selected(&mut self, _: &GraphActivate, _: &mut Window, cx: &mut Context<Self>) {
+		if self.selected.is_none() {
+			return;
+		}
+		let conversation = self.selected_conversation_id();
+		if let Some(conversation) = conversation {
+			cx.emit(ProgramGraphEvent::OpenConversation(conversation));
+		}
+	}
+
+	fn render_lens(
+		&self,
+		lens: GraphLens,
+		title: String,
+		status: String,
+		fixed_height: Option<f32>,
+		cx: &mut Context<Self>,
+	) -> AnyElement {
+		let scene = self.scene(lens).cloned();
+		let selected = self.selected.clone();
+		let relations = scene.as_ref().map_or_else(
+			|| vec!["Projection unavailable.".to_owned()],
+			|scene| scene.relation_readout(selected.as_ref()),
+		);
+		let zoom = scene
+			.as_ref()
+			.and_then(|scene| {
+				self.viewport(lens).bounds.map(|bounds| {
+					ViewTransform::for_viewport(
+						self.viewport(lens),
+						bounds,
+						scene.layout.world_size,
+					)
+					.zoom
+				})
+			})
+			.unwrap_or(1.0);
+		let relation_accessibility =
+			format!("{} relations. {}", lens.label(), relations.join(". "));
+		let surface = cx.entity();
+		let mut panel = div()
+			.id(format!("bounded-graph-lens/{}", lens.element_id()))
+			.role(Role::Group)
+			.aria_label(format!("{} graph lens", lens.label()))
+			.min_h_0()
+			.flex()
+			.flex_col()
+			.border_1()
+			.border_color(rgba(0xffffff16))
+			.rounded(px(11.0))
+			.overflow_hidden()
+			.bg(rgba(ui_theme::SURFACE_MATERIAL))
+			.child(graph_lens_header(lens, title, status, zoom, surface.downgrade()))
+			.child(div().flex_1().min_h_0().relative().child(GraphContentElement { surface, lens }))
+			.child(graph_relation_path(lens, relation_accessibility, relations));
+		if let Some(height) = fixed_height {
+			panel = panel.h(px(height)).min_h(px(height));
+		} else {
+			panel = panel.flex_1();
+		}
+		panel.into_any_element()
+	}
+
+	fn render_unbound_domain(&self) -> AnyElement {
+		div()
+			.id("program-domain-unbound")
+			.role(Role::Group)
+			.aria_label("Legacy Program Domain Pack is unbound")
+			.h(px(74.0))
+			.min_h(px(74.0))
+			.px_4()
+			.flex()
+			.items_center()
+			.justify_between()
+			.border_1()
+			.border_color(rgba(0xf0a64a35))
+			.rounded(px(10.0))
+			.bg(rgba(0xf0a64a0a))
+			.child(
+				div()
+					.flex()
+					.flex_col()
+					.gap_1()
+					.child(
+						div()
+							.font_family("SF Mono")
+							.text_size(px(8.0))
+							.text_color(rgb(AMBER))
+							.child("LEGACY PROGRAM · DOMAIN PACK UNBOUND"),
+					)
+					.child(
+						div().text_size(px(9.0)).text_color(rgb(TEXT_MUTED)).child(
+							"Bind one built-in Pack once to enable its distinct domain lens.",
+						),
+					),
+			)
+			.into_any_element()
+	}
+
+	fn on_move_left(&mut self, _: &GraphMoveLeft, window: &mut Window, cx: &mut Context<Self>) {
+		self.move_selection(MoveDirection::Left, window, cx);
+	}
+
+	fn on_move_right(&mut self, _: &GraphMoveRight, window: &mut Window, cx: &mut Context<Self>) {
+		self.move_selection(MoveDirection::Right, window, cx);
+	}
+
+	fn on_move_up(&mut self, _: &GraphMoveUp, window: &mut Window, cx: &mut Context<Self>) {
+		self.move_selection(MoveDirection::Up, window, cx);
+	}
+
+	fn on_move_down(&mut self, _: &GraphMoveDown, window: &mut Window, cx: &mut Context<Self>) {
+		self.move_selection(MoveDirection::Down, window, cx);
+	}
+
+	fn on_fit(&mut self, _: &GraphFit, _: &mut Window, cx: &mut Context<Self>) {
+		self.viewport_command(self.active_lens, ViewportCommand::Fit, cx);
+	}
+
+	fn on_zoom_in(&mut self, _: &GraphZoomIn, _: &mut Window, cx: &mut Context<Self>) {
+		self.viewport_command(self.active_lens, ViewportCommand::ZoomIn, cx);
+	}
+
+	fn on_zoom_out(&mut self, _: &GraphZoomOut, _: &mut Window, cx: &mut Context<Self>) {
+		self.viewport_command(self.active_lens, ViewportCommand::ZoomOut, cx);
+	}
+
+	fn on_reset(&mut self, _: &GraphReset, _: &mut Window, cx: &mut Context<Self>) {
+		self.viewport_command(self.active_lens, ViewportCommand::Reset, cx);
+	}
+}
+
+impl Render for ProgramGraphSurface {
+	fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+		self.bind_focus_updates(window, cx);
+		let domain = if self.domain.scene.is_some() {
+			self.render_lens(
+				GraphLens::Domain,
+				self.domain_title.clone().unwrap_or_else(|| "Domain projection".to_owned()),
+				self.domain_status.clone().unwrap_or_else(|| "BOUNDED PROJECTION".to_owned()),
+				Some(190.0),
+				cx,
+			)
+		} else {
+			self.render_unbound_domain()
+		};
+		let program_status = self.program.scene.as_ref().map_or_else(
+			|| "PROJECTION UNAVAILABLE".to_owned(),
+			|scene| format!("{} NODES · {} RELATIONS", scene.nodes.len(), scene.edges.len()),
+		);
+		div()
+			.id("program-graph-surface")
+			.role(Role::Group)
+			.aria_label("Bounded Program Graph Surface")
+			.on_action(cx.listener(Self::on_move_left))
+			.on_action(cx.listener(Self::on_move_right))
+			.on_action(cx.listener(Self::on_move_up))
+			.on_action(cx.listener(Self::on_move_down))
+			.on_action(cx.listener(Self::activate_selected))
+			.on_action(cx.listener(Self::on_fit))
+			.on_action(cx.listener(Self::on_zoom_in))
+			.on_action(cx.listener(Self::on_zoom_out))
+			.on_action(cx.listener(Self::on_reset))
+			.flex_1()
+			.min_h_0()
+			.flex()
+			.flex_col()
+			.gap_2()
+			.child(domain)
+			.when_some(self.projection_error.clone(), |surface, error| {
+				surface.child(
+					div()
+						.id("program-graph-projection-error")
+						.role(Role::Alert)
+						.aria_label(error.clone())
+						.px_3()
+						.py_2()
+						.text_size(px(8.0))
+						.text_color(rgb(AMBER))
+						.child(error),
+				)
+			})
+			.child(self.render_lens(
+				GraphLens::Program,
+				"Accepted Program lineage".to_owned(),
+				program_status,
+				None,
+				cx,
+			))
+	}
+}
+
+fn graph_lens_header(
+	lens: GraphLens,
+	title: String,
+	status: String,
+	zoom: f32,
+	surface: gpui::WeakEntity<ProgramGraphSurface>,
+) -> AnyElement {
+	let controls = [
+		("FIT", "Fit graph to viewport", ViewportCommand::Fit),
+		("−", "Zoom out graph", ViewportCommand::ZoomOut),
+		("+", "Zoom in graph", ViewportCommand::ZoomIn),
+		("1:1", "Reset graph to 100 percent", ViewportCommand::Reset),
+	]
+	.into_iter()
+	.enumerate()
+	.map(|(index, (label, aria, command))| {
+		viewport_button(lens, index, label, aria, command, surface.clone())
+	});
+	div()
+		.h(px(38.0))
+		.min_h(px(38.0))
+		.px_3()
+		.flex()
+		.items_center()
+		.justify_between()
+		.border_b_1()
+		.border_color(rgba(0xffffff10))
+		.child(
+			div()
+				.min_w_0()
+				.flex()
+				.items_center()
+				.gap_2()
+				.child(
+					div()
+						.font_family("SF Mono")
+						.text_size(px(7.0))
+						.text_color(rgb(if lens == GraphLens::Domain { BLUE } else { GREEN }))
+						.child(lens.label().to_uppercase()),
+				)
+				.child(
+					div()
+						.max_w(px(300.0))
+						.overflow_hidden()
+						.whitespace_nowrap()
+						.text_ellipsis()
+						.text_size(px(9.0))
+						.font_weight(FontWeight::SEMIBOLD)
+						.child(title),
+				)
+				.child(
+					div()
+						.max_w(px(250.0))
+						.overflow_hidden()
+						.whitespace_nowrap()
+						.text_ellipsis()
+						.font_family("SF Mono")
+						.text_size(px(6.5))
+						.text_color(rgb(TEXT_FAINT))
+						.child(status),
+				),
+		)
+		.child(
+			div()
+				.flex()
+				.items_center()
+				.gap_1()
+				.child(
+					div()
+						.w(px(40.0))
+						.text_right()
+						.font_family("SF Mono")
+						.text_size(px(6.5))
+						.text_color(rgb(TEXT_FAINT))
+						.child(format!("{:.0}%", zoom * 100.0)),
+				)
+				.children(controls),
+		)
+		.into_any_element()
+}
+
+fn graph_relation_path(
+	lens: GraphLens,
+	accessibility: String,
+	relations: Vec<String>,
+) -> AnyElement {
+	let relation_chips = relations.into_iter().enumerate().map(|(index, relation)| {
+		div()
+			.id(format!("graph-relation-readout/{}/{index}", lens.element_id()))
+			.role(Role::Label)
+			.px_2()
+			.py_1()
+			.rounded(px(5.0))
+			.bg(rgba(0xffffff08))
+			.font_family("SF Mono")
+			.text_size(px(7.0))
+			.text_color(rgb(TEXT_FAINT))
+			.child(relation)
+	});
+	div()
+		.id(format!("graph-relation-path/{}", lens.element_id()))
+		.role(Role::Group)
+		.aria_label(accessibility)
+		.h(px(27.0))
+		.min_h(px(27.0))
+		.px_2()
+		.flex()
+		.items_center()
+		.gap_1()
+		.overflow_x_scroll()
+		.border_t_1()
+		.border_color(rgba(0xffffff0c))
+		.children(relation_chips)
+		.into_any_element()
+}
+
+struct GraphContentElement {
+	surface: Entity<ProgramGraphSurface>,
+	lens: GraphLens,
+}
+
+impl IntoElement for GraphContentElement {
+	type Element = Self;
+
+	fn into_element(self) -> Self::Element {
+		self
+	}
+}
+
+impl Element for GraphContentElement {
+	type PrepaintState = Option<AnyElement>;
+	type RequestLayoutState = ();
+
+	fn id(&self) -> Option<ElementId> {
+		None
+	}
+
+	fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+		None
+	}
+
+	fn request_layout(
+		&mut self,
+		_: Option<&GlobalElementId>,
+		_: Option<&InspectorElementId>,
+		window: &mut Window,
+		cx: &mut App,
+	) -> (LayoutId, Self::RequestLayoutState) {
+		(
+			window.request_layout(
+				Style {
+					size: size(relative(1.0).into(), relative(1.0).into()),
+					..Default::default()
+				},
+				[],
+				cx,
+			),
+			(),
+		)
+	}
+
+	fn prepaint(
+		&mut self,
+		_: Option<&GlobalElementId>,
+		_: Option<&InspectorElementId>,
+		bounds: Bounds<Pixels>,
+		_: &mut Self::RequestLayoutState,
+		window: &mut Window,
+		cx: &mut App,
+	) -> Self::PrepaintState {
+		let (scene, selected, viewport, handles) = {
+			let surface = self.surface.read(cx);
+			(
+				surface.scene(self.lens).cloned(),
+				surface.selected.clone(),
+				surface.viewport(self.lens),
+				surface.focus_handles.clone(),
+			)
+		};
+		self.surface.update(cx, |surface, _| surface.update_bounds(self.lens, bounds));
+
+		let weak = self.surface.downgrade();
+		let dragging = viewport.drag_anchor.is_some();
+		let mut content = div()
+			.id(format!("graph-content/{}", self.lens.element_id()))
+			.role(Role::Group)
+			.aria_label(format!(
+				"{} graph viewport. Drag or scroll to pan. Command-scroll zooms. Arrow keys move between nodes.",
+				self.lens.label()
+			))
+			.size_full()
+			.relative()
+			.overflow_hidden()
+			.cursor(if dragging { CursorStyle::ClosedHand } else { CursorStyle::OpenHand })
+			.on_scroll_wheel({
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_scroll(lens, event, bounds, cx))
+						.ok();
+				}
+			})
+			.on_mouse_down(MouseButton::Left, {
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_mouse_down(lens, event, cx))
+						.ok();
+				}
+			})
+			.on_mouse_down(MouseButton::Middle, {
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_mouse_down(lens, event, cx))
+						.ok();
+				}
+			})
+			.on_mouse_move({
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_mouse_move(lens, event, cx))
+						.ok();
+				}
+			})
+			.on_mouse_up(MouseButton::Left, {
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_mouse_up(lens, event, cx))
+						.ok();
+				}
+			})
+			.on_mouse_up(MouseButton::Middle, {
+				let weak = weak.clone();
+				let lens = self.lens;
+				move |event, _, cx| {
+					weak.update(cx, |surface, cx| surface.handle_mouse_up(lens, event, cx))
+						.ok();
+				}
+			});
+
+		if let Some(scene) = scene {
+			let transform = ViewTransform::for_viewport(viewport, bounds, scene.layout.world_size);
+			content = content.child(graph_canvas(Arc::clone(&scene), transform, selected.clone()));
+			for (index, edge) in scene.edges.iter().enumerate() {
+				if let Some(label) =
+					edge_label_element(index, edge, &scene, transform, selected.as_ref())
+				{
+					content = content.child(label);
+				}
+			}
+			for node in &scene.nodes {
+				let key = FocusKey { lens: self.lens, id: node.id.as_str().to_owned() };
+				if let Some(handle) = handles.get(&key) {
+					content = content.child(graph_node_element(
+						node,
+						&scene,
+						transform,
+						selected.as_ref() == Some(&node.id),
+						handle.clone(),
+						self.lens,
+						weak.clone(),
+					));
+				}
+			}
+		} else {
+			content = content.child(
+				div()
+					.absolute()
+					.inset_0()
+					.flex()
+					.items_center()
+					.justify_center()
+					.text_size(px(9.0))
+					.text_color(rgb(TEXT_FAINT))
+					.child("Projection unavailable"),
+			);
+		}
+
+		let mut content = content.into_any_element();
+		content.prepaint_as_root(bounds.origin, bounds.size.into(), window, cx);
+		Some(content)
+	}
+
+	fn paint(
+		&mut self,
+		_: Option<&GlobalElementId>,
+		_: Option<&InspectorElementId>,
+		_: Bounds<Pixels>,
+		_: &mut Self::RequestLayoutState,
+		prepaint: &mut Self::PrepaintState,
+		window: &mut Window,
+		cx: &mut App,
+	) {
+		if let Some(mut content) = prepaint.take() {
+			content.paint(window, cx);
+		}
+	}
+}
+
+fn viewport_button(
+	lens: GraphLens,
+	index: usize,
+	label: &'static str,
+	aria: &'static str,
+	command: ViewportCommand,
+	surface: gpui::WeakEntity<ProgramGraphSurface>,
+) -> AnyElement {
+	div()
+		.id(format!("graph-viewport-control/{}/{index}", lens.element_id()))
+		.role(Role::Button)
+		.aria_label(format!("{aria} for {}", lens.label()))
+		.tab_index(index as isize)
+		.w(px(if index == 0 { 35.0 } else { 25.0 }))
+		.h(px(23.0))
+		.flex()
+		.items_center()
+		.justify_center()
+		.rounded(px(5.0))
+		.border_1()
+		.border_color(rgba(0xffffff14))
+		.font_family("SF Mono")
+		.text_size(px(7.0))
+		.text_color(rgb(TEXT_MUTED))
+		.cursor_pointer()
+		.focus_visible(|style| style.border_color(rgb(BLUE)).text_color(rgb(TEXT)))
+		.hover(|style| style.bg(rgba(0xffffff0c)).text_color(rgb(TEXT)))
+		.on_click({
+			let surface = surface.clone();
+			move |_, _, cx| {
+				surface.update(cx, |surface, cx| surface.viewport_command(lens, command, cx)).ok();
+			}
+		})
+		.on_key_down(move |event, _, cx| {
+			if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+				cx.stop_propagation();
+				surface.update(cx, |surface, cx| surface.viewport_command(lens, command, cx)).ok();
+			}
+		})
+		.child(label)
+		.into_any_element()
+}
+
+fn graph_node_element(
+	node: &GraphNode,
+	scene: &GraphScene,
+	transform: ViewTransform,
+	selected: bool,
+	focus: FocusHandle,
+	lens: GraphLens,
+	surface: gpui::WeakEntity<ProgramGraphSurface>,
+) -> AnyElement {
+	let Some(world) = scene.layout.positions.get(node.id.as_str()).copied() else {
+		return div().into_any_element();
+	};
+	let screen = transform.world_to_screen(world);
+	let width = NODE_WIDTH * transform.zoom;
+	let height = NODE_HEIGHT * transform.zoom;
+	let compact = transform.zoom < 0.58;
+	let node_id = node.id.clone();
+	let relations = scene.relation_readout(Some(&node.id)).join(". ");
+	let accessibility = format!(
+		"{} node, {}, {}, state {}. Identity {}. {}",
+		node.kind,
+		node.title,
+		node.summary,
+		node.state,
+		node.id.as_str(),
+		relations
+	);
+	div()
+		.id(format!("{}-graph-node/{}", lens.element_id(), node.id.as_str()))
+		.role(Role::Button)
+		.aria_label(accessibility)
+		.aria_selected(selected)
+		.aria_value(node.state.clone())
+		.track_focus(&focus)
+		.key_context("ProgramGraphNode")
+		.absolute()
+		.left(px(screen.x - width / 2.0))
+		.top(px(screen.y - height / 2.0))
+		.w(px(width.max(22.0)))
+		.h(px(height.max(18.0)))
+		.p(px((9.0 * transform.zoom).max(3.0)))
+		.flex()
+		.flex_col()
+		.gap(px((5.0 * transform.zoom).max(1.5)))
+		.overflow_hidden()
+		.border_1()
+		.border_color(if selected { rgb(node.color) } else { rgba(0xffffff20) })
+		.rounded(px((9.0 * transform.zoom).max(3.0)))
+		.bg(if selected { rgba(ui_theme::SURFACE_RAISED_MATERIAL) } else { rgba(0x15131cda) })
+		.cursor_pointer()
+		.focus_visible(|style| style.border_color(rgb(BLUE)))
+		.hover(|style| style.border_color(rgba(0xffffff40)))
+		.on_mouse_down(MouseButton::Left, |_, window, cx| {
+			window.prevent_default();
+			cx.stop_propagation();
+		})
+		.on_click(move |_, _, cx| {
+			surface.update(cx, |surface, cx| surface.set_selection(lens, node_id.clone(), cx)).ok();
+		})
+		.child(
+			div()
+				.flex()
+				.items_center()
+				.justify_between()
+				.font_family("SF Mono")
+				.text_size(px((7.0 * transform.zoom).max(5.0)))
+				.text_color(rgb(node.color))
+				.child(node.kind.clone())
+				.when(!compact, |row| {
+					row.child(div().text_color(rgb(TEXT_FAINT)).child(node.state.clone()))
+				}),
+		)
+		.child(
+			div()
+				.max_h(px((30.0 * transform.zoom).max(10.0)))
+				.overflow_hidden()
+				.text_size(px((10.0 * transform.zoom).max(6.0)))
+				.font_weight(FontWeight::SEMIBOLD)
+				.text_color(rgb(TEXT))
+				.child(node.title.clone()),
+		)
+		.when(!compact, |card| {
+			card.child(
+				div()
+					.max_h(px((43.0 * transform.zoom).max(16.0)))
+					.overflow_hidden()
+					.text_size(px((7.8 * transform.zoom).max(5.5)))
+					.text_color(rgb(TEXT_MUTED))
+					.child(node.summary.clone()),
+			)
+		})
+		.into_any_element()
+}
+
+fn edge_label_element(
+	index: usize,
+	edge: &GraphEdge,
+	scene: &GraphScene,
+	transform: ViewTransform,
+	selected: Option<&EntityId>,
+) -> Option<AnyElement> {
+	if transform.zoom < 0.34 {
+		return None;
+	}
+	let from = scene.layout.positions.get(&edge.identity.from).copied()?;
+	let to = scene.layout.positions.get(&edge.identity.to).copied()?;
+	let from = transform.world_to_screen(from);
+	let to = transform.world_to_screen(to);
+	let feedback = scene.layout.feedback_edges.contains(&edge.identity);
+	let touches = selected.is_some_and(|selected| {
+		edge.identity.from == selected.as_str() || edge.identity.to == selected.as_str()
+	});
+	let x = (from.x + to.x) / 2.0;
+	let y = if feedback {
+		from.y.min(to.y) - (34.0 + (index % 3) as f32 * 7.0) * transform.zoom
+	} else {
+		(from.y + to.y) / 2.0 - 7.0
+	};
+	let label = if feedback { format!("↶ {}", edge.label) } else { edge.label.clone() };
+	Some(
+		div()
+			.id(("graph-edge-label", index))
+			.role(Role::Label)
+			.aria_label(format!(
+				"Relation from {} to {}: {}{}",
+				edge.identity.from,
+				edge.identity.to,
+				edge.label,
+				if feedback { ", feedback path" } else { "" }
+			))
+			.absolute()
+			.left(px(x - 32.0))
+			.top(px(y))
+			.max_w(px(84.0))
+			.px_1()
+			.py(px(1.0))
+			.overflow_hidden()
+			.whitespace_nowrap()
+			.text_ellipsis()
+			.rounded(px(3.0))
+			.bg(rgba(0x0b0a0fdc))
+			.font_family("SF Mono")
+			.text_size(px((6.6 * transform.zoom).max(5.4)))
+			.text_color(rgb(if touches { TEXT_MUTED } else { TEXT_FAINT }))
+			.child(label)
+			.into_any_element(),
+	)
+}
+
+fn graph_canvas(
+	scene: Arc<GraphScene>,
+	transform: ViewTransform,
+	selected: Option<EntityId>,
+) -> AnyElement {
+	canvas(
+		|_, _, _| (),
+		move |bounds, _, window, _| {
+			paint_grid(window, bounds, transform);
+			for edge in &scene.edges {
+				paint_edge(window, bounds, &scene, edge, transform, selected.as_ref());
+			}
+			if let Some(selected) = selected.as_ref()
+				&& let Some(world) = scene.layout.positions.get(selected.as_str()).copied()
+			{
+				paint_selection(window, bounds, transform.world_to_screen(world), transform.zoom);
+			}
+		},
+	)
+	.absolute()
+	.size_full()
+	.into_any_element()
+}
+
+fn paint_grid(window: &mut Window, bounds: Bounds<Pixels>, transform: ViewTransform) {
+	let spacing = (48.0 * transform.zoom).max(24.0);
+	let world_origin = transform.world_to_screen(WorldPoint { x: 0.0, y: 0.0 });
+	let mut builder = PathBuilder::stroke(px(0.55));
+	let mut x = world_origin.x.rem_euclid(spacing);
+	while x <= transform.view_size.width {
+		builder.move_to(point(bounds.origin.x + px(x), bounds.origin.y));
+		builder.line_to(point(bounds.origin.x + px(x), bounds.bottom()));
+		x += spacing;
+	}
+	let mut y = world_origin.y.rem_euclid(spacing);
+	while y <= transform.view_size.height {
+		builder.move_to(point(bounds.origin.x, bounds.origin.y + px(y)));
+		builder.line_to(point(bounds.right(), bounds.origin.y + px(y)));
+		y += spacing;
+	}
+	if let Ok(path) = builder.build() {
+		window.paint_path(path, rgba(0xffffff07));
+	}
+}
+
+fn paint_edge(
+	window: &mut Window,
+	bounds: Bounds<Pixels>,
+	scene: &GraphScene,
+	edge: &GraphEdge,
+	transform: ViewTransform,
+	selected: Option<&EntityId>,
+) {
+	let Some(from) = scene.layout.positions.get(&edge.identity.from).copied() else { return };
+	let Some(to) = scene.layout.positions.get(&edge.identity.to).copied() else { return };
+	let from = transform.world_to_screen(from);
+	let to = transform.world_to_screen(to);
+	let feedback = scene.layout.feedback_edges.contains(&edge.identity);
+	let touches = selected.is_some_and(|selected| {
+		edge.identity.from == selected.as_str() || edge.identity.to == selected.as_str()
+	});
+	let color = if touches {
+		BLUE
+	} else if feedback {
+		GREEN
+	} else {
+		LINE
+	};
+	let mut builder = PathBuilder::stroke(px(if touches { 1.7 } else { 1.0 }));
+	if feedback {
+		builder = builder.dash_array(&[px(6.0), px(4.0)]);
+	}
+	let half_width = NODE_WIDTH * transform.zoom / 2.0;
+	let half_height = NODE_HEIGHT * transform.zoom / 2.0;
+	let (start, end, control_a, control_b) = if feedback {
+		let start = point(from.x, from.y - half_height);
+		let end = point(to.x, to.y - half_height);
+		let rail = start.y.min(end.y) - 42.0 * transform.zoom;
+		(start, end, point(start.x, rail), point(end.x, rail))
+	} else {
+		let start = point(from.x + half_width, from.y);
+		let end = point(to.x - half_width, to.y);
+		let control = ((end.x - start.x).abs() * 0.48).max(22.0 * transform.zoom);
+		(start, end, point(start.x + control, start.y), point(end.x - control, end.y))
+	};
+	builder.move_to(offset(bounds, start));
+	builder.cubic_bezier_to(
+		offset(bounds, end),
+		offset(bounds, control_a),
+		offset(bounds, control_b),
+	);
+	if let Ok(path) = builder.build() {
+		window.paint_path(path, rgb(color));
+	}
+	paint_arrow_head(window, bounds, control_b, end, color, touches);
+}
+
+fn paint_arrow_head(
+	window: &mut Window,
+	bounds: Bounds<Pixels>,
+	from: Point<f32>,
+	to: Point<f32>,
+	color: u32,
+	selected: bool,
+) {
+	let dx = to.x - from.x;
+	let dy = to.y - from.y;
+	let length = (dx * dx + dy * dy).sqrt().max(0.001);
+	let ux = dx / length;
+	let uy = dy / length;
+	let size = if selected { 7.0 } else { 5.5 };
+	let left = point(to.x - ux * size - uy * size * 0.6, to.y - uy * size + ux * size * 0.6);
+	let right = point(to.x - ux * size + uy * size * 0.6, to.y - uy * size - ux * size * 0.6);
+	let mut builder = PathBuilder::stroke(px(if selected { 1.6 } else { 1.0 }));
+	builder.move_to(offset(bounds, left));
+	builder.line_to(offset(bounds, to));
+	builder.line_to(offset(bounds, right));
+	if let Ok(path) = builder.build() {
+		window.paint_path(path, rgb(color));
+	}
+}
+
+fn paint_selection(window: &mut Window, bounds: Bounds<Pixels>, center: Point<f32>, zoom: f32) {
+	let half_width = NODE_WIDTH * zoom / 2.0 + 5.0;
+	let half_height = NODE_HEIGHT * zoom / 2.0 + 5.0;
+	let mut builder = PathBuilder::stroke(px(1.6));
+	let top_left = point(center.x - half_width, center.y - half_height);
+	let top_right = point(center.x + half_width, center.y - half_height);
+	let bottom_right = point(center.x + half_width, center.y + half_height);
+	let bottom_left = point(center.x - half_width, center.y + half_height);
+	builder.move_to(offset(bounds, top_left));
+	builder.line_to(offset(bounds, top_right));
+	builder.line_to(offset(bounds, bottom_right));
+	builder.line_to(offset(bounds, bottom_left));
+	builder.close();
+	if let Ok(path) = builder.build() {
+		window.paint_path(path, rgba(0x8baaf770));
+	}
+}
+
+fn offset(bounds: Bounds<Pixels>, value: Point<f32>) -> Point<Pixels> {
+	point(bounds.origin.x + px(value.x), bounds.origin.y + px(value.y))
+}
+
+fn program_input(cycle: &ProgramCycleDto) -> GraphInput {
+	let mut nodes = Vec::with_capacity(cycle.nodes.len().saturating_add(1));
+	nodes.push(GraphNode {
+		id: cycle.program.program_id.clone(),
+		kind: "PROGRAM".to_owned(),
+		title: cycle.program.name.as_str().to_owned(),
+		summary: cycle.program.purpose.as_str().to_owned(),
+		state: cycle.program.state.as_str().to_owned(),
+		color: TEXT,
+		conversation_id: None,
+	});
+	nodes.extend(cycle.nodes.iter().map(program_node));
+	let edges = cycle
+		.edges
+		.iter()
+		.map(|edge| {
+			let label = relation_label(edge.kind).to_owned();
+			GraphEdge {
+				identity: EdgeIdentity {
+					from: edge.from.as_str().to_owned(),
+					relation: label.clone(),
+					to: edge.to.as_str().to_owned(),
+				},
+				label,
+				explicit_feedback: edge.kind == ProgramRelationKind::Validates,
+			}
+		})
+		.collect();
+	GraphInput { nodes, edges }
+}
+
+fn domain_input(
+	cycle: &ProgramCycleDto,
+	pack: &decodex_protocol::DomainPackProjectionDto,
+) -> GraphInput {
+	let mut nodes = Vec::with_capacity(pack.entities.len().saturating_add(1));
+	nodes.push(GraphNode {
+		id: cycle.program.program_id.clone(),
+		kind: "PROGRAM".to_owned(),
+		title: cycle.program.name.as_str().to_owned(),
+		summary: "Root Program for this bounded Domain Pack projection.".to_owned(),
+		state: cycle.program.state.as_str().to_owned(),
+		color: TEXT,
+		conversation_id: None,
+	});
+	nodes.extend(pack.entities.iter().map(domain_node));
+	let edges = pack
+		.relations
+		.iter()
+		.map(|relation| {
+			let label = domain_relation_label(relation.kind.as_str());
+			GraphEdge {
+				identity: EdgeIdentity {
+					from: relation.from.as_str().to_owned(),
+					relation: label.clone(),
+					to: relation.to.as_str().to_owned(),
+				},
+				label,
+				explicit_feedback: false,
+			}
+		})
+		.collect();
+	GraphInput { nodes, edges }
+}
+
+fn program_node(node: &ProgramNodeDto) -> GraphNode {
+	GraphNode {
+		id: node.id.clone(),
+		kind: node_kind_label(node.kind).to_owned(),
+		title: node.title.as_str().to_owned(),
+		summary: node.summary.as_str().to_owned(),
+		state: node.state.as_str().to_owned(),
+		color: program_node_color(node.kind),
+		conversation_id: node.conversation_id.clone(),
+	}
+}
+
+fn domain_node(entity: &DomainEntityDto) -> GraphNode {
+	GraphNode {
+		id: entity.id.clone(),
+		kind: domain_kind_label(entity.kind.as_str()),
+		title: entity.title.as_str().to_owned(),
+		summary: entity.summary.as_str().to_owned(),
+		state: entity.state.as_str().to_owned(),
+		color: if entity.kind.as_str().starts_with("finance.") { GREEN } else { BLUE },
+		conversation_id: None,
+	}
+}
+
+fn compute_layout(input: &GraphInput) -> Result<GraphLayout, GraphLayoutError> {
+	if input.nodes.is_empty() {
+		return Err(GraphLayoutError::Empty);
+	}
+	let node_ids =
+		input.nodes.iter().map(|node| node.id.as_str().to_owned()).collect::<BTreeSet<_>>();
+	if node_ids.len() != input.nodes.len() {
+		return Err(GraphLayoutError::DuplicateNode);
+	}
+	let edge_ids = input.edges.iter().map(|edge| edge.identity.clone()).collect::<BTreeSet<_>>();
+	if edge_ids.len() != input.edges.len() {
+		return Err(GraphLayoutError::DuplicateEdge);
+	}
+	if input.edges.iter().any(|edge| {
+		!node_ids.contains(&edge.identity.from) || !node_ids.contains(&edge.identity.to)
+	}) {
+		return Err(GraphLayoutError::DanglingEdge);
+	}
+
+	let mut feedback_edges = input
+		.edges
+		.iter()
+		.filter(|edge| edge.explicit_feedback)
+		.map(|edge| edge.identity.clone())
+		.collect::<BTreeSet<_>>();
+	let order = loop {
+		let order = topological_order(input, &feedback_edges);
+		if order.len() == node_ids.len() {
+			break order;
+		}
+		let ordered = order.iter().cloned().collect::<HashSet<_>>();
+		let candidate = input
+			.edges
+			.iter()
+			.filter(|edge| !feedback_edges.contains(&edge.identity))
+			.filter(|edge| {
+				!ordered.contains(&edge.identity.from) && !ordered.contains(&edge.identity.to)
+			})
+			.map(|edge| edge.identity.clone())
+			.min();
+		let Some(candidate) = candidate else { return Err(GraphLayoutError::CycleBreakFailed) };
+		feedback_edges.insert(candidate);
+	};
+
+	let mut ranks = node_ids.iter().map(|id| (id.clone(), 0usize)).collect::<BTreeMap<_, _>>();
+	let mut outgoing = HashMap::<String, Vec<&GraphEdge>>::new();
+	let mut incoming = HashMap::<String, Vec<&GraphEdge>>::new();
+	for edge in input.edges.iter().filter(|edge| !feedback_edges.contains(&edge.identity)) {
+		outgoing.entry(edge.identity.from.clone()).or_default().push(edge);
+		incoming.entry(edge.identity.to.clone()).or_default().push(edge);
+	}
+	for edges in outgoing.values_mut() {
+		edges.sort_by(|left, right| left.identity.cmp(&right.identity));
+	}
+	for edges in incoming.values_mut() {
+		edges.sort_by(|left, right| left.identity.cmp(&right.identity));
+	}
+	for id in &order {
+		let rank = incoming.get(id).map_or(0, |edges| {
+			edges
+				.iter()
+				.filter_map(|edge| {
+					ranks.get(&edge.identity.from).map(|rank| rank.saturating_add(1))
+				})
+				.max()
+				.unwrap_or(0)
+		});
+		ranks.insert(id.clone(), rank);
+	}
+	let maximum_rank = ranks.values().copied().max().unwrap_or(0);
+	let mut layers = vec![Vec::<String>::new(); maximum_rank.saturating_add(1)];
+	for (id, rank) in &ranks {
+		layers[*rank].push(id.clone());
+	}
+	for layer in &mut layers {
+		layer.sort();
+	}
+	for _ in 0..4 {
+		reorder_layers(&mut layers, &incoming, true);
+		reorder_layers(&mut layers, &outgoing, false);
+	}
+
+	let maximum_rows = layers.iter().map(Vec::len).max().unwrap_or(1);
+	let world_width = WORLD_PADDING * 2.0
+		+ layers.len() as f32 * NODE_WIDTH
+		+ layers.len().saturating_sub(1) as f32 * LAYER_GAP;
+	let world_height = WORLD_PADDING * 2.0
+		+ maximum_rows as f32 * NODE_HEIGHT
+		+ maximum_rows.saturating_sub(1) as f32 * ROW_GAP;
+	let mut positions = BTreeMap::new();
+	for (rank, layer) in layers.iter().enumerate() {
+		let layer_height =
+			layer.len() as f32 * NODE_HEIGHT + layer.len().saturating_sub(1) as f32 * ROW_GAP;
+		let top = (world_height - layer_height) / 2.0 + NODE_HEIGHT / 2.0;
+		for (row, id) in layer.iter().enumerate() {
+			positions.insert(
+				id.clone(),
+				WorldPoint {
+					x: WORLD_PADDING + NODE_WIDTH / 2.0 + rank as f32 * (NODE_WIDTH + LAYER_GAP),
+					y: top + row as f32 * (NODE_HEIGHT + ROW_GAP),
+				},
+			);
+		}
+	}
+	Ok(GraphLayout {
+		positions,
+		#[cfg(test)]
+		ranks,
+		feedback_edges,
+		world_size: size(world_width, world_height),
+	})
+}
+
+fn topological_order(input: &GraphInput, feedback: &BTreeSet<EdgeIdentity>) -> Vec<String> {
+	let mut indegree = input
+		.nodes
+		.iter()
+		.map(|node| (node.id.as_str().to_owned(), 0usize))
+		.collect::<BTreeMap<_, _>>();
+	let mut outgoing = BTreeMap::<String, Vec<&GraphEdge>>::new();
+	for edge in input.edges.iter().filter(|edge| !feedback.contains(&edge.identity)) {
+		if let Some(value) = indegree.get_mut(&edge.identity.to) {
+			*value = value.saturating_add(1);
+		}
+		outgoing.entry(edge.identity.from.clone()).or_default().push(edge);
+	}
+	for edges in outgoing.values_mut() {
+		edges.sort_by(|left, right| left.identity.cmp(&right.identity));
+	}
+	let mut ready = indegree
+		.iter()
+		.filter(|(_, degree)| **degree == 0)
+		.map(|(id, _)| id.clone())
+		.collect::<BTreeSet<_>>();
+	let mut order = Vec::with_capacity(indegree.len());
+	while let Some(id) = ready.pop_first() {
+		order.push(id.clone());
+		for edge in outgoing.get(&id).into_iter().flatten() {
+			if let Some(degree) = indegree.get_mut(&edge.identity.to) {
+				*degree = degree.saturating_sub(1);
+				if *degree == 0 {
+					ready.insert(edge.identity.to.clone());
+				}
+			}
+		}
+	}
+	order
+}
+
+fn reorder_layers(
+	layers: &mut [Vec<String>],
+	neighbors: &HashMap<String, Vec<&GraphEdge>>,
+	forward: bool,
+) {
+	let layer_positions = layers
+		.iter()
+		.flat_map(|layer| layer.iter().enumerate().map(|(index, id)| (id.clone(), index as f32)))
+		.collect::<HashMap<_, _>>();
+	let indices: Box<dyn Iterator<Item = usize>> = if forward {
+		Box::new(1..layers.len())
+	} else {
+		Box::new((0..layers.len().saturating_sub(1)).rev())
+	};
+	for index in indices {
+		layers[index].sort_by(|left, right| {
+			let barycenter = |id: &str| {
+				let values = neighbors.get(id).into_iter().flatten().filter_map(|edge| {
+					let neighbor = if forward { &edge.identity.from } else { &edge.identity.to };
+					layer_positions.get(neighbor).copied()
+				});
+				let values = values.collect::<Vec<_>>();
+				if values.is_empty() {
+					f32::INFINITY
+				} else {
+					values.iter().sum::<f32>() / values.len() as f32
+				}
+			};
+			barycenter(left).total_cmp(&barycenter(right)).then_with(|| left.cmp(right))
+		});
+	}
+}
+
+const fn program_node_color(kind: ProgramNodeKind) -> u32 {
+	match kind {
+		ProgramNodeKind::Signal | ProgramNodeKind::Claim => BLUE,
+		ProgramNodeKind::Proposal | ProgramNodeKind::Objective => AMBER,
+		ProgramNodeKind::WorkItem | ProgramNodeKind::Run => 0x8d7cf6,
+		ProgramNodeKind::Evidence | ProgramNodeKind::Review => GREEN,
+	}
+}
+
+const fn node_kind_label(kind: ProgramNodeKind) -> &'static str {
+	match kind {
+		ProgramNodeKind::Signal => "SIGNAL",
+		ProgramNodeKind::Claim => "CLAIM",
+		ProgramNodeKind::Proposal => "PROPOSAL",
+		ProgramNodeKind::Objective => "OBJECTIVE",
+		ProgramNodeKind::WorkItem => "WORK ITEM",
+		ProgramNodeKind::Run => "CODEX RUN",
+		ProgramNodeKind::Evidence => "EVIDENCE",
+		ProgramNodeKind::Review => "REVIEW",
+	}
+}
+
+const fn relation_label(kind: ProgramRelationKind) -> &'static str {
+	match kind {
+		ProgramRelationKind::Continues => "continues",
+		ProgramRelationKind::Observes => "observes",
+		ProgramRelationKind::Supports => "supports",
+		ProgramRelationKind::Justifies => "justifies",
+		ProgramRelationKind::Proposes => "proposes",
+		ProgramRelationKind::DecomposesTo => "decomposes",
+		ProgramRelationKind::Executes => "executes",
+		ProgramRelationKind::Produces => "produces",
+		ProgramRelationKind::Validates => "validates",
+	}
+}
+
+fn domain_kind_label(kind: &str) -> String {
+	kind.rsplit('.').next().unwrap_or(kind).replace('_', " ").to_uppercase()
+}
+
+fn domain_relation_label(kind: &str) -> String {
+	kind.rsplit('.').next().unwrap_or(kind).replace('_', " ")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[cfg(feature = "visual-capture")] use crate::programs::Programs;
+
+	fn id(index: usize) -> EntityId {
+		EntityId::new(format!("00000000-0000-4000-8000-{index:012}"))
+			.expect("bounded graph identity")
+	}
+
+	fn node(index: usize) -> GraphNode {
+		GraphNode {
+			id: id(index),
+			kind: "TEST".to_owned(),
+			title: format!("Node {index}"),
+			summary: "Deterministic graph node".to_owned(),
+			state: "ready".to_owned(),
+			color: BLUE,
+			conversation_id: None,
+		}
+	}
+
+	fn edge(from: usize, to: usize, relation: &str, feedback: bool) -> GraphEdge {
+		GraphEdge {
+			identity: EdgeIdentity {
+				from: id(from).as_str().to_owned(),
+				relation: relation.to_owned(),
+				to: id(to).as_str().to_owned(),
+			},
+			label: relation.to_owned(),
+			explicit_feedback: feedback,
+		}
+	}
+
+	#[test]
+	fn layered_layout_places_branches_together_and_merges_after_them() {
+		let input = GraphInput {
+			nodes: (1..=4).map(node).collect(),
+			edges: vec![
+				edge(1, 2, "branches", false),
+				edge(1, 3, "branches", false),
+				edge(2, 4, "merges", false),
+				edge(3, 4, "merges", false),
+			],
+		};
+		let layout = compute_layout(&input).expect("branch and merge layout");
+		assert_eq!(layout.ranks[id(1).as_str()], 0);
+		assert_eq!(layout.ranks[id(2).as_str()], 1);
+		assert_eq!(layout.ranks[id(3).as_str()], 1);
+		assert_eq!(layout.ranks[id(4).as_str()], 2);
+		assert_ne!(layout.positions[id(2).as_str()].y, layout.positions[id(3).as_str()].y);
+	}
+
+	#[test]
+	fn feedback_edges_preserve_forward_layers_across_three_cycles() {
+		let input = GraphInput {
+			nodes: (1..=7).map(node).collect(),
+			edges: vec![
+				edge(1, 2, "observes", false),
+				edge(2, 3, "supports", false),
+				edge(3, 1, "validates", true),
+				edge(3, 4, "continues", false),
+				edge(4, 5, "supports", false),
+				edge(5, 1, "validates", true),
+				edge(5, 6, "continues", false),
+				edge(6, 7, "supports", false),
+				edge(7, 1, "validates", true),
+			],
+		};
+		let layout = compute_layout(&input).expect("three-cycle layout");
+		assert!(layout.ranks[id(2).as_str()] < layout.ranks[id(4).as_str()]);
+		assert!(layout.ranks[id(4).as_str()] < layout.ranks[id(6).as_str()]);
+		assert_eq!(layout.feedback_edges.len(), 3);
+	}
+
+	#[test]
+	fn stable_layout_does_not_depend_on_projection_vector_order() {
+		let mut first = GraphInput {
+			nodes: (1..=5).map(node).collect(),
+			edges: vec![
+				edge(1, 2, "a", false),
+				edge(1, 3, "b", false),
+				edge(2, 4, "c", false),
+				edge(3, 4, "d", false),
+				edge(4, 5, "e", false),
+			],
+		};
+		let mut second = first.clone();
+		second.nodes.reverse();
+		second.edges.reverse();
+		let first_layout = compute_layout(&first).expect("first stable layout");
+		let second_layout = compute_layout(&second).expect("second stable layout");
+		assert_eq!(first_layout.positions, second_layout.positions);
+		assert_eq!(first_layout.ranks, second_layout.ranks);
+		first.nodes.rotate_left(2);
+		assert_eq!(first.structure_key(), second.structure_key());
+	}
+
+	#[test]
+	fn undeclared_cycles_are_broken_deterministically() {
+		let input = GraphInput {
+			nodes: (1..=3).map(node).collect(),
+			edges: vec![
+				edge(1, 2, "one", false),
+				edge(2, 3, "two", false),
+				edge(3, 1, "three", false),
+			],
+		};
+		let layout = compute_layout(&input).expect("cycle-break layout");
+		assert_eq!(layout.feedback_edges.len(), 1);
+		assert_eq!(layout.positions.len(), 3);
+	}
+
+	#[test]
+	fn viewport_fit_reset_zoom_and_pan_stay_finite() {
+		let bounds = Bounds::new(point(px(10.0), px(20.0)), size(px(600.0), px(300.0)));
+		let world = size(1_800.0, 500.0);
+		let fit = ViewTransform::for_viewport(GraphViewport::default(), bounds, world);
+		assert!(fit.zoom >= MIN_ZOOM && fit.zoom < 1.0);
+		let manual = GraphViewport {
+			mode: ViewportMode::Manual { zoom: 1.0, pan: point(99_999.0, -99_999.0) },
+			bounds: Some(bounds),
+			drag_anchor: None,
+		};
+		let transform = ViewTransform::for_viewport(manual, bounds, world);
+		assert!(transform.pan.x.is_finite() && transform.pan.y.is_finite());
+		assert!(transform.pan.x < 99_999.0 && transform.pan.y > -99_999.0);
+	}
+
+	#[test]
+	fn invalid_and_unavailable_projections_fail_closed() {
+		assert_eq!(
+			compute_layout(&GraphInput { nodes: Vec::new(), edges: Vec::new() }).unwrap_err(),
+			GraphLayoutError::Empty
+		);
+		let duplicate = GraphInput { nodes: vec![node(1), node(1)], edges: Vec::new() };
+		assert_eq!(compute_layout(&duplicate).unwrap_err(), GraphLayoutError::DuplicateNode);
+		let dangling = GraphInput { nodes: vec![node(1)], edges: vec![edge(1, 2, "bad", false)] };
+		assert_eq!(compute_layout(&dangling).unwrap_err(), GraphLayoutError::DanglingEdge);
+	}
+
+	#[test]
+	fn layout_cache_reuses_positions_when_only_presentation_data_changes() {
+		let mut cache = GraphCache::default();
+		let input = GraphInput {
+			nodes: vec![node(1), node(2)],
+			edges: vec![edge(1, 2, "supports", false)],
+		};
+		assert_eq!(cache.update(input.clone()), Ok(true));
+		let first_positions = cache.layout.as_ref().expect("layout").positions.clone();
+		let mut changed = input;
+		changed.nodes[1].state = "done".to_owned();
+		assert_eq!(cache.update(changed), Ok(false));
+		assert_eq!(cache.computations, 1);
+		assert_eq!(cache.layout.as_ref().expect("layout").positions, first_positions);
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[test]
+	fn dto_mapping_preserves_exact_program_and_domain_relation_identities() {
+		let cycle = Programs::visual_development_three_cycle()
+			.snapshot()
+			.cycle
+			.expect("development visual cycle");
+		let program = program_input(&cycle);
+		assert_eq!(program.nodes.len(), cycle.nodes.len() + 1);
+		assert_eq!(program.edges.len(), cycle.edges.len());
+		for edge in &cycle.edges {
+			let label = relation_label(edge.kind);
+			assert!(program.edges.iter().any(|mapped| {
+				mapped.identity.from == edge.from.as_str()
+					&& mapped.identity.to == edge.to.as_str()
+					&& mapped.identity.relation == label
+			}));
+		}
+		let layout = compute_layout(&program).expect("mapped Program layout");
+		assert_eq!(
+			layout.feedback_edges.len(),
+			cycle.edges.iter().filter(|edge| edge.kind == ProgramRelationKind::Validates).count()
+		);
+
+		let pack = cycle.domain_pack.as_ref().expect("development domain projection");
+		let domain = domain_input(&cycle, pack);
+		assert_eq!(domain.nodes.len(), pack.entities.len() + 1);
+		assert_eq!(domain.edges.len(), pack.relations.len());
+		for relation in &pack.relations {
+			assert!(domain.edges.iter().any(|mapped| {
+				mapped.identity.from == relation.from.as_str()
+					&& mapped.identity.to == relation.to.as_str()
+					&& mapped.identity.relation == domain_relation_label(relation.kind.as_str())
+			}));
+		}
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[gpui::test]
+	fn one_selection_maps_to_exact_conversation_and_rejects_unknown_identity(
+		cx: &mut gpui::TestAppContext,
+	) {
+		let cycle = Programs::visual_development_three_cycle()
+			.snapshot()
+			.cycle
+			.expect("development visual cycle");
+		let run = cycle
+			.nodes
+			.iter()
+			.rev()
+			.find(|node| node.kind == ProgramNodeKind::Run)
+			.expect("latest Run")
+			.clone();
+		let expected_conversation = run.conversation_id.clone();
+		let (surface, visual) = cx.add_window_view(|_, cx| {
+			let mut surface = ProgramGraphSurface::new(cx);
+			surface.set_cycle(Some(cycle), cx);
+			surface
+		});
+		surface.update(visual, |surface, cx| {
+			assert!(surface.select(run.id.clone(), cx));
+		});
+		assert_eq!(
+			surface.read_with(visual, |surface, _| surface.selected_conversation_id()),
+			expected_conversation
+		);
+		let unknown = EntityId::new("ffffffff-ffff-4fff-8fff-ffffffffffff")
+			.expect("bounded unknown identity");
+		surface.update(visual, |surface, cx| {
+			assert!(!surface.select(unknown, cx));
+		});
+		assert_eq!(
+			surface.read_with(visual, |surface, _| surface.selected().cloned()),
+			Some(run.id)
+		);
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[gpui::test]
+	fn keyboard_arrow_moves_focus_and_shared_selection_by_layout(cx: &mut gpui::TestAppContext) {
+		cx.update(bind_keys);
+		let cycle = Programs::visual_development_three_cycle()
+			.snapshot()
+			.cycle
+			.expect("development visual cycle");
+		let first = cycle.nodes.first().expect("first Signal").id.clone();
+		let first_key = FocusKey { lens: GraphLens::Program, id: first.as_str().to_owned() };
+		let (surface, visual) = cx.add_window_view(|_, cx| {
+			let mut surface = ProgramGraphSurface::new(cx);
+			surface.set_cycle(Some(cycle), cx);
+			surface
+		});
+		visual.update(|window, cx| window.draw(cx).clear());
+		let focus = surface.read_with(visual, |surface, _| {
+			surface.focus_handles.get(&first_key).expect("first node focus").clone()
+		});
+		visual.update(|window, cx| window.focus(&focus, cx));
+		visual.simulate_keystrokes("right");
+		let selected = surface.read_with(visual, |surface, _| surface.selected().cloned());
+		assert!(selected.is_some());
+		assert_ne!(selected, Some(first));
+	}
+}

--- a/apps/decodex-gpui/src/programs.rs
+++ b/apps/decodex-gpui/src/programs.rs
@@ -120,7 +120,7 @@ impl Programs {
 	}
 
 	#[cfg(feature = "visual-capture")]
-	pub(crate) fn visual_closed_cycle() -> Self {
+	pub(crate) fn visual_paper_investment() -> Self {
 		use decodex_protocol::{
 			DomainEntityDto, DomainEntityFieldDto, DomainPackCapabilityDto,
 			DomainPackCapabilityStatus, DomainPackDescriptorDto, DomainPackProjectionDto,
@@ -517,6 +517,280 @@ impl Programs {
 			state.session = Some(SessionBinding {
 				generation: 1,
 				server_id: ServerId::new("visual-programs")
+					.expect("visual server identity is bounded"),
+			});
+			state.load = ProgramsLoadState::Ready;
+			state.programs = vec![program];
+			state.selected = Some(program_id);
+			state.cycle = Some(cycle);
+		}
+		programs
+	}
+
+	#[cfg(feature = "visual-capture")]
+	pub(crate) fn visual_development_three_cycle() -> Self {
+		use decodex_protocol::{
+			DEVELOPMENT_DOMAIN_PACK_ID, DomainEntityDto, DomainEntityFieldDto,
+			DomainPackCapabilityDto, DomainPackCapabilityStatus, DomainPackDescriptorDto,
+			DomainPackProjectionDto, DomainPackViewKind, DomainRelationDto, EntityRevision,
+			ProgramCycleDto, ProgramEdgeDto, ProgramNodeDto, ProgramNodeFieldDto,
+			ProgramRelationKind, Sha256Digest, WireText,
+		};
+
+		let snapshot = Self::visual_paper_investment().snapshot();
+		let mut paper = snapshot.cycle.expect("paper visual Program cycle");
+		let id = |value: &str| EntityId::new(value).expect("visual Program identity is valid");
+		let text = |value: &str| WireText::new(value).expect("visual Program text is bounded");
+		let field = |label: &str, value: &str| ProgramNodeFieldDto {
+			label: text(label),
+			value: text(value),
+		};
+		let node = |id: EntityId,
+		            kind: ProgramNodeKind,
+		            title: &str,
+		            summary: &str,
+		            state: &str,
+		            source: Option<&str>,
+		            conversation_id: Option<EntityId>,
+		            fields: Vec<ProgramNodeFieldDto>,
+		            offset: i64| ProgramNodeDto {
+			id,
+			kind,
+			title: text(title),
+			summary: text(summary),
+			state: text(state),
+			source: source.map(text),
+			observed_at_micros: Some(1_786_000_000_000_000 + offset),
+			conversation_id,
+			fields,
+		};
+		let program_id = paper.program.program_id.clone();
+		let review_2_id = id("81000000-0000-4000-8000-000000000017");
+		let signal_3_id = id("81000000-0000-4000-8000-000000000018");
+		let claim_3_id = id("81000000-0000-4000-8000-000000000019");
+		let proposal_3_id = id("81000000-0000-4000-8000-000000000020");
+		let objective_3_id = id("81000000-0000-4000-8000-000000000021");
+		let work_item_3_id = id("81000000-0000-4000-8000-000000000022");
+		let conversation_3_id = id("10000000-0000-4000-8000-000000000003");
+		let deterministic_3_id = id("81000000-0000-4000-8000-000000000023");
+		let external_3_id = id("81000000-0000-4000-8000-000000000024");
+		let review_3_id = id("81000000-0000-4000-8000-000000000025");
+		paper.nodes.extend([
+			node(
+				signal_3_id.clone(),
+				ProgramNodeKind::Signal,
+				"Signal",
+				"Two safe continuations left the Domain Pack boundary as the next uncertainty.",
+				"observed",
+				Some("Second Program Review"),
+				None,
+				Vec::new(),
+				18,
+			),
+			node(
+				claim_3_id.clone(),
+				ProgramNodeKind::Claim,
+				"Claim",
+				"One host-owned projection can support a real development lens without new authority.",
+				"current",
+				None,
+				None,
+				Vec::new(),
+				19,
+			),
+			node(
+				proposal_3_id.clone(),
+				ProgramNodeKind::Proposal,
+				"Proposal",
+				"Pressure-test the closed Program vocabulary with the built-in Development Pack.",
+				"non_executable",
+				None,
+				None,
+				vec![
+					field("Expected effect", "One reusable host graph across two domain lenses"),
+					field("Risk", "A Pack becomes a second execution or storage owner"),
+				],
+				20,
+			),
+			node(
+				objective_3_id.clone(),
+				ProgramNodeKind::Objective,
+				"Objective",
+				"Bind, execute, review, restart, and reopen the Development projection.",
+				"achieved",
+				None,
+				None,
+				vec![field("Validation", "Exact Pack digest, restart, and projection readback")],
+				21,
+			),
+			node(
+				work_item_3_id.clone(),
+				ProgramNodeKind::WorkItem,
+				"Prove the built-in Domain Pack boundary",
+				"Validate one development projection through the ordinary Quick Task path.",
+				"done",
+				None,
+				Some(conversation_3_id.clone()),
+				vec![field("Working directory", "/Users/x/code/acg-box/decodex")],
+				22,
+			),
+			node(
+				conversation_3_id.clone(),
+				ProgramNodeKind::Run,
+				"Codex Quick Task",
+				"The third cycle used the same account, process, and provider safety path.",
+				"ready",
+				None,
+				Some(conversation_3_id.clone()),
+				Vec::new(),
+				23,
+			),
+			node(
+				deterministic_3_id.clone(),
+				ProgramNodeKind::Evidence,
+				"Deterministic validation",
+				"Pack registry, protocol, SQLite, runtime, GPUI, and restart checks passed.",
+				"deterministic_validation",
+				Some("Repository gates"),
+				None,
+				Vec::new(),
+				24,
+			),
+			node(
+				external_3_id.clone(),
+				ProgramNodeKind::Evidence,
+				"External evidence",
+				"The three-cycle Program and Development lens remained exact after restart.",
+				"external",
+				Some("Signed local GPUI dogfood"),
+				None,
+				Vec::new(),
+				25,
+			),
+			node(
+				review_3_id.clone(),
+				ProgramNodeKind::Review,
+				"Program Review",
+				"Three cycles now prove the bounded sequential Program and host projection boundary.",
+				"capability_progress",
+				None,
+				None,
+				Vec::new(),
+				26,
+			),
+		]);
+		let edge = |from: EntityId, to: EntityId, kind| ProgramEdgeDto { from, to, kind };
+		paper.edges.extend([
+			edge(review_2_id, signal_3_id.clone(), ProgramRelationKind::Continues),
+			edge(signal_3_id, claim_3_id.clone(), ProgramRelationKind::Supports),
+			edge(claim_3_id, proposal_3_id.clone(), ProgramRelationKind::Justifies),
+			edge(proposal_3_id, objective_3_id.clone(), ProgramRelationKind::Proposes),
+			edge(objective_3_id, work_item_3_id.clone(), ProgramRelationKind::DecomposesTo),
+			edge(work_item_3_id.clone(), conversation_3_id.clone(), ProgramRelationKind::Executes),
+			edge(work_item_3_id.clone(), deterministic_3_id.clone(), ProgramRelationKind::Produces),
+			edge(work_item_3_id.clone(), external_3_id.clone(), ProgramRelationKind::Produces),
+			edge(deterministic_3_id, review_3_id.clone(), ProgramRelationKind::Supports),
+			edge(external_3_id, review_3_id.clone(), ProgramRelationKind::Supports),
+			edge(review_3_id, program_id.clone(), ProgramRelationKind::Validates),
+		]);
+		paper.program.name = text("Adaptive Factory Spine");
+		paper.program.purpose = text("Make several Codex tasks one explainable feedback system.");
+		paper.program.revision = EntityRevision(6);
+		paper.program.updated_at_micros = 1_786_000_000_000_026;
+		let program = paper.program.clone();
+		let cycle = ProgramCycleDto::new(
+			program.clone(),
+			paper.non_goals,
+			paper.review_policy,
+			paper.nodes,
+			paper.edges,
+		)
+		.expect("three-cycle development visual Program is valid");
+
+		let domain_field = |label: &str, value: &str| DomainEntityFieldDto {
+			label: text(label),
+			value: text(value),
+		};
+		let repository = id("92000000-0000-4000-8000-000000000001");
+		let change = id("92000000-0000-4000-8000-000000000002");
+		let validation = id("92000000-0000-4000-8000-000000000003");
+		let domain_pack = DomainPackProjectionDto::new(
+			DomainPackDescriptorDto {
+				id: text(DEVELOPMENT_DOMAIN_PACK_ID),
+				version: text("1.0.0"),
+				digest: Sha256Digest::new(
+					"cdecdff922ef1ec29fbe48cc5b72877fa70cce564bbb783272dd47ce614dc146",
+				)
+				.expect("visual Development Pack digest"),
+				name: text("Software Development"),
+				namespace: text("dev"),
+				view: DomainPackViewKind::GraphInspector,
+				capabilities: vec![DomainPackCapabilityDto {
+					id: text("codex.quick_task"),
+					status: DomainPackCapabilityStatus::Granted,
+				}],
+				entity_types: vec![
+					text("dev.repository"),
+					text("dev.change"),
+					text("dev.validation"),
+				],
+				relation_types: vec![text("dev.contains"), text("dev.validated_by")],
+			},
+			vec![
+				DomainEntityDto {
+					id: repository.clone(),
+					kind: text("dev.repository"),
+					title: text("decodex"),
+					summary: program.purpose.clone(),
+					state: text("active"),
+					source: Some(text("/Users/x/code/acg-box/decodex")),
+					fields: vec![domain_field("Program cycles", "3")],
+				},
+				DomainEntityDto {
+					id: change.clone(),
+					kind: text("dev.change"),
+					title: text("Prove the built-in Domain Pack boundary"),
+					summary: text(
+						"Validate one development projection through the ordinary Quick Task path.",
+					),
+					state: text("done"),
+					source: Some(
+						WireText::new(format!("codex://threads/{}", conversation_3_id.as_str()))
+							.expect("visual Conversation source is bounded"),
+					),
+					fields: vec![domain_field("Work item", work_item_3_id.as_str())],
+				},
+				DomainEntityDto {
+					id: validation.clone(),
+					kind: text("dev.validation"),
+					title: text("Latest Program review"),
+					summary: text(
+						"Three cycles prove the bounded sequential Program and host projection boundary.",
+					),
+					state: text("capability_progress"),
+					source: Some(text("Signed local GPUI dogfood")),
+					fields: vec![domain_field("Evidence records", "2")],
+				},
+			],
+			vec![
+				DomainRelationDto {
+					from: repository,
+					to: change.clone(),
+					kind: text("dev.contains"),
+				},
+				DomainRelationDto { from: change, to: validation, kind: text("dev.validated_by") },
+			],
+			&program_id,
+		)
+		.expect("visual Development Pack is valid");
+		let cycle = cycle.with_domain_pack(domain_pack).expect("visual Development Pack attaches");
+		let programs = Self::production();
+		{
+			let mut state = programs.lock();
+			state.active = true;
+			state.session = Some(SessionBinding {
+				generation: 1,
+				server_id: ServerId::new("visual-development-programs")
 					.expect("visual server identity is bounded"),
 			});
 			state.load = ProgramsLoadState::Ready;
@@ -1261,8 +1535,9 @@ fn canonical_uuid_v4() -> Result<String, ProgramInputError> {
 #[cfg(test)]
 mod tests {
 	use decodex_protocol::{
-		Channel, Cursor, EntityRevision, PAPER_INVESTMENT_DOMAIN_PACK_ID, ProgramState,
-		QuickTaskState, QuickTaskSummary, QuickTaskWorkingDirectory, WireText,
+		Channel, Cursor, DEVELOPMENT_DOMAIN_PACK_ID, EntityRevision,
+		PAPER_INVESTMENT_DOMAIN_PACK_ID, ProgramRelationKind, ProgramState, QuickTaskState,
+		QuickTaskSummary, QuickTaskWorkingDirectory, WireText,
 	};
 
 	use super::*;
@@ -1277,8 +1552,8 @@ mod tests {
 
 	#[cfg(feature = "visual-capture")]
 	#[test]
-	fn visual_program_preserves_two_review_linked_cycles() {
-		let snapshot = Programs::visual_closed_cycle().snapshot();
+	fn paper_visual_program_preserves_two_review_linked_cycles() {
+		let snapshot = Programs::visual_paper_investment().snapshot();
 		let cycle = snapshot.cycle.expect("visual Program cycle");
 
 		assert_eq!(
@@ -1309,6 +1584,34 @@ mod tests {
 				.iter()
 				.any(|relation| { relation.kind.as_str() == "finance.compared_with" })
 		);
+	}
+
+	#[cfg(feature = "visual-capture")]
+	#[test]
+	fn development_visual_program_preserves_real_three_cycle_shape() {
+		let snapshot = Programs::visual_development_three_cycle().snapshot();
+		let cycle = snapshot.cycle.expect("development visual Program cycle");
+		assert_eq!(
+			cycle.nodes.iter().filter(|node| node.kind == ProgramNodeKind::Signal).count(),
+			3
+		);
+		assert_eq!(
+			cycle.nodes.iter().filter(|node| node.kind == ProgramNodeKind::Review).count(),
+			3
+		);
+		assert_eq!(
+			cycle.edges.iter().filter(|edge| edge.kind == ProgramRelationKind::Continues).count(),
+			2
+		);
+		assert_eq!(
+			cycle.edges.iter().filter(|edge| edge.kind == ProgramRelationKind::Validates).count(),
+			3
+		);
+		assert_eq!(cycle.program.revision, EntityRevision(6));
+		let pack = cycle.domain_pack.expect("visual Development Pack");
+		assert_eq!(pack.descriptor.id.as_str(), DEVELOPMENT_DOMAIN_PACK_ID);
+		assert_eq!(pack.entities.len(), 3);
+		assert_eq!(pack.relations.len(), 2);
 	}
 
 	#[test]

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -1004,7 +1004,7 @@ impl Shell {
 			can_retry: false,
 			last_stale_cancellation: None,
 		});
-		let programs = Programs::visual_closed_cycle();
+		let programs = Programs::visual_development_three_cycle();
 		shell.program = programs.snapshot();
 		shell.programs = programs.clone();
 		shell.factory.update(cx, |factory, cx| factory.bind_programs(programs, cx));

--- a/openwiki/.claims/evidence/program-graph-surface-v1.json
+++ b/openwiki/.claims/evidence/program-graph-surface-v1.json
@@ -1,0 +1,146 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:1955ff44795591d4beef3aaac26c0d992de8c6966c7a48b6ec11f3dcd3c52528",
+  "claims": [
+    {
+      "id": "claim_49898b42f27b41d4b263129b7ff26c6a",
+      "statement": "Program Graph Surface V1 maps the bounded Program cycle and Domain Pack projections into distinct Program and Domain lenses that reuse one private GPUI graph input, layout, viewport, and renderer owner.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1577-L1651",
+          "version": "repo-lines-v1:sha256:4dc2265f0699454383d7aafac3fadc11a9d684cedb0f84711d41e36bf9529f0e:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE4M2QwMzllYjFmZDU1ZGY2MmZhMzczYjFjNDUxOTcxYzM1OTkxM2YxODE4MjgwM2MxY2VhYmZkZDNmNmMyMTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY4ZWE3YTFjZTIzMDc4ZWRkNWRjNjdlNTAwYTg3ZDUxYjAwY2MwMGRlNDBiNWRiOWFhODU3N2ZhMjlkZjkyMGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYxMWJjOWYxZmYyZDQ5MTE0NmFjMzY1MmIwMmRmZmZkNTNlNzQzY2I3YTE0YmFiM2FlOGQ3NGQzNzM4ZDgyYTAifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L78-L150",
+          "version": "repo-lines-v1:sha256:26749a32818ca695217d355fe2a0590a9239e20122307ed4643c39ac15f400ca:eyJzZWxlY3RlZExpbmVDb3VudCI6NzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYxZDgzOWZiOGYzYjFmYjRjNjAzNDYzMzFkZTU0ZjQ1YWU1NGM3NmU0NzI1OGRkOTYyNjljODEyZjU3OGIxNjUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijk2ZjBkZTFjM2M3OGMzMmRhY2FlZmExNDJjMDNmOTIxN2M0MDY0ZGZjMDM3MDBjM2U5ZGIzMTZhYjJhMmE2NjkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZmMDQ5Zjg4YmFhY2I0MWRmMjRhYmM3NDZjYzk0NWI2ZmJiMjM0NDc1MDVhM2UzODZiNTIxZDc4MTg2NzNjZDcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3ef88c6096e84a4aadc2531112e94d5e",
+      "statement": "The private graph cache keys layout by sorted stable node identities and exact from-relation-to edge identities, so presentation-only changes can reuse the existing positions.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L100-L150",
+          "version": "repo-lines-v1:sha256:b5d17b43b37f0e99e9bc7aaf6b6d75ec095648aa28a43a6a01fab671961d71e5:eyJzZWxlY3RlZExpbmVDb3VudCI6NTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE3ZWI3ZDg4ZDdjMjBjMzY2ZGJjNmFhYWRiZDcwZmE5MzIzNjJkMzY3M2MyZmFlZDYwZDdjZmJjNTE5ZGZjNWEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjZmMDQ5Zjg4YmFhY2I0MWRmMjRhYmM3NDZjYzk0NWI2ZmJiMjM0NDc1MDVhM2UzODZiNTIxZDc4MTg2NzNjZDcifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L232-L260",
+          "version": "repo-lines-v1:sha256:97ed99ecb6c3fbdbd89200ace6e88c9602b79785b235e6f294330ce91d5f4069:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBlNDg1ODIyNTYzYTE0NDhhZWZhYzUzZjQ0OWMwNDM3ZjIwOTFmMmExZGI1NTY1NThjNWM4MDU1ODI0NzBmZDYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjQ3MDc3MzAxMTY5ZmU4NjAxYWE4YzYzZWE0Y2ZiZGRjMTgxODQ3ZjAxZmU2ZmM5YjlkMWFkNGQ5N2NhOWRkZjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI2ZDViZDJlMzY0NTlhZmNlNGYxZDY3MGIxNThlYTRhYzMzMzI1MTdjMmI0MDE4MTU3NzY0NDhiMDM2NWU4NWYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_a5f26384786c47398037329e53120e15",
+      "statement": "The layered layout fails closed on empty, duplicate, or dangling input; excludes declared feedback from forward ranking; breaks any remaining cycle deterministically; and assigns stable ranks and rows for branches and merges.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1666-L1845",
+          "version": "repo-lines-v1:sha256:5136dfddea42be967702935d5867cd68c08ff269e33ec7434df561bc2057b1a3:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5M2E2NzQwOTQ1ODI0YjMxOGUxMjQ3ZTY1ZDk5NmExODhiNzY0ZWQ0YzkxMTEyZWM0YWUzZmJlNzE4YWRiYjgyIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1ZDg3NmFiNDgxMzk3ZDgzNTFiNjQyMzU2M2E1ODM1MGI2NGZjNGMzZmUwMDY2NzkwNjM1OGFlOTBjN2I4OGJlIn0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1921-L2044",
+          "version": "repo-lines-v1:sha256:ab63433f5dd5769990efbc6ca462e7b27cd5806d7f85b622d9bf53f009d59e31:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4MDI5NmEzYzA0NzhmMTEzMWQxYzM0NTgyNGIwOWQ4YzEzMGQ4NzZhZDNkOTc3NjY2OGQyMjYxNWM5MzViMDMyIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJhYzZiZjY2ZmJkNzI5YjhhNTFmMTU3MWMyZmQ0OTRjNjM2NWFkMmVlMzI5ZjViODkyMWJkY2I0Njk2ZGM5OWQxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0OTNhOTBmYTJiYjNkMzVjNTIzMWIyZmE2MGIyOWU5NWI0NTA5MzAyZWUxNmMyOWZkNTIwZjZmNDA1MGNiYjIwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI3NmE0YTQ3OGU1MGVhMDdmYjAyMTkzMzdiNDhhYmRiNWFlMzUyZGE3MjY4NzZmNzk5NjlkNzhmZTM4ZWY3NWIwIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_6568f9a24d8c4f169470f0b9195637a3",
+      "statement": "Each graph lens has a finite bounded viewport with Fit, zoom, pan, and 100-percent reset; zoom and pan are clamped, and static scenes change only through projection, viewport, selection, focus, or size-driven rendering state.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L263-L329",
+          "version": "repo-lines-v1:sha256:ebc98433422af46055ad97861d27d6dde85e4c8b4963c6318f2de1ab285d433d:eyJzZWxlY3RlZExpbmVDb3VudCI6NjcsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxNDA5YTRkYmVjY2QwMzMzNzY2NWM4MDM4NmM4MjczYzE4MWQ3NmNlMWZiNmUxOWQ2ZGNhZTdlOWFhOWFkYzAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjgxY2I5MzVlYzc4YzlmYTdlOGQ0MDM0NTBkN2Y1NTk4M2E0ZmIzNGE1MjI4ZDQyNDRkMDc2OWEwNGJhNDc0Y2MifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L571-L700",
+          "version": "repo-lines-v1:sha256:106dad53b51b2fa27e6d8190ceb07b8cd80326f335e9517209cbf2566cf8dae5:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIxZDc4M2FiZjk3ODUxZTU4NGY5ZDI5NTg1ZDA0ODU5MWNiZTcyYmMyMDE5NzY1YzYzYzA1NTJkNmE2Y2VhNWIzIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyMmYyZmY1ZmVlYzYwZjU4N2M4ZmFlNGU4N2Y4MDlhNjYxY2ZmZWQ2YjQ3YWFlNWY2ZDZhMjY1M2FhODk1MmVmIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIzNTI4NjI5MmFlYmE3ODA4MzQwMzI3YTdjZDQ0ZTJhMjU1YzIyOGRkMjhkMjk5NTFmMDQzNDBjMGNjOTFkNWYxIn0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L948-L1018",
+          "version": "repo-lines-v1:sha256:f234968eb69f1c20880491a8858aa505147abee41d74a826a2530543e2939c97:eyJzZWxlY3RlZExpbmVDb3VudCI6NzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZjNWVlY2JlNmZkMDU4NDFiODQ3ODJmNDZlNDZlMzJmY2FmZTI2ZWFlZWNlMzFlZWMwNTNiZmE4MGUwMjFkZDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY5Njk0Zjg0NDg0Mjk4ZjcwYmMxZWY3ZTQyMGYyODdiMTk3M2E3YjJjMGU3MjkyMDk4OThiY2U4ZjkzMDY2ODUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJjYzNmN2VhYzVkYTY4M2RlYzUwOWYyNGVlODVkMTBjMzIwOWU1MDA2NzAxMWY4ZTk0MTM4MTU4OWYzNzlhNTIifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_5ac5537a2b0b4e52b03cfbd2ae0745a7",
+      "statement": "One selected EntityId synchronizes graph focus and clicks with the Factory semantic inspector and causal timeline, and activation opens the exact Conversation only when the selected Program node carries that Conversation identity.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/factory_surface.rs#L3019-L3082",
+          "version": "repo-lines-v1:sha256:0470c61c1033cd25cd829b6495b9db5338f18397f38de192d1ba07af13f864d0:eyJzZWxlY3RlZExpbmVDb3VudCI6NjQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImJmYjhkY2Q4MTg1MTM2OWIyNjgyMzlkOGQ2MDIxZjFlM2I5NjRhMTgzYzI5MGQ1NWViMDE4NGJjZjhkODU2YTciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjM5NDZiNzU2NTVlMTQ1ZWJmY2Y1YzQ1YjczMTJjZWVjMWE5MDI0ZDA1MDQwMTc4ZGViM2QwNDFkM2E4ODBiMzEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM3M2FjMDMxZjM0Y2RmZDllMWU0YzJjZjhiNmQyODEzOTkwMDVlZDI0OTlkYzhiNDQ3OWYyMmNjZTRiYjU4YjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImVjYjdlZWZjOWNiMWMyYWZhOGIwZmM3NjdlZjFlNTEyZTRlNmY4OTljMWQ4OWI3OGVmZDg5NWY3NTRkYjNkOWEifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/factory_surface.rs#L533-L536",
+          "version": "repo-lines-v1:sha256:564ab3a05735456c3df5deec71832f4fa48ace59e9ef0406a3fbf5a37f05e4e9:eyJzZWxlY3RlZExpbmVDb3VudCI6NCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNWNlMzE1OTE5YzYxZGQyNjU1NzVkNmZiNGU0MzkxMWQ2ZjY0OTZiOGEzY2NjOTVkOGNjMDFlN2MwYzFkMTRmYyIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiNjdjZGE4MmRhNjA2MjM4ZTA1ZTYyMzk5NTY5YzVlZTAzOTkzNDE5NjQ4YWU1ZDQzYTJiZjhjZDYzNDdmODI2MyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiMjJmMmZmNWZlZWM2MGY1ODdjOGZhZTRlODdmODA5YTY2MWNmZmVkNmI0N2FhZTVmNmQ2YTI2NTNhYTg5NTJlZiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMmM2NDRmZGE4NzY2ZWU2NTI1ZDA5YjllNTEwM2M4NjhlNmJlMGNmNTBjZjAxMjI1ZDVlNjdkODJhYTcxMjFhNCJ9"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L391-L548",
+          "version": "repo-lines-v1:sha256:1e2cc027b3730960dc08ee142e1cdc13d2c5f499a058b37d32f1443e16880f9a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTU4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJkYTcxZTk4MGVjMjY4ZmFlNTI1NTI2MDA4NmQ4MjRlN2NhNmZmZDUyMTFmZTEyNTUzZmVlNjRhYTI2YTM1MjU0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIyMmYyZmY1ZmVlYzYwZjU4N2M4ZmFlNGU4N2Y4MDlhNjYxY2ZmZWQ2YjQ3YWFlNWY2ZDZhMjY1M2FhODk1MmVmIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI3ZjEyZDM0YjE1MTVkZjY0OGYzNTg1MTYwN2M5YzY0MzA2MmM0NDc3NThiNDNiZDRiZmZkM2U1NWMyNDg2OTRhIn0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L702-L755",
+          "version": "repo-lines-v1:sha256:9da6c6ef94d3f02097b1e3a0f023b397757ba8769e3d87e7cc9440033e0429e8:eyJzZWxlY3RlZExpbmVDb3VudCI6NTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImM3NzViZTM0MmQ4ZmU2MGE3OTAxOGQ2ODQ4ODk3MzQyMTBmOTA2OWVlNzE5YWE1MjRiOWU1NTdmYTk4ZDIzYTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjIyZjJmZjVmZWVjNjBmNTg3YzhmYWU0ZTg3ZjgwOWE2NjFjZmZlZDZiNDdhYWU1ZjZkNmEyNjUzYWE4OTUyZWYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImEzOTYzZjA2NmUyZjRlOGY0ZjhlYTBkMmEyYmYwNWYwOGViMjZjZDlmM2MzYmYzZDY1ZDBmNmI4MDUxM2E3MGYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_d9900cd12e3c449b8c7fd4f1c8c21e99",
+      "statement": "Graph nodes and viewport controls are native keyboard-focusable GPUI elements with semantic accessibility labels, and each lens exposes the selected node's incoming, outgoing, and feedback relations as native text.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1020-L1068",
+          "version": "repo-lines-v1:sha256:d4fec1f2c8554c2834409acef71df9a0552a700b02a93cff629aed90aef603ec:eyJzZWxlY3RlZExpbmVDb3VudCI6NDksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjBmYzdhNTM2YzgxYmU0YWE1MDQyMmU3ZTdjMGE4ZjMxMjQxNzBhNzZjNjU3NDQ4MTA3ZmJjYjZhM2NkNGZlODUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVjNTMxOTg1OWZkNDY5MDNiZDM2MWQ2YmJmN2NjZGIwYzgzNWRiNWQ2NTYzY2RlMjgxZDg1MTdjYmZlOTExMDkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImRjNDUzNGVjMmNlZGI4MTk5OWVkYmRlOWQxZWZiYzc5OGE5NzdhZTc2M2ZhZWYxZDRmNDZiMmYzNGE2ODFiODMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijk3MTg1ZGI1MTg4YzliYjMyZjFiYzU3YmZlM2E3OWIxMGUxMGE4Y2NiZTg5Mzc4ZDBlMTdjODRhZWYxOGZmNTIifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1284-L1382",
+          "version": "repo-lines-v1:sha256:70be44533fd0760c5d8b14ffe03476f14ffa356746f4895c48ec87ed97c0a201:eyJzZWxlY3RlZExpbmVDb3VudCI6OTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU1MDZhZGRjYzljMzk2MWY0YThmMDY5ZmJiM2ViMzNiMjhhN2RiYmEzYmI3ODRlYTc1OTk3MjgxNmI4NTRmMDkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImU5Y2YyMWVmNmNlZDU5Yzg0MmVhYjcyMDY1MjI5YWE3YWFjNmQ0ZmY3NTVmZWIwNTgwNDM2YmNlM2MxM2MxMGEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImRjNDUzNGVjMmNlZGI4MTk5OWVkYmRlOWQxZWZiYzc5OGE5NzdhZTc2M2ZhZWYxZDRmNDZiMmYzNGE2ODFiODMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImUzY2EyY2MzMmQyNTJjODliYmEyZjQ4ZjFiOWE0MzQ3NjA2Mjg3Nzg1MjY3YWFhMTc0NjQzNjM5Nzc5YjZhMzYifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L42-L70",
+          "version": "repo-lines-v1:sha256:0e00a4d39d23af380d77b342973a18060184d162660e72d34b8a1a1d871d19ce:eyJzZWxlY3RlZExpbmVDb3VudCI6MjksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUzZjVkYmRhNTI2ZmUxMmMxMGZkY2JiYTEyOWQ0NDhhMDkxOTIwNGY1Yjc4MzcyZmQyM2ZhOTE0ZGQ5NTdmZjAiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjcxOWRjZGIxMGFmYmNhZTM0MGIwYjY4NzRiODZmMWY0Y2I4M2Y3OWRhYWM4NTQ0NzhlNjVkNjkyMWNkMTU1N2IiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFlMzlkY2MwZjBlYzZkZjA5YTI2NGRlNGJjYjhhMmQ3MzBmNzU2NDkzY2RkNDg3NzQ4OGRhOTA3YzEzYzg4NjUifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_efccfe5072964fe6acd3e863b8ad1a14",
+      "statement": "The visual-capture harness selects separate Development and Paper Investment scenarios; the fixtures preserve a three-cycle Development Program and the bounded Paper Investment projection without entering the production data path.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/bin/factory_visual_capture.rs#L29-L102",
+          "version": "repo-lines-v1:sha256:a8abde7048c22f3fbeead5b7e4ef6c8fa0d3d0cd34c1696c271cfca49a91c840:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2MWEyNTI1NzkyNDgyM2UyOGYzYjMwMjkzMTY0YjNkYTRjZjBkMzZlM2JiYWZkMjAxZmY5YTA4ZTkzZjc0NzciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJmMTIyNGQzOTRmMDEzNjNjYzA1YmIyN2YwMTRmNmVkZTE3Y2NiZDNiMGZiMDdmNWVmY2M3YWUwMDFjNWU0Y2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRhYWYwMWQ4MTNkNGYwMjE5YzkxZmMzNjg0ODc1OGViZWRmMGUxMjhmOGE5Mzg2MmMzZTE3Y2NlYThjMzYwNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/programs.rs#L120-L529",
+          "version": "repo-lines-v1:sha256:f7eb86d01b5bbb5d83d91469aff63676e2933e875789d2d416fa99c5011107e7:eyJzZWxlY3RlZExpbmVDb3VudCI6NDEwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIwMWJhNDcxOWM4MGI2ZmU5MTFiMDkxYTdjMDUxMjRiNjRlZWVjZTk2NGUwOWMwNThlZjhmOTgwNWRhY2E1NDZiIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI3NDU2MDgxZGY5ZTVlMmU2NmEzODU0Y2MwNmI3MGNmM2NlYjBmNDY3NmQyNWI5ZDQwODM0YmVmOGYxZTllMmQ2IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmNDE4NmU3Yzk3ZDc3NmViNjBmZjcxYmJhMTcwOTlmMDM5ZDY1MWMwN2U2NjhhNDQ2MzA4ZDdlNmI0MDlkMjc3In0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/programs.rs#L530-L802",
+          "version": "repo-lines-v1:sha256:f6417de739cdc45bb4c8a0e502bcdded904e44a58c996cbab182f684136339ee:eyJzZWxlY3RlZExpbmVDb3VudCI6MjczLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2NGYzYjdhNzUyZjlmMTk0ZWM3MTM1NTlkZTU2ZDZjNjU1ZTBlYWY0OTZlODM2NTIwNzUzOGVjZjRjMDBhYTdkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIzNzEwYmNiZWU5ZmM0YzMxMTA2YTliMTQwZTVhNmIxYmEyNzUwNjkwZGI2OTJlZWFiNjkwYjJjOTFlZmI4YjJmIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwNDY0YmY0MTQ1M2UwOTVmZGVhZTc5MjUxOTVjN2QxYjQwZjEyNWFlZmIxNTIwZmY0MTY5ZDg0MmE5ZTIzY2U5In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_b05821b4d8124b0bbd2beeed78e3a2d3",
+      "statement": "Focused tests cover branches, merges, multiple Program cycles, feedback, stable ordering, invalid projections, viewport bounds, cache reuse, exact DTO mapping, selection, Conversation mapping, keyboard navigation, and the minimum laptop draw size.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/factory_surface.rs#L4450-L4482",
+          "version": "repo-lines-v1:sha256:1673b21476cbae0b8103e4c960e25a1dc71aa35ad70ff832456aa5bc091081aa:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI4OGY4MmFlNTY0YWU0MGEzNmFhMjNhZGVmNTYwOWQ0MmMwM2JmYjg3MTI3ZjUxMGE1YTVkOTQ3ZWQ3NmMyMjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc5ZmIzYThmOGM2NmJmYWM2YzYwNzk2NGMyMmEyM2ZjNjM0MmEwNDdhMzJjYjllNTE5ZmUxYmVkNmVlYjRhZWUifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1904-L2152",
+          "version": "repo-lines-v1:sha256:f949160bd2560bc9c53707ce7fce786965ba3609a06998a9c60c1ff0ffc1bb79:eyJzZWxlY3RlZExpbmVDb3VudCI6MjQ5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhN2I4OTgzZDgyNjI4MTRlYmMzMGVlNDIwMDYzMzJhN2NkOTg3NTY2OTQ5MWI1NzE3YTUzMTUxMjRhZjVlYTY0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1MGFhZjU0M2IwYjMxYmJmMjMyMGM2NWE2NTU5YTcyMjA1YjMxZGNmNzNhYWRkYmM2NmI0ODI4ZTYxN2E2YWZhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MCwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/programs.rs#L1548-L1615",
+          "version": "repo-lines-v1:sha256:d9dea500852702b7cf311fbbbe2e5f84219d76e05fa8109870f11ce66c1da9ef:eyJzZWxlY3RlZExpbmVDb3VudCI6NjgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ0MjIwYzQ5M2I4YmVkOWVhNmFhMTcxNjI0YjAxODI3ODk0MGVlMTRlMTc5YWJmZDhjNGIwYjJhNGRiYjU1MWIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImY0NDYyYTJmM2FiMjMxZTBjMmIwNWQwMjUyNmU0YTkzM2M1YzQ3N2EzZDMyOGE1MjUyMjZlMmU3M2FiNzRhNmUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ0MjU5OWVjYjljOGNlMzYwZTFmN2NiYjRkNTY5MDIzZDYxY2ExYWNkYjYwODczYjVmZjYxNTc4OTU4M2JhZDgifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.0",
+    "at": "2026-08-26T21:13:26.303Z"
+  }
+}

--- a/openwiki/.claims/quickstart.json
+++ b/openwiki/.claims/quickstart.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:e53e9d31b596bd1399618af6542bc17a4f884ed67cc828e808e3d95c3f597b1b",
+  "claims": [
+    {
+      "id": "claim_b34298a8647a4e0b8653926b7568c5d4",
+      "statement": "Decodex GPUI owns a private bounded Program Graph Surface that renders the Program causal and Domain Pack projections from protocol DTOs without adding a second product-state authority.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/factory_surface.rs#L533-L536",
+          "version": "repo-lines-v1:sha256:564ab3a05735456c3df5deec71832f4fa48ace59e9ef0406a3fbf5a37f05e4e9:eyJzZWxlY3RlZExpbmVDb3VudCI6NCwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiNWNlMzE1OTE5YzYxZGQyNjU1NzVkNmZiNGU0MzkxMWQ2ZjY0OTZiOGEzY2NjOTVkOGNjMDFlN2MwYzFkMTRmYyIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiNjdjZGE4MmRhNjA2MjM4ZTA1ZTYyMzk5NTY5YzVlZTAzOTkzNDE5NjQ4YWU1ZDQzYTJiZjhjZDYzNDdmODI2MyIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiMjJmMmZmNWZlZWM2MGY1ODdjOGZhZTRlODdmODA5YTY2MWNmZmVkNmI0N2FhZTVmNmQ2YTI2NTNhYTg5NTJlZiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMmM2NDRmZGE4NzY2ZWU2NTI1ZDA5YjllNTEwM2M4NjhlNmJlMGNmNTBjZjAxMjI1ZDVlNjdkODJhYTcxMjFhNCJ9"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1-L19",
+          "version": "repo-lines-v1:sha256:10d3c7c7bd900ddb2b08f17410907066d8538e7e0e3a846f963e599b5080f553:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZkNzU5Y2VkMDNkYzEwYjZiOGM2OGM2YTM3MzEzYmE2MGU0NjY4OGI2ZGMyN2Q5OTkyYjY0ZDhmNmZhNTcyMTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFhMWQxYTYzMzkwMjI5Yzc5ODM0N2U4M2EwNDA1NDQxYzk0MDAwMzUyODRhZDE2OGMxYmY2Y2RmMWQ3MGEzNzAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImZmMThkYjM5NjdhZTdlZjE0OTA0NTNkYTBiYzQwNjFiNjc1NDBmYjEzY2E2NDI2Zjg5YjgxNDhlOThhMjBjNzQifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1577-L1651",
+          "version": "repo-lines-v1:sha256:4dc2265f0699454383d7aafac3fadc11a9d684cedb0f84711d41e36bf9529f0e:eyJzZWxlY3RlZExpbmVDb3VudCI6NzUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE4M2QwMzllYjFmZDU1ZGY2MmZhMzczYjFjNDUxOTcxYzM1OTkxM2YxODE4MjgwM2MxY2VhYmZkZDNmNmMyMTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY4ZWE3YTFjZTIzMDc4ZWRkNWRjNjdlNTAwYTg3ZDUxYjAwY2MwMGRlNDBiNWRiOWFhODU3N2ZhMjlkZjkyMGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYxMWJjOWYxZmYyZDQ5MTE0NmFjMzY1MmIwMmRmZmZkNTNlNzQzY2I3YTE0YmFiM2FlOGQ3NGQzNzM4ZDgyYTAifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_47309cff8741452783c174c8b950ab6a",
+      "statement": "The Program Graph Surface validation path includes deterministic layout and mapping tests, keyboard and selection tests, a minimum laptop-size GPUI draw, and separate Development and Paper Investment visual-capture scenarios.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/src/bin/factory_visual_capture.rs#L29-L102",
+          "version": "repo-lines-v1:sha256:a8abde7048c22f3fbeead5b7e4ef6c8fa0d3d0cd34c1696c271cfca49a91c840:eyJzZWxlY3RlZExpbmVDb3VudCI6NzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY2MWEyNTI1NzkyNDgyM2UyOGYzYjMwMjkzMTY0YjNkYTRjZjBkMzZlM2JiYWZkMjAxZmY5YTA4ZTkzZjc0NzciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJmMTIyNGQzOTRmMDEzNjNjYzA1YmIyN2YwMTRmNmVkZTE3Y2NiZDNiMGZiMDdmNWVmY2M3YWUwMDFjNWU0Y2IiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRhYWYwMWQ4MTNkNGYwMjE5YzkxZmMzNjg0ODc1OGViZWRmMGUxMjhmOGE5Mzg2MmMzZTE3Y2NlYThjMzYwNzgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjoxLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/factory_surface.rs#L4450-L4482",
+          "version": "repo-lines-v1:sha256:1673b21476cbae0b8103e4c960e25a1dc71aa35ad70ff832456aa5bc091081aa:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjI4OGY4MmFlNTY0YWU0MGEzNmFhMjNhZGVmNTYwOWQ0MmMwM2JmYjg3MTI3ZjUxMGE1YTVkOTQ3ZWQ3NmMyMjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijc5ZmIzYThmOGM2NmJmYWM2YzYwNzk2NGMyMmEyM2ZjNjM0MmEwNDdhMzJjYjllNTE5ZmUxYmVkNmVlYjRhZWUifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/program_graph.rs#L1904-L2152",
+          "version": "repo-lines-v1:sha256:f949160bd2560bc9c53707ce7fce786965ba3609a06998a9c60c1ff0ffc1bb79:eyJzZWxlY3RlZExpbmVDb3VudCI6MjQ5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhN2I4OTgzZDgyNjI4MTRlYmMzMGVlNDIwMDYzMzJhN2NkOTg3NTY2OTQ5MWI1NzE3YTUzMTUxMjRhZjVlYTY0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1MGFhZjU0M2IwYjMxYmJmMjMyMGM2NWE2NTU5YTcyMjA1YjMxZGNmNzNhYWRkYmM2NmI0ODI4ZTYxN2E2YWZhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MCwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.0",
+    "at": "2026-08-26T21:13:26.303Z"
+  }
+}

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,8 +1,8 @@
 {
-  "updatedAt": "2026-08-25T15:53:47.509Z",
+  "updatedAt": "2026-08-26T21:16:55.754Z",
   "command": "update",
-  "gitHead": "f6432a3c5fb9d698ba93479c8c955886228eae3f",
-  "model": "gpt-5.6-luna-nosystem",
+  "gitHead": "526ad15027311988c7ef77ddb9908f03c57f125b",
+  "model": "host-agent/codex",
   "status": "complete",
   "language": "en"
 }

--- a/openwiki/evidence/index.md
+++ b/openwiki/evidence/index.md
@@ -3,6 +3,7 @@
 - [Adaptive Factory Spine V1 Evidence](adaptive-factory-spine-v1.md) - Implementation, restart, protocol, GPUI, and dogfood evidence for the first bounded Program feedback cycle.
 - [Built-in Domain Pack Pressure Test V1 Evidence](builtin-domain-pack-pressure-test-v1.md) - Implementation, capability, GPUI, live execution, and restart evidence for Development and Paper Investment built-in Domain Packs.
 - [Credential Vault Cutover Evidence](credential-vault-cutover.md)
+- [Program Graph Surface V1 Evidence](program-graph-surface-v1.md) - Architecture, interaction, accessibility, deterministic layout, visual capture, and validation evidence for the bounded native Program Graph Surface.
 - [Repeatable Program Loop V1 Evidence](repeatable-program-loop-v1.md) - Implementation, restart, replay, GPUI, and three-cycle live evidence for manual sequential Program continuation.
 - [SQLite Local-Product Evidence](sqlite-local-product.md) - Current automated and native evidence for daemon-owned SQLite, protocol-only clients, and the single Decodex.app desktop architecture.
 - [XY-1262 Codex runtime proof](vnext-codex-runtime-proof.md)

--- a/openwiki/evidence/program-graph-surface-v1.md
+++ b/openwiki/evidence/program-graph-surface-v1.md
@@ -1,0 +1,128 @@
+---
+type: "Evidence"
+title: "Program Graph Surface V1 Evidence"
+description: "Architecture, interaction, accessibility, deterministic layout, visual capture, and validation evidence for the bounded native Program Graph Surface."
+tags: [adaptive-factory, program, domain-pack, graph, gpui, accessibility, evidence]
+verified:
+  - by: openwiki/0.4.0
+    at: 2026-08-26T21:13:26.303Z
+sources:
+  - id: openwiki-source-e3cbf7660b5f77bbecd437c5
+    resource: repo://apps/decodex-gpui/src/bin/factory_visual_capture.rs
+  - id: openwiki-source-4d0807cef0e852e926ce0974
+    resource: repo://apps/decodex-gpui/src/factory_surface.rs
+  - id: openwiki-source-31df4748243df01f1137f62f
+    resource: repo://apps/decodex-gpui/src/program_graph.rs
+  - id: openwiki-source-e9af71a768d2e84c84c2bdc3
+    resource: repo://apps/decodex-gpui/src/programs.rs
+generated: {by: "codex", at: "2026-08-26T21:13:26.303Z"}
+---
+
+# Program Graph Surface V1 Evidence
+
+Status: implemented and locally verified.
+
+Program Graph Surface V1 replaces the horizontal Program and Domain Pack strips with a
+private, host-owned GPUI component. The component reads only the bounded
+`ProgramCycleDto` and `DomainPackProjectionDto` projections. SQLite and `decodexd`
+remain the product-state authority. The graph does not store or mutate product facts.
+
+## Ownership and projection boundary
+
+`program_graph.rs` owns one private node, edge, layout, viewport, focus, and rendering
+model. It adapts two distinct lenses:
+
+- the Program causal lens contains the Program root, Program nodes, and exact Program
+  relation tuples;
+- the Domain Pack lens contains the same Program root, Pack-derived entities, and exact
+  namespaced relation tuples.
+
+The two lenses reuse layout and rendering mechanics, but they do not merge their
+vocabulary or identity sets. The Factory surface owns the surrounding Program pulse,
+semantic inspector, causal timeline, evidence controls, Review controls, Pack binding,
+and legal Conversation actions.
+
+## Deterministic layered layout
+
+The renderer uses stable node identities and `(from, relation, to)` edge identities as
+its structural cache key. It validates empty, duplicate, and dangling inputs before it
+creates a scene. The layout sorts identities, removes explicit feedback edges from the
+forward rank calculation, deterministically breaks any remaining cycle, assigns the
+longest-path rank, and uses bounded barycentric passes for stable row order. Branches
+share a layer, merges follow their inputs, and multiple Program cycles continue forward.
+
+`validates` relations are explicit feedback edges. They remain in the scene as dashed
+curved paths back to the Program root. The renderer does not present the Program as a
+directed acyclic graph. The selected edge set receives a stronger canvas treatment, but
+edge color is not the only relation channel.
+
+The layout cache recomputes only when node or edge structure changes. A title, summary,
+state, selection, theme repaint, viewport change, or size change can reuse the existing
+positions. Static scenes do not start an animation or continuous refresh loop.
+
+## Bounded viewport and interaction
+
+Each lens has a finite world size and an independent bounded viewport. Native controls
+provide Fit, zoom out, zoom in, and 100-percent reset. Pointer drag and ordinary scroll
+pan the scene. Command-scroll or Control-scroll zooms around the pointer. Zoom and pan
+are clamped so the user cannot lose the complete finite scene.
+
+The Graph Surface owns one selected `EntityId`. Graph clicks, keyboard focus, arrow-key
+navigation, and causal-timeline activation update that identity. The Factory reads the
+same identity for the semantic inspector. If the selected Program node has a
+Conversation identity, Enter, Space, and the inspector action open that exact retained
+Conversation.
+
+## Keyboard and accessibility behavior
+
+Every graph node is a native focusable GPUI button with a stable element identity,
+selected state, semantic kind, title, summary, state, exact identity, and incoming and
+outgoing relation text in its accessibility label. Arrow keys choose the nearest node
+in the requested spatial direction. Enter and Space activate the selected node. `F`,
+`=`, `-`, and `0` operate the active viewport. Viewport controls are also native
+keyboard and accessibility actions.
+
+Each lens includes a native relation-readout row for the selected identity. It states
+incoming, outgoing, and feedback relations in text. This is the equivalent non-color,
+non-pointer path for reading the canvas edges. The graph and Program timeline use no
+reveal animation, so reduced-motion use does not depend on a separate animated path.
+
+## Automated and visual evidence
+
+Focused layout tests cover branches, merges, three Program cycles, explicit feedback,
+deterministic cycle breaking, stable ordering under reversed input, viewport bounds,
+invalid and unavailable projections, and cache reuse. DTO mapping tests prove that the
+private scene preserves exact Program and Domain Pack node and relation identities.
+GPUI tests cover one shared selection, exact Conversation mapping, unknown-identity
+refusal, arrow-key focus navigation, and a complete three-cycle draw at the 1180 by 720
+minimum laptop window size.
+
+The visual-capture binary now has two explicit scenarios:
+
+- `development` renders the real three-cycle Development Program shape with three
+  Review-to-Program validation paths and the `dev.repository`, `dev.change`, and
+  `dev.validation` lens;
+- `paper-investment` renders the Paper Investment Pack with two Treasury assets, one
+  thesis, one scenario, and the exact comparison, informs, and tests relations.
+
+Both 1490 by 1092 captures were generated after the scene settled and were inspected.
+The focused GPUI all-target run passed for the production binary and both capture
+targets. Strict package Clippy passed with warnings denied. The schema-11 local database
+gate and the 12-test vNext architecture suite also passed. Native signed-app and
+accessibility acceptance remain separate completion gates because the capture binary is
+test-only and is never staged in `Decodex.app`.
+
+## Retained limits
+
+This surface is a bounded read projection. It does not add a graph database, scheduler,
+workflow editor, ontology editor, public scene format, Wasm host, Extension SDK,
+arbitrary Pack rendering code, Run Trace facts, provider-attempt facts, or a new product
+hierarchy. It does not make the canvas an authoring surface. Normal Program creation,
+Pack binding, WorkItem start, Evidence, Review, continuation, and Conversation actions
+remain the only legal mutations around the graph.
+
+See [Repeatable Program Loop V1 evidence](repeatable-program-loop-v1.md) for the Program
+lineage contract, [Built-in Domain Pack Pressure Test V1 evidence](builtin-domain-pack-pressure-test-v1.md)
+for Pack authority and two-domain behavior, and the
+[adaptive Program and extension architecture](../decisions/adaptive-program-extension-architecture.md)
+for the accepted graph and host-rendering boundary.

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -1,5 +1,5 @@
 ---
-okf_version: "0.1"
+okf_version: "0.2"
 ---
 
 # Files

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -7,6 +7,17 @@ openwiki:
   roles: [repository, architecture, workflow]
   change_kinds: [navigation]
   source_paths: [crates/decodex-runtime/src/quick_task.rs, crates/decodex-protocol/src/quick_task.rs, database/src/lib.rs]
+verified:
+  - by: openwiki/0.4.0
+    at: 2026-08-26T21:13:26.303Z
+sources:
+  - id: openwiki-source-e3cbf7660b5f77bbecd437c5
+    resource: repo://apps/decodex-gpui/src/bin/factory_visual_capture.rs
+  - id: openwiki-source-4d0807cef0e852e926ce0974
+    resource: repo://apps/decodex-gpui/src/factory_surface.rs
+  - id: openwiki-source-31df4748243df01f1137f62f
+    resource: repo://apps/decodex-gpui/src/program_graph.rs
+generated: {by: "codex", at: "2026-08-26T21:13:26.303Z"}
 ---
 
 # OpenWiki Quickstart
@@ -55,6 +66,9 @@ one-shot transfer tool.
 - [Built-in Domain Pack Pressure Test V1 evidence](evidence/builtin-domain-pack-pressure-test-v1.md):
   immutable Pack binding, namespaced domain projections, frozen Treasury provenance,
   fail-before-attempt capability checks, GPUI evidence, and two-domain live restart proof.
+- [Program Graph Surface V1 evidence](evidence/program-graph-surface-v1.md): the private
+  host renderer, deterministic layered Program and Domain Pack lenses, bounded viewport,
+  synchronized selection, keyboard and accessibility behavior, and inspected captures.
 - [Adaptive Factory Spine V1 evidence](evidence/adaptive-factory-spine-v1.md): the exact
   historical first-cycle boundary, causal projection, restart proof, and local dogfood
   record.
@@ -195,6 +209,7 @@ base. It does not make deferred extension or multi-agent surfaces partially avai
 | Change the signed macOS app bundle | [Runtime architecture](architecture/runtime-architecture.md) | `scripts/macos/stage_decodex_app.sh`, `apps/decodex-gpui/packaging/Info.plist` | `Decodex.app`, `decodex-gpui`, `DECODEX_APP_SIGN_IDENTITY` | `scripts/macos/test_decodex_app_stage.sh` | `scripts/macos/test_decodex_app_stage.sh` |
 | Change local daemon startup from the GUI or login-item visibility | [Runtime architecture](architecture/runtime-architecture.md) | `apps/decodex-gpui/src/bundled_daemon.rs`, `apps/decodex-gpui/src/main.rs` | `BundledDaemonGuard`, `bundled_daemon_path`, `lifetime_channel`, `order_out_native_windows`, `activate_main_window` | `tests/scripts/test_vnext_architecture.py`, bundled-daemon unit tests in `apps/decodex-gpui/src/bundled_daemon.rs` | `cargo +stable test -p decodex-gpui --all-targets` |
 | Change the menu-bar presentation bridge | [Runtime architecture](architecture/runtime-architecture.md) | `apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexApp.swift`, `apps/decodex-gpui/src/native_menu_bar.rs` | `decodex_menu_bar_create`, `decodex_menu_bar_set_visible`, `DecodexMenuBarHost` | `apps/decodex-gpui/menubar/Tests/DecodexAppTests/` | `swift test --package-path apps/decodex-gpui/menubar` |
+| Change the Program or Domain Pack graph layout, viewport, selection, keyboard, accessibility, or capture evidence | [Program Graph Surface V1 evidence](evidence/program-graph-surface-v1.md) | `apps/decodex-gpui/src/program_graph.rs`, `apps/decodex-gpui/src/factory_surface.rs`, `apps/decodex-gpui/src/programs.rs`, `apps/decodex-gpui/src/bin/factory_visual_capture.rs` | `ProgramGraphSurface`, `GraphLayout`, `GraphViewport`, `ProgramGraphEvent`, `VisualScenario` | colocated graph, Factory, Program fixture, keyboard, mapping, and minimum-size tests | `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo +stable test -p decodex-gpui --all-targets --features visual-capture` |
 | Validate or package the desktop surface | [Commands and validation](operations/commands-and-validation.md) | `scripts/macos/test_decodex_app_stage.sh`, `scripts/macos/run_decodex_gpui_accessibility_gate.swift` | bundle shape, signing team, exported ABI | app stage test and GPUI visual-capture tests | `scripts/macos/test_decodex_app_stage.sh` |
 
 ## First commands


### PR DESCRIPTION
## Summary

- replace the Program and Domain Pack horizontal strips with one private bounded GPUI graph renderer and deterministic layered layout
- add fit, zoom, pan, reset, shared selection, exact Conversation activation, native focus, keyboard navigation, and textual relation readout
- add three-cycle Development and Paper Investment capture scenarios plus OpenWiki evidence

## Validation

- cargo make test: 1158 passed, 9 declared skips; automation, gate, database, architecture, and CLI diagnostics passed
- focused GPUI all-target matrix: 151/31/149 passed with only 3 declared live-daemon tests ignored in the two production-shaped targets
- strict touched-package Clippy with warnings denied passed
- local database gate passed at schema 11; vNext architecture passed 12 tests
- signed Decodex.app stage and bundle/signature/ABI checks passed
- final Development and Paper captures were inspected
- native Accessibility harness passed TCC and exact signed-app launch identity, then stopped because the host console session was locked/inactive

## Known repository baseline

With the pinned npm, cargo make check passed dependency audits, site build/typecheck, and workspace cargo check, then stopped at the existing repository-wide rustfmt baseline in untouched files.