### PR TITLE
Synchronize Codex auth without refresh conflicts

### DIFF
--- a/apps/decodex-cli/src/account.rs
+++ b/apps/decodex-cli/src/account.rs
@@ -1,4 +1,4 @@
-//! Operator account client over the same-UID V2.10 daemon protocol.
+//! Operator account client over the same-UID V2.11 daemon protocol.
 
 use std::path::{Path, PathBuf};
 

--- a/apps/decodex-cli/src/lib.rs
+++ b/apps/decodex-cli/src/lib.rs
@@ -122,7 +122,7 @@ pub enum Command {
 	/// Observe and consume reset cards through the common daemon authority.
 	#[command(subcommand)]
 	ResetCard(reset_card::ResetCardCommand),
-	/// Manage daemon-owned accounts through the same-UID V2.10 protocol.
+	/// Manage daemon-owned accounts through the same-UID V2.11 protocol.
 	#[command(subcommand)]
 	Account(account::AccountCommand),
 	/// Read or update the current user's local Codex Fast mode setting.

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -55,22 +55,30 @@ struct AccountRoutePending: Decodable, Equatable, Sendable {
 	let operationID: String
 	let accountID: String
 	let routingRevision: UInt64
+	let waitReason: AccountRouteWaitReason
 
-	init(operationID: String, accountID: String, routingRevision: UInt64) {
+	init(
+		operationID: String,
+		accountID: String,
+		routingRevision: UInt64,
+		waitReason: AccountRouteWaitReason
+	) {
 		self.operationID = operationID
 		self.accountID = accountID
 		self.routingRevision = routingRevision
+		self.waitReason = waitReason
 	}
 
 	init(from decoder: Decoder) throws {
 		try requireExactFields(
 			in: decoder,
-			expected: ["operation_id", "account_id", "routing_revision"]
+			expected: ["operation_id", "account_id", "routing_revision", "wait_reason"]
 		)
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 		operationID = try container.decode(String.self, forKey: .operationID)
 		accountID = try container.decode(String.self, forKey: .accountID)
 		routingRevision = try container.decode(UInt64.self, forKey: .routingRevision)
+		waitReason = try container.decode(AccountRouteWaitReason.self, forKey: .waitReason)
 		guard DecodexNativeClient.isCanonicalAccountID(operationID),
 			DecodexNativeClient.isCanonicalAccountID(accountID),
 			routingRevision > 0
@@ -83,6 +91,138 @@ struct AccountRoutePending: Decodable, Equatable, Sendable {
 		case operationID = "operation_id"
 		case accountID = "account_id"
 		case routingRevision = "routing_revision"
+		case waitReason = "wait_reason"
+	}
+}
+
+enum AccountRouteBlockingProcess: String, Decodable, Equatable, Sendable {
+	case chatgpt
+	case codex
+}
+
+enum AccountRouteAuthHome: String, Decodable, Equatable, Sendable {
+	case shared
+	case unknown
+}
+
+struct AccountRouteProcessBlocker: Decodable, Equatable, Sendable {
+	let pid: UInt32
+	let process: AccountRouteBlockingProcess
+	let authHome: AccountRouteAuthHome
+
+	init(
+		pid: UInt32,
+		process: AccountRouteBlockingProcess,
+		authHome: AccountRouteAuthHome
+	) {
+		self.pid = pid
+		self.process = process
+		self.authHome = authHome
+	}
+
+	init(from decoder: Decoder) throws {
+		try requireExactFields(in: decoder, expected: ["pid", "process", "auth_home"])
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		pid = try container.decode(UInt32.self, forKey: .pid)
+		process = try container.decode(AccountRouteBlockingProcess.self, forKey: .process)
+		authHome = try container.decode(AccountRouteAuthHome.self, forKey: .authHome)
+		guard pid > 0 else {
+			throw AccountControlError.invalidResponse
+		}
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case pid
+		case process
+		case authHome = "auth_home"
+	}
+}
+
+enum AccountRouteWaitReason: Decodable, Equatable, Sendable {
+	case externalCodex(blockers: [AccountRouteProcessBlocker], omitted: UInt16)
+	case codexObservationUnavailable
+	case accountReadiness(ResetCardLifecycleReadiness)
+	case sharedAuthStabilizing
+	case sharedAuthUnavailable
+	case projectionReadback
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		switch try container.decode(String.self, forKey: .reason) {
+		case "external_codex":
+			try requireExactFields(in: decoder, expected: ["reason", "data"])
+			let data = try container.decode(ExternalCodexData.self, forKey: .data)
+			guard data.blockers.isEmpty == false,
+				data.blockers.count <= 8,
+				data.omitted == 0 || data.blockers.count == 8,
+				Set(data.blockers.map(\.pid)).count == data.blockers.count
+			else {
+				throw AccountControlError.invalidResponse
+			}
+			self = .externalCodex(blockers: data.blockers, omitted: data.omitted)
+		case "codex_observation_unavailable":
+			try requireExactFields(in: decoder, expected: ["reason"])
+			self = .codexObservationUnavailable
+		case "account_readiness":
+			try requireExactFields(in: decoder, expected: ["reason", "data"])
+			let data = try container.decode(AccountReadinessData.self, forKey: .data)
+			guard [
+				ResetCardLifecycleReadiness.storeUnavailable,
+				.storeMismatch,
+				.operationUnsettled,
+				.callbackCapabilityUnready,
+			].contains(data.readiness) else {
+				throw AccountControlError.invalidResponse
+			}
+			self = .accountReadiness(data.readiness)
+		case "shared_auth_stabilizing":
+			try requireExactFields(in: decoder, expected: ["reason"])
+			self = .sharedAuthStabilizing
+		case "shared_auth_unavailable":
+			try requireExactFields(in: decoder, expected: ["reason"])
+			self = .sharedAuthUnavailable
+		case "projection_readback":
+			try requireExactFields(in: decoder, expected: ["reason"])
+			self = .projectionReadback
+		default:
+			throw AccountControlError.invalidResponse
+		}
+	}
+
+	private struct ExternalCodexData: Decodable {
+		let blockers: [AccountRouteProcessBlocker]
+		let omitted: UInt16
+
+		init(from decoder: Decoder) throws {
+			try requireExactFields(in: decoder, expected: ["blockers", "omitted"])
+			let container = try decoder.container(keyedBy: CodingKeys.self)
+			blockers = try container.decode([AccountRouteProcessBlocker].self, forKey: .blockers)
+			omitted = try container.decode(UInt16.self, forKey: .omitted)
+		}
+
+		private enum CodingKeys: String, CodingKey {
+			case blockers
+			case omitted
+		}
+	}
+
+	private struct AccountReadinessData: Decodable {
+		let readiness: ResetCardLifecycleReadiness
+
+		init(from decoder: Decoder) throws {
+			try requireExactFields(in: decoder, expected: ["readiness"])
+			let container = try decoder.container(keyedBy: CodingKeys.self)
+			readiness = try container.decode(ResetCardLifecycleReadiness.self, forKey: .readiness)
+		}
+
+		private enum CodingKeys: String, CodingKey {
+			case readiness
+		}
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case reason
+		case data
 	}
 }
 

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
@@ -36,10 +36,14 @@ struct AccountPrimaryActionsView: View {
 	var body: some View {
 		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
-				title: presentation.isCurrent ? "Routed" : "Route",
-				symbol: presentation.isCurrent
-					? "point.3.connected.trianglepath.dotted"
-					: "arrow.triangle.branch",
+				title: isPendingTarget
+					? "Pending"
+					: (keepsCurrentRoute ? "Keep" : (presentation.isCurrent ? "Routed" : "Route")),
+				symbol: isPendingTarget
+					? "clock"
+					: (presentation.isCurrent
+						? "point.3.connected.trianglepath.dotted"
+						: "arrow.triangle.branch"),
 				isActive: presentation.isCurrent,
 				isDisabled: presentation.isDisabled,
 				isVisuallyDisabled: presentation.isVisuallyDisabled,
@@ -48,9 +52,14 @@ struct AccountPrimaryActionsView: View {
 					state.account.accountID,
 					activity: .route
 				),
-				help: presentation.isCurrent
-					? "This account is used by Decodex routing and new Codex processes. Restart ChatGPT to load it there."
-					: "Route Decodex now. Restart ChatGPT afterward to load this account; Decodex does not restart it."
+				help: isPendingTarget
+					? store.pendingRoute?.helpText
+						?? "Keep ChatGPT or Codex closed until Pending changes to Routed, then reopen it."
+					: (keepsCurrentRoute
+						? "Keep this account and replace the other pending route."
+						: (presentation.isCurrent
+							? "This account is synchronized for Decodex and Codex."
+							: "Synchronize this account for Decodex and Codex."))
 			) {
 				Task {
 					await store.routeAccount(state.account.accountID)
@@ -66,7 +75,11 @@ struct AccountPrimaryActionsView: View {
 	}
 
 	private var isRouteCurrent: Bool {
-		isCodexProjection && isFixed
+		isCodexProjection && isFixed && store.pendingRoute == nil
+	}
+
+	private var keepsCurrentRoute: Bool {
+		isCodexProjection && isFixed && store.pendingRoute != nil && isPendingTarget == false
 	}
 
 	private var presentation: AccountRouteActionPresentation {
@@ -80,7 +93,11 @@ struct AccountPrimaryActionsView: View {
 	}
 
 	private var canSelect: Bool {
-		state.routeCapability == .ready
+		state.routeCapability == .ready && store.pendingRoute?.accountID != state.account.accountID
+	}
+
+	private var isPendingTarget: Bool {
+		store.pendingRoute?.accountID == state.account.accountID
 	}
 
 	private var isFixed: Bool {
@@ -88,6 +105,100 @@ struct AccountPrimaryActionsView: View {
 			return false
 		}
 		return accountID == state.account.accountID
+	}
+}
+
+struct AccountRoutePendingStatusView: View {
+	let pending: AccountRoutePending
+	@Environment(\.colorScheme) private var colorScheme
+
+	var body: some View {
+		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.related) {
+			Image(systemName: "clock.arrow.circlepath")
+				.font(PanelFont.tertiary)
+				.foregroundStyle(PanelPalette.warning(colorScheme))
+				.accessibilityHidden(true)
+
+			Text(pending.statusText)
+				.font(PanelFont.tertiary)
+				.foregroundStyle(PanelPalette.secondaryText(colorScheme))
+				.fixedSize(horizontal: false, vertical: true)
+				.frame(maxWidth: .infinity, alignment: .leading)
+		}
+		.help(pending.helpText)
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(pending.statusText)
+		.accessibilityHint(pending.helpText)
+	}
+}
+
+extension AccountRoutePending {
+	var statusText: String {
+		switch waitReason {
+		case .externalCodex(let blockers, let omitted):
+			let total = blockers.count + Int(omitted)
+			let first = blockers.first.map(Self.blockerLabel) ?? "Codex"
+			if total == 1 {
+				return "Waiting for \(first) to quit."
+			}
+			let remaining = total - 1
+			let noun = remaining == 1 ? "process" : "Codex processes"
+			return "Waiting for \(first) and \(remaining) more \(noun) to quit."
+		case .codexObservationUnavailable:
+			return "Waiting for safe Codex process inspection."
+		case .accountReadiness(let readiness):
+			return Self.accountReadinessStatus(readiness)
+		case .sharedAuthStabilizing:
+			return "Waiting for shared Codex auth to stabilize."
+		case .sharedAuthUnavailable:
+			return "Shared Codex auth is unavailable or unsafe."
+		case .projectionReadback:
+			return "Verifying the atomic auth.json update."
+		}
+	}
+
+	var helpText: String {
+		switch waitReason {
+		case .externalCodex(let blockers, let omitted):
+			var labels = blockers.map(Self.blockerLabel)
+			if omitted > 0 {
+				labels.append("\(omitted) more")
+			}
+			return "Quit \(labels.joined(separator: ", ")), then keep ChatGPT or Codex closed until Pending changes to Routed. Reopen it after routing completes."
+		case .codexObservationUnavailable:
+			return "Decodex could not prove which Codex process owns the shared auth home, so the account switch remains safely blocked."
+		case .accountReadiness(let readiness):
+			return "\(Self.accountReadinessStatus(readiness)) Decodex retries automatically."
+		case .sharedAuthStabilizing:
+			return "Decodex is waiting for two matching auth.json observations before the atomic update."
+		case .sharedAuthUnavailable:
+			return "Check ~/.codex ownership, permissions, and path safety. Decodex retries automatically."
+		case .projectionReadback:
+			return "The auth.json update may have completed. Decodex is reading it back before routing is committed."
+		}
+	}
+
+	private static func blockerLabel(_ blocker: AccountRouteProcessBlocker) -> String {
+		let process = blocker.process == .chatgpt ? "ChatGPT" : "Codex"
+		let uncertainty = blocker.authHome == .unknown ? "; auth home unknown" : ""
+		return "\(process) PID \(blocker.pid)\(uncertainty)"
+	}
+
+	private static func accountReadinessStatus(
+		_ readiness: ResetCardLifecycleReadiness
+	) -> String {
+		switch readiness {
+		case .storeUnavailable:
+			return "Waiting for the credential store."
+		case .storeMismatch:
+			return "Waiting for credential binding reconciliation."
+		case .operationUnsettled:
+			return "Waiting for the current account operation to settle."
+		case .callbackCapabilityUnready:
+			return "Waiting for Codex refresh callback readiness."
+		case .ready, .credentialAbsent, .providerMismatch, .tombstoned:
+			return "Waiting for target account readiness."
+		}
 	}
 }
 
@@ -189,6 +300,7 @@ struct AccountUtilityActionsView: View {
 
 	private var lifecycleActionIsDisabled: Bool {
 		store.canPerformDirectAccountControl == false
+			|| store.pendingRoute != nil
 			|| store.isAccountControlInProgress
 			|| store.submittingKey != nil
 	}

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexApp.swift
@@ -78,7 +78,7 @@ enum AppAssets {
 }
 
 private let menuBarABIVersion: UInt32 = 1
-private let menuBarArtifactCohort: UInt32 = 6
+private let menuBarArtifactCohort: UInt32 = 7
 
 @_cdecl("decodex_menu_bar_abi_version")
 public func decodexMenuBarABIVersion() -> UInt32 {

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 
 let decodexNativeClientABIVersion: UInt32 = 1
-let decodexNativeArtifactCohort: UInt32 = 6
+let decodexNativeArtifactCohort: UInt32 = 7
 
 enum DecodexNativeCompatibility {
 	private typealias Version = @convention(c) () -> UInt32

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardSectionView.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardSectionView.swift
@@ -208,6 +208,13 @@ struct ResetCardAccountRow: View {
 				)
 			}
 
+			if let pending = store.pendingRoute,
+				pending.accountID == state.account.accountID
+			{
+				AccountRoutePendingStatusView(pending: pending)
+					.transition(.panelInline)
+			}
+
 			if exceptionalStatusText != nil {
 				exceptionalStatus
 					.transition(.panelInline)

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardStore.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardStore.swift
@@ -472,6 +472,7 @@ final class ResetCardStore {
 
 	var canBeginEnrollment: Bool {
 		accountControlClient != nil
+			&& pendingRoute == nil
 			&& canPerformDirectAccountControl
 			&& isAccountControlInProgress == false
 	}
@@ -482,6 +483,7 @@ final class ResetCardStore {
 		}
 		let accountIDs = accounts.map { $0.account.accountID }
 		return accountControlClient != nil
+			&& pendingRoute == nil
 			&& accountIDs.count > 1
 			&& accountIDs.count == routing.order.count
 			&& Set(accountIDs) == Set(routing.order)
@@ -1293,11 +1295,17 @@ final class ResetCardStore {
 	}
 
 	func canRouteAccount(_ accountID: String) -> Bool {
+		guard pendingRoute?.accountID != accountID else {
+			return false
+		}
 		guard let state = accounts.first(where: { $0.account.accountID == accountID }) else {
 			return false
 		}
 		guard state.routeCapability == .ready else {
 			return false
+		}
+		if pendingRoute != nil {
+			return true
 		}
 		let isFixedRoute: Bool
 		if let routing,
@@ -1307,8 +1315,7 @@ final class ResetCardStore {
 		} else {
 			isFixedRoute = false
 		}
-		return isFixedRoute == false
-			|| isCodexProjection(accountID) == false
+		return isFixedRoute == false || isCodexProjection(accountID) == false
 	}
 
 	func enrollFromSharedCodex(enabled: Bool = true) async {
@@ -1347,7 +1354,8 @@ final class ResetCardStore {
 		_ accountID: String,
 		enabled: Bool
 	) async {
-		guard let account = accountRecord(accountID),
+		guard pendingRoute == nil,
+			let account = accountRecord(accountID),
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -1371,7 +1379,8 @@ final class ResetCardStore {
 	}
 
 	func logoutAccount(_ accountID: String) async {
-		guard let account = accountRecord(accountID),
+		guard pendingRoute == nil,
+			let account = accountRecord(accountID),
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
@@ -1398,8 +1407,10 @@ final class ResetCardStore {
 
 	func routeAccount(_ accountID: String) async {
 		guard let account = accountRecord(accountID),
+			canRouteAccount(accountID),
 			let routing,
-			routing.order.contains(accountID)
+			routing.order.contains(accountID),
+			let accountControlClient
 		else {
 			presentAccountControlUnavailable()
 			return
@@ -1411,13 +1422,8 @@ final class ResetCardStore {
 		} else {
 			needsFixedRouting = true
 		}
-		guard needsCodexProjection || needsFixedRouting else {
-			return
-		}
-		guard canRouteAccount(accountID),
-			let accountControlClient
-		else {
-			presentAccountControlUnavailable()
+		let replacesPendingRoute = pendingRoute != nil
+		guard needsCodexProjection || needsFixedRouting || replacesPendingRoute else {
 			return
 		}
 
@@ -1441,7 +1447,8 @@ final class ResetCardStore {
 	}
 
 	func selectBalancedAccounts() async {
-		guard let routing,
+		guard pendingRoute == nil,
+			let routing,
 			let accountControlClient
 		else {
 			presentAccountControlUnavailable()

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountControlCLIClientTests.swift
@@ -29,7 +29,11 @@ final class AccountControlNativeClientTests: XCTestCase {
 				    \(controlUnsettledAccountJSON(accountID: secondAccountID, operationID: operationID))
 				  ],
 				  "routing":{"revision":9,"mode":{"mode":"fixed","account_id":"\(secondAccountID)"},"order":["\(secondAccountID)","\(accountID)"]},
-				  "pending_route":{"operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9}
+				  "pending_route":{"operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9,
+				    "wait_reason":{"reason":"external_codex","data":{"blockers":[
+				      {"pid":44662,"process":"chatgpt","auth_home":"shared"},
+				      {"pid":44768,"process":"codex","auth_home":"shared"}
+				    ],"omitted":0}}}
 				}}
 				"""
 			)
@@ -52,7 +56,22 @@ final class AccountControlNativeClientTests: XCTestCase {
 			AccountRoutePending(
 				operationID: operationID,
 				accountID: accountID,
-				routingRevision: 9
+				routingRevision: 9,
+				waitReason: .externalCodex(
+					blockers: [
+						AccountRouteProcessBlocker(
+							pid: 44662,
+							process: .chatgpt,
+							authHome: .shared
+						),
+						AccountRouteProcessBlocker(
+							pid: 44768,
+							process: .codex,
+							authHome: .shared
+						),
+					],
+					omitted: 0
+				)
 			)
 		)
 		XCTAssertEqual(snapshot.accounts[1].credentialBinding?.version, 3)
@@ -78,7 +97,11 @@ final class AccountControlNativeClientTests: XCTestCase {
 				data: """
 				{"outcome":"applied","data":{"entity_revision":9,
 				  "result":{"name":"account_route_pending","data":{"pending":{
-				    "operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9
+				    "operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9,
+				    "wait_reason":{"reason":"external_codex","data":{"blockers":[
+				      {"pid":44662,"process":"chatgpt","auth_home":"shared"},
+				      {"pid":44768,"process":"codex","auth_home":"shared"}
+				    ],"omitted":0}}
 				  }}}}}
 				"""
 			)
@@ -99,7 +122,47 @@ final class AccountControlNativeClientTests: XCTestCase {
 				AccountRoutePending(
 					operationID: operationID,
 					accountID: accountID,
-					routingRevision: 9
+					routingRevision: 9,
+					waitReason: .externalCodex(
+						blockers: [
+							AccountRouteProcessBlocker(
+								pid: 44662,
+								process: .chatgpt,
+								authHome: .shared
+							),
+							AccountRouteProcessBlocker(
+								pid: 44768,
+								process: .codex,
+								authHome: .shared
+							),
+						],
+						omitted: 0
+					)
+				)
+			)
+		)
+	}
+
+	func testPendingRouteRejectsInvalidBlockerAndReadinessReasons() throws {
+		let prefix = """
+		{"operation_id":"\(operationID)","account_id":"\(accountID)","routing_revision":9,
+		"wait_reason":
+		"""
+		XCTAssertThrowsError(
+			try JSONDecoder().decode(
+				AccountRoutePending.self,
+				from: Data(
+					"\(prefix){\"reason\":\"external_codex\",\"data\":{\"blockers\":[],\"omitted\":0}}}"
+						.utf8
+				)
+			)
+		)
+		XCTAssertThrowsError(
+			try JSONDecoder().decode(
+				AccountRoutePending.self,
+				from: Data(
+					"\(prefix){\"reason\":\"account_readiness\",\"data\":{\"readiness\":\"ready\"}}}"
+						.utf8
 				)
 			)
 		)

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountControlStoreTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountControlStoreTests.swift
@@ -57,7 +57,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNil(store.message)
 	}
 
-	func testLegacyPendingSnapshotDoesNotBlockOrdinaryRouteSelection() async throws {
+	func testNewRouteCanReplaceADifferentPendingTarget() async throws {
 		let secondID = "22222222-2222-4222-8222-222222222222"
 		let first = accountRecord()
 		let second = accountRecord(accountID: secondID, alias: "Second")
@@ -68,7 +68,8 @@ final class AccountControlStoreTests: XCTestCase {
 			pendingRoute: AccountRoutePending(
 				operationID: "33333333-3333-4333-8333-333333333333",
 				accountID: accountID,
-				routingRevision: 9
+				routingRevision: 9,
+				waitReason: .sharedAuthStabilizing
 			)
 		)
 		let fixture = pendingFixture()
@@ -80,7 +81,7 @@ final class AccountControlStoreTests: XCTestCase {
 		)
 		await store.refresh()
 
-		XCTAssertTrue(store.canRouteAccount(accountID))
+		XCTAssertFalse(store.canRouteAccount(accountID))
 		XCTAssertTrue(store.canRouteAccount(secondID))
 		await store.routeAccount(secondID)
 		let routeRequest = await client.routeRequest()
@@ -89,7 +90,7 @@ final class AccountControlStoreTests: XCTestCase {
 		XCTAssertNil(store.pendingRoute)
 	}
 
-	func testCurrentRouteRemainsNoOpWhenLegacyPendingSnapshotIsPresent() async throws {
+	func testCurrentRouteCanCancelADifferentPendingTarget() async throws {
 		let secondID = "22222222-2222-4222-8222-222222222222"
 		let first = accountRecord()
 		let second = accountRecord(accountID: secondID, alias: "Second")
@@ -105,7 +106,8 @@ final class AccountControlStoreTests: XCTestCase {
 			pendingRoute: AccountRoutePending(
 				operationID: "33333333-3333-4333-8333-333333333333",
 				accountID: secondID,
-				routingRevision: 9
+				routingRevision: 9,
+				waitReason: .sharedAuthStabilizing
 			),
 			projection: .current(
 				accountID: accountID,
@@ -122,12 +124,12 @@ final class AccountControlStoreTests: XCTestCase {
 		)
 		await store.refresh()
 
-		XCTAssertFalse(store.canRouteAccount(accountID))
+		XCTAssertTrue(store.canRouteAccount(accountID))
 		await store.routeAccount(accountID)
 		let routeRequest = await client.routeRequest()
-		XCTAssertNil(routeRequest)
+		XCTAssertEqual(routeRequest?.accountID, accountID)
 		XCTAssertEqual(store.routing?.mode, .fixed(accountID: accountID))
-		XCTAssertNotNil(store.pendingRoute)
+		XCTAssertNil(store.pendingRoute)
 	}
 
 	func testDirectActionsWaitForTheCurrentSkeletonBeforeDispatch() async throws {
@@ -1054,7 +1056,8 @@ final class AccountControlStoreTests: XCTestCase {
 			pendingRoute: AccountRoutePending(
 				operationID: "33333333-3333-4333-8333-333333333333",
 				accountID: targetAccountID,
-				routingRevision: 9
+				routingRevision: 9,
+				waitReason: .sharedAuthStabilizing
 			),
 			projection: .current(
 				accountID: accountID,

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -34,6 +34,43 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertTrue(presentation.usesDisabledEnvironment)
 	}
 
+	func testPendingRouteNamesConcreteSharedAuthBlockers() {
+		let pending = AccountRoutePending(
+			operationID: "33333333-3333-4333-8333-333333333333",
+			accountID: "11111111-1111-4111-8111-111111111111",
+			routingRevision: 9,
+			waitReason: .externalCodex(
+				blockers: [
+					AccountRouteProcessBlocker(
+						pid: 44662,
+						process: .chatgpt,
+						authHome: .shared
+					),
+					AccountRouteProcessBlocker(
+						pid: 44768,
+						process: .codex,
+						authHome: .unknown
+					),
+				],
+				omitted: 0
+			)
+		)
+
+		XCTAssertEqual(
+			pending.statusText,
+			"Waiting for ChatGPT PID 44662 and 1 more process to quit."
+		)
+		XCTAssertTrue(pending.helpText.contains("Codex PID 44768; auth home unknown"))
+
+		let hostingView = NSHostingView(
+			rootView: AccountRoutePendingStatusView(pending: pending)
+				.frame(width: 276)
+		)
+		hostingView.layoutSubtreeIfNeeded()
+		XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+		XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 52)
+	}
+
 	func testRouteCapabilityDoesNotDependOnQuickTaskCallbackReadiness() {
 		let authority = ResetCardAuthority(
 			profileName: "local",

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -624,6 +624,10 @@ final class ResetCardArchitectureTests: XCTestCase {
 			contentsOf: sourceURL.appendingPathComponent("AccountControlViews.swift"),
 			encoding: .utf8
 		)
+		let section = try String(
+			contentsOf: sourceURL.appendingPathComponent("ResetCardSectionView.swift"),
+			encoding: .utf8
+		)
 
 		XCTAssertTrue(store.contains("accountControlClient.routeAccount("))
 		XCTAssertFalse(store.contains("PendingAccountRoutePreparation"))
@@ -633,18 +637,24 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertFalse(store.contains("useAccountInCodex("))
 		XCTAssertFalse(store.contains("setFixedSelection("))
 		XCTAssertTrue(client.contains(#"operation: "route_account""#))
+		XCTAssertTrue(client.contains("AccountRouteWaitReason"))
+		XCTAssertTrue(client.contains(#"case waitReason = "wait_reason""#))
 		XCTAssertFalse(client.contains(#"operation: "use_account_in_codex""#))
 		XCTAssertFalse(client.contains(#"operation: "set_fixed_selection""#))
-		XCTAssertFalse(store.contains("guard pendingRoute == nil"))
-		XCTAssertFalse(store.contains("&& pendingRoute == nil"))
-		XCTAssertFalse(store.contains("pendingRoute?.accountID != accountID"))
-		XCTAssertFalse(store.contains("replacesPendingRoute = pendingRoute != nil"))
-		XCTAssertFalse(actions.contains("isPendingTarget"))
-		XCTAssertFalse(actions.contains(#"? "Pending""#))
-		XCTAssertFalse(actions.contains("keepsCurrentRoute"))
-		XCTAssertFalse(actions.contains("Quit ChatGPT"))
-		XCTAssertTrue(actions.contains("Restart ChatGPT afterward"))
-		XCTAssertTrue(actions.contains("Decodex does not restart it"))
+		XCTAssertTrue(store.contains("guard pendingRoute == nil"))
+		XCTAssertTrue(store.contains("&& pendingRoute == nil"))
+		XCTAssertTrue(store.contains("pendingRoute?.accountID != accountID"))
+		XCTAssertTrue(store.contains("replacesPendingRoute = pendingRoute != nil"))
+		XCTAssertTrue(actions.contains("title: isPendingTarget"))
+		XCTAssertTrue(actions.contains(#"? "Pending""#))
+		XCTAssertTrue(actions.contains("keepsCurrentRoute"))
+		XCTAssertTrue(actions.contains("keep ChatGPT or Codex closed until Pending changes to Routed"))
+		XCTAssertTrue(actions.contains("AccountRoutePendingStatusView"))
+		XCTAssertTrue(actions.contains("PID \\(blocker.pid)"))
+		XCTAssertTrue(section.contains("AccountRoutePendingStatusView(pending: pending)"))
+		XCTAssertTrue(
+			actions.contains("store.pendingRoute?.accountID != state.account.accountID")
+		)
 	}
 
 	func testMenuBarOwnerDisablesAutomaticAndSuddenTermination() throws {
@@ -805,7 +815,7 @@ final class ResetCardArchitectureTests: XCTestCase {
 			compatibility.contains("decodexNativeClientABIVersion: UInt32 = 1")
 		)
 		XCTAssertTrue(
-			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 6")
+			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 7")
 		)
 		XCTAssertTrue(
 			compatibility.contains("static func openLibrary(at libraryURL: URL)")

--- a/apps/decodex-gpui/src/accounts.rs
+++ b/apps/decodex-gpui/src/accounts.rs
@@ -13,10 +13,11 @@ use tokio::sync::Notify;
 
 use decodex_protocol::{
 	AccountDto, AccountRoutePendingDto, AccountRoutingControlDto, AccountSelectionModeDto,
-	AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId, CommandEnvelope, CommandOutcome,
-	CommandPayload, CommandReceipt, CommandResultEnvelope, CorrelationId, EntityId, EntityRevision,
-	EventEnvelope, EventPayload, IdempotencyKey, QueryEnvelope, QueryId, QueryPayload,
-	QueryResultEnvelope, QueryResultPayload, ReceiptDisposition, ResultPayload, ServerId,
+	AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId,
+	CommandEnvelope, CommandOutcome, CommandPayload, CommandReceipt, CommandResultEnvelope,
+	CorrelationId, EntityId, EntityRevision, EventEnvelope, EventPayload, IdempotencyKey,
+	QueryEnvelope, QueryId, QueryPayload, QueryResultEnvelope, QueryResultPayload,
+	ReceiptDisposition, ResultPayload, ServerId,
 };
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
@@ -31,7 +32,7 @@ pub(crate) struct AccountsSnapshot {
 	pub(crate) pending_route: Option<AccountRoutePendingDto>,
 	pub(crate) can_manage: bool,
 	pub(crate) can_route: bool,
-	pub(crate) route_restart_notice: bool,
+	pub(crate) route_reopen_notice: bool,
 }
 
 /// Finite account-pool readback state.
@@ -401,7 +402,7 @@ impl AccountsController {
 				state.upsert_account((**account).clone());
 				state.routing = Some(routing.clone());
 				state.pending_route = None;
-				state.route_restart_notice = true;
+				state.route_reopen_notice = true;
 				state.sort_accounts();
 			},
 			EventPayload::AccountRoutePending { pending } => {
@@ -588,7 +589,7 @@ struct State {
 	accounts: Vec<AccountDto>,
 	routing: Option<AccountRoutingControlDto>,
 	pending_route: Option<AccountRoutePendingDto>,
-	route_restart_notice: bool,
+	route_reopen_notice: bool,
 }
 
 impl State {
@@ -607,7 +608,7 @@ impl State {
 			accounts: Vec::new(),
 			routing: None,
 			pending_route: None,
-			route_restart_notice: false,
+			route_reopen_notice: false,
 		}
 	}
 
@@ -630,7 +631,7 @@ impl State {
 			pending_route: self.pending_route.clone(),
 			can_manage: idle,
 			can_route: idle,
-			route_restart_notice: self.route_restart_notice,
+			route_reopen_notice: self.route_reopen_notice,
 		}
 	}
 
@@ -684,7 +685,7 @@ impl State {
 			causation_id: None::<CausationId>,
 			payload,
 		});
-		self.route_restart_notice = false;
+		self.route_reopen_notice = false;
 		self.command = AccountCommandState::Sending;
 		Ok(())
 	}
@@ -761,7 +762,7 @@ impl State {
 				self.upsert_account((**account).clone());
 				self.routing = Some(routing.clone());
 				self.pending_route = None;
-				self.route_restart_notice = true;
+				self.route_reopen_notice = true;
 				self.sort_accounts();
 				true
 			},
@@ -986,7 +987,7 @@ mod tests {
 		);
 		let routed_snapshot = controller.snapshot();
 		assert_eq!(routed_snapshot.routing, Some(routed));
-		assert!(routed_snapshot.route_restart_notice);
+		assert!(routed_snapshot.route_reopen_notice);
 		assert!(routed_snapshot.pending_route.is_none());
 	}
 
@@ -1024,6 +1025,7 @@ mod tests {
 							.unwrap(),
 							account_id: first.account_id.clone(),
 							routing_revision: EntityRevision(5),
+							wait_reason: decodex_protocol::AccountRouteWaitReasonDto::SharedAuthStabilizing,
 						}),
 					}),
 				},

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -102,16 +102,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_10() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_11() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.10");
+		.expect("production lifecycle constructs at protocol V2.11");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 10);
+	assert_eq!(CURRENT_VERSION.minor, 11);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -21,11 +21,12 @@ use gpui::{
 use decodex_protocol::{
 	AccountDto, AccountLifecycleReadinessDto, AccountLoginInstallMode, AccountLoginMethod,
 	AccountLoginStart, AccountLoginState, AccountLoginStatus, AccountObservedStateDto,
-	AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto, AccountSelectionModeDto,
-	AppServerCapability, ClientFailure, DoctorComponent, DoctorIssue, DoctorStatus, EntityId,
-	HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto, HistoryPayloadDto, HistoryTurnRole,
-	IdempotencyKey, QuickTaskRecoveryAction, QuickTaskState, QuickTaskSummary, WorkItemBoardCard,
-	WorkItemState,
+	AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto, AccountRouteAuthHomeDto,
+	AccountRouteBlockingProcessDto, AccountRoutePendingDto, AccountRouteWaitReasonDto,
+	AccountSelectionModeDto, AppServerCapability, ClientFailure, DoctorComponent, DoctorIssue,
+	DoctorStatus, EntityId, HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto,
+	HistoryPayloadDto, HistoryTurnRole, IdempotencyKey, QuickTaskRecoveryAction, QuickTaskState,
+	QuickTaskSummary, WorkItemBoardCard, WorkItemState,
 };
 
 use crate::{
@@ -873,7 +874,7 @@ impl Shell {
 			pending_route: None,
 			can_manage: true,
 			can_route: true,
-			route_restart_notice: false,
+			route_reopen_notice: false,
 		};
 		let health_checks = DoctorComponent::ALL
 			.into_iter()
@@ -2908,8 +2909,14 @@ fn accounts_content(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 		.is_some_and(|routing| routing.mode == AccountSelectionModeDto::Balanced);
 	let can_manage = snapshot.can_manage;
 	let status = snapshot
-		.route_restart_notice
-		.then(|| "Route succeeded. Restart ChatGPT or Codex to load this account.".to_owned())
+		.pending_route
+		.as_ref()
+		.map(account_route_pending_label)
+		.or_else(|| {
+			snapshot
+				.route_reopen_notice
+				.then(|| "Route succeeded. You can reopen ChatGPT or Codex now.".to_owned())
+		})
 		.or_else(|| shell.account_status.as_ref().map(SharedString::to_string))
 		.or_else(|| account_command_label(snapshot.command).map(str::to_owned))
 		.unwrap_or_else(|| accounts_load_label(snapshot.load).to_owned());
@@ -3076,6 +3083,50 @@ fn accounts_content(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 				),
 		)
 		.into_any_element()
+}
+
+fn account_route_pending_label(pending: &AccountRoutePendingDto) -> String {
+	match &pending.wait_reason {
+		AccountRouteWaitReasonDto::ExternalCodex { blockers, omitted } => {
+			let mut labels = blockers
+				.iter()
+				.map(|blocker| {
+					let process = match blocker.process {
+						AccountRouteBlockingProcessDto::Chatgpt => "ChatGPT",
+						AccountRouteBlockingProcessDto::Codex => "Codex",
+					};
+					let uncertainty = match blocker.auth_home {
+						AccountRouteAuthHomeDto::Shared => "",
+						AccountRouteAuthHomeDto::Unknown => "; auth home unknown",
+					};
+					format!("{process} PID {}{uncertainty}", blocker.pid)
+				})
+				.collect::<Vec<_>>();
+		if *omitted > 0 {
+			labels.push(format!("{omitted} more"));
+		}
+		format!(
+			"Route pending. Quit {}. Keep ChatGPT or Codex closed until routing completes.",
+			labels.join(", ")
+		)
+		},
+		AccountRouteWaitReasonDto::CodexObservationUnavailable => {
+			"Route pending. Codex process ownership could not be inspected safely.".to_owned()
+		},
+		AccountRouteWaitReasonDto::AccountReadiness { readiness } => format!(
+			"Route pending. Target account readiness is {}.",
+			account_readiness_label(*readiness)
+		),
+		AccountRouteWaitReasonDto::SharedAuthStabilizing => {
+			"Route pending. Waiting for stable shared Codex auth.".to_owned()
+		},
+		AccountRouteWaitReasonDto::SharedAuthUnavailable => {
+			"Route pending. Shared Codex auth is unavailable or unsafe.".to_owned()
+		},
+		AccountRouteWaitReasonDto::ProjectionReadback => {
+			"Route pending. Verifying the atomic shared-auth update.".to_owned()
+		},
+	}
 }
 
 fn account_mode_button(
@@ -5940,6 +5991,27 @@ mod tests {
 				},
 			)
 			.is_some()
+		);
+	}
+
+	#[test]
+	fn pending_route_status_names_the_blocking_process() {
+		let pending = AccountRoutePendingDto {
+			operation_id: EntityId::new("30000000-0000-4000-8000-000000000001").unwrap(),
+			account_id: EntityId::new("10000000-0000-4000-8000-000000000001").unwrap(),
+			routing_revision: decodex_protocol::EntityRevision(9),
+			wait_reason: AccountRouteWaitReasonDto::ExternalCodex {
+				blockers: vec![decodex_protocol::AccountRouteProcessBlockerDto {
+					pid: 44_662,
+					process: AccountRouteBlockingProcessDto::Chatgpt,
+					auth_home: AccountRouteAuthHomeDto::Shared,
+				}],
+				omitted: 0,
+			},
+		};
+		assert_eq!(
+			account_route_pending_label(&pending),
+			"Route pending. Quit ChatGPT PID 44662. Keep ChatGPT or Codex closed until routing completes."
 		);
 	}
 

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -866,7 +866,7 @@ impl ResetCardClient {
 	}
 }
 
-/// Read-only V2.10 client for bounded canonical WorkItem board pages.
+/// Read-only V2.11 client for bounded canonical WorkItem board pages.
 pub struct WorkItemBoardClient {
 	transport: ResetCardClient,
 }
@@ -1059,7 +1059,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.10 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.11 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1694,8 +1694,8 @@ mod tests {
 	use crate::{
 		AccountClient, AccountCommandResponse, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto,
-		AccountProfileResult, AccountRoutePendingDto, CURRENT_ARTIFACT_COHORT, CURRENT_VERSION,
-		Channel, ClientCommandId,
+		AccountProfileResult, AccountRoutePendingDto, AccountRouteWaitReasonDto,
+		CURRENT_ARTIFACT_COHORT, CURRENT_VERSION, Channel, ClientCommandId,
 		ClientFailure, ClientMessage, ClientProfile, CommandError, CommandOutcome, CommandPayload,
 		CommandReceipt, CommandResultEnvelope, CorrelationId, Cursor, DoctorCheck, DoctorClient,
 		DoctorComponent,
@@ -1768,6 +1768,7 @@ mod tests {
 				operation_id,
 				account_id,
 				routing_revision: EntityRevision(9),
+				wait_reason: AccountRouteWaitReasonDto::SharedAuthStabilizing,
 			},
 		};
 		assert!(super::account_result_matches(&command, EntityRevision(9), &result));
@@ -1838,6 +1839,7 @@ mod tests {
 							operation_id: expected_operation_id,
 							account_id: expected_account_id,
 							routing_revision: EntityRevision(9),
+							wait_reason: AccountRouteWaitReasonDto::SharedAuthStabilizing,
 						},
 					}),
 					error: None,
@@ -2070,12 +2072,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_10_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 10 });
+	fn protocol_constants_expose_only_the_exact_v2_11_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 11 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 10, maximum_minor: 10 },
+			SupportedVersions { major: 2, minimum_minor: 11, maximum_minor: 11 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -64,8 +64,10 @@ pub use self::{
 		AccountObservedStateDto, AccountOperationKindDto, AccountOperationPhaseDto,
 		AccountProfileDailyUsageDto, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto, AccountProfileResult, AccountProviderDto, AccountQuotaErrorDto,
-		AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutePendingDto,
-		AccountRoutingControlDto, AccountSelectionModeDto, AccountSelectionRecoveryDto,
+		AccountQuotaStateDto, AccountQuotaWindowDto, AccountRouteAuthHomeDto,
+		AccountRouteBlockingProcessDto, AccountRoutePendingDto, AccountRouteProcessBlockerDto,
+		AccountRouteWaitReasonDto, AccountRoutingControlDto, AccountSelectionModeDto,
+		AccountSelectionRecoveryDto,
 		AccountUnsettledOperationDto, AccountsResult, CausationId, Channel, ClientCommandId,
 		ClientHello, ClientMessage, CodexAuthProjectionResult, CommandEnvelope, CommandError,
 		CommandOutcome, CommandPayload, CommandReceipt, CommandResultEnvelope,
@@ -79,7 +81,8 @@ pub use self::{
 		HistoryItemKindDto, HistoryItemStatusDto, HistoryMediaType, HistoryMetadata,
 		HistoryMetadataValue, HistoryPayloadDto, HistoryQueryError, HistorySideEffectState,
 		HistoryText, HistoryTurnRole, IdempotencyKey, IdempotencyKeyError,
-		MAX_ACCOUNT_PROFILE_DAILY_USAGE, MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
+		MAX_ACCOUNT_PROFILE_DAILY_USAGE, MAX_ACCOUNT_ROUTE_PROCESS_BLOCKERS,
+		MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS,
 		MAX_HISTORY_METADATA_KEY_BYTES, MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE,
 		MAX_IDEMPOTENCY_KEY_BYTES, MAX_PROJECT_LIST_ITEMS, MAX_RESET_CARD_ITEMS,
 		MAX_WIRE_TEXT_BYTES, MAX_WORK_ITEM_BOARD_OBJECTIVES, MAX_WORK_ITEM_BOARD_PAGE_SIZE,
@@ -103,9 +106,9 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 10 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 11 };
 /// Build/protocol cohort that must agree across the daemon and every local consumer.
-pub const CURRENT_ARTIFACT_COHORT: u32 = 6;
+pub const CURRENT_ARTIFACT_COHORT: u32 = 7;
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -78,7 +78,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.10 local endpoint authority.
+/// The complete V2.11 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.10 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.11 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -31,7 +31,7 @@ use crate::{
 	},
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.10.
+/// Maximum UTF-8 size of any human-readable text carried by V2.11.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -52,6 +52,8 @@ pub const MAX_WORK_ITEM_BOARD_TITLE_BYTES: usize = decodex_core::MAX_WORK_ITEM_T
 pub const MAX_PROJECT_LIST_ITEMS: usize = 64;
 /// Maximum daily usage facts retained and returned for one account profile.
 pub const MAX_ACCOUNT_PROFILE_DAILY_USAGE: usize = 36;
+/// Maximum concrete process blockers returned for one pending account Route.
+pub const MAX_ACCOUNT_ROUTE_PROCESS_BLOCKERS: usize = 8;
 /// Maximum verified payload length representable in a history blob reference.
 pub const MAX_HISTORY_BLOB_BYTES: u64 = 64 * 1_024 * 1_024;
 
@@ -156,7 +158,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded its V2.10 byte limit.
+/// A string-backed wire scalar exceeded its V2.11 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -177,7 +179,7 @@ impl Display for WireScalarTooLong {
 	}
 }
 
-/// Closed construction failures for the V2.10 WorkItem board contract.
+/// Closed construction failures for the V2.11 WorkItem board contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkItemBoardContractError {
 	/// An identity was not canonical lowercase RFC 9562 UUID-v4 text.
@@ -279,7 +281,7 @@ impl<'de> Deserialize<'de> for WorkItemBoardTitle {
 #[serde(transparent)]
 pub struct WorkItemBoardPageSize(u16);
 impl WorkItemBoardPageSize {
-	/// Construct a page size inside the closed V2.10 protocol bound.
+	/// Construct a page size inside the closed V2.11 protocol bound.
 	pub const fn new(value: u16) -> Result<Self, WorkItemBoardContractError> {
 		if value == 0 || value > MAX_WORK_ITEM_BOARD_PAGE_SIZE {
 			Err(WorkItemBoardContractError::InvalidPageSize)
@@ -600,7 +602,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.10 resume requires this field. Older hello envelopes can omit it
+	/// A V2.11 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -656,7 +658,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.10 welcome.
+	/// This is present in the exact-current V2.11 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1786,7 +1788,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.10 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.11 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -1956,7 +1958,65 @@ pub struct AccountRoutingControlDto {
 	pub order: Vec<EntityId>,
 }
 
-/// Legacy durable Route intent retained for exact decode and one-time startup recovery.
+/// Closed process identity for one shared-auth Route blocker.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountRouteBlockingProcessDto {
+	/// The ChatGPT desktop application.
+	Chatgpt,
+	/// A Codex desktop, app-server, or CLI process.
+	Codex,
+}
+
+/// Evidence for the auth home used by one blocking process.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountRouteAuthHomeDto {
+	/// The process is proved to use the normal shared Codex home.
+	Shared,
+	/// The process home could not be read or proved isolated, so the gate fails closed.
+	Unknown,
+}
+
+/// One credential-negative process blocker for a pending Route.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountRouteProcessBlockerDto {
+	/// Positive local process identity.
+	pub pid: u32,
+	/// Closed user-facing process identity.
+	pub process: AccountRouteBlockingProcessDto,
+	/// Shared-home evidence used by the safety gate.
+	pub auth_home: AccountRouteAuthHomeDto,
+}
+
+/// Current reason why an accepted Route cannot complete yet.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "reason", content = "data", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AccountRouteWaitReasonDto {
+	/// Concrete external processes can still write the normal shared auth file.
+	ExternalCodex {
+		/// Bounded deterministic blocker list.
+		blockers: Vec<AccountRouteProcessBlockerDto>,
+		/// Additional blockers omitted from the bounded list.
+		omitted: u16,
+	},
+	/// Process enumeration or auth-home inspection was unavailable and therefore failed closed.
+	CodexObservationUnavailable,
+	/// The target account cannot safely resume its retained Route yet.
+	AccountReadiness {
+		/// Exact daemon-owned readiness state.
+		readiness: AccountLifecycleReadinessDto,
+	},
+	/// The shared auth source needs another stable observation.
+	SharedAuthStabilizing,
+	/// The shared auth source or its owner-safe path cannot currently be read.
+	SharedAuthUnavailable,
+	/// The atomic projection may have completed and requires exact readback.
+	ProjectionReadback,
+}
+
+/// Durable Route handoff retained while one exact safe-cutover prerequisite remains open.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccountRoutePendingDto {
 	/// Stable Route operation identity.
@@ -1965,6 +2025,8 @@ pub struct AccountRoutePendingDto {
 	pub account_id: EntityId,
 	/// Routing revision fenced when the intent was accepted.
 	pub routing_revision: EntityRevision,
+	/// Current credential-negative wait reason.
+	pub wait_reason: AccountRouteWaitReasonDto,
 }
 
 impl Serialize for AccountRoutePendingDto {
@@ -1972,22 +2034,19 @@ impl Serialize for AccountRoutePendingDto {
 	where
 		S: serde::Serializer,
 	{
-		if !is_canonical_uuid(self.operation_id.as_str())
-			|| !is_canonical_uuid(self.account_id.as_str())
-			|| self.routing_revision.0 == 0
-		{
-			return Err(S::Error::custom("pending account Route is invalid"));
-		}
+		validate_account_route_pending(self).map_err(S::Error::custom)?;
 		#[derive(Serialize)]
 		struct Raw<'a> {
 			operation_id: &'a EntityId,
 			account_id: &'a EntityId,
 			routing_revision: EntityRevision,
+			wait_reason: &'a AccountRouteWaitReasonDto,
 		}
 		Raw {
 			operation_id: &self.operation_id,
 			account_id: &self.account_id,
 			routing_revision: self.routing_revision,
+			wait_reason: &self.wait_reason,
 		}
 		.serialize(serializer)
 	}
@@ -2004,19 +2063,17 @@ impl<'de> Deserialize<'de> for AccountRoutePendingDto {
 			operation_id: EntityId,
 			account_id: EntityId,
 			routing_revision: EntityRevision,
+			wait_reason: AccountRouteWaitReasonDto,
 		}
 		let raw = Raw::deserialize(deserializer)?;
-		if !is_canonical_uuid(raw.operation_id.as_str())
-			|| !is_canonical_uuid(raw.account_id.as_str())
-			|| raw.routing_revision.0 == 0
-		{
-			return Err(D::Error::custom("pending account Route is invalid"));
-		}
-		Ok(Self {
+		let pending = Self {
 			operation_id: raw.operation_id,
 			account_id: raw.account_id,
 			routing_revision: raw.routing_revision,
-		})
+			wait_reason: raw.wait_reason,
+		};
+		validate_account_route_pending(&pending).map_err(D::Error::custom)?;
+		Ok(pending)
 	}
 }
 impl Serialize for AccountRoutingControlDto {
@@ -2178,7 +2235,7 @@ pub enum AccountsResult {
 		/// Routing controls with an exact account permutation, when that capability read
 		/// succeeded.
 		routing: Option<AccountRoutingControlDto>,
-		/// One legacy pending Route intent awaiting startup compatibility recovery.
+		/// One pending Route waiting for safe shared-auth cutover.
 		pending_route: Option<AccountRoutePendingDto>,
 	},
 	/// The account authority could not return a safe snapshot.
@@ -2401,7 +2458,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.10 protocol.
+/// Live queries available through the exact-current V2.11 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2505,7 +2562,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.10 protocol.
+/// Commands available through the exact-current V2.11 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2896,7 +2953,7 @@ pub enum EventPayload {
 		/// Credential-negative digest of the projected account binding.
 		projection_digest: Sha256Digest,
 	},
-	/// A legacy durable Route intent was recovered from a pre-immediate implementation.
+	/// One durable Route is waiting for external Codex quiescence and safe projection.
 	AccountRoutePending {
 		/// Complete credential-negative pending intent.
 		pending: AccountRoutePendingDto,
@@ -3054,7 +3111,7 @@ pub enum ResultPayload {
 		/// Credential-negative digest of the projected account binding.
 		projection_digest: Sha256Digest,
 	},
-	/// A legacy durable Route result retained for decode and startup recovery compatibility.
+	/// One durable Route was accepted and is waiting for safe shared-auth cutover.
 	AccountRoutePending {
 		/// Complete credential-negative pending intent.
 		pending: AccountRoutePendingDto,
@@ -3069,13 +3126,13 @@ pub enum ResultPayload {
 }
 
 impl ResultPayload {
-	/// A legacy evolving receipt must be replayed by the application, not transport memory.
+	/// A pending Route receipt evolves after the daemon proves safe cutover.
 	pub const fn is_evolving_receipt(&self) -> bool {
 		matches!(self, Self::AccountRoutePending { .. })
 	}
 }
 
-/// Typed live-query results available through the exact-current V2.10 protocol.
+/// Typed live-query results available through the exact-current V2.11 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -4027,12 +4084,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.10 wire encoding.
+/// Serialize a message using the only V2.11 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.10 wire encoding.
+/// Parse a client message using the only V2.11 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -4455,9 +4512,7 @@ fn validate_accounts_result(
 		}
 	}
 	if let Some(pending) = pending_route {
-		if !is_canonical_uuid(pending.operation_id.as_str())
-			|| !is_canonical_uuid(pending.account_id.as_str())
-			|| pending.routing_revision.0 == 0
+		if validate_account_route_pending(pending).is_err()
 			|| !universe.contains(pending.account_id.as_str())
 		{
 			return Err("pending account Route is invalid");
@@ -4467,6 +4522,46 @@ fn validate_accounts_result(
 		{
 			return Err("pending account Route revision is stale");
 		}
+	}
+	Ok(())
+}
+
+fn validate_account_route_pending(pending: &AccountRoutePendingDto) -> Result<(), &'static str> {
+	if !is_canonical_uuid(pending.operation_id.as_str())
+		|| !is_canonical_uuid(pending.account_id.as_str())
+		|| pending.routing_revision.0 == 0
+	{
+		return Err("pending account Route is invalid");
+	}
+	match &pending.wait_reason {
+		AccountRouteWaitReasonDto::ExternalCodex { blockers, omitted } => {
+			if blockers.is_empty()
+				|| blockers.len() > MAX_ACCOUNT_ROUTE_PROCESS_BLOCKERS
+				|| (*omitted > 0 && blockers.len() != MAX_ACCOUNT_ROUTE_PROCESS_BLOCKERS)
+			{
+				return Err("pending account Route blocker list is invalid");
+			}
+			let mut pids = HashSet::new();
+			if blockers.iter().any(|blocker| blocker.pid == 0 || !pids.insert(blocker.pid)) {
+				return Err("pending account Route blocker identity is invalid");
+			}
+		},
+		AccountRouteWaitReasonDto::AccountReadiness { readiness }
+			if !matches!(
+				readiness,
+				AccountLifecycleReadinessDto::StoreUnavailable
+					| AccountLifecycleReadinessDto::StoreMismatch
+					| AccountLifecycleReadinessDto::OperationUnsettled
+					| AccountLifecycleReadinessDto::CallbackCapabilityUnready
+			) =>
+		{
+			return Err("pending account Route readiness is invalid");
+		},
+		AccountRouteWaitReasonDto::CodexObservationUnavailable
+		| AccountRouteWaitReasonDto::AccountReadiness { .. }
+		| AccountRouteWaitReasonDto::SharedAuthStabilizing
+		| AccountRouteWaitReasonDto::SharedAuthUnavailable
+		| AccountRouteWaitReasonDto::ProjectionReadback => {},
 	}
 	Ok(())
 }
@@ -4724,8 +4819,10 @@ mod tests {
 		AccountLifecycleReadinessDto, AccountObservationSignal, AccountObservedStateDto,
 		AccountProfileDailyUsageDto, AccountProfileDto, AccountProfileEmailDto,
 		AccountProfileErrorDto, AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto,
-		AccountRoutePendingDto, AccountsResult, CURRENT_VERSION, CausationId, ClientCommandId,
-		CodexAuthProjectionResult, CommandError, CorrelationId, EntityId, EventPayload,
+		AccountRouteAuthHomeDto, AccountRouteBlockingProcessDto, AccountRoutePendingDto,
+		AccountRouteProcessBlockerDto, AccountRouteWaitReasonDto, AccountsResult, CURRENT_VERSION,
+		CausationId, ClientCommandId, CodexAuthProjectionResult, CommandError, CorrelationId, EntityId,
+		EventPayload,
 		HistoryCursorToken, HistoryText, IdempotencyKey, MAX_HISTORY_INLINE_BYTES,
 		MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
 		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
@@ -4852,17 +4949,38 @@ mod tests {
 			operation_id: EntityId::new("33333333-3333-4333-8333-333333333333").unwrap(),
 			account_id: EntityId::new("11111111-1111-4111-8111-111111111111").unwrap(),
 			routing_revision: EntityRevision(9),
+			wait_reason: AccountRouteWaitReasonDto::ExternalCodex {
+				blockers: vec![AccountRouteProcessBlockerDto {
+					pid: 42,
+					process: AccountRouteBlockingProcessDto::Codex,
+					auth_home: AccountRouteAuthHomeDto::Shared,
+				}],
+				omitted: 0,
+			},
 		};
 		let payload = ResultPayload::AccountRoutePending { pending: pending.clone() };
 		let encoded = serde_json::to_value(&payload).unwrap();
 		assert_eq!(encoded["name"], "account_route_pending");
 		assert_eq!(encoded["data"]["pending"]["routing_revision"], 9);
-		assert_eq!(serde_json::from_value::<ResultPayload>(encoded).unwrap(), payload);
+		assert_eq!(encoded["data"]["pending"]["wait_reason"]["reason"], "external_codex");
+		assert_eq!(encoded["data"]["pending"]["wait_reason"]["data"]["blockers"][0]["pid"], 42);
+		assert_eq!(serde_json::from_value::<ResultPayload>(encoded.clone()).unwrap(), payload);
 		assert!(payload.is_evolving_receipt());
 
 		let mut invalid = serde_json::to_value(pending).unwrap();
 		invalid["routing_revision"] = serde_json::json!(0);
 		assert!(serde_json::from_value::<AccountRoutePendingDto>(invalid).is_err());
+
+		let mut empty_blockers = encoded["data"]["pending"].clone();
+		empty_blockers["wait_reason"]["data"]["blockers"] = serde_json::json!([]);
+		assert!(serde_json::from_value::<AccountRoutePendingDto>(empty_blockers).is_err());
+
+		let mut invalid_readiness = encoded["data"]["pending"].clone();
+		invalid_readiness["wait_reason"] = serde_json::json!({
+			"reason": "account_readiness",
+			"data": {"readiness": "ready"},
+		});
+		assert!(serde_json::from_value::<AccountRoutePendingDto>(invalid_readiness).is_err());
 	}
 
 	#[test]
@@ -5695,8 +5813,8 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":10},"#,
-				r#""artifact_cohort":6,"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":11},"#,
+				r#""artifact_cohort":7,"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -5705,7 +5823,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":10},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":11},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -5747,7 +5865,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":10},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":11},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5990,7 +6108,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 11 };
+		let future = crate::ProtocolVersion { major: 2, minor: 12 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/account_launch/process.rs
+++ b/crates/decodex-runtime/src/account_launch/process.rs
@@ -5402,7 +5402,7 @@ mod tests {
 	}
 
 	#[test]
-	fn manual_bound_fixture_preserves_shared_auth_pool_and_plugin_files() {
+	fn process_scoped_projection_uses_selected_account_and_preserves_shared_home_metadata() {
 		let temp = TempDir::new().unwrap();
 		let home = temp.path().join("home");
 		let codex_home = home.join(".codex");
@@ -5411,7 +5411,10 @@ mod tests {
 		fs::create_dir_all(&plugin_dir).unwrap();
 
 		let fixtures = [
-			(codex_home.join("auth.json"), b"{}".as_slice()),
+			(
+				codex_home.join("auth.json"),
+				br#"{"tokens":{"account_id":"codex-desktop-provider"}}"#.as_slice(),
+			),
 			(
 				codex_home.join("account-pool.json"),
 				br#"{"account_id":"10000000-0000-4000-8000-000000000001","state":"available"}"#
@@ -5422,11 +5425,27 @@ mod tests {
 
 		for (path, contents) in &fixtures {
 			fs::write(path, contents).unwrap();
+			fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
 		}
 
 		let before = fixtures
 			.iter()
-			.map(|(path, _)| (path.clone(), fs::read(path).unwrap()))
+			.map(|(path, _)| {
+				let metadata = fs::metadata(path).unwrap();
+				(
+					path.clone(),
+					fs::read(path).unwrap(),
+					metadata.dev(),
+					metadata.ino(),
+					metadata.len(),
+					metadata.mtime(),
+					metadata.mtime_nsec(),
+					metadata.ctime(),
+					metadata.ctime_nsec(),
+					metadata.mode(),
+					metadata.nlink(),
+				)
+			})
 			.collect::<Vec<_>>();
 		let bound_account = AccountBinding::for_test(codex_home);
 		let result = ReadOnlyProbe::new_for_test(
@@ -5440,8 +5459,31 @@ mod tests {
 
 		assert_eq!(result.account_id, bound_account.account_id().clone());
 
-		for (path, contents) in before {
-			assert_eq!(fs::read(path).unwrap(), contents);
+		for (
+			path,
+			bytes,
+			device,
+			inode,
+			length,
+			modified_seconds,
+			modified_nanoseconds,
+			changed_seconds,
+			changed_nanoseconds,
+			mode,
+			link_count,
+		) in before
+		{
+			let metadata = fs::metadata(&path).unwrap();
+			assert_eq!(fs::read(path).unwrap(), bytes);
+			assert_eq!(metadata.dev(), device);
+			assert_eq!(metadata.ino(), inode);
+			assert_eq!(metadata.len(), length);
+			assert_eq!(metadata.mtime(), modified_seconds);
+			assert_eq!(metadata.mtime_nsec(), modified_nanoseconds);
+			assert_eq!(metadata.ctime(), changed_seconds);
+			assert_eq!(metadata.ctime_nsec(), changed_nanoseconds);
+			assert_eq!(metadata.mode(), mode);
+			assert_eq!(metadata.nlink(), link_count);
 		}
 	}
 

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -26,7 +26,9 @@ use decodex_database::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
-use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, OwnedMutexGuard, broadcast};
+use tokio::sync::{
+	Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, Notify, OwnedMutexGuard, broadcast,
+};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
@@ -39,7 +41,10 @@ use crate::{
 	host_credentials::{
 		CredentialSecretBundle, CredentialStoreError, HostCredentialStore, StoredCredential,
 	},
-	shared_auth_coordinator::{SharedAuthCoordinator, StableSharedAuthPoll, StableSharedAuthRead},
+		shared_auth_coordinator::{
+			CodexAuthOwnerBlocker, CodexLiveness, CodexLivenessObservation, SharedAuthCoordinator,
+			StableSharedAuthPoll, StableSharedAuthRead,
+		},
 };
 
 const REFRESH_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
@@ -165,22 +170,53 @@ pub(crate) struct CredentialRefreshResult {
 	bundle: CredentialSecretBundle,
 }
 
+#[allow(clippy::large_enum_variant)] // The secret-bearing result is matched immediately and remains zeroizing in one owner.
+enum RefreshResolution {
+	Rotate { refreshed: CredentialRefreshResult, projected_source: Option<SharedCodexAuthVersion> },
+	Current,
+}
+
+enum SharedRefreshConvergence {
+	Current,
+	Previous(SharedCodexAuthVersion),
+	Winner(CredentialRefreshResult),
+	Unrelated,
+	Conflict,
+}
+
 struct RefreshPlan {
 	allow_disabled: bool,
-	require_callback_capability: bool,
+	shared_family: SharedFamilyRefreshPolicy,
 	supplied_refresh: Option<CredentialRefreshResult>,
 }
 
+#[derive(Clone, Copy)]
+enum SharedFamilyRefreshPolicy {
+	Guard,
+	ProvedInactive,
+}
+
 impl RefreshPlan {
-	const ADMISSION: Self =
-		Self { allow_disabled: false, require_callback_capability: true, supplied_refresh: None };
-	const EXISTING_WORK: Self =
-		Self { allow_disabled: true, require_callback_capability: true, supplied_refresh: None };
+	const ADMISSION: Self = Self {
+		allow_disabled: false,
+		shared_family: SharedFamilyRefreshPolicy::Guard,
+		supplied_refresh: None,
+	};
+	const EXISTING_WORK: Self = Self {
+		allow_disabled: true,
+		shared_family: SharedFamilyRefreshPolicy::Guard,
+		supplied_refresh: None,
+	};
+	const ROUTE_TARGET: Self = Self {
+		allow_disabled: false,
+		shared_family: SharedFamilyRefreshPolicy::ProvedInactive,
+		supplied_refresh: None,
+	};
 
 	fn route_source(supplied_refresh: CredentialRefreshResult) -> Self {
 		Self {
 			allow_disabled: true,
-			require_callback_capability: false,
+			shared_family: SharedFamilyRefreshPolicy::Guard,
 			supplied_refresh: Some(supplied_refresh),
 		}
 	}
@@ -207,7 +243,42 @@ pub(crate) struct AccountRouteCompletion {
 	pub(crate) commit: AccountRouteCommit,
 }
 
+/// Credential-negative accepted state while one exact safe-cutover prerequisite remains open.
+pub(crate) struct AccountRoutePending {
+	pub(crate) operation_id: AccountOperationId,
+	pub(crate) account_id: AccountId,
+	pub(crate) routing_revision: i64,
+	pub(crate) wait_reason: AccountRouteWaitReason,
+}
+
+/// Current credential-negative reason why an accepted Route cannot finish yet.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum AccountRouteWaitReason {
+	ExternalCodex {
+		blockers: Vec<CodexAuthOwnerBlocker>,
+		omitted: u16,
+	},
+	CodexObservationUnavailable,
+	AccountReadiness(AccountLifecycleReadiness),
+	SharedAuthStabilizing,
+	SharedAuthUnavailable,
+	ProjectionReadback,
+}
+
+impl AccountRouteWaitReason {
+	fn from_liveness(observation: CodexLivenessObservation) -> Self {
+		match observation {
+			CodexLivenessObservation::Blocked { blockers, omitted } => {
+				Self::ExternalCodex { blockers, omitted }
+			},
+			CodexLivenessObservation::Unavailable => Self::CodexObservationUnavailable,
+			CodexLivenessObservation::Quiescent => Self::SharedAuthStabilizing,
+		}
+	}
+}
+
 pub(crate) enum AccountRouteResult {
+	Pending(AccountRoutePending),
 	Committed(Box<AccountRouteCommit>),
 }
 
@@ -215,7 +286,6 @@ pub(crate) enum AccountRouteResult {
 pub(crate) enum AccountRouteFailure {
 	Lifecycle(AccountLifecycleError),
 	Routing(RoutingControlOutcome),
-	ProjectionOutcomeUnknown,
 }
 
 struct RouteSharedAuthSource {
@@ -532,6 +602,7 @@ pub struct AccountService {
 	refresher: Arc<dyn CredentialRefreshPort>,
 	shared_auth: Arc<SharedAuthCoordinator>,
 	route_events: broadcast::Sender<AccountRouteCompletion>,
+	pending_route_notify: Notify,
 	route_command_lock: AsyncMutex<()>,
 	routing_lock: AsyncMutex<()>,
 	account_locks: Mutex<HashMap<AccountId, Arc<AsyncMutex<()>>>>,
@@ -552,6 +623,7 @@ impl AccountService {
 			refresher,
 			shared_auth: Arc::new(SharedAuthCoordinator::production()),
 			route_events,
+			pending_route_notify: Notify::new(),
 			route_command_lock: AsyncMutex::new(()),
 			routing_lock: AsyncMutex::new(()),
 			account_locks: Mutex::new(HashMap::new()),
@@ -568,6 +640,10 @@ impl AccountService {
 		self.route_command_lock.lock().await
 	}
 
+	pub(crate) async fn pending_route_notified(&self) {
+		self.pending_route_notify.notified().await;
+	}
+
 	#[cfg(test)]
 	fn with_shared_auth_coordinator(mut self, coordinator: Arc<SharedAuthCoordinator>) -> Self {
 		self.shared_auth = coordinator;
@@ -581,16 +657,73 @@ impl AccountService {
 		let StableSharedAuthPoll::Changed(snapshot) = self.shared_auth.poll_stable_change() else {
 			return Ok(None);
 		};
-		let crate::auth_projection::SharedCodexAuthSnapshot::Managed { credential, .. } = *snapshot
+		let crate::auth_projection::SharedCodexAuthSnapshot::Managed { version, credential } =
+			*snapshot
 		else {
 			return Ok(None);
 		};
-		self.import_known_shared_auth_rotation(credential).await
+		self.import_known_shared_auth_rotation(version, credential).await
+	}
+
+	pub(crate) fn shared_auth_may_be_running(&self) -> bool {
+		self.shared_auth.liveness() == CodexLiveness::MayBeRunning
+	}
+
+	pub(crate) async fn pending_route_wait_reason(
+		&self,
+		account_id: &AccountId,
+	) -> AccountRouteWaitReason {
+		match self.inspect(account_id).await {
+			Ok(inspection)
+				if matches!(
+					inspection.readiness,
+					AccountLifecycleReadiness::CallbackCapabilityUnready
+						| AccountLifecycleReadiness::StoreUnavailable
+						| AccountLifecycleReadiness::StoreMismatch
+						| AccountLifecycleReadiness::OperationUnsettled
+				) =>
+			{
+				return AccountRouteWaitReason::AccountReadiness(inspection.readiness);
+			},
+			Ok(_) => {},
+			Err(_) => {
+				return AccountRouteWaitReason::AccountReadiness(
+					AccountLifecycleReadiness::StoreUnavailable,
+				);
+			},
+		}
+
+		let observation = self.shared_auth.liveness_observation();
+		if observation.state() == CodexLiveness::MayBeRunning
+			&& !self.shared_auth_is_current_for(account_id).await
+		{
+			return AccountRouteWaitReason::from_liveness(observation);
+		}
+		AccountRouteWaitReason::SharedAuthStabilizing
+	}
+
+	pub(crate) async fn shared_auth_is_current_for(&self, account_id: &AccountId) -> bool {
+		let Ok(lock) = self.lock_for(account_id) else {
+			return false;
+		};
+		let _guard = lock.lock().await;
+		let Ok(account) = self.load_account(account_id).await else {
+			return false;
+		};
+		let StableSharedAuthRead::Ready(snapshot) = self.shared_auth.read_current_stable() else {
+			return false;
+		};
+		self.confirm_shared_auth_target_locked(account_id, account.revision, &snapshot)
+			.await
+			.ok()
+			.flatten()
+			.is_some()
 	}
 
 	async fn import_known_shared_auth_rotation(
 		&self,
-		credential: ImportedCredential,
+		version: SharedCodexAuthVersion,
+		mut credential: ImportedCredential,
 	) -> Result<Option<AccountRecord>, AccountLifecycleError> {
 		let mut matches =
 			self.store.read_account_registry(None, MAX_ACCOUNT_READ).await?.into_iter().filter(
@@ -612,6 +745,34 @@ impl AccountService {
 		let account = self.load_account(&account_id).await?;
 		let binding = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
 		let stored = self.credentials.read_exact(&account_id, binding)?;
+		if self
+			.refresh_predecessor(&account_id, binding)
+			.await
+			.map_err(AccountLifecycleError::Refresh)?
+			.as_ref()
+			.is_some_and(|previous| {
+				bundle_matches_binding(&account_id, previous, &credential.bundle)
+			}) {
+			let _ = self.shared_auth.project_exact_source(
+				stored.bundle(),
+				binding.provider.account_id(),
+				&version,
+			);
+			let latest = self
+				.shared_auth
+				.read_current_exact()
+				.map_err(|_| AccountLifecycleError::CoordinatorUnavailable)?;
+			let SharedCodexAuthSnapshot::Managed { credential: latest, .. } = *latest else {
+				return Err(AccountLifecycleError::CoordinatorUnavailable);
+			};
+			if latest.provider != binding.provider {
+				return Err(AccountLifecycleError::CoordinatorUnavailable);
+			}
+			if same_refresh_bundle(stored.bundle(), &latest.bundle) {
+				return Ok(None);
+			}
+			credential = latest;
+		}
 		let Some(supplied_refresh) = matching_shared_refresh(
 			binding,
 			stored.bundle(),
@@ -926,7 +1087,7 @@ impl AccountService {
 				}
 				target_account.revision
 			};
-		let target_binding = match route_projection_binding(&target_account, target_revision) {
+		let target_binding = match projection_binding(&target_account, target_revision) {
 			Ok(binding) => binding.clone(),
 			Err(error) => {
 				return self
@@ -938,15 +1099,28 @@ impl AccountService {
 					.await;
 			},
 		};
-		let stable = match self.shared_auth.read_current_exact() {
-			Ok(snapshot) => *snapshot,
-			Err(_) => {
+		let stable = match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) => *snapshot,
+			StableSharedAuthRead::Waiting => {
 				return self
-					.complete_route_command_failure(
+					.defer_route_command(
 						lease,
-						AccountRouteFailure::Lifecycle(
-							AccountLifecycleError::CoordinatorUnavailable,
-						),
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						AccountRouteWaitReason::SharedAuthStabilizing,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+			StableSharedAuthRead::Unavailable => {
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						AccountRouteWaitReason::SharedAuthUnavailable,
 						build_response.take().expect("Route builder is retained"),
 					)
 					.await;
@@ -955,6 +1129,58 @@ impl AccountService {
 		let shared_auth =
 			match self.shared_auth_route_source(account_id, &target_binding, stable).await {
 				Ok(source) => source,
+				Err(_) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							AccountRouteWaitReason::SharedAuthUnavailable,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+			};
+		let source_is_target =
+			shared_auth.source.as_ref().is_some_and(|source| &source.account_id == account_id);
+		let liveness = self.shared_auth.liveness_observation();
+		if !source_is_target && liveness.state() != CodexLiveness::Quiescent {
+			return self
+				.defer_route_command(
+					lease,
+					operation_id,
+					account_id,
+					expected_routing_revision,
+					AccountRouteWaitReason::from_liveness(liveness),
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
+		if let Some(source) = shared_auth.source.as_ref() {
+			let result = if source_is_target {
+				self.reconcile_shared_auth_route_source_while_locked(&operation_id, source).await
+			} else {
+				self.reconcile_shared_auth_route_source(&operation_id, source).await
+			};
+			if let Err(error) = result {
+				let _ = error;
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						AccountRouteWaitReason::SharedAuthUnavailable,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			}
+		}
+
+		if !source_is_target {
+			let target_operation_id = match route_refresh_operation_id(&operation_id, account_id) {
+				Ok(operation_id) => operation_id,
 				Err(error) => {
 					return self
 						.complete_route_command_failure(
@@ -965,46 +1191,21 @@ impl AccountService {
 						.await;
 				},
 			};
-		let source_is_target =
-			shared_auth.source.as_ref().is_some_and(|source| &source.account_id == account_id);
-		if let Some(source) = shared_auth.source.as_ref() {
-			let result = if source_is_target {
-				self.reconcile_shared_auth_route_source_while_locked(&operation_id, source).await
-			} else {
-				self.reconcile_shared_auth_route_source(&operation_id, source).await
-			};
-			if let Err(error) = result {
+			if let Err(error) = self
+				.refresh_while_locked(
+					target_operation_id,
+					account_id,
+					Some(expected_account_revision),
+					None,
+					None,
+					RefreshPlan::ROUTE_TARGET,
+				)
+				.await
+			{
 				return self
 					.complete_route_command_failure(
 						lease,
 						AccountRouteFailure::Lifecycle(error),
-						build_response.take().expect("Route builder is retained"),
-					)
-					.await;
-			}
-		}
-
-		if !source_is_target {
-			let target_needs_refresh =
-				match self.route_target_needs_refresh(account_id, &target_binding) {
-					Ok(needs_refresh) => needs_refresh,
-					Err(error) => {
-						return self
-							.complete_route_command_failure(
-								lease,
-								AccountRouteFailure::Lifecycle(error),
-								build_response.take().expect("Route builder is retained"),
-							)
-							.await;
-					},
-				};
-			if target_needs_refresh {
-				return self
-					.complete_route_command_failure(
-						lease,
-						AccountRouteFailure::Lifecycle(AccountLifecycleError::Refresh(
-							CredentialRefreshError::Unavailable,
-						)),
 						build_response.take().expect("Route builder is retained"),
 					)
 					.await;
@@ -1022,21 +1223,49 @@ impl AccountService {
 					.await;
 			},
 		};
+		let liveness = self.shared_auth.liveness_observation();
+		if !source_is_target && liveness.state() != CodexLiveness::Quiescent {
+			return self
+				.defer_route_command(
+					lease,
+					operation_id,
+					account_id,
+					expected_routing_revision,
+					AccountRouteWaitReason::from_liveness(liveness),
+					build_response.take().expect("Route builder is retained"),
+				)
+				.await;
+		}
+		let final_source = match self.shared_auth.read_current_stable() {
+			StableSharedAuthRead::Ready(snapshot) if snapshot.version() == &shared_auth.version => {
+				*snapshot
+			},
+			StableSharedAuthRead::Ready(_) | StableSharedAuthRead::Waiting => {
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						AccountRouteWaitReason::SharedAuthStabilizing,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+			StableSharedAuthRead::Unavailable => {
+				return self
+					.defer_route_command(
+						lease,
+						operation_id,
+						account_id,
+						expected_routing_revision,
+						AccountRouteWaitReason::SharedAuthUnavailable,
+						build_response.take().expect("Route builder is retained"),
+					)
+					.await;
+			},
+		};
 		let (projected_revision, projection_digest) = if source_is_target {
-			let final_source = match self.shared_auth.read_current_exact() {
-				Ok(snapshot) if snapshot.version() == &shared_auth.version => *snapshot,
-				Ok(_) | Err(_) => {
-					return self
-						.complete_route_command_failure(
-							lease,
-							AccountRouteFailure::Lifecycle(
-								AccountLifecycleError::CoordinatorUnavailable,
-							),
-							build_response.take().expect("Route builder is retained"),
-						)
-						.await;
-				},
-			};
 			match self
 				.confirm_shared_auth_target_locked(
 					account_id,
@@ -1048,11 +1277,24 @@ impl AccountService {
 				Ok(Some(projection)) => projection,
 				Ok(None) => {
 					return self
-						.complete_route_command_failure(
+						.defer_route_command(
 							lease,
-							AccountRouteFailure::Lifecycle(
-								AccountLifecycleError::CoordinatorUnavailable,
-							),
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							AccountRouteWaitReason::SharedAuthStabilizing,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+				Err(AccountLifecycleError::CoordinatorUnavailable) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							AccountRouteWaitReason::SharedAuthUnavailable,
 							build_response.take().expect("Route builder is retained"),
 						)
 						.await;
@@ -1079,9 +1321,26 @@ impl AccountService {
 				Ok(projection) => projection,
 				Err(SharedAuthProjectionError::OutcomeUnknown) => {
 					return self
-						.complete_route_command_failure(
+						.defer_route_command(
 							lease,
-							AccountRouteFailure::ProjectionOutcomeUnknown,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							AccountRouteWaitReason::ProjectionReadback,
+							build_response.take().expect("Route builder is retained"),
+						)
+						.await;
+				},
+				Err(SharedAuthProjectionError::Rejected(
+					AccountLifecycleError::CoordinatorUnavailable,
+				)) => {
+					return self
+						.defer_route_command(
+							lease,
+							operation_id,
+							account_id,
+							expected_routing_revision,
+							AccountRouteWaitReason::SharedAuthUnavailable,
 							build_response.take().expect("Route builder is retained"),
 						)
 						.await;
@@ -1151,19 +1410,6 @@ impl AccountService {
 		Ok(response)
 	}
 
-	fn route_target_needs_refresh(
-		&self,
-		account_id: &AccountId,
-		binding: &CredentialBinding,
-	) -> Result<bool, AccountLifecycleError> {
-		let stored = self.credentials.read_exact(account_id, binding)?;
-		access_token_needs_refresh(
-			stored.bundle().access_token_expires_at_unix_micros(),
-			current_unix_micros()?,
-			Duration::ZERO,
-		)
-	}
-
 	async fn confirm_shared_auth_target_locked(
 		&self,
 		account_id: &AccountId,
@@ -1174,7 +1420,7 @@ impl AccountService {
 			return Ok(None);
 		};
 		let account = self.load_account(account_id).await?;
-		let binding = route_projection_binding(&account, expected_revision)?;
+		let binding = projection_binding(&account, expected_revision)?;
 		if binding.provider != credential.provider {
 			return Ok(None);
 		}
@@ -1193,7 +1439,7 @@ impl AccountService {
 	) -> Result<(i64, String), SharedAuthProjectionError> {
 		let account =
 			self.load_account(account_id).await.map_err(SharedAuthProjectionError::Rejected)?;
-		let binding = route_projection_binding(&account, expected_revision)
+		let binding = projection_binding(&account, expected_revision)
 			.map_err(SharedAuthProjectionError::Rejected)?
 			.clone();
 		let stored = self
@@ -1224,7 +1470,7 @@ impl AccountService {
 		{
 			return Err(SharedAuthProjectionError::Rejected(AccountLifecycleError::StaleAccount));
 		}
-		match self.shared_auth.project_exact_source(
+		match self.shared_auth.project_if_quiescent(
 			stored.bundle(),
 			binding.provider.account_id(),
 			expected_source,
@@ -1547,23 +1793,76 @@ impl AccountService {
 
 	async fn refresh_or_reconcile_shared(
 		&self,
+		account_id: &AccountId,
 		current: &CredentialBinding,
 		stored: StoredCredential,
-	) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+		shared_family: SharedFamilyRefreshPolicy,
+	) -> Result<RefreshResolution, CredentialRefreshError> {
 		let now_unix_micros =
 			current_unix_micros().map_err(|_| CredentialRefreshError::Unavailable)?;
-		let shared =
-			self.shared_auth.read_current_exact().map_err(|_| CredentialRefreshError::OwnerBusy)?;
-		if let SharedCodexAuthSnapshot::Managed { credential, .. } = *shared {
-			let shares_provider = credential.provider == current.provider;
-			if let Some(shared) =
-				matching_shared_refresh(current, stored.bundle(), now_unix_micros, Ok(credential))
-			{
-				return Ok(shared);
-			}
-			if shares_provider {
+		let shared = match self.shared_auth.read_current_exact() {
+			Ok(snapshot) => Some(*snapshot),
+			Err(_) if matches!(shared_family, SharedFamilyRefreshPolicy::ProvedInactive) => None,
+			Err(_) => return Err(CredentialRefreshError::OwnerBusy),
+		};
+		let mut projected_source = None;
+		if let Some(SharedCodexAuthSnapshot::Managed { version, credential }) = shared
+			&& credential.provider == current.provider
+		{
+			if same_refresh_bundle(stored.bundle(), &credential.bundle) {
+				projected_source = Some(version);
+			} else if self.refresh_predecessor(account_id, current).await?.as_ref().is_some_and(
+				|previous| bundle_matches_binding(account_id, previous, &credential.bundle),
+			) {
+				let _ = self.shared_auth.project_exact_source(
+					stored.bundle(),
+					current.provider.account_id(),
+					&version,
+				);
+				let latest = self
+					.shared_auth
+					.read_current_exact()
+					.map_err(|_| CredentialRefreshError::OwnerBusy)?;
+				let SharedCodexAuthSnapshot::Managed { credential: latest, .. } = *latest else {
+					return Err(CredentialRefreshError::OwnerBusy);
+				};
+				if latest.provider != current.provider {
+					return Err(CredentialRefreshError::OwnerBusy);
+				}
+				if same_refresh_bundle(stored.bundle(), &latest.bundle) {
+					return Ok(RefreshResolution::Current);
+				}
+				if let Some(winner) = matching_shared_refresh(
+					current,
+					stored.bundle(),
+					now_unix_micros,
+					Ok(latest),
+				) {
+					return Ok(RefreshResolution::Rotate {
+						refreshed: winner,
+						projected_source: None,
+					});
+				}
+				return Err(CredentialRefreshError::OwnerBusy);
+			} else if let Some(shared) = matching_shared_refresh(
+				current,
+				stored.bundle(),
+				now_unix_micros,
+				Ok(credential),
+			) {
+				return Ok(RefreshResolution::Rotate {
+					refreshed: shared,
+					projected_source: None,
+				});
+			} else {
 				return Err(CredentialRefreshError::OwnerBusy);
 			}
+		}
+		if projected_source.is_none()
+			&& matches!(shared_family, SharedFamilyRefreshPolicy::Guard)
+			&& self.shared_auth.liveness() == CodexLiveness::MayBeRunning
+		{
+			return Err(CredentialRefreshError::OwnerBusy);
 		}
 
 		let refresher = Arc::clone(&self.refresher);
@@ -1575,27 +1874,49 @@ impl AccountService {
 		.map_err(|_| CredentialRefreshError::Ambiguous)?;
 
 		match result {
+			Ok(refreshed) => Ok(RefreshResolution::Rotate { refreshed, projected_source }),
 			Err(CredentialRefreshError::Rejected) => recover_rejected_refresh_from_shared(
 				current,
 				stored.bundle(),
 				current_unix_micros().map_err(|_| CredentialRefreshError::Rejected)?,
-				self.stable_shared_auth_credential(),
-			),
-			result => result,
+				self.exact_shared_auth_credential(),
+			)
+			.map(|refreshed| RefreshResolution::Rotate { refreshed, projected_source: None }),
+			Err(error) => Err(error),
 		}
 	}
 
-	fn stable_shared_auth_credential(&self) -> Result<ImportedCredential, CredentialImportError> {
-		match self.shared_auth.read_current_stable() {
-			StableSharedAuthRead::Ready(snapshot) => match *snapshot {
-				SharedCodexAuthSnapshot::Managed { credential, .. } => Ok(credential),
-				SharedCodexAuthSnapshot::Unmanaged { .. } => {
-					Err(CredentialImportError::Unavailable)
-				},
-			},
-			StableSharedAuthRead::Waiting | StableSharedAuthRead::Unavailable => {
-				Err(CredentialImportError::Unavailable)
-			},
+	async fn refresh_predecessor(
+		&self,
+		account_id: &AccountId,
+		current: &CredentialBinding,
+	) -> Result<Option<CredentialBinding>, CredentialRefreshError> {
+		let operation = self
+			.store
+			.read_account_operation(&current.writer_operation_id)
+			.await
+			.map_err(|_| CredentialRefreshError::OwnerBusy)?;
+		Ok(operation.and_then(|operation| {
+			(operation.account_id == *account_id
+				&& operation.kind == AccountOperationKind::Refresh
+				&& operation.target.as_ref() == Some(current)
+				&& matches!(
+					operation.phase,
+					AccountOperationPhase::StoreApplied | AccountOperationPhase::Committed
+				))
+			.then_some(operation.expected)
+			.flatten()
+		}))
+	}
+
+	fn exact_shared_auth_credential(&self) -> Result<ImportedCredential, CredentialImportError> {
+		match *self
+			.shared_auth
+			.read_current_exact()
+			.map_err(|_| CredentialImportError::Unavailable)?
+		{
+			SharedCodexAuthSnapshot::Managed { credential, .. } => Ok(credential),
+			SharedCodexAuthSnapshot::Unmanaged { .. } => Err(CredentialImportError::Unavailable),
 		}
 	}
 
@@ -1609,7 +1930,7 @@ impl AccountService {
 		previous_provider_account_id: Option<&str>,
 		plan: RefreshPlan,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
-		let RefreshPlan { allow_disabled, require_callback_capability, supplied_refresh } = plan;
+		let RefreshPlan { allow_disabled, shared_family, supplied_refresh } = plan;
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
@@ -1617,28 +1938,26 @@ impl AccountService {
 		let account = self.load_account(account_id).await?;
 		let current = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
 		if current.writer_operation_id == operation_id {
-			return self.project_refresh_result(account_id, current, callback_generation).await;
+			return self
+				.project_committed_refresh_result(&operation_id, account_id, callback_generation)
+				.await;
 		}
 		if previous_provider_account_id.is_some_and(|value| value != current.provider.account_id())
 		{
 			return Err(AccountLifecycleError::ProviderMismatch);
 		}
 		if let Some((_, process_binding)) = callback_generation
-			&& &process_binding.credential != current
+			&& callback_uses_current_successor(account.revision, process_binding, current)?
 		{
-			return Err(AccountLifecycleError::StaleAccount);
+			return self.project_refresh_result(account_id, current, callback_generation).await;
 		}
 		if let Some(operation) = self.store.read_account_operation(&operation_id).await? {
 			self.require_operation_identity(&operation, account_id, AccountOperationKind::Refresh)?;
 			return match self.reconcile_operation(&operation).await? {
 				ReconciliationDisposition::Committed => {
-					let latest = self.load_account(account_id).await?;
-					self.project_refresh_result(
+					self.project_committed_refresh_result(
+						&operation_id,
 						account_id,
-						latest
-							.credential
-							.as_ref()
-							.ok_or(AccountLifecycleError::CredentialAbsent)?,
 						callback_generation,
 					)
 					.await
@@ -1656,8 +1975,6 @@ impl AccountService {
 		}
 		let stored = if callback_generation.is_some() {
 			self.read_exact_for_bound_callback(&account).await?
-		} else if !require_callback_capability {
-			self.read_exact_for_api(&account).await?
 		} else if allow_disabled {
 			self.read_exact_for_existing_work(&account).await?
 		} else {
@@ -1676,13 +1993,8 @@ impl AccountService {
 		};
 		let phase = accepted_phase(self.store.prepare_account_operation(&preparation).await?)?;
 		if phase == AccountOperationPhase::Committed {
-			let latest = self.load_account(account_id).await?;
 			return self
-				.project_refresh_result(
-					account_id,
-					latest.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?,
-					callback_generation,
-				)
+				.project_committed_refresh_result(&operation_id, account_id, callback_generation)
 				.await;
 		}
 		if phase == AccountOperationPhase::Prepared {
@@ -1698,10 +2010,12 @@ impl AccountService {
 			)?;
 		}
 		let refreshed = match supplied_refresh {
-			Some(refreshed) => Ok(refreshed),
-			None => self.refresh_or_reconcile_shared(current, stored).await,
+			Some(refreshed) => Ok(RefreshResolution::Rotate { refreshed, projected_source: None }),
+			None => {
+				self.refresh_or_reconcile_shared(account_id, current, stored, shared_family).await
+			},
 		};
-		let refreshed = match refreshed {
+		let resolution = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(CredentialRefreshError::Rejected) => {
 				self.recover_or_cancel(
@@ -1732,6 +2046,21 @@ impl AccountService {
 				)
 				.await?;
 				return Err(AccountLifecycleError::Refresh(error));
+			},
+		};
+		let (refreshed, projected_source) = match resolution {
+			RefreshResolution::Rotate { refreshed, projected_source } => {
+				(refreshed, projected_source)
+			},
+			RefreshResolution::Current => {
+				self.recover_or_cancel(
+					&operation_id,
+					AccountOperationPhase::ProviderEffectPending,
+					"shared_auth_predecessor_repaired",
+					false,
+				)
+				.await?;
+				return self.project_refresh_result(account_id, current, callback_generation).await;
 			},
 		};
 		let target =
@@ -1772,7 +2101,13 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		self.commit_and_project_refresh_result(&operation_id, account_id, callback_generation).await
+		self.commit_and_project_refresh_result(
+			&operation_id,
+			account_id,
+			callback_generation,
+			projected_source,
+		)
+		.await
 	}
 
 	/// Replace one exact account credential from a private Codex auth file.
@@ -2121,7 +2456,18 @@ impl AccountService {
 			}
 			match operation.phase {
 				AccountOperationPhase::Committed | AccountOperationPhase::StoreApplied => {
-					self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
+					if operation.phase == AccountOperationPhase::StoreApplied {
+						self.commit_and_project_refresh_result(
+							&operation_id,
+							account_id,
+							None,
+							None,
+						)
+						.await?;
+					} else {
+						self.project_committed_refresh_result(&operation_id, account_id, None)
+							.await?;
+					}
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -2214,7 +2560,8 @@ impl AccountService {
 							)
 							.await?,
 					)?;
-					self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
+					self.commit_and_project_refresh_result(&operation_id, account_id, None, None)
+						.await?;
 					return self
 						.complete_account_operation_success(
 							lease,
@@ -2292,8 +2639,15 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		let refreshed = self.refresh_or_reconcile_shared(&current, stored).await;
-		let refreshed = match refreshed {
+		let refreshed = self
+			.refresh_or_reconcile_shared(
+				account_id,
+				&current,
+				stored,
+				SharedFamilyRefreshPolicy::Guard,
+			)
+			.await;
+		let resolution = match refreshed {
 			Ok(refreshed) => refreshed,
 			Err(error @ CredentialRefreshError::Rejected) => {
 				return self
@@ -2330,6 +2684,22 @@ impl AccountService {
 						AccountOperationPhase::RecoveryRequired,
 						Some("provider_refresh_ambiguous"),
 						AccountLifecycleError::Refresh(error),
+						build_response.take().expect("builder is retained"),
+					)
+					.await;
+			},
+		};
+		let (refreshed, projected_source) = match resolution {
+			RefreshResolution::Rotate { refreshed, projected_source } => {
+				(refreshed, projected_source)
+			},
+			RefreshResolution::Current => {
+				return self
+					.complete_account_operation_success(
+						lease,
+						&operation_id,
+						AccountOperationPhase::ProviderEffectPending,
+						AccountOperationPhase::Cancelled,
 						build_response.take().expect("builder is retained"),
 					)
 					.await;
@@ -2382,7 +2752,8 @@ impl AccountService {
 				)
 				.await?,
 		)?;
-		self.commit_and_project_refresh_result(&operation_id, account_id, None).await?;
+		self.commit_and_project_refresh_result(&operation_id, account_id, None, projected_source)
+			.await?;
 		self.complete_account_operation_success(
 			lease,
 			&operation_id,
@@ -2400,7 +2771,8 @@ impl AccountService {
 		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
 		let stored = self.credentials.read_exact(account_id, binding)?;
-		// Ordinary refresh never writes shared auth. Route owns the exact-source CAS projection.
+		// The refresh state machine mirrors a successor only when it proved that this exact
+		// account bundle was the shared source. This projection helper itself stays file-agnostic.
 		if let Some((generation_id, process_binding)) = callback_generation {
 			self.require_active_callback_generation(account_id, generation_id, process_binding)
 				.await?;
@@ -2413,11 +2785,150 @@ impl AccountService {
 		operation_id: &AccountOperationId,
 		account_id: &AccountId,
 		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+		projected_source: Option<SharedCodexAuthVersion>,
 	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
 		self.commit_store_applied(operation_id).await?;
+		self.project_committed_refresh_result_with_source(
+			operation_id,
+			account_id,
+			callback_generation,
+			projected_source,
+		)
+		.await
+	}
+
+	async fn project_committed_refresh_result(
+		&self,
+		operation_id: &AccountOperationId,
+		account_id: &AccountId,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		self.project_committed_refresh_result_with_source(
+			operation_id,
+			account_id,
+			callback_generation,
+			None,
+		)
+		.await
+	}
+
+	async fn project_committed_refresh_result_with_source(
+		&self,
+		operation_id: &AccountOperationId,
+		account_id: &AccountId,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+		projected_source: Option<SharedCodexAuthVersion>,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		let operation = self
+			.store
+			.read_account_operation(operation_id)
+			.await?
+			.ok_or(AccountLifecycleError::InvalidOperation)?;
+		self.require_operation_identity(&operation, account_id, AccountOperationKind::Refresh)?;
+		let expected =
+			operation.expected.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
+		let target = operation.target.as_ref().ok_or(AccountLifecycleError::InvalidOperation)?;
 		let account = self.load_account(account_id).await?;
 		let binding = account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)?;
-		self.project_refresh_result(account_id, binding, callback_generation).await
+		if binding != target {
+			return Err(AccountLifecycleError::StaleAccount);
+		}
+		let stored = self.credentials.read_exact(account_id, binding)?;
+		if let Some(source) = projected_source {
+			let _ = self.shared_auth.project_exact_source(
+				stored.bundle(),
+				binding.provider.account_id(),
+				&source,
+			);
+		}
+		self.resolve_shared_refresh_convergence(
+			account_id,
+			expected,
+			binding,
+			stored.bundle(),
+			callback_generation,
+			true,
+		)
+		.await
+	}
+
+	#[allow(clippy::too_many_arguments)] // Both durable bindings, current secret, callback fence, and one retry boundary define the arbitration proof.
+	async fn resolve_shared_refresh_convergence(
+		&self,
+		account_id: &AccountId,
+		expected: &CredentialBinding,
+		target: &CredentialBinding,
+		target_bundle: &CredentialSecretBundle,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+		allow_previous_projection: bool,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		let snapshot = self
+			.shared_auth
+			.read_current_exact()
+			.map_err(|_| AccountLifecycleError::CoordinatorUnavailable)?;
+		match classify_shared_refresh_convergence(
+			account_id,
+			expected,
+			target,
+			target_bundle,
+			*snapshot,
+			current_unix_micros()?,
+		) {
+			SharedRefreshConvergence::Current | SharedRefreshConvergence::Unrelated => {
+				self.project_refresh_result(account_id, target, callback_generation).await
+			},
+			SharedRefreshConvergence::Winner(winner) => {
+				self.adopt_shared_refresh_winner(account_id, target, winner, callback_generation)
+					.await
+			},
+			SharedRefreshConvergence::Previous(version) if allow_previous_projection => {
+				let _ = self.shared_auth.project_exact_source(
+					target_bundle,
+					target.provider.account_id(),
+					&version,
+				);
+				Box::pin(self.resolve_shared_refresh_convergence(
+					account_id,
+					expected,
+					target,
+					target_bundle,
+					callback_generation,
+					false,
+				))
+				.await
+			},
+			SharedRefreshConvergence::Previous(_) | SharedRefreshConvergence::Conflict => {
+				Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy))
+			},
+		}
+	}
+
+	async fn adopt_shared_refresh_winner(
+		&self,
+		account_id: &AccountId,
+		current: &CredentialBinding,
+		winner: CredentialRefreshResult,
+		callback_generation: Option<(&ProcessGenerationId, &ProcessGenerationAccountBinding)>,
+	) -> Result<ChatgptTokenProjection, AccountLifecycleError> {
+		let operation_id = shared_auth_import_operation_id(account_id, current, &winner.bundle)?;
+		let account = self.load_account(account_id).await?;
+		if account.credential.as_ref() != Some(current) {
+			return Err(AccountLifecycleError::StaleAccount);
+		}
+		let projection = Box::pin(self.refresh_while_locked(
+			operation_id,
+			account_id,
+			Some(account.revision),
+			None,
+			None,
+			RefreshPlan::route_source(winner),
+		))
+		.await?;
+		if let Some((generation_id, process_binding)) = callback_generation {
+			self.require_active_callback_generation(account_id, generation_id, process_binding)
+				.await?;
+		}
+		Ok(projection)
 	}
 
 	async fn require_active_callback_generation(
@@ -2786,6 +3297,31 @@ impl AccountService {
 	{
 		let response = build_response(Err(failure))?;
 		self.store.complete_account_command(lease, &response).await?;
+		Ok(response)
+	}
+
+	async fn defer_route_command<F>(
+		&self,
+		lease: AccountCommandReceiptLease,
+		operation_id: AccountOperationId,
+		account_id: &AccountId,
+		routing_revision: i64,
+		wait_reason: AccountRouteWaitReason,
+		build_response: F,
+	) -> Result<Value, AccountLifecycleError>
+	where
+		F: FnOnce(Result<AccountRouteResult, AccountRouteFailure>) -> Result<Value, StoreError>
+			+ Send
+			+ 'static,
+	{
+		let response = build_response(Ok(AccountRouteResult::Pending(AccountRoutePending {
+			operation_id,
+			account_id: account_id.clone(),
+			routing_revision,
+			wait_reason,
+		})))?;
+		self.store.defer_account_route_command(lease, &response).await?;
+		self.pending_route_notify.notify_one();
 		Ok(response)
 	}
 
@@ -4108,6 +4644,25 @@ fn projection(
 	}
 }
 
+fn callback_uses_current_successor(
+	account_revision: i64,
+	initial: &ProcessGenerationAccountBinding,
+	current: &CredentialBinding,
+) -> Result<bool, AccountLifecycleError> {
+	if &initial.credential == current {
+		return Ok(false);
+	}
+	if initial.credential.provider != current.provider {
+		return Err(AccountLifecycleError::ProviderMismatch);
+	}
+	if current.version.get() <= initial.credential.version.get()
+		|| account_revision < initial.account_revision
+	{
+		return Err(AccountLifecycleError::StaleAccount);
+	}
+	Ok(true)
+}
+
 fn current_unix_micros() -> Result<i64, AccountLifecycleError> {
 	SystemTime::now()
 		.duration_since(UNIX_EPOCH)
@@ -4196,6 +4751,40 @@ const fn resolve_reauthentication_store_effect(
 		Err(_) if target_is_exact => Ok(()),
 		Err(error) => Err(error),
 	}
+}
+
+fn bundle_matches_binding(
+	account_id: &AccountId,
+	binding: &CredentialBinding,
+	bundle: &CredentialSecretBundle,
+) -> bool {
+	bundle
+		.binding_for(account_id, &binding.writer_operation_id, binding.version, &binding.provider)
+		.is_ok_and(|derived| derived == *binding)
+}
+
+fn classify_shared_refresh_convergence(
+	account_id: &AccountId,
+	expected: &CredentialBinding,
+	target: &CredentialBinding,
+	target_bundle: &CredentialSecretBundle,
+	snapshot: SharedCodexAuthSnapshot,
+	now_unix_micros: i64,
+) -> SharedRefreshConvergence {
+	let SharedCodexAuthSnapshot::Managed { version, credential } = snapshot else {
+		return SharedRefreshConvergence::Unrelated;
+	};
+	if credential.provider != target.provider {
+		return SharedRefreshConvergence::Unrelated;
+	}
+	if bundle_matches_binding(account_id, target, &credential.bundle) {
+		return SharedRefreshConvergence::Current;
+	}
+	if bundle_matches_binding(account_id, expected, &credential.bundle) {
+		return SharedRefreshConvergence::Previous(version);
+	}
+	matching_shared_refresh(target, target_bundle, now_unix_micros, Ok(credential))
+		.map_or(SharedRefreshConvergence::Conflict, SharedRefreshConvergence::Winner)
 }
 
 fn matching_shared_refresh(
@@ -4318,7 +4907,7 @@ where
 	}
 }
 
-fn route_projection_binding(
+fn projection_binding(
 	account: &AccountRecord,
 	expected_revision: i64,
 ) -> Result<&CredentialBinding, AccountLifecycleError> {
@@ -4334,10 +4923,7 @@ fn route_projection_binding(
 	if account.unsettled_operation.is_some() {
 		return Err(AccountLifecycleError::NotReady(AccountLifecycleReadiness::OperationUnsettled));
 	}
-	if !matches!(
-		account.lifecycle_readiness,
-		AccountLifecycleReadiness::Ready | AccountLifecycleReadiness::CallbackCapabilityUnready
-	) {
+	if account.lifecycle_readiness != AccountLifecycleReadiness::Ready {
 		return Err(AccountLifecycleError::NotReady(account.lifecycle_readiness));
 	}
 	account.credential.as_ref().ok_or(AccountLifecycleError::CredentialAbsent)
@@ -4494,7 +5080,7 @@ mod tests {
 		AccountOperationPhase, AccountProvider, AccountQuotaWindow, AccountQuotaWindowObservation,
 		AccountRecord, AccountSelectionMode, AccountState, CredentialBinding,
 		CredentialFingerprint, CredentialStoreSchemaVersion, CredentialVersion, DecodexRoot,
-		ProviderIdentity,
+		ProcessGenerationAccountBinding, ProviderIdentity,
 	};
 	use decodex_database::{
 		AccountCommandKind, AccountCommandReceiptClaim, AccountLifecycleMutationOutcome,
@@ -4505,29 +5091,32 @@ mod tests {
 
 	use super::{
 		ACCOUNT_ALIAS_WORDS, AccountLifecycleError, AccountRouteFailure, AccountRouteResult,
-		AccountService, CodexAuthProjectionError, CredentialImportError, CredentialRefreshError,
+		AccountRouteWaitReason, AccountService, CodexAuthProjectionError, CredentialImportError,
+		CredentialRefreshError,
 		CredentialRefreshPort, CredentialRefreshResult, CredentialSecretBundle,
 		CredentialStoreError, HostCredentialStore, ImportedCredential,
 		PROVIDER_REFRESH_OUTCOME_UNKNOWN, PreparedRefreshReconciliation,
 		ReauthenticationReplayDisposition, RefreshResponse, accepted_phase,
 		access_token_needs_refresh, account_lock_for, classify_prepared_refresh_reconciliation,
 		classify_reauthentication_replay, codex_auth_projection_digest, credential_refresh_result,
-		matching_shared_refresh, reauthentication_current, reauthentication_target,
-		recover_rejected_refresh_from_shared, refreshed_credential_target,
-		require_refreshed_access_token_for_observation, resolve_reauthentication_store_effect,
-		route_projection_binding, route_resume_revision_is_valid, stable_account_alias,
+		callback_uses_current_successor, decode_chatgpt_identity, matching_shared_refresh,
+		projection_binding,
+		reauthentication_current, reauthentication_target, recover_rejected_refresh_from_shared,
+		refreshed_credential_target, require_refreshed_access_token_for_observation,
+		resolve_reauthentication_store_effect, route_resume_revision_is_valid,
+		stable_account_alias,
 	};
 	use std::{
-		collections::{HashMap, HashSet},
+		collections::{HashMap, HashSet, VecDeque},
 		fs,
 		os::unix::fs::PermissionsExt as _,
 		sync::{
 			Arc, Mutex,
-			atomic::{AtomicUsize, Ordering},
+			atomic::{AtomicBool, AtomicUsize, Ordering},
 		},
-		time::{Duration, Instant},
+		time::Duration,
 	};
-	use tempfile::{tempdir, tempdir_in};
+	use tempfile::tempdir;
 	use tokio::time;
 
 	use crate::{
@@ -4536,7 +5125,9 @@ mod tests {
 		},
 		host_credentials::SqliteCredentialStore,
 		shared_auth_coordinator::{
-			SharedAuthCoordinator, SharedAuthFilePort, StableSharedAuthPoll,
+			CodexAuthHomeEvidence, CodexAuthOwnerBlocker, CodexAuthOwnerKind, CodexLiveness,
+			CodexLivenessObservation, CodexLivenessPort, SharedAuthCoordinator, SharedAuthFilePort,
+			StableSharedAuthPoll,
 		},
 	};
 
@@ -4552,6 +5143,31 @@ mod tests {
 		}
 	}
 
+	struct FixedLiveness(CodexLiveness);
+	impl CodexLivenessPort for FixedLiveness {
+		fn observe(&self) -> CodexLivenessObservation {
+			CodexLivenessObservation::from_state(self.0)
+		}
+	}
+
+	struct MutableLiveness(Arc<AtomicBool>);
+	impl CodexLivenessPort for MutableLiveness {
+		fn observe(&self) -> CodexLivenessObservation {
+			if self.0.load(Ordering::Relaxed) {
+				CodexLivenessObservation::Blocked {
+					blockers: vec![CodexAuthOwnerBlocker {
+						pid: 44_768,
+						kind: CodexAuthOwnerKind::Codex,
+						auth_home: CodexAuthHomeEvidence::Shared,
+					}],
+					omitted: 0,
+				}
+			} else {
+				CodexLivenessObservation::Quiescent
+			}
+		}
+	}
+
 	struct RouteSharedAuthFile {
 		source_provider: &'static str,
 		source_access: &'static str,
@@ -4559,40 +5175,6 @@ mod tests {
 		target_provider: &'static str,
 		target_access: &'static str,
 		projections: AtomicUsize,
-	}
-
-	struct FailingProjectionSharedAuthFile {
-		source_provider: &'static str,
-		source_access: &'static str,
-		source_expiry: i64,
-		failure: CodexAuthProjectionError,
-		project_attempts: AtomicUsize,
-	}
-
-	impl SharedAuthFilePort for FailingProjectionSharedAuthFile {
-		fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
-			Ok(RouteSharedAuthFile::version().stamp)
-		}
-
-		fn read(
-			&self,
-			_expected: &SharedCodexAuthFileStamp,
-		) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
-			Ok(SharedCodexAuthSnapshot::Managed {
-				version: RouteSharedAuthFile::version(),
-				credential: imported(self.source_provider, self.source_access, self.source_expiry),
-			})
-		}
-
-		fn project(
-			&self,
-			_bundle: &CredentialSecretBundle,
-			_provider_account_id: &str,
-			_expected: &SharedCodexAuthVersion,
-		) -> Result<(), CodexAuthProjectionError> {
-			self.project_attempts.fetch_add(1, Ordering::Relaxed);
-			Err(self.failure)
-		}
 	}
 
 	impl RouteSharedAuthFile {
@@ -4642,15 +5224,25 @@ mod tests {
 		}
 	}
 
-	fn test_coordinator(file: Arc<dyn SharedAuthFilePort>) -> Arc<SharedAuthCoordinator> {
-		let coordinator = Arc::new(SharedAuthCoordinator::with_file(file));
+	fn test_coordinator(
+		file: Arc<dyn SharedAuthFilePort>,
+		liveness: CodexLiveness,
+	) -> Arc<SharedAuthCoordinator> {
+		test_coordinator_with_liveness(file, Arc::new(FixedLiveness(liveness)))
+	}
+
+	fn test_coordinator_with_liveness(
+		file: Arc<dyn SharedAuthFilePort>,
+		liveness: Arc<dyn CodexLivenessPort>,
+	) -> Arc<SharedAuthCoordinator> {
+		let coordinator = Arc::new(SharedAuthCoordinator::with_ports(liveness, file));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
 		coordinator
 	}
 
 	fn route_test_coordinator(file: Arc<RouteSharedAuthFile>) -> Arc<SharedAuthCoordinator> {
-		test_coordinator(file)
+		test_coordinator(file, CodexLiveness::Quiescent)
 	}
 
 	struct UnmanagedSharedAuthFile {
@@ -4693,6 +5285,149 @@ mod tests {
 		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
 			self.0.fetch_add(1, Ordering::Relaxed);
 			Err(CredentialRefreshError::Rejected)
+		}
+	}
+
+	struct RouteCredentialRefresher;
+	impl CredentialRefreshPort for RouteCredentialRefresher {
+		fn refresh(
+			&self,
+			current: &CredentialSecretBundle,
+		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+			let identity = decode_chatgpt_identity(
+				current.id_token().ok_or(CredentialRefreshError::Rejected)?,
+			)
+			.map_err(|_| CredentialRefreshError::Rejected)?;
+			Ok(CredentialRefreshResult {
+				bundle: shared_bundle(
+					identity.provider.account_id(),
+					"target-refreshed-access",
+					i64::MAX / 2,
+				),
+				returned_provider: identity.provider,
+			})
+		}
+	}
+
+	struct RefreshRaceState {
+		provider: ProviderIdentity,
+		bundle: CredentialSecretBundle,
+		sequence: u64,
+		winner_on_project: Option<CredentialSecretBundle>,
+	}
+
+	struct RefreshRaceSharedAuthFile {
+		state: Mutex<RefreshRaceState>,
+		project_attempts: AtomicUsize,
+	}
+
+	impl RefreshRaceSharedAuthFile {
+		fn new(provider_account_id: &str, bundle: CredentialSecretBundle) -> Self {
+			Self {
+				state: Mutex::new(RefreshRaceState {
+					provider: ProviderIdentity::new(AccountProvider::Chatgpt, provider_account_id)
+						.expect("provider identity"),
+					bundle,
+					sequence: 1,
+					winner_on_project: None,
+				}),
+				project_attempts: AtomicUsize::new(0),
+			}
+		}
+
+		fn version(sequence: u64) -> SharedCodexAuthVersion {
+			SharedCodexAuthVersion {
+				stamp: SharedCodexAuthFileStamp::Present {
+					device: 41,
+					inode: 42,
+					length: sequence,
+					modified_seconds: 43,
+					modified_nanoseconds: i64::try_from(sequence).expect("test sequence fits i64"),
+				},
+				sha256: Some([u8::try_from(sequence).expect("test sequence fits u8"); 32]),
+			}
+		}
+
+		fn set_winner_on_project(&self, winner: CredentialSecretBundle) {
+			self.state.lock().expect("shared auth state").winner_on_project = Some(winner);
+		}
+
+		fn replace_from_codex(&self, winner: CredentialSecretBundle) {
+			let mut state = self.state.lock().expect("shared auth state");
+			state.sequence += 1;
+			state.bundle = winner;
+		}
+
+		fn current_tokens(&self) -> (String, String) {
+			let state = self.state.lock().expect("shared auth state");
+			(state.bundle.access_token().to_owned(), state.bundle.refresh_token().to_owned())
+		}
+	}
+
+	impl SharedAuthFilePort for RefreshRaceSharedAuthFile {
+		fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError> {
+			let state = self.state.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+			Ok(Self::version(state.sequence).stamp)
+		}
+
+		fn read(
+			&self,
+			expected: &SharedCodexAuthFileStamp,
+		) -> Result<SharedCodexAuthSnapshot, CodexAuthProjectionError> {
+			let state = self.state.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+			let version = Self::version(state.sequence);
+			if &version.stamp != expected {
+				return Err(CodexAuthProjectionError::SourceChanged);
+			}
+			Ok(SharedCodexAuthSnapshot::Managed {
+				version,
+				credential: ImportedCredential {
+					provider: state.provider.clone(),
+					bundle: state.bundle.clone(),
+				},
+			})
+		}
+
+		fn project(
+			&self,
+			bundle: &CredentialSecretBundle,
+			provider_account_id: &str,
+			expected: &SharedCodexAuthVersion,
+		) -> Result<(), CodexAuthProjectionError> {
+			let mut state = self.state.lock().map_err(|_| CodexAuthProjectionError::Unavailable)?;
+			if expected != &Self::version(state.sequence) {
+				return Err(CodexAuthProjectionError::SourceChanged);
+			}
+			let provider = ProviderIdentity::new(AccountProvider::Chatgpt, provider_account_id)
+				.map_err(|_| CodexAuthProjectionError::InvalidCredential)?;
+			self.project_attempts.fetch_add(1, Ordering::Relaxed);
+			state.sequence += 1;
+			if let Some(winner) = state.winner_on_project.take() {
+				state.bundle = winner;
+				return Err(CodexAuthProjectionError::SourceChanged);
+			}
+			state.provider = provider;
+			state.bundle = bundle.clone();
+			Ok(())
+		}
+	}
+
+	struct ScriptedCredentialRefresher {
+		calls: Arc<AtomicUsize>,
+		results: Mutex<VecDeque<CredentialRefreshResult>>,
+	}
+
+	impl CredentialRefreshPort for ScriptedCredentialRefresher {
+		fn refresh(
+			&self,
+			_current: &CredentialSecretBundle,
+		) -> Result<CredentialRefreshResult, CredentialRefreshError> {
+			self.calls.fetch_add(1, Ordering::Relaxed);
+			self.results
+				.lock()
+				.map_err(|_| CredentialRefreshError::Unavailable)?
+				.pop_front()
+				.ok_or(CredentialRefreshError::Unavailable)
 		}
 	}
 
@@ -4827,7 +5562,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn exact_shared_family_guard_blocks_managed_source_but_not_unmanaged_auth() {
+	async fn live_codex_allows_only_the_exact_projected_family_to_refresh() {
 		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
@@ -4858,7 +5593,8 @@ mod tests {
 			Arc::new(CountingCredentialRefresher(Arc::clone(&provider_calls))),
 		)
 		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&managed_file) as Arc<dyn SharedAuthFilePort>
+			Arc::clone(&managed_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
 		));
 		assert!(
 			managed
@@ -4884,7 +5620,7 @@ mod tests {
 					None,
 				)
 				.await,
-			Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy))
+			Err(AccountLifecycleError::Refresh(CredentialRefreshError::Rejected))
 		));
 
 		let unmanaged_file = Arc::new(UnmanagedSharedAuthFile { projections: AtomicUsize::new(0) });
@@ -4894,7 +5630,8 @@ mod tests {
 			Arc::new(CountingCredentialRefresher(Arc::clone(&provider_calls))),
 		)
 		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&unmanaged_file) as Arc<dyn SharedAuthFilePort>
+			Arc::clone(&unmanaged_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
 		));
 		assert!(
 			unmanaged
@@ -4920,11 +5657,166 @@ mod tests {
 					None,
 				)
 				.await,
-			Err(AccountLifecycleError::Refresh(CredentialRefreshError::Rejected))
+			Err(AccountLifecycleError::Refresh(CredentialRefreshError::OwnerBusy))
 		));
 		assert_eq!(provider_calls.load(Ordering::Relaxed), 1);
 		assert_eq!(managed_file.projections.load(Ordering::Relaxed), 0);
 		assert_eq!(unmanaged_file.projections.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test]
+	async fn projected_refresh_mirrors_success_and_adopts_a_concurrent_codex_winner() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let provider_account_id = "refresh-race-provider";
+		let initial_expiry = i64::MAX / 4;
+		let account_id = enroll_route_test_account_with_expiry(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-000000000071",
+			"22000000-0000-4000-8000-000000000071",
+			provider_account_id,
+			"initial-access",
+			initial_expiry,
+		)
+		.await;
+		let provider = ProviderIdentity::new(AccountProvider::Chatgpt, provider_account_id)
+			.expect("provider identity");
+		let shared_auth_file = Arc::new(RefreshRaceSharedAuthFile::new(
+			provider_account_id,
+			shared_bundle(provider_account_id, "initial-access", initial_expiry),
+		));
+		let provider_calls = Arc::new(AtomicUsize::new(0));
+		let refresher = Arc::new(ScriptedCredentialRefresher {
+			calls: Arc::clone(&provider_calls),
+			results: Mutex::new(VecDeque::from([
+				CredentialRefreshResult {
+					returned_provider: provider.clone(),
+					bundle: shared_bundle_with_refresh(
+						provider_account_id,
+						"decodex-first-access",
+						"decodex-first-refresh",
+						initial_expiry + 1_000_000,
+					),
+				},
+				CredentialRefreshResult {
+					returned_provider: provider,
+					bundle: shared_bundle_with_refresh(
+						provider_account_id,
+						"decodex-loser-access",
+						"decodex-loser-refresh",
+						initial_expiry + 2_000_000,
+					),
+				},
+			])),
+		});
+		let service = AccountService::new(store.clone(), Arc::clone(&credentials), refresher)
+			.with_shared_auth_coordinator(test_coordinator(
+				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+				CodexLiveness::MayBeRunning,
+			));
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "refresh-race-build".to_owned(),
+					executable_sha256: "1".repeat(64),
+					schema_sha256: "2".repeat(64),
+					callback_profile_sha256: "3".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback")
+		);
+
+		let first = service
+			.refresh(
+				AccountOperationId::new("22000000-0000-4000-8000-000000000072")
+					.expect("first refresh operation"),
+				&account_id,
+				Some(1),
+				None,
+				None,
+			)
+			.await
+			.expect("refresh the exact projected family");
+		assert_eq!(first.access_token(), "decodex-first-access");
+		assert_eq!(
+			shared_auth_file.current_tokens(),
+			("decodex-first-access".to_owned(), "decodex-first-refresh".to_owned())
+		);
+
+		let after_first = store
+			.read_account_registry(Some(&account_id), 1)
+			.await
+			.expect("read first refresh")
+			.into_iter()
+			.next()
+			.expect("refreshed account");
+		let codex_winner = shared_bundle_with_refresh(
+			provider_account_id,
+			"codex-winner-access",
+			"codex-winner-refresh",
+			initial_expiry + 3_000_000,
+		);
+		shared_auth_file.set_winner_on_project(codex_winner);
+
+		let winner = service
+			.refresh(
+				AccountOperationId::new("22000000-0000-4000-8000-000000000073")
+					.expect("racing refresh operation"),
+				&account_id,
+				Some(after_first.revision),
+				None,
+				None,
+			)
+			.await
+			.expect("adopt the concurrent Codex winner");
+		assert_eq!(winner.access_token(), "codex-winner-access");
+		assert_eq!(
+			shared_auth_file.current_tokens(),
+			("codex-winner-access".to_owned(), "codex-winner-refresh".to_owned())
+		);
+		let final_account = store
+			.read_account_registry(Some(&account_id), 1)
+			.await
+			.expect("read converged account")
+			.into_iter()
+			.next()
+			.expect("converged account");
+		let final_binding = final_account.credential.expect("converged credential binding");
+		let final_stored =
+			credentials.read_exact(&account_id, &final_binding).expect("read converged credential");
+		assert_eq!(final_stored.bundle().access_token(), "codex-winner-access");
+		assert_eq!(final_stored.bundle().refresh_token(), "codex-winner-refresh");
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 2);
+		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 2);
+
+		shared_auth_file.replace_from_codex(shared_bundle_with_refresh(
+			provider_account_id,
+			"decodex-loser-access",
+			"decodex-loser-refresh",
+			initial_expiry + 2_000_000,
+		));
+		assert!(service.follow_shared_auth_once().await.unwrap().is_none());
+		assert!(service.follow_shared_auth_once().await.unwrap().is_none());
+		assert_eq!(
+			shared_auth_file.current_tokens(),
+			("codex-winner-access".to_owned(), "codex-winner-refresh".to_owned())
+		);
+		let after_stale_rewrite = store
+			.read_account_registry(Some(&account_id), 1)
+			.await
+			.expect("read stale-rewrite repair")
+			.into_iter()
+			.next()
+			.expect("repaired account");
+		assert_eq!(after_stale_rewrite.revision, final_account.revision);
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 2);
 	}
 
 	#[tokio::test]
@@ -4954,8 +5846,9 @@ mod tests {
 			target_access: "rotated-access",
 			projections: AtomicUsize::new(0),
 		});
-		let coordinator = Arc::new(SharedAuthCoordinator::with_file(
-			Arc::clone(&file) as Arc<dyn SharedAuthFilePort>
+		let coordinator = Arc::new(SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::MayBeRunning)),
+			Arc::clone(&file) as Arc<dyn SharedAuthFilePort>,
 		));
 		let service = AccountService::new(
 			store.clone(),
@@ -4992,8 +5885,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn route_command_confirms_an_already_current_shared_target_without_rewriting_it() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
@@ -5087,7 +5979,8 @@ mod tests {
 			Arc::new(UnusedCredentialRefresher),
 		)
 		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
 		));
 		assert!(
 			service
@@ -5118,7 +6011,7 @@ mod tests {
 							"routing_revision": commit.routing.revision,
 							"projection_digest": commit.projection_digest,
 						}),
-						Err(_) => {
+						Ok(AccountRouteResult::Pending(_)) | Err(_) => {
 							json!({"outcome": "unexpected"})
 						},
 					})
@@ -5183,8 +6076,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn cross_account_route_preserves_the_exact_shared_source_before_projection() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
@@ -5199,14 +6091,13 @@ mod tests {
 			"source-access",
 		)
 		.await;
-		let target_account_id = enroll_route_test_account_with_expiry(
+		let target_account_id = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-000000000052",
 			"22000000-0000-4000-8000-000000000052",
 			"target-provider",
 			"target-access",
-			i64::MAX / 2,
 		)
 		.await;
 		let routing = store.read_account_routing_control().await.expect("read routing");
@@ -5231,13 +6122,13 @@ mod tests {
 			source_access: "source-rotated-access",
 			source_expiry: i64::MAX / 2,
 			target_provider: "target-provider",
-			target_access: "target-access",
+			target_access: "target-refreshed-access",
 			projections: AtomicUsize::new(0),
 		});
 		let service = AccountService::new(
 			store.clone(),
 			Arc::clone(&credentials),
-			Arc::new(UnusedCredentialRefresher),
+			Arc::new(RouteCredentialRefresher),
 		)
 		.with_shared_auth_coordinator(route_test_coordinator(Arc::clone(&shared_auth_file)));
 		assert!(
@@ -5269,7 +6160,7 @@ mod tests {
 							"account_revision": commit.account.revision,
 							"routing_revision": commit.routing.revision,
 						}),
-						Err(_) => {
+						Ok(AccountRouteResult::Pending(_)) | Err(_) => {
 							json!({"outcome": "unexpected"})
 						},
 					})
@@ -5278,7 +6169,7 @@ mod tests {
 			.await
 			.expect("complete cross-account Route");
 
-		assert_eq!(response["account_revision"], 1);
+		assert_eq!(response["account_revision"], 2);
 		assert_eq!(response["routing_revision"], routing.revision + 1);
 		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 1);
 		let source = store
@@ -5296,32 +6187,29 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn cross_account_route_is_synchronous_even_when_codex_may_be_running() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+	async fn live_cross_account_route_waits_for_quiescence_then_follows_same_account_rotation() {
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
 		let credentials: Arc<dyn HostCredentialStore> =
 			Arc::new(SqliteCredentialStore::new(store.clone()));
-		let _source_account_id = enroll_route_test_account_with_expiry(
+		let _source_account_id = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-000000000071",
 			"22000000-0000-4000-8000-000000000071",
 			"pending-source-provider",
 			"pending-source-access",
-			i64::MAX / 2,
 		)
 		.await;
-		let account_id = enroll_route_test_account_with_expiry(
+		let account_id = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-000000000073",
 			"22000000-0000-4000-8000-000000000073",
 			"pending-target-provider",
 			"pending-target-access",
-			i64::MAX / 2,
 		)
 		.await;
 		let routing = store.read_account_routing_control().await.expect("read routing");
@@ -5341,20 +6229,35 @@ mod tests {
 				panic!("new Route replayed")
 			},
 		};
-		let shared_auth_file = Arc::new(RouteSharedAuthFile {
-			source_provider: "pending-source-provider",
-			source_access: "pending-source-access",
-			source_expiry: i64::MAX / 2,
-			target_provider: "pending-target-provider",
-			target_access: "pending-target-access",
-			projections: AtomicUsize::new(0),
-		});
-		let coordinator =
-			test_coordinator(Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>);
+		let shared_auth_file = Arc::new(RefreshRaceSharedAuthFile::new(
+			"pending-source-provider",
+			shared_bundle("pending-source-provider", "pending-source-access", 2_000_000),
+		));
+		let running = Arc::new(AtomicBool::new(true));
+		let coordinator = test_coordinator_with_liveness(
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			Arc::new(MutableLiveness(Arc::clone(&running))),
+		);
+		let provider_calls = Arc::new(AtomicUsize::new(0));
 		let service = AccountService::new(
 			store.clone(),
 			Arc::clone(&credentials),
-			Arc::new(UnusedCredentialRefresher),
+			Arc::new(ScriptedCredentialRefresher {
+				calls: Arc::clone(&provider_calls),
+				results: Mutex::new(VecDeque::from([CredentialRefreshResult {
+					returned_provider: ProviderIdentity::new(
+						AccountProvider::Chatgpt,
+						"pending-target-provider",
+					)
+					.expect("target provider"),
+					bundle: shared_bundle_with_refresh(
+						"pending-target-provider",
+						"target-refreshed-access",
+						"target-refreshed-refresh",
+						i64::MAX / 2,
+					),
+				}])),
+			}),
 		)
 		.with_shared_auth_coordinator(coordinator);
 		assert!(
@@ -5373,7 +6276,24 @@ mod tests {
 		let operation_id = AccountOperationId::new("22000000-0000-4000-8000-000000000072")
 			.expect("Route operation");
 		let response_builder = |result| {
-			Ok(match result {
+				Ok(match result {
+					Ok(AccountRouteResult::Pending(pending)) => {
+						let wait_reason = match pending.wait_reason {
+							AccountRouteWaitReason::ExternalCodex { blockers, omitted } => json!({
+								"reason": "external_codex",
+								"pids": blockers.into_iter().map(|blocker| blocker.pid).collect::<Vec<_>>(),
+								"omitted": omitted,
+							}),
+							_ => json!({"reason": "unexpected"}),
+						};
+						json!({
+							"outcome": "pending",
+							"operation_id": pending.operation_id.as_str(),
+							"account_id": pending.account_id.as_str(),
+							"routing_revision": pending.routing_revision,
+							"wait_reason": wait_reason,
+						})
+					},
 				Ok(AccountRouteResult::Committed(commit)) => json!({
 					"outcome": "routed",
 					"routing_revision": commit.routing.revision,
@@ -5381,8 +6301,7 @@ mod tests {
 				Err(_) => json!({"outcome": "unexpected"}),
 			})
 		};
-		let started = Instant::now();
-		let routed_response = service
+		let pending_response = service
 			.route_account_command(
 				lease,
 				operation_id.clone(),
@@ -5393,326 +6312,94 @@ mod tests {
 				response_builder,
 			)
 			.await
-			.expect("complete Route synchronously");
-		let elapsed = started.elapsed();
-		assert_eq!(routed_response["outcome"], "routed");
-		assert!(elapsed < Duration::from_secs(1), "local Route took {elapsed:?}");
-		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 1);
-		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
+			.expect("defer Route");
+		assert_eq!(pending_response["outcome"], "pending");
+		assert_eq!(pending_response["wait_reason"]["reason"], "external_codex");
+		assert_eq!(pending_response["wait_reason"]["pids"], json!([44_768]));
+		time::timeout(Duration::from_millis(10), service.pending_route_notified())
+			.await
+			.expect("Pending Route wakes the recovery loop immediately");
+		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 0);
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 0);
+		assert_eq!(shared_auth_file.current_tokens().0, "pending-source-access");
 		assert!(matches!(
 			store
 				.reserve_account_route_command(&command, routing.revision, &request)
 				.await
-				.expect("replay routed Route"),
-			AccountCommandReceiptClaim::Replayed(value) if value == routed_response
+				.expect("replay pending Route"),
+			AccountCommandReceiptClaim::Pending(value) if value == pending_response
 		));
+
+		running.store(false, Ordering::Relaxed);
+		time::sleep(Duration::from_millis(2)).await;
+		let pending = store
+			.read_pending_account_route_commands(1)
+			.await
+			.expect("read pending Route")
+			.pop()
+			.expect("pending Route");
+		let lease = match store
+			.reclaim_account_route_command(&pending)
+			.await
+			.expect("reclaim pending Route")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("pending Route did not reclaim")
+			},
+		};
+		let routed = service
+			.route_account_command(
+				lease,
+				operation_id,
+				&account_id,
+				1,
+				routing.revision,
+				true,
+				response_builder,
+			)
+			.await
+			.expect("complete Route");
+		assert_eq!(routed["outcome"], "routed");
+		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 1);
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 1);
+		assert_eq!(
+			shared_auth_file.current_tokens(),
+			("target-refreshed-access".to_owned(), "target-refreshed-refresh".to_owned())
+		);
+		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
 		assert_eq!(
 			store.read_account_routing_control().await.unwrap().mode,
-			AccountSelectionMode::Fixed(account_id)
+			AccountSelectionMode::Fixed(account_id.clone())
 		);
+
+		shared_auth_file.replace_from_codex(shared_bundle_with_refresh(
+			"pending-target-provider",
+			"codex-rotated-access",
+			"codex-rotated-refresh",
+			i64::MAX / 2,
+		));
+		assert!(service.follow_shared_auth_once().await.unwrap().is_none());
+		let followed = service
+			.follow_shared_auth_once()
+			.await
+			.unwrap()
+			.expect("stable same-account rotation is adopted");
+		assert_eq!(followed.account_id, account_id);
+		assert_eq!(followed.revision, 3);
+		let followed_binding = followed.credential.expect("followed credential binding");
+		let followed_stored = credentials
+			.read_exact(&followed.account_id, &followed_binding)
+			.expect("read followed credential");
+		assert_eq!(followed_stored.bundle().access_token(), "codex-rotated-access");
+		assert_eq!(followed_stored.bundle().refresh_token(), "codex-rotated-refresh");
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 1);
 	}
 
 	#[tokio::test]
-	async fn expired_target_route_fails_without_provider_refresh_or_pending() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
-		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
-			.expect("typed product root");
-		let store = SqliteStore::open(&root.paths()).expect("open product store");
-		let credentials: Arc<dyn HostCredentialStore> =
-			Arc::new(SqliteCredentialStore::new(store.clone()));
-		let _source = enroll_route_test_account_with_expiry(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000075",
-			"22000000-0000-4000-8000-000000000075",
-			"expired-source-provider",
-			"expired-source-access",
-			i64::MAX / 2,
-		)
-		.await;
-		let target = enroll_route_test_account(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000076",
-			"22000000-0000-4000-8000-000000000076",
-			"expired-target-provider",
-			"expired-target-access",
-		)
-		.await;
-		let routing = store.read_account_routing_control().await.expect("read routing");
-		let request = format!(
-			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000077","account_id":"{}","expected_account_revision":1}}}}"#,
-			target.as_str(),
-		);
-		let command = CommandIdentity::new("expired-target-route", request.as_bytes())
-			.expect("Route identity");
-		let lease = match store
-			.reserve_account_route_command(&command, routing.revision, &request)
-			.await
-			.expect("reserve Route")
-		{
-			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
-				panic!("new Route replayed")
-			},
-		};
-		let provider_calls = Arc::new(AtomicUsize::new(0));
-		let shared_auth_file = Arc::new(RouteSharedAuthFile {
-			source_provider: "expired-source-provider",
-			source_access: "expired-source-access",
-			source_expiry: i64::MAX / 2,
-			target_provider: "expired-target-provider",
-			target_access: "expired-target-access",
-			projections: AtomicUsize::new(0),
-		});
-		let service = AccountService::new(
-			store.clone(),
-			Arc::clone(&credentials),
-			Arc::new(CountingCredentialRefresher(Arc::clone(&provider_calls))),
-		)
-		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
-		));
-		let response = service
-			.route_account_command(
-				lease,
-				AccountOperationId::new("22000000-0000-4000-8000-000000000077")
-					.expect("Route operation"),
-				&target,
-				1,
-				routing.revision,
-				false,
-				|result| {
-					Ok(match result {
-						Err(AccountRouteFailure::Lifecycle(AccountLifecycleError::Refresh(
-							CredentialRefreshError::Unavailable,
-						))) => json!({"outcome": "credential_refresh_required"}),
-						_ => json!({"outcome": "unexpected"}),
-					})
-				},
-			)
-			.await
-			.expect("complete unavailable target Route");
-		assert_eq!(response["outcome"], "credential_refresh_required");
-		assert_eq!(provider_calls.load(Ordering::Relaxed), 0);
-		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
-		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
-		assert_eq!(store.read_account_routing_control().await.unwrap().revision, routing.revision);
-		assert!(matches!(
-			store
-				.reserve_account_route_command(&command, routing.revision, &request)
-				.await
-				.expect("replay terminal unavailable target"),
-			AccountCommandReceiptClaim::Replayed(value) if value == response
-		));
-	}
-
-	#[tokio::test]
-	async fn shared_auth_cas_drift_is_a_terminal_route_failure() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
-		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
-			.expect("typed product root");
-		let store = SqliteStore::open(&root.paths()).expect("open product store");
-		let credentials: Arc<dyn HostCredentialStore> =
-			Arc::new(SqliteCredentialStore::new(store.clone()));
-		let _source = enroll_route_test_account_with_expiry(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000081",
-			"22000000-0000-4000-8000-000000000081",
-			"cas-source-provider",
-			"cas-source-access",
-			i64::MAX / 2,
-		)
-		.await;
-		let target = enroll_route_test_account_with_expiry(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000082",
-			"22000000-0000-4000-8000-000000000082",
-			"cas-target-provider",
-			"cas-target-access",
-			i64::MAX / 2,
-		)
-		.await;
-		let routing = store.read_account_routing_control().await.expect("read routing");
-		let request = format!(
-			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000083","account_id":"{}","expected_account_revision":1}}}}"#,
-			target.as_str(),
-		);
-		let command =
-			CommandIdentity::new("cas-drift-route", request.as_bytes()).expect("Route identity");
-		let lease = match store
-			.reserve_account_route_command(&command, routing.revision, &request)
-			.await
-			.expect("reserve Route")
-		{
-			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
-				panic!("new Route replayed")
-			},
-		};
-		let shared_auth_file = Arc::new(FailingProjectionSharedAuthFile {
-			source_provider: "cas-source-provider",
-			source_access: "cas-source-access",
-			source_expiry: i64::MAX / 2,
-			failure: CodexAuthProjectionError::SourceChanged,
-			project_attempts: AtomicUsize::new(0),
-		});
-		let service = AccountService::new(
-			store.clone(),
-			Arc::clone(&credentials),
-			Arc::new(UnusedCredentialRefresher),
-		)
-		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
-		));
-		assert!(
-			service
-				.attest_callback_capability(CodexAccountCapabilityAttestation {
-					build_identity: "cas-drift-route-build".to_owned(),
-					executable_sha256: "a".repeat(64),
-					schema_sha256: "b".repeat(64),
-					callback_profile_sha256: "c".repeat(64),
-					login_chatgpt_auth_tokens: true,
-					refresh_callback: true,
-				})
-				.await
-				.expect("attest callback")
-		);
-		let response = service
-			.route_account_command(
-				lease,
-				AccountOperationId::new("22000000-0000-4000-8000-000000000083")
-					.expect("Route operation"),
-				&target,
-				1,
-				routing.revision,
-				false,
-				|result| {
-					Ok(match result {
-						Err(AccountRouteFailure::Lifecycle(
-							AccountLifecycleError::CoordinatorUnavailable,
-						)) => json!({"outcome": "source_changed"}),
-						_ => json!({"outcome": "unexpected"}),
-					})
-				},
-			)
-			.await
-			.expect("terminalize CAS drift");
-		assert_eq!(response["outcome"], "source_changed");
-		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 1);
-		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
-		assert_eq!(store.read_account_routing_control().await.unwrap().revision, routing.revision);
-		assert!(matches!(
-			store
-				.reserve_account_route_command(&command, routing.revision, &request)
-				.await
-				.expect("replay terminal CAS failure"),
-			AccountCommandReceiptClaim::Replayed(value) if value == response
-		));
-	}
-
-	#[tokio::test]
-	async fn post_replace_filesystem_ambiguity_is_terminal_outcome_unknown() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
-		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
-			.expect("typed product root");
-		let store = SqliteStore::open(&root.paths()).expect("open product store");
-		let credentials: Arc<dyn HostCredentialStore> =
-			Arc::new(SqliteCredentialStore::new(store.clone()));
-		let _source = enroll_route_test_account_with_expiry(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000084",
-			"22000000-0000-4000-8000-000000000084",
-			"unknown-source-provider",
-			"unknown-source-access",
-			i64::MAX / 2,
-		)
-		.await;
-		let target = enroll_route_test_account_with_expiry(
-			&store,
-			&credentials,
-			"21000000-0000-4000-8000-000000000085",
-			"22000000-0000-4000-8000-000000000085",
-			"unknown-target-provider",
-			"unknown-target-access",
-			i64::MAX / 2,
-		)
-		.await;
-		let routing = store.read_account_routing_control().await.expect("read routing");
-		let request = format!(
-			r#"{{"name":"route_account","arguments":{{"operation_id":"22000000-0000-4000-8000-000000000086","account_id":"{}","expected_account_revision":1}}}}"#,
-			target.as_str(),
-		);
-		let command = CommandIdentity::new("filesystem-unknown-route", request.as_bytes())
-			.expect("Route identity");
-		let lease = match store
-			.reserve_account_route_command(&command, routing.revision, &request)
-			.await
-			.expect("reserve Route")
-		{
-			AccountCommandReceiptClaim::Owned(lease) => lease,
-			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
-				panic!("new Route replayed")
-			},
-		};
-		let shared_auth_file = Arc::new(FailingProjectionSharedAuthFile {
-			source_provider: "unknown-source-provider",
-			source_access: "unknown-source-access",
-			source_expiry: i64::MAX / 2,
-			failure: CodexAuthProjectionError::OutcomeUnknown,
-			project_attempts: AtomicUsize::new(0),
-		});
-		let service = AccountService::new(
-			store.clone(),
-			Arc::clone(&credentials),
-			Arc::new(UnusedCredentialRefresher),
-		)
-		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
-		));
-		let response = service
-			.route_account_command(
-				lease,
-				AccountOperationId::new("22000000-0000-4000-8000-000000000086")
-					.expect("Route operation"),
-				&target,
-				1,
-				routing.revision,
-				false,
-				|result| {
-					Ok(match result {
-						Err(AccountRouteFailure::ProjectionOutcomeUnknown) => {
-							json!({"outcome": "projection_outcome_unknown"})
-						},
-						_ => json!({"outcome": "unexpected"}),
-					})
-				},
-			)
-			.await
-			.expect("complete ambiguous projection Route");
-		assert_eq!(response["outcome"], "projection_outcome_unknown");
-		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 1);
-		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
-		assert_eq!(store.read_account_routing_control().await.unwrap().revision, routing.revision);
-		assert!(matches!(
-			store
-				.reserve_account_route_command(&command, routing.revision, &request)
-				.await
-				.expect("replay terminal filesystem ambiguity"),
-			AccountCommandReceiptClaim::Replayed(value) if value == response
-		));
-	}
-
-	#[tokio::test]
-	async fn startup_reclaims_legacy_pending_without_callback_or_process_gate() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+	async fn restarted_pending_route_waits_for_callback_readiness_then_converges_if_auth_is_current()
+	 {
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
@@ -5759,96 +6446,116 @@ mod tests {
 				Arc::clone(&credentials),
 				Arc::new(UnusedCredentialRefresher),
 			)
-			.with_shared_auth_coordinator(test_coordinator(
-				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
-			)),
+				.with_shared_auth_coordinator(test_coordinator(
+					Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+					CodexLiveness::MayBeRunning,
+				)),
+		);
+		assert_eq!(
+			service.pending_route_wait_reason(&target).await,
+			AccountRouteWaitReason::AccountReadiness(
+				AccountLifecycleReadiness::CallbackCapabilityUnready
+			)
 		);
 		time::sleep(Duration::from_millis(2)).await;
-		crate::application::recover_pending_account_routes_once(Arc::clone(&service), &store, None)
-			.await;
+		let _ =
+			crate::application::recover_pending_account_routes_once(Arc::clone(&service), &store, None)
+				.await;
+		assert_eq!(store.read_pending_account_route_commands(1).await.unwrap().len(), 1);
+
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "restart-route-build".to_owned(),
+					executable_sha256: "a".repeat(64),
+					schema_sha256: "b".repeat(64),
+					callback_profile_sha256: "c".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.unwrap()
+		);
+		let _ = crate::application::recover_pending_account_routes_once(service, &store, None).await;
 		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
-		let recovered = store
-			.reserve_account_route_command(&command, routing.revision, &request)
-			.await
-			.expect("replay recovered Route");
-		let AccountCommandReceiptClaim::Replayed(recovered) = recovered else {
-			panic!("recovered Route did not replay")
-		};
-		let publication = crate::application::decode_account_command_receipt(recovered)
-			.expect("decode recovered Route receipt")
-			.expect("recovered Route succeeded");
-		assert!(matches!(
-			publication.result,
-			decodex_protocol::ResultPayload::AccountRouted { .. }
-		));
 		assert_eq!(
 			store.read_account_routing_control().await.unwrap().mode,
-			AccountSelectionMode::Fixed(target.clone())
+			AccountSelectionMode::Fixed(target)
 		);
 		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
 	}
 
 	#[tokio::test]
-	async fn newer_route_supersedes_legacy_pending_then_routes_synchronously() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+	async fn newer_pending_route_replaces_the_target_without_a_shared_auth_write() {
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
 		let credentials: Arc<dyn HostCredentialStore> =
 			Arc::new(SqliteCredentialStore::new(store.clone()));
-		let _source = enroll_route_test_account_with_expiry(
+		let _source = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-0000000000d1",
 			"22000000-0000-4000-8000-0000000000d1",
 			"replace-source-provider",
 			"replace-source-access",
-			i64::MAX / 2,
 		)
 		.await;
-		let first_target = enroll_route_test_account_with_expiry(
+		let first_target = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-0000000000d2",
 			"22000000-0000-4000-8000-0000000000d2",
 			"replace-first-provider",
 			"replace-first-access",
-			i64::MAX / 2,
 		)
 		.await;
-		let second_target = enroll_route_test_account_with_expiry(
+		let second_target = enroll_route_test_account(
 			&store,
 			&credentials,
 			"21000000-0000-4000-8000-0000000000d3",
 			"22000000-0000-4000-8000-0000000000d3",
 			"replace-second-provider",
 			"replace-second-access",
-			i64::MAX / 2,
 		)
 		.await;
 		let routing = store.read_account_routing_control().await.unwrap();
 		let shared_auth_file = Arc::new(RouteSharedAuthFile {
 			source_provider: "replace-source-provider",
 			source_access: "replace-source-access",
-			source_expiry: i64::MAX / 2,
+			source_expiry: 2_000_000,
 			target_provider: "replace-second-provider",
-			target_access: "replace-second-access",
+			target_access: "target-refreshed-access",
 			projections: AtomicUsize::new(0),
 		});
 		let service = AccountService::new(
 			store.clone(),
 			Arc::clone(&credentials),
-			Arc::new(UnusedCredentialRefresher),
+			Arc::new(RouteCredentialRefresher),
 		)
 		.with_shared_auth_coordinator(test_coordinator(
-			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
 		));
-		let routed_response = |result| {
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "replace-route-build".to_owned(),
+					executable_sha256: "d".repeat(64),
+					schema_sha256: "e".repeat(64),
+					callback_profile_sha256: "f".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.unwrap()
+		);
+		let pending_response = |result| {
 			Ok(match result {
-				Ok(AccountRouteResult::Committed(commit)) => json!({
-					"outcome": "routed",
-					"account_id": commit.account.account_id.as_str(),
+				Ok(AccountRouteResult::Pending(pending)) => json!({
+					"outcome": "pending",
+					"account_id": pending.account_id.as_str(),
 				}),
 				_ => json!({"outcome": "unexpected"}),
 			})
@@ -5868,13 +6575,19 @@ mod tests {
 			AccountCommandReceiptClaim::Owned(lease) => lease,
 			_ => panic!("first Route replayed"),
 		};
-		store
-			.defer_account_route_command(
+		let first_result = service
+			.route_account_command(
 				first_lease,
-				&json!({"outcome": "pending", "account_id": first_target.as_str()}),
+				AccountOperationId::new(first_operation).unwrap(),
+				&first_target,
+				1,
+				routing.revision,
+				false,
+				pending_response,
 			)
 			.await
 			.unwrap();
+		assert_eq!(first_result["account_id"], first_target.as_str());
 
 		let second_operation = "22000000-0000-4000-8000-0000000000d5";
 		let second_request = format!(
@@ -5906,13 +6619,12 @@ mod tests {
 				1,
 				routing.revision,
 				false,
-				routed_response,
+				pending_response,
 			)
 			.await
 			.unwrap();
-		assert_eq!(second_result["outcome"], "routed");
 		assert_eq!(second_result["account_id"], second_target.as_str());
-		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 1);
+		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
 		assert!(matches!(
 			store
 				.reserve_account_route_command(&first_command, routing.revision, &first_request)
@@ -5920,17 +6632,14 @@ mod tests {
 				.unwrap(),
 			AccountCommandReceiptClaim::Replayed(value) if value == superseded
 		));
-		assert!(store.read_pending_account_route_commands(8).await.unwrap().is_empty());
-		assert_eq!(
-			store.read_account_routing_control().await.unwrap().mode,
-			AccountSelectionMode::Fixed(second_target)
-		);
+		let pending = store.read_pending_account_route_commands(8).await.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].idempotency_key, "replace-second-route");
 	}
 
 	#[tokio::test]
-	async fn legacy_pending_route_routing_drift_terminalizes_immediately() {
-		let directory = tempdir_in(std::env::var_os("HOME").expect("HOME is configured"))
-			.expect("temporary product root");
+	async fn live_codex_does_not_delay_terminal_pending_route_routing_drift() {
+		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
 		let store = SqliteStore::open(&root.paths()).expect("open product store");
@@ -5989,11 +6698,12 @@ mod tests {
 				Arc::new(UnusedCredentialRefresher),
 			)
 			.with_shared_auth_coordinator(test_coordinator(
-				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>
+				Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+				CodexLiveness::MayBeRunning,
 			)),
 		);
 		time::sleep(Duration::from_millis(2)).await;
-		crate::application::recover_pending_account_routes_once(service, &store, None).await;
+		let _ = crate::application::recover_pending_account_routes_once(service, &store, None).await;
 
 		assert!(store.read_pending_account_route_commands(1).await.unwrap().is_empty());
 		assert_eq!(shared_auth_file.projections.load(Ordering::Relaxed), 0);
@@ -6001,7 +6711,7 @@ mod tests {
 
 	#[tokio::test]
 	#[allow(clippy::too_many_lines)] // The precommitted refresh fixture and receipt readback form one crash-window proof.
-	async fn committed_refresh_finishes_its_receipt_without_a_shared_auth_write() {
+	async fn committed_refresh_replay_mirrors_its_successor_without_provider_work() {
 		let directory = tempdir().expect("temporary product root");
 		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
 			.expect("typed product root");
@@ -6015,6 +6725,10 @@ mod tests {
 		let enrollment_operation = AccountOperationId::new("22000000-0000-4000-8000-000000000031")
 			.expect("enrollment operation");
 		let initial_bundle = shared_bundle(provider.account_id(), "initial-access", 2_000_000);
+		let shared_auth_file = Arc::new(RefreshRaceSharedAuthFile::new(
+			provider.account_id(),
+			initial_bundle.clone(),
+		));
 		let initial_binding = initial_bundle
 			.binding_for(
 				&account_id,
@@ -6157,7 +6871,11 @@ mod tests {
 			store.clone(),
 			Arc::clone(&credentials),
 			Arc::new(UnusedCredentialRefresher),
-		);
+		)
+		.with_shared_auth_coordinator(test_coordinator(
+			Arc::clone(&shared_auth_file) as Arc<dyn SharedAuthFilePort>,
+			CodexLiveness::MayBeRunning,
+		));
 		let response = service
 			.refresh_command(lease, refresh_operation.clone(), &account_id, 1, |result| {
 				Ok(match result {
@@ -6175,6 +6893,11 @@ mod tests {
 		let refreshed = service.inspect(&account_id).await.expect("read refreshed account").account;
 		assert_eq!(refreshed.revision, 2);
 		assert_eq!(refreshed.credential.as_ref(), Some(&refreshed_binding));
+		assert_eq!(
+			shared_auth_file.current_tokens().0,
+			"refreshed-access"
+		);
+		assert_eq!(shared_auth_file.project_attempts.load(Ordering::Relaxed), 1);
 		let operation = store
 			.read_account_operation(&refresh_operation)
 			.await
@@ -7078,6 +7801,29 @@ mod tests {
 	}
 
 	#[test]
+	fn quick_task_callback_accepts_only_a_newer_same_provider_sqlite_successor() {
+		let initial = binding("callback-provider", 3);
+		let process = ProcessGenerationAccountBinding::new(7, initial.clone(), "a".repeat(64))
+			.expect("process binding");
+		assert!(!callback_uses_current_successor(7, &process, &initial).unwrap());
+
+		let mut successor = binding("callback-provider", 4);
+		successor.writer_operation_id =
+			AccountOperationId::new("10000000-0000-4000-8000-000000000004").unwrap();
+		assert!(callback_uses_current_successor(8, &process, &successor).unwrap());
+		assert!(matches!(
+			callback_uses_current_successor(6, &process, &successor),
+			Err(AccountLifecycleError::StaleAccount)
+		));
+
+		let switched = binding("different-callback-provider", 4);
+		assert!(matches!(
+			callback_uses_current_successor(8, &process, &switched),
+			Err(AccountLifecycleError::ProviderMismatch)
+		));
+	}
+
+	#[test]
 	fn codex_projection_digest_changes_with_only_credential_negative_binding_state() {
 		let first = projection_account(Some(binding("projection-provider", 3)));
 		let first_binding = first.credential.as_ref().unwrap();
@@ -7186,9 +7932,23 @@ mod tests {
 		access_token: &str,
 		expires_at_unix_micros: i64,
 	) -> CredentialSecretBundle {
+		shared_bundle_with_refresh(
+			provider_account_id,
+			access_token,
+			"shared-refresh",
+			expires_at_unix_micros,
+		)
+	}
+
+	fn shared_bundle_with_refresh(
+		provider_account_id: &str,
+		access_token: &str,
+		refresh_token: &str,
+		expires_at_unix_micros: i64,
+	) -> CredentialSecretBundle {
 		CredentialSecretBundle::chatgpt(
 			access_token.to_owned(),
-			"shared-refresh".to_owned(),
+			refresh_token.to_owned(),
 			Some(identity_token(provider_account_id, "shared@example.test", "pro")),
 			Some("pro".to_owned()),
 			"shared@example.test".to_owned(),
@@ -7236,22 +7996,19 @@ mod tests {
 		let exact = projection_account(Some(binding("projection-provider", 3)));
 
 		assert_eq!(
-			route_projection_binding(&exact, 9).unwrap().provider.account_id(),
+			projection_binding(&exact, 9).unwrap().provider.account_id(),
 			"projection-provider",
 		);
+		assert!(matches!(projection_binding(&exact, 8), Err(AccountLifecycleError::StaleAccount)));
 		assert!(matches!(
-			route_projection_binding(&exact, 8),
-			Err(AccountLifecycleError::StaleAccount)
-		));
-		assert!(matches!(
-			route_projection_binding(&projection_account(None), 9),
+			projection_binding(&projection_account(None), 9),
 			Err(AccountLifecycleError::CredentialAbsent)
 		));
 
 		let mut disabled = exact.clone();
 		disabled.enabled = false;
 		assert!(matches!(
-			route_projection_binding(&disabled, 9),
+			projection_binding(&disabled, 9),
 			Err(AccountLifecycleError::AccountDisabled)
 		));
 
@@ -7259,7 +8016,7 @@ mod tests {
 		tombstoned.tombstoned = true;
 		tombstoned.lifecycle_readiness = AccountLifecycleReadiness::Tombstoned;
 		assert!(matches!(
-			route_projection_binding(&tombstoned, 9),
+			projection_binding(&tombstoned, 9),
 			Err(AccountLifecycleError::NotReady(AccountLifecycleReadiness::Tombstoned))
 		));
 	}

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -38,7 +38,9 @@ use decodex_protocol::{
 	AccountOperationPhaseDto, AccountProfileDailyUsageDto, AccountProfileDto,
 	AccountProfileEmailDto, AccountProfileErrorDto, AccountProfileResult, AccountProviderDto,
 	AccountQuotaErrorDto, AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutePendingDto,
-	AccountRoutingControlDto, AccountSelectionModeDto, AccountSelectionRecoveryDto,
+	AccountRouteAuthHomeDto, AccountRouteBlockingProcessDto, AccountRouteProcessBlockerDto,
+	AccountRouteWaitReasonDto, AccountRoutingControlDto, AccountSelectionModeDto,
+	AccountSelectionRecoveryDto,
 	AccountUnsettledOperationDto, AccountsResult, CausationId, Channel, CodexAuthProjectionResult,
 	CommandEnvelope, CommandError, CommandPayload, ConversationHistoryPage,
 	ConversationHistoryResult, CorrelationId, DESKTOP_SETTINGS_ENTITY_ID, DesktopSettingsDto,
@@ -78,9 +80,11 @@ use crate::{
 	},
 	account_service::{
 		AccountLifecycleError, AccountManualRecoveryAction, AccountManualRecoveryOutcome,
-		AccountRouteCommit, AccountRouteCompletion, AccountRouteFailure, AccountRouteResult,
-		AccountService, CodexAuthProjectionInspection, stable_account_alias,
+		AccountRouteCommit, AccountRouteCompletion, AccountRouteFailure, AccountRoutePending,
+		AccountRouteResult, AccountRouteWaitReason, AccountService, CodexAuthProjectionInspection,
+		stable_account_alias,
 	},
+	shared_auth_coordinator::{CodexAuthHomeEvidence, CodexAuthOwnerKind},
 	domain_packs::{self, DomainPackError, QUICK_TASK_CAPABILITY},
 	managed_repository_runtime::ManagedRepositoryCapability,
 	quick_task::{
@@ -406,14 +410,30 @@ impl ServiceApplication {
 	}
 }
 
+const PENDING_ROUTE_RETRY_DELAY: Duration = Duration::from_millis(100);
+const IDLE_ROUTE_RETRY_DELAY: Duration = Duration::from_secs(1);
+
 pub(crate) async fn recover_pending_account_routes_once(
 	accounts: Arc<AccountService>,
 	store: &SqliteStore,
 	observations: Option<&AccountObservationService>,
-) {
+) -> bool {
+	if let Ok(Some(account)) = accounts.follow_shared_auth_once().await
+		&& let Some(observations) = observations
+	{
+		observations.invalidate_account(&account.account_id).await;
+		observations.request_refresh();
+	}
+	let mut has_pending_routes = false;
 	if let Ok(pending) = store.read_pending_account_route_commands(64).await {
+		has_pending_routes = !pending.is_empty();
+		let codex_may_be_running = accounts.shared_auth_may_be_running();
 		for pending_command in pending {
 			let _route_guard = accounts.lock_route_command().await;
+			let routing_is_stale =
+				store.read_account_routing_control().await.ok().is_some_and(|routing| {
+					routing.revision != pending_command.expected_routing_revision
+				});
 			let Ok(CommandPayload::RouteAccount {
 				operation_id,
 				account_id,
@@ -429,6 +449,24 @@ pub(crate) async fn recover_pending_account_routes_once(
 			) else {
 				continue;
 			};
+			if !routing_is_stale
+				&& accounts.inspect(&account_id).await.ok().is_some_and(|inspection| {
+					matches!(
+						inspection.readiness,
+						AccountLifecycleReadiness::CallbackCapabilityUnready
+							| AccountLifecycleReadiness::StoreUnavailable
+							| AccountLifecycleReadiness::StoreMismatch
+							| AccountLifecycleReadiness::OperationUnsettled
+					)
+				}) {
+				continue;
+			}
+			if codex_may_be_running
+				&& !routing_is_stale
+				&& !accounts.shared_auth_is_current_for(&account_id).await
+			{
+				continue;
+			}
 			let lease = match store.reclaim_account_route_command(&pending_command).await {
 				Ok(AccountCommandReceiptClaim::Owned(lease)) => lease,
 				Ok(
@@ -455,6 +493,7 @@ pub(crate) async fn recover_pending_account_routes_once(
 			}
 		}
 	}
+	has_pending_routes
 }
 
 fn account_route_receipt_committed(
@@ -467,8 +506,9 @@ fn account_route_receipt_committed(
 	})
 }
 
-async fn follow_shared_auth_changes(
+async fn recover_pending_account_routes(
 	accounts: Arc<AccountService>,
+	store: SqliteStore,
 	observations: Option<AccountObservationService>,
 	mut stop: watch::Receiver<bool>,
 ) {
@@ -476,12 +516,14 @@ async fn follow_shared_auth_changes(
 		if *stop.borrow() {
 			return;
 		}
-		if let Ok(Some(account)) = accounts.follow_shared_auth_once().await
-			&& let Some(observations) = observations.as_ref()
-		{
-			observations.invalidate_account(&account.account_id).await;
-			observations.request_refresh();
-		}
+		let has_pending_routes =
+			recover_pending_account_routes_once(Arc::clone(&accounts), &store, observations.as_ref())
+				.await;
+		let retry_delay = if has_pending_routes {
+			PENDING_ROUTE_RETRY_DELAY
+		} else {
+			IDLE_ROUTE_RETRY_DELAY
+		};
 
 		tokio::select! {
 			biased;
@@ -490,7 +532,8 @@ async fn follow_shared_auth_changes(
 					return;
 				}
 			},
-			() = time::sleep(Duration::from_secs(1)) => {},
+			() = accounts.pending_route_notified() => {},
+			() = time::sleep(retry_delay) => {},
 		}
 	}
 }
@@ -563,7 +606,9 @@ impl ServiceApplication {
 				.await
 			{
 				Ok(pending) if pending.is_empty() => None,
-				Ok(pending) if pending.len() == 1 => pending_account_route_dto(&pending[0]).ok(),
+				Ok(pending) if pending.len() == 1 => {
+					pending_account_route_dto(service, &pending[0]).await.ok()
+				},
 				Ok(_) | Err(_) => return AccountsResult::Unavailable,
 			},
 			ProductStore::Unavailable(_) => None,
@@ -1913,9 +1958,10 @@ impl Application for ServiceApplication {
 		if let Some(control) = &self.provider_attempts {
 			tasks.push(Box::pin(control.reconciliation_task(stop.clone())));
 		}
-		if let Some(accounts) = &self.accounts {
-			tasks.push(Box::pin(follow_shared_auth_changes(
+		if let (Some(accounts), ProductStore::Available(store)) = (&self.accounts, &self.store) {
+			tasks.push(Box::pin(recover_pending_account_routes(
 				Arc::clone(accounts),
+				store.clone(),
 				self.account_observations.clone(),
 				stop.clone(),
 			)));
@@ -3828,21 +3874,46 @@ fn account_routed_publication(
 	})
 }
 
+fn account_route_pending_publication(
+	pending: AccountRoutePending,
+) -> Result<ApplicationPublication, CommandError> {
+	let pending = AccountRoutePendingDto {
+		operation_id: EntityId::new(pending.operation_id.as_str().to_owned())
+			.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		account_id: EntityId::new(pending.account_id.as_str().to_owned())
+			.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		routing_revision: EntityRevision(
+			u64::try_from(pending.routing_revision)
+				.map_err(|_| application_unavailable("account Route progress is incompatible"))?,
+		),
+		wait_reason: account_route_wait_reason_dto(pending.wait_reason),
+	};
+	let entity_id = EntityId::new("account-routing").expect("account routing entity is bounded");
+	Ok(ApplicationPublication {
+		channel: Channel::AccountsHealth,
+		entity_id,
+		entity_revision: pending.routing_revision,
+		result: ResultPayload::AccountRoutePending { pending: pending.clone() },
+		event: EventPayload::AccountRoutePending { pending },
+	})
+}
+
 fn account_route_result(
 	result: Result<AccountRouteResult, AccountRouteFailure>,
 ) -> Result<ApplicationPublication, CommandError> {
 	match result {
 		Ok(AccountRouteResult::Committed(commit)) => account_routed_publication(*commit),
+		Ok(AccountRouteResult::Pending(pending)) => account_route_pending_publication(pending),
 		Err(AccountRouteFailure::Lifecycle(error)) => Err(account_lifecycle_command_error(error)),
 		Err(AccountRouteFailure::Routing(outcome)) => match routing_command_result(&outcome) {
 			Err(error) => Err(error),
 			Ok(_) => Err(application_unavailable("account Route result is incompatible")),
 		},
-		Err(AccountRouteFailure::ProjectionOutcomeUnknown) => Err(CommandError::AcceptanceUnknown),
 	}
 }
 
-fn pending_account_route_dto(
+async fn pending_account_route_dto(
+	service: &AccountService,
 	pending: &decodex_database::PendingAccountRouteCommand,
 ) -> Result<AccountRoutePendingDto, ()> {
 	let CommandPayload::RouteAccount { operation_id, account_id, .. } =
@@ -3850,13 +3921,57 @@ fn pending_account_route_dto(
 	else {
 		return Err(());
 	};
+	let internal_account_id = AccountId::new(account_id.as_str()).map_err(|_| ())?;
+	let wait_reason = service.pending_route_wait_reason(&internal_account_id).await;
 	Ok(AccountRoutePendingDto {
 		operation_id,
 		account_id,
 		routing_revision: EntityRevision(
 			u64::try_from(pending.expected_routing_revision).map_err(|_| ())?,
 		),
+		wait_reason: account_route_wait_reason_dto(wait_reason),
 	})
+}
+
+fn account_route_wait_reason_dto(reason: AccountRouteWaitReason) -> AccountRouteWaitReasonDto {
+	match reason {
+		AccountRouteWaitReason::ExternalCodex { blockers, omitted } => {
+			AccountRouteWaitReasonDto::ExternalCodex {
+				blockers: blockers
+					.into_iter()
+					.map(|blocker| AccountRouteProcessBlockerDto {
+						pid: blocker.pid,
+						process: match blocker.kind {
+							CodexAuthOwnerKind::Chatgpt => AccountRouteBlockingProcessDto::Chatgpt,
+							CodexAuthOwnerKind::Codex => AccountRouteBlockingProcessDto::Codex,
+						},
+						auth_home: match blocker.auth_home {
+							CodexAuthHomeEvidence::Shared => AccountRouteAuthHomeDto::Shared,
+							CodexAuthHomeEvidence::Unknown => AccountRouteAuthHomeDto::Unknown,
+						},
+					})
+					.collect(),
+				omitted,
+			}
+		},
+		AccountRouteWaitReason::CodexObservationUnavailable => {
+			AccountRouteWaitReasonDto::CodexObservationUnavailable
+		},
+		AccountRouteWaitReason::AccountReadiness(readiness) => {
+			AccountRouteWaitReasonDto::AccountReadiness {
+				readiness: lifecycle_readiness_dto(readiness),
+			}
+		},
+		AccountRouteWaitReason::SharedAuthStabilizing => {
+			AccountRouteWaitReasonDto::SharedAuthStabilizing
+		},
+		AccountRouteWaitReason::SharedAuthUnavailable => {
+			AccountRouteWaitReasonDto::SharedAuthUnavailable
+		},
+		AccountRouteWaitReason::ProjectionReadback => {
+			AccountRouteWaitReasonDto::ProjectionReadback
+		},
+	}
 }
 
 fn routing_command_result(
@@ -4324,24 +4439,30 @@ mod tests {
 		ProgramEvidenceRecord, ProgramObjectiveRecord, ProgramProposalRecord, ProgramReviewRecord,
 		ProgramSignalRecord, ProgramWorkItemRecord, SqliteStore,
 	};
-	use decodex_protocol::{
-		AccountCommandRejectionDto, AccountProfileEmailDto, AccountQuotaStateDto,
-		AccountRoutePendingDto, Channel, CommandError, EntityId, EntityRevision, EventPayload,
-		ProgramNodeKind, ProgramRelationKind, QuickTaskRecoveryAction, QuickTaskState,
-		ResetCardError, ResetCardOperationResult, ResultPayload,
-	};
+		use decodex_protocol::{
+			AccountCommandRejectionDto, AccountProfileEmailDto, AccountQuotaStateDto,
+			AccountRouteAuthHomeDto, AccountRoutePendingDto, AccountRouteWaitReasonDto, Channel,
+			CommandError, EntityId, EntityRevision, EventPayload, ProgramNodeKind, ProgramRelationKind,
+			QuickTaskRecoveryAction, QuickTaskState, ResetCardError, ResetCardOperationResult,
+			ResultPayload,
+		};
 
-	use super::{
-		ACCOUNT_COMMAND_RECEIPT_SCHEMA, AccountLifecycleError, AccountProfileClaimsView,
-		AccountProfileRuntimeError, AccountProfileView, AccountRouteFailure,
-		ApplicationPublication, ProductStore, ResetCardServiceError, StoredAccountCommandOutcome,
-		account_dto, account_lifecycle_command_error, account_profile_dto,
-		account_profile_unavailable_dto, account_route_receipt_committed, account_route_result,
-		authorize_program_capability, decode_account_command_receipt,
-		encode_account_command_receipt, lifecycle_rejection, operation_query_result,
-		program_cycle_dto, protocol_reset_error, quick_task_summary_from_row, quota_dto,
+		use super::{
+			ACCOUNT_COMMAND_RECEIPT_SCHEMA, AccountLifecycleError, AccountProfileClaimsView,
+			AccountProfileRuntimeError, AccountProfileView, AccountRouteWaitReason,
+			ApplicationPublication, ProductStore, ResetCardServiceError, StoredAccountCommandOutcome,
+			account_dto,
+			account_lifecycle_command_error, account_profile_dto, account_profile_unavailable_dto,
+			account_route_receipt_committed, account_route_wait_reason_dto,
+			authorize_program_capability,
+		decode_account_command_receipt, encode_account_command_receipt, lifecycle_rejection,
+		operation_query_result, program_cycle_dto, protocol_reset_error,
+		quick_task_summary_from_row, quota_dto,
 	};
-	use crate::domain_packs::{QUICK_TASK_CAPABILITY, resolve_identity};
+		use crate::domain_packs::{QUICK_TASK_CAPABILITY, resolve_identity};
+		use crate::shared_auth_coordinator::{
+			CodexAuthHomeEvidence, CodexAuthOwnerBlocker, CodexAuthOwnerKind,
+		};
 
 	fn program_preflight_fixture(
 		sequence: u64,
@@ -5007,11 +5128,37 @@ mod tests {
 	}
 
 	#[test]
+	fn pending_route_recovery_uses_an_interactive_retry_delay() {
+		assert_eq!(super::PENDING_ROUTE_RETRY_DELAY, std::time::Duration::from_millis(100));
+		assert_eq!(super::IDLE_ROUTE_RETRY_DELAY, std::time::Duration::from_secs(1));
+	}
+
+	#[test]
+	fn pending_route_wait_reason_projects_bounded_process_evidence() {
+		let projected = account_route_wait_reason_dto(AccountRouteWaitReason::ExternalCodex {
+			blockers: vec![CodexAuthOwnerBlocker {
+				pid: 44_768,
+				kind: CodexAuthOwnerKind::Codex,
+				auth_home: CodexAuthHomeEvidence::Unknown,
+			}],
+			omitted: 0,
+		});
+		assert!(matches!(
+			projected,
+			AccountRouteWaitReasonDto::ExternalCodex { blockers, omitted: 0 }
+				if blockers.len() == 1
+					&& blockers[0].pid == 44_768
+					&& blockers[0].auth_home == AccountRouteAuthHomeDto::Unknown
+		));
+	}
+
+	#[test]
 	fn pending_route_receipt_does_not_trigger_committed_account_observation_work() {
 		let pending = AccountRoutePendingDto {
 			operation_id: EntityId::new("22000000-0000-4000-8000-0000000000a1").unwrap(),
 			account_id: EntityId::new("21000000-0000-4000-8000-0000000000a1").unwrap(),
 			routing_revision: EntityRevision(7),
+			wait_reason: AccountRouteWaitReasonDto::SharedAuthStabilizing,
 		};
 		let publication = ApplicationPublication {
 			channel: Channel::AccountsHealth,
@@ -5023,14 +5170,6 @@ mod tests {
 		let encoded = encode_account_command_receipt(&Ok(publication)).unwrap();
 
 		assert!(!account_route_receipt_committed(Ok(encoded)));
-	}
-
-	#[test]
-	fn filesystem_projection_ambiguity_maps_to_acceptance_unknown() {
-		assert!(matches!(
-			account_route_result(Err(AccountRouteFailure::ProjectionOutcomeUnknown)),
-			Err(CommandError::AcceptanceUnknown)
-		));
 	}
 
 	#[test]

--- a/crates/decodex-runtime/src/bootstrap.rs
+++ b/crates/decodex-runtime/src/bootstrap.rs
@@ -176,7 +176,7 @@ impl ServiceBootstrap {
 		};
 		if let (ProductStore::Available(store), Some(accounts)) = (&store, &accounts) {
 			let _ = store.release_interrupted_account_route_claims().await;
-			recover_pending_account_routes_once(
+			let _ = recover_pending_account_routes_once(
 				Arc::clone(accounts),
 				store,
 				account_observations.as_ref(),

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.10 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.11 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Quick Task owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.

--- a/crates/decodex-runtime/src/shared_auth_coordinator.rs
+++ b/crates/decodex-runtime/src/shared_auth_coordinator.rs
@@ -2,6 +2,19 @@
 
 use std::sync::{Arc, Mutex};
 
+#[cfg(target_os = "macos")]
+use std::{
+	collections::{HashMap, HashSet},
+	ffi::{OsStr, OsString, c_void},
+	fs,
+	mem::{MaybeUninit, size_of},
+	os::unix::ffi::{OsStrExt as _, OsStringExt as _},
+	path::{Path, PathBuf},
+};
+
+#[cfg(target_os = "macos")]
+use zeroize::Zeroizing;
+
 use crate::{
 	auth_projection::{
 		CodexAuthProjectionError, SharedCodexAuthFileStamp, SharedCodexAuthSnapshot,
@@ -12,6 +25,78 @@ use crate::{
 };
 
 const REQUIRED_STABLE_POLLS: u8 = 2;
+pub(crate) const MAX_CODEX_AUTH_OWNER_BLOCKERS: usize = 8;
+
+#[cfg(target_os = "macos")]
+const MAX_PROCESS_ENVIRONMENT_BYTES: usize = 2 * 1024 * 1024;
+
+#[cfg(target_os = "macos")]
+const MAX_PROCESS_HOME_BYTES: usize = 4 * 1024;
+
+#[cfg(target_os = "macos")]
+const MAX_CODEX_HOME_INSPECTIONS: usize = 16;
+
+/// Conservative process observation. Any uncertainty keeps the shared writer handoff closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CodexLiveness {
+	Quiescent,
+	MayBeRunning,
+}
+
+/// Credential-negative process identity shown when a Route waits for shared-auth ownership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CodexAuthOwnerKind {
+	Chatgpt,
+	Codex,
+}
+
+/// Whether one blocking process is proved to use the normal shared Codex home.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CodexAuthHomeEvidence {
+	Shared,
+	Unknown,
+}
+
+/// One bounded same-UID process that can still write the normal shared Codex auth file.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CodexAuthOwnerBlocker {
+	pub(crate) pid: u32,
+	pub(crate) kind: CodexAuthOwnerKind,
+	pub(crate) auth_home: CodexAuthHomeEvidence,
+}
+
+/// Structured liveness readback. `Unavailable` remains fail-closed but is distinguishable from a
+/// concrete process blocker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CodexLivenessObservation {
+	Quiescent,
+	Blocked {
+		blockers: Vec<CodexAuthOwnerBlocker>,
+		omitted: u16,
+	},
+	Unavailable,
+}
+
+impl CodexLivenessObservation {
+	pub(crate) const fn state(&self) -> CodexLiveness {
+		match self {
+			Self::Quiescent => CodexLiveness::Quiescent,
+			Self::Blocked { .. } | Self::Unavailable => CodexLiveness::MayBeRunning,
+		}
+	}
+
+	#[cfg(test)]
+	pub(crate) fn from_state(state: CodexLiveness) -> Self {
+		match state {
+			CodexLiveness::Quiescent => Self::Quiescent,
+			CodexLiveness::MayBeRunning => Self::Unavailable,
+		}
+	}
+}
+
+pub(crate) trait CodexLivenessPort: Send + Sync {
+	fn observe(&self) -> CodexLivenessObservation;
+}
 
 pub(crate) trait SharedAuthFilePort: Send + Sync {
 	fn stamp(&self) -> Result<SharedCodexAuthFileStamp, CodexAuthProjectionError>;
@@ -74,6 +159,7 @@ pub(crate) enum StableSharedAuthRead {
 
 /// One coordinator instance owns all shared-auth polling and projection decisions in `decodexd`.
 pub(crate) struct SharedAuthCoordinator {
+	liveness: Arc<dyn CodexLivenessPort>,
 	file: Arc<dyn SharedAuthFilePort>,
 	state: Mutex<StableReadState>,
 }
@@ -81,14 +167,26 @@ pub(crate) struct SharedAuthCoordinator {
 impl SharedAuthCoordinator {
 	pub(crate) fn production() -> Self {
 		Self {
+			liveness: Arc::new(ProductionCodexLiveness),
 			file: Arc::new(ProductionSharedAuthFile),
 			state: Mutex::new(StableReadState::default()),
 		}
 	}
 
 	#[cfg(test)]
-	pub(crate) fn with_file(file: Arc<dyn SharedAuthFilePort>) -> Self {
-		Self { file, state: Mutex::new(StableReadState::default()) }
+	pub(crate) fn with_ports(
+		liveness: Arc<dyn CodexLivenessPort>,
+		file: Arc<dyn SharedAuthFilePort>,
+	) -> Self {
+		Self { liveness, file, state: Mutex::new(StableReadState::default()) }
+	}
+
+	pub(crate) fn liveness(&self) -> CodexLiveness {
+		self.liveness.observe().state()
+	}
+
+	pub(crate) fn liveness_observation(&self) -> CodexLivenessObservation {
+		self.liveness.observe()
 	}
 
 	pub(crate) fn poll_stable_change(&self) -> StableSharedAuthPoll {
@@ -153,6 +251,7 @@ impl SharedAuthCoordinator {
 		}
 	}
 
+	/// Read one exact source version without waiting for the passive two-poll coalescer.
 	pub(crate) fn read_current_exact(
 		&self,
 	) -> Result<Box<SharedCodexAuthSnapshot>, CodexAuthProjectionError> {
@@ -160,6 +259,8 @@ impl SharedAuthCoordinator {
 		self.file.read(&stamp).map(Box::new)
 	}
 
+	/// Replace one proved same-account source without requiring external Codex quiescence.
+	/// The Account Service must prove the provider and credential lineage before this call.
 	pub(crate) fn project_exact_source(
 		&self,
 		bundle: &CredentialSecretBundle,
@@ -168,6 +269,560 @@ impl SharedAuthCoordinator {
 	) -> Result<(), CodexAuthProjectionError> {
 		self.file.project(bundle, provider_account_id, expected)
 	}
+
+	pub(crate) fn project_if_quiescent(
+		&self,
+		bundle: &CredentialSecretBundle,
+		provider_account_id: &str,
+		expected: &SharedCodexAuthVersion,
+	) -> Result<(), CodexAuthProjectionError> {
+		if self.liveness() != CodexLiveness::Quiescent {
+			return Err(CodexAuthProjectionError::SourceChanged);
+		}
+		self.file.project(bundle, provider_account_id, expected)
+	}
+}
+
+struct ProductionCodexLiveness;
+
+#[cfg(target_os = "macos")]
+impl CodexLivenessPort for ProductionCodexLiveness {
+	fn observe(&self) -> CodexLivenessObservation {
+		observe_macos_codex_liveness()
+	}
+}
+
+#[cfg(not(target_os = "macos"))]
+impl CodexLivenessPort for ProductionCodexLiveness {
+	fn observe(&self) -> CodexLivenessObservation {
+		CodexLivenessObservation::Unavailable
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_codex_liveness() -> CodexLivenessObservation {
+	// Apple SDK `sys/proc_info.h` defines `PROC_ALL_PIDS` as 1. libc exposes the
+	// functions but not this selector, so keep the one SDK-named value local.
+	const PROC_ALL_PIDS: u32 = 1;
+	let Some(shared_codex_home) = std::env::var_os("HOME")
+		.filter(|home| !home.is_empty())
+		.map(PathBuf::from)
+		.map(|home| home.join(".codex"))
+	else {
+		return CodexLivenessObservation::Unavailable;
+	};
+	let required = unsafe { libc::proc_listpids(PROC_ALL_PIDS, 0, std::ptr::null_mut(), 0) };
+	let pid_size = std::mem::size_of::<libc::pid_t>();
+	let Ok(required) = usize::try_from(required) else {
+		return CodexLivenessObservation::Unavailable;
+	};
+	if required == 0 || pid_size == 0 {
+		return CodexLivenessObservation::Unavailable;
+	}
+	let capacity = required / pid_size + 64;
+	let mut pids = vec![0 as libc::pid_t; capacity];
+	let Ok(buffer_bytes) = i32::try_from(pids.len().saturating_mul(pid_size)) else {
+		return CodexLivenessObservation::Unavailable;
+	};
+	let returned = unsafe {
+		libc::proc_listpids(PROC_ALL_PIDS, 0, pids.as_mut_ptr().cast::<c_void>(), buffer_bytes)
+	};
+	let Ok(returned) = usize::try_from(returned) else {
+		return CodexLivenessObservation::Unavailable;
+	};
+	if returned == 0 || returned >= pids.len().saturating_mul(pid_size) {
+		return CodexLivenessObservation::Unavailable;
+	}
+	pids.truncate(returned / pid_size);
+	let Ok(own_pid) = libc::pid_t::try_from(std::process::id()) else {
+		return CodexLivenessObservation::Unavailable;
+	};
+	let mut observations = pids
+		.into_iter()
+		.filter(|pid| *pid > 0)
+		.map(observe_macos_process)
+		.collect::<Vec<_>>();
+	enrich_macos_codex_home_evidence(own_pid, &shared_codex_home, &mut observations);
+	classify_macos_codex_liveness(own_pid, &observations)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum MacosProcessField<T> {
+	Value(T),
+	Unavailable,
+	Vanished,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MacosProcessObservation {
+	pid: libc::pid_t,
+	parent_pid: MacosProcessField<libc::pid_t>,
+	name: MacosProcessField<OsString>,
+	path: MacosProcessField<PathBuf>,
+	auth_home: MacosProcessField<MacosCodexHomeRelation>,
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process(pid: libc::pid_t) -> MacosProcessObservation {
+	let name = observe_macos_process_name(pid);
+	let path = match &name {
+		MacosProcessField::Value(name) if !process_name_looks_like_codex(name) => {
+			MacosProcessField::Unavailable
+		},
+		MacosProcessField::Vanished => MacosProcessField::Vanished,
+		MacosProcessField::Value(_) | MacosProcessField::Unavailable => {
+			observe_macos_process_path(pid)
+		},
+	};
+	let mut observation = MacosProcessObservation {
+		pid,
+		parent_pid: observe_macos_parent_pid(pid),
+		name,
+		path,
+		auth_home: MacosProcessField::Unavailable,
+	};
+	if matches!(
+		&observation.path,
+		MacosProcessField::Value(path) if path_is_official_shared_codex(path)
+	) {
+		// Official desktop and bundled app-server identities are strict blockers. Only a
+		// standalone Codex executable is eligible for best-effort isolated-home proof.
+		observation.auth_home = MacosProcessField::Value(MacosCodexHomeRelation::Shared);
+	}
+	observation
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process_name(pid: libc::pid_t) -> MacosProcessField<OsString> {
+	let mut bytes = vec![0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+	let length = unsafe {
+		libc::proc_name(
+			pid,
+			bytes.as_mut_ptr().cast::<c_void>(),
+			libc::PROC_PIDPATHINFO_MAXSIZE as u32,
+		)
+	};
+	if length == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	let Ok(length) = usize::try_from(length) else {
+		return MacosProcessField::Unavailable;
+	};
+	if length > bytes.len() {
+		return MacosProcessField::Unavailable;
+	}
+	let length = bytes[..length].iter().position(|byte| *byte == 0).unwrap_or(length);
+	if length == 0 {
+		return MacosProcessField::Unavailable;
+	}
+	bytes.truncate(length);
+	MacosProcessField::Value(OsString::from_vec(bytes))
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_process_path(pid: libc::pid_t) -> MacosProcessField<PathBuf> {
+	let mut bytes = vec![0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+	let length = unsafe {
+		libc::proc_pidpath(
+			pid,
+			bytes.as_mut_ptr().cast::<c_void>(),
+			libc::PROC_PIDPATHINFO_MAXSIZE as u32,
+		)
+	};
+	if length == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	let Ok(length) = usize::try_from(length) else {
+		return MacosProcessField::Unavailable;
+	};
+	if length > bytes.len() {
+		return MacosProcessField::Unavailable;
+	}
+	let length = bytes[..length].iter().position(|byte| *byte == 0).unwrap_or(length);
+	if length == 0 {
+		return MacosProcessField::Unavailable;
+	}
+	bytes.truncate(length);
+	MacosProcessField::Value(PathBuf::from(OsString::from_vec(bytes)))
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_parent_pid(pid: libc::pid_t) -> MacosProcessField<libc::pid_t> {
+	let mut info = MaybeUninit::<libc::proc_bsdinfo>::zeroed();
+	let Ok(size) = i32::try_from(std::mem::size_of::<libc::proc_bsdinfo>()) else {
+		return MacosProcessField::Unavailable;
+	};
+	let returned = unsafe {
+		libc::proc_pidinfo(pid, libc::PROC_PIDTBSDINFO, 0, info.as_mut_ptr().cast::<c_void>(), size)
+	};
+	if returned == 0 {
+		return if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+			MacosProcessField::Vanished
+		} else {
+			MacosProcessField::Unavailable
+		};
+	}
+	if returned != size {
+		return MacosProcessField::Unavailable;
+	}
+	let info = unsafe { info.assume_init() };
+	libc::pid_t::try_from(info.pbi_ppid)
+		.map(MacosProcessField::Value)
+		.unwrap_or(MacosProcessField::Unavailable)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MacosCodexHomeRelation {
+	Shared,
+	Isolated,
+}
+
+#[cfg(target_os = "macos")]
+struct MacosProcessAuthEnvironment {
+	codex_home: Option<OsString>,
+	home: Option<OsString>,
+}
+
+#[cfg(target_os = "macos")]
+fn observe_macos_codex_home(
+	pid: libc::pid_t,
+	shared_codex_home: &Path,
+) -> MacosProcessField<MacosCodexHomeRelation> {
+	let environment = match read_macos_process_auth_environment(pid) {
+		MacosProcessField::Value(environment) => environment,
+		MacosProcessField::Unavailable => return MacosProcessField::Unavailable,
+		MacosProcessField::Vanished => return MacosProcessField::Vanished,
+	};
+	let process_codex_home = environment
+		.codex_home
+		.filter(|value| !value.is_empty())
+		.map(PathBuf::from)
+		.or_else(|| {
+			environment.home.filter(|value| !value.is_empty()).map(PathBuf::from).map(|home| {
+				home.join(".codex")
+			})
+		});
+	let Some(process_codex_home) = process_codex_home else {
+		return MacosProcessField::Unavailable;
+	};
+	classify_macos_codex_home(&process_codex_home, shared_codex_home)
+}
+
+#[cfg(target_os = "macos")]
+fn classify_macos_codex_home(
+	process_codex_home: &Path,
+	shared_codex_home: &Path,
+) -> MacosProcessField<MacosCodexHomeRelation> {
+	if !process_codex_home.is_absolute()
+		|| !shared_codex_home.is_absolute()
+		|| process_codex_home.as_os_str().as_bytes().len() > MAX_PROCESS_HOME_BYTES
+		|| shared_codex_home.as_os_str().as_bytes().len() > MAX_PROCESS_HOME_BYTES
+	{
+		return MacosProcessField::Unavailable;
+	}
+	if process_codex_home == shared_codex_home {
+		return MacosProcessField::Value(MacosCodexHomeRelation::Shared);
+	}
+	let (Ok(process_codex_home), Ok(shared_codex_home)) =
+		(fs::canonicalize(process_codex_home), fs::canonicalize(shared_codex_home))
+	else {
+		return MacosProcessField::Unavailable;
+	};
+	MacosProcessField::Value(if process_codex_home == shared_codex_home {
+		MacosCodexHomeRelation::Shared
+	} else {
+		MacosCodexHomeRelation::Isolated
+	})
+}
+
+#[cfg(target_os = "macos")]
+fn read_macos_process_auth_environment(
+	pid: libc::pid_t,
+) -> MacosProcessField<MacosProcessAuthEnvironment> {
+	// KERN_PROCARGS2 is a same-UID best-effort seam. Some macOS builds return argv without
+	// environment entries. That decodes as no HOME evidence and therefore remains fail-closed.
+	let mut argmax_mib = [libc::CTL_KERN, libc::KERN_ARGMAX];
+	let mut argmax: libc::c_int = 0;
+	let mut argmax_length = size_of::<libc::c_int>();
+	let measured = unsafe {
+		libc::sysctl(
+			argmax_mib.as_mut_ptr(),
+			argmax_mib.len() as libc::c_uint,
+			std::ptr::addr_of_mut!(argmax).cast::<c_void>(),
+			&mut argmax_length,
+			std::ptr::null_mut(),
+			0,
+		)
+	};
+	if measured == -1 {
+		return MacosProcessField::Unavailable;
+	}
+	let Ok(length) = usize::try_from(argmax) else {
+		return MacosProcessField::Unavailable;
+	};
+	if argmax_length != size_of::<libc::c_int>()
+		|| length < size_of::<libc::c_int>()
+		|| length > MAX_PROCESS_ENVIRONMENT_BYTES
+	{
+		return MacosProcessField::Unavailable;
+	}
+	let mut bytes = Zeroizing::new(vec![0_u8; length]);
+	let mut returned = length;
+	let mut procargs_mib = [libc::CTL_KERN, libc::KERN_PROCARGS2, pid];
+	let read = unsafe {
+		libc::sysctl(
+			procargs_mib.as_mut_ptr(),
+			procargs_mib.len() as libc::c_uint,
+			bytes.as_mut_ptr().cast::<c_void>(),
+			&mut returned,
+			std::ptr::null_mut(),
+			0,
+		)
+	};
+	if read == -1 {
+		return macos_process_read_failure();
+	}
+	if returned < size_of::<libc::c_int>() || returned > bytes.len() {
+		return MacosProcessField::Unavailable;
+	}
+	parse_macos_process_auth_environment(&bytes[..returned])
+		.map(MacosProcessField::Value)
+		.unwrap_or(MacosProcessField::Unavailable)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_read_failure<T>() -> MacosProcessField<T> {
+	if std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+		MacosProcessField::Vanished
+	} else {
+		MacosProcessField::Unavailable
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn parse_macos_process_auth_environment(bytes: &[u8]) -> Option<MacosProcessAuthEnvironment> {
+	let argc = libc::c_int::from_ne_bytes(bytes.get(..size_of::<libc::c_int>())?.try_into().ok()?);
+	let argc = usize::try_from(argc).ok()?;
+	if argc > 4_096 {
+		return None;
+	}
+	let mut remaining = &bytes[size_of::<libc::c_int>()..];
+	remaining = skip_macos_process_entry(remaining)?;
+	remaining = skip_nul_padding(remaining);
+	for _ in 0..argc {
+		remaining = skip_macos_process_entry(remaining)?;
+		remaining = skip_nul_padding(remaining);
+	}
+
+	let mut codex_home = None;
+	let mut home = None;
+	while !remaining.is_empty() {
+		let end = remaining.iter().position(|byte| *byte == 0).unwrap_or(remaining.len());
+		let entry = &remaining[..end];
+		if entry.is_empty() {
+			break;
+		}
+		if let Some(value) = entry.strip_prefix(b"CODEX_HOME=") {
+			if codex_home.is_some() || value.len() > MAX_PROCESS_HOME_BYTES {
+				return None;
+			}
+			codex_home = Some(OsString::from_vec(value.to_vec()));
+		} else if let Some(value) = entry.strip_prefix(b"HOME=") {
+			if home.is_some() || value.len() > MAX_PROCESS_HOME_BYTES {
+				return None;
+			}
+			home = Some(OsString::from_vec(value.to_vec()));
+		}
+		remaining = if end == remaining.len() { &[] } else { &remaining[end + 1..] };
+		remaining = skip_nul_padding(remaining);
+	}
+	Some(MacosProcessAuthEnvironment { codex_home, home })
+}
+
+#[cfg(target_os = "macos")]
+fn skip_macos_process_entry(bytes: &[u8]) -> Option<&[u8]> {
+	let end = bytes.iter().position(|byte| *byte == 0)?;
+	Some(&bytes[end + 1..])
+}
+
+#[cfg(target_os = "macos")]
+fn skip_nul_padding(mut bytes: &[u8]) -> &[u8] {
+	while bytes.first() == Some(&0) {
+		bytes = &bytes[1..];
+	}
+	bytes
+}
+
+#[cfg(target_os = "macos")]
+fn enrich_macos_codex_home_evidence(
+	own_pid: libc::pid_t,
+	shared_codex_home: &Path,
+	observations: &mut [MacosProcessObservation],
+) {
+	let parents = observations
+		.iter()
+		.filter_map(|observation| match observation.parent_pid {
+			MacosProcessField::Value(parent) => Some((observation.pid, parent)),
+			MacosProcessField::Unavailable | MacosProcessField::Vanished => None,
+		})
+		.collect::<HashMap<_, _>>();
+	let mut inspected = 0_usize;
+	for observation in observations {
+		if observation.pid == own_pid
+			|| !macos_process_looks_like_external_codex(observation)
+			|| process_descends_from(observation.pid, own_pid, &parents)
+			|| matches!(
+				observation.auth_home,
+				MacosProcessField::Value(MacosCodexHomeRelation::Shared)
+					| MacosProcessField::Vanished
+			)
+		{
+			continue;
+		}
+		if inspected >= MAX_CODEX_HOME_INSPECTIONS {
+			continue;
+		}
+		inspected += 1;
+		observation.auth_home = observe_macos_codex_home(observation.pid, shared_codex_home);
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn classify_macos_codex_liveness(
+	own_pid: libc::pid_t,
+	observations: &[MacosProcessObservation],
+) -> CodexLivenessObservation {
+	let parents = observations
+		.iter()
+		.filter_map(|observation| match observation.parent_pid {
+			MacosProcessField::Value(parent) => Some((observation.pid, parent)),
+			MacosProcessField::Unavailable | MacosProcessField::Vanished => None,
+		})
+		.collect::<HashMap<_, _>>();
+	let mut blockers = Vec::new();
+	for observation in observations {
+		if observation.pid == own_pid || !macos_process_looks_like_external_codex(observation) {
+			continue;
+		}
+		// Decodex-owned app-server children use the daemon's attested external-token
+		// path and cannot own the normal shared auth writer. Counting them would make
+		// the coordinator permanently wait on itself.
+		if process_descends_from(observation.pid, own_pid, &parents) {
+			continue;
+		}
+		let auth_home = match observation.auth_home {
+			MacosProcessField::Value(MacosCodexHomeRelation::Isolated)
+			| MacosProcessField::Vanished => continue,
+			MacosProcessField::Value(MacosCodexHomeRelation::Shared) => {
+				CodexAuthHomeEvidence::Shared
+			},
+			MacosProcessField::Unavailable => CodexAuthHomeEvidence::Unknown,
+		};
+		let Ok(pid) = u32::try_from(observation.pid) else {
+			continue;
+		};
+		let blocker = CodexAuthOwnerBlocker {
+			pid,
+			kind: macos_process_kind(observation),
+			auth_home,
+		};
+		blockers.push(blocker);
+	}
+	blockers.sort_by_key(|blocker| blocker.pid);
+	if blockers.is_empty() {
+		CodexLivenessObservation::Quiescent
+	} else {
+		let omitted = u16::try_from(blockers.len().saturating_sub(MAX_CODEX_AUTH_OWNER_BLOCKERS))
+			.unwrap_or(u16::MAX);
+		blockers.truncate(MAX_CODEX_AUTH_OWNER_BLOCKERS);
+		CodexLivenessObservation::Blocked { blockers, omitted }
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_kind(observation: &MacosProcessObservation) -> CodexAuthOwnerKind {
+	let chatgpt_path = matches!(
+		&observation.path,
+		MacosProcessField::Value(path)
+			if path.ends_with("ChatGPT.app/Contents/MacOS/ChatGPT")
+	);
+	let chatgpt_name = matches!(
+		&observation.name,
+		MacosProcessField::Value(name) if name == OsStr::new("ChatGPT")
+	);
+	if chatgpt_path || chatgpt_name {
+		CodexAuthOwnerKind::Chatgpt
+	} else {
+		CodexAuthOwnerKind::Codex
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_looks_like_external_codex(observation: &MacosProcessObservation) -> bool {
+	match &observation.path {
+		MacosProcessField::Value(path) => path_looks_like_codex(path),
+		MacosProcessField::Vanished => false,
+		MacosProcessField::Unavailable => match &observation.name {
+			MacosProcessField::Value(name) => process_name_looks_like_codex(name),
+			MacosProcessField::Unavailable | MacosProcessField::Vanished => false,
+		},
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn process_descends_from(
+	pid: libc::pid_t,
+	ancestor: libc::pid_t,
+	parents: &HashMap<libc::pid_t, libc::pid_t>,
+) -> bool {
+	let mut current = pid;
+	let mut visited = HashSet::new();
+	while current > 1 && visited.insert(current) {
+		let Some(parent) = parents.get(&current).copied() else {
+			return false;
+		};
+		if parent == ancestor {
+			return true;
+		}
+		current = parent;
+	}
+	false
+}
+
+#[cfg(target_os = "macos")]
+fn process_name_looks_like_codex(name: &OsStr) -> bool {
+	name == OsStr::new("ChatGPT")
+		|| name == OsStr::new("Codex")
+		|| name == OsStr::new("codex")
+		|| name == OsStr::new("verified-codex-image")
+}
+
+#[cfg(target_os = "macos")]
+fn path_looks_like_codex(path: &Path) -> bool {
+	let executable = path.file_name();
+	path_is_official_shared_codex(path)
+		|| executable == Some(OsStr::new("codex"))
+		|| executable == Some(OsStr::new("Codex"))
+		|| executable == Some(OsStr::new("verified-codex-image"))
+}
+
+#[cfg(target_os = "macos")]
+fn path_is_official_shared_codex(path: &Path) -> bool {
+	path.ends_with("ChatGPT.app/Contents/MacOS/ChatGPT")
+		|| path.ends_with("ChatGPT.app/Contents/Resources/codex")
+		|| path.ends_with("Codex.app/Contents/MacOS/Codex")
+		|| path.ends_with("Codex.app/Contents/Resources/codex")
 }
 
 #[cfg(test)]
@@ -178,6 +833,13 @@ mod tests {
 	};
 
 	use super::*;
+
+	struct FixedLiveness(CodexLiveness);
+	impl CodexLivenessPort for FixedLiveness {
+		fn observe(&self) -> CodexLivenessObservation {
+			CodexLivenessObservation::from_state(self.0)
+		}
+	}
 
 	struct ScriptedFile {
 		stamps: Mutex<VecDeque<Result<SharedCodexAuthFileStamp, CodexAuthProjectionError>>>,
@@ -224,22 +886,6 @@ mod tests {
 	}
 
 	#[test]
-	fn exact_read_does_not_wait_for_passive_stability_polls() {
-		let file = Arc::new(ScriptedFile {
-			stamps: Mutex::new(VecDeque::from([Ok(SharedCodexAuthFileStamp::Absent)])),
-			reads: AtomicUsize::new(0),
-			failed_reads: AtomicUsize::new(0),
-		});
-		let coordinator = SharedAuthCoordinator::with_file(file.clone());
-
-		assert!(matches!(
-			*coordinator.read_current_exact().expect("read exact shared auth"),
-			SharedCodexAuthSnapshot::Unmanaged { .. }
-		));
-		assert_eq!(file.reads.load(Ordering::Relaxed), 1);
-	}
-
-	#[test]
 	fn stable_poll_requires_two_equal_metadata_observations_and_coalesces_reads() {
 		let file = Arc::new(ScriptedFile {
 			stamps: Mutex::new(VecDeque::from([
@@ -250,7 +896,10 @@ mod tests {
 			reads: AtomicUsize::new(0),
 			failed_reads: AtomicUsize::new(0),
 		});
-		let coordinator = SharedAuthCoordinator::with_file(file.clone());
+		let coordinator = SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::Quiescent)),
+			file.clone(),
+		);
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Unchanged));
@@ -268,10 +917,255 @@ mod tests {
 			reads: AtomicUsize::new(0),
 			failed_reads: AtomicUsize::new(1),
 		});
-		let coordinator = SharedAuthCoordinator::with_file(file.clone());
+		let coordinator = SharedAuthCoordinator::with_ports(
+			Arc::new(FixedLiveness(CodexLiveness::Quiescent)),
+			file.clone(),
+		);
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Waiting));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Unavailable));
 		assert!(matches!(coordinator.poll_stable_change(), StableSharedAuthPoll::Changed(_)));
 		assert_eq!(file.reads.load(Ordering::Relaxed), 2);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn codex_path_matcher_covers_current_and_legacy_apps_without_generic_helpers() {
+		assert!(process_name_looks_like_codex(OsStr::new("ChatGPT")));
+		assert!(process_name_looks_like_codex(OsStr::new("codex")));
+		assert!(!process_name_looks_like_codex(OsStr::new("launchd")));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
+		)));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/Resources/codex",
+		)));
+		assert!(path_looks_like_codex(Path::new("/Applications/Codex.app/Contents/MacOS/Codex",)));
+		assert!(path_looks_like_codex(Path::new(
+			"/Applications/Codex.app/Contents/Resources/codex",
+		)));
+		assert!(!path_looks_like_codex(Path::new(
+			"/Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper",
+		)));
+	}
+
+	#[cfg(target_os = "macos")]
+	fn process(
+		pid: libc::pid_t,
+		parent_pid: MacosProcessField<libc::pid_t>,
+		name: MacosProcessField<&str>,
+		path: MacosProcessField<&str>,
+		auth_home: MacosProcessField<MacosCodexHomeRelation>,
+	) -> MacosProcessObservation {
+		MacosProcessObservation {
+			pid,
+			parent_pid,
+			name: match name {
+				MacosProcessField::Value(name) => MacosProcessField::Value(OsString::from(name)),
+				MacosProcessField::Unavailable => MacosProcessField::Unavailable,
+				MacosProcessField::Vanished => MacosProcessField::Vanished,
+			},
+			path: match path {
+				MacosProcessField::Value(path) => MacosProcessField::Value(PathBuf::from(path)),
+				MacosProcessField::Unavailable => MacosProcessField::Unavailable,
+				MacosProcessField::Vanished => MacosProcessField::Vanished,
+			},
+			auth_home,
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn unrelated_inaccessible_process_does_not_prevent_quiescence() {
+		let observations = [process(
+			20,
+			MacosProcessField::Value(1),
+			MacosProcessField::Value("launchd"),
+			MacosProcessField::Unavailable,
+			MacosProcessField::Unavailable,
+		)];
+		assert_eq!(
+			classify_macos_codex_liveness(10, &observations),
+			CodexLivenessObservation::Quiescent
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn named_codex_with_inaccessible_path_fails_closed() {
+		let observations = [process(
+			20,
+			MacosProcessField::Value(1),
+			MacosProcessField::Value("codex"),
+			MacosProcessField::Unavailable,
+			MacosProcessField::Unavailable,
+		)];
+		assert_eq!(
+			classify_macos_codex_liveness(10, &observations),
+			CodexLivenessObservation::Blocked {
+				blockers: vec![CodexAuthOwnerBlocker {
+					pid: 20,
+					kind: CodexAuthOwnerKind::Codex,
+					auth_home: CodexAuthHomeEvidence::Unknown,
+				}],
+				omitted: 0,
+			}
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn no_candidate_or_vanished_candidate_is_quiescent() {
+		let observations = [process(
+			20,
+			MacosProcessField::Vanished,
+			MacosProcessField::Value("codex"),
+			MacosProcessField::Vanished,
+			MacosProcessField::Vanished,
+		)];
+		assert_eq!(
+			classify_macos_codex_liveness(10, &[]),
+			CodexLivenessObservation::Quiescent
+		);
+		assert_eq!(
+			classify_macos_codex_liveness(10, &observations),
+			CodexLivenessObservation::Quiescent
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn matching_chatgpt_parent_or_codex_child_blocks_cutover() {
+		let observations = [
+			process(
+				20,
+				MacosProcessField::Value(1),
+				MacosProcessField::Value("ChatGPT"),
+				MacosProcessField::Value("/Applications/ChatGPT.app/Contents/MacOS/ChatGPT"),
+				MacosProcessField::Value(MacosCodexHomeRelation::Shared),
+			),
+			process(
+				21,
+				MacosProcessField::Value(20),
+				MacosProcessField::Value("codex"),
+				MacosProcessField::Value("/Applications/ChatGPT.app/Contents/Resources/codex"),
+				MacosProcessField::Value(MacosCodexHomeRelation::Shared),
+			),
+		];
+		let observation = classify_macos_codex_liveness(10, &observations);
+		assert_eq!(observation.state(), CodexLiveness::MayBeRunning);
+		let CodexLivenessObservation::Blocked { blockers, omitted: 0 } = observation else {
+			panic!("matching shared-home processes must be reported")
+		};
+		assert_eq!(blockers.len(), 2);
+		assert_eq!(blockers[0].kind, CodexAuthOwnerKind::Chatgpt);
+		assert_eq!(blockers[1].kind, CodexAuthOwnerKind::Codex);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn daemon_owned_codex_descendant_does_not_block_its_coordinator() {
+		let observations = [
+			process(
+				11,
+				MacosProcessField::Value(10),
+				MacosProcessField::Value("helper"),
+				MacosProcessField::Unavailable,
+				MacosProcessField::Unavailable,
+			),
+			process(
+				12,
+				MacosProcessField::Value(11),
+				MacosProcessField::Value("codex"),
+				MacosProcessField::Value("/Applications/ChatGPT.app/Contents/Resources/codex"),
+				MacosProcessField::Value(MacosCodexHomeRelation::Shared),
+			),
+		];
+		assert_eq!(
+			classify_macos_codex_liveness(10, &observations),
+			CodexLivenessObservation::Quiescent
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn isolated_codex_home_does_not_block_shared_auth_cutover() {
+		let observations = [process(
+			20,
+			MacosProcessField::Value(1),
+			MacosProcessField::Value("codex"),
+			MacosProcessField::Value("/usr/local/bin/codex"),
+			MacosProcessField::Value(MacosCodexHomeRelation::Isolated),
+		)];
+		assert_eq!(
+			classify_macos_codex_liveness(10, &observations),
+			CodexLivenessObservation::Quiescent
+		);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn blocker_snapshot_is_pid_ordered_and_bounded() {
+		let observations = (20..30)
+			.rev()
+			.map(|pid| {
+				process(
+					pid,
+					MacosProcessField::Value(1),
+					MacosProcessField::Value("codex"),
+					MacosProcessField::Value("/Applications/ChatGPT.app/Contents/Resources/codex"),
+					MacosProcessField::Value(MacosCodexHomeRelation::Shared),
+				)
+			})
+			.collect::<Vec<_>>();
+		let CodexLivenessObservation::Blocked { blockers, omitted } =
+			classify_macos_codex_liveness(10, &observations)
+		else {
+			panic!("shared-home Codex processes must block")
+		};
+		assert_eq!(
+			blockers.iter().map(|blocker| blocker.pid).collect::<Vec<_>>(),
+			(20_u32..28).collect::<Vec<_>>()
+		);
+		assert_eq!(omitted, 2);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn process_environment_parser_reads_only_home_authority_fields() {
+		let mut bytes = Vec::new();
+		bytes.extend_from_slice(&2_i32.to_ne_bytes());
+		bytes.extend_from_slice(b"/usr/local/bin/codex\0\0");
+		bytes.extend_from_slice(b"codex\0app-server\0");
+		bytes.extend_from_slice(b"TOKEN=must-not-escape\0");
+		bytes.extend_from_slice(b"HOME=/Users/test\0");
+		bytes.extend_from_slice(b"CODEX_HOME=/tmp/isolated-codex\0");
+		let parsed = parse_macos_process_auth_environment(&bytes).expect("parse environment");
+		assert_eq!(parsed.home.as_deref(), Some(OsStr::new("/Users/test")));
+		assert_eq!(parsed.codex_home.as_deref(), Some(OsStr::new("/tmp/isolated-codex")));
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn codex_home_relation_proves_shared_symlinks_and_distinct_isolated_homes() {
+		let root = tempfile::tempdir().expect("temporary root");
+		let shared = root.path().join("shared-codex");
+		let isolated = root.path().join("isolated-codex");
+		let linked = root.path().join("linked-codex");
+		fs::create_dir(&shared).expect("shared home");
+		fs::create_dir(&isolated).expect("isolated home");
+		std::os::unix::fs::symlink(&shared, &linked).expect("linked home");
+
+		assert_eq!(
+			classify_macos_codex_home(&linked, &shared),
+			MacosProcessField::Value(MacosCodexHomeRelation::Shared)
+		);
+		assert_eq!(
+			classify_macos_codex_home(&isolated, &shared),
+			MacosProcessField::Value(MacosCodexHomeRelation::Isolated)
+		);
+		assert_eq!(
+			classify_macos_codex_home(&root.path().join("missing"), &shared),
+			MacosProcessField::Unavailable
+		);
 	}
 }

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -364,7 +364,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 11 },
+			version: ProtocolVersion { major: 2, minor: 12 },
 			artifact_cohort: Some(decodex_protocol::CURRENT_ARTIFACT_COHORT),
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
@@ -372,7 +372,7 @@ async fn assert_exact_current_doctor_queries(
 	)
 	.await;
 	let ServerMessage::Refusal(refusal) = receive(&mut future).await else {
-		panic!("expected V2.11 minor-version refusal");
+		panic!("expected V2.12 minor-version refusal");
 	};
 	assert!(matches!(
 		refusal.refusal,
@@ -418,7 +418,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 11 },
+			ProtocolVersion { major: 2, minor: 12 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -552,8 +552,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 10);
-	assert_eq!(welcome.supported.maximum_minor, 10);
+	assert_eq!(welcome.supported.minimum_minor, 11);
+	assert_eq!(welcome.supported.maximum_minor, 11);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;

--- a/openwiki/.claims/evidence/sqlite-local-product.json
+++ b/openwiki/.claims/evidence/sqlite-local-product.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:8d7736b4ba211e4236f2f46490b573b6e40ef7f5dad24aa9bc679d0de7c08731",
+  "claims": [
+    {
+      "id": "claim_57467868d3114a4f8efa994a912c927d",
+      "statement": "The exact local wire contract is protocol 2.11 with artifact cohort 7, and every pending account Route carries one validated credential-negative wait reason with a bounded concrete blocker list or a closed typed fallback.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-protocol/src/lib.rs#L108-L116",
+          "version": "repo-lines-v1:sha256:53580d5cda74d1e06d80ddc27cc3d418b6c408c2c79fa52b0f2e1ec69c97884f:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiN2I2ODEwNzM5MjdjZDE5YTY2N2ExN2YyYjZhMzlkNDBjOGU4YzkzOWRkMWU3OWRkZjE4MjE4YjM2NGEwYjZhNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiYzkzNTRlYmE2ODEzNGY3YWU5ZGQwM2I4OTE1NjhjN2JhMjFmZGMwYzU4MTgyOTVmYTE2NTI2YTE1ZmU3ODM0MiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjBjODVjMjJlZWNjYWY1ZGQxMGI2NTYyMWFkNWM1MTEwYzE5NTU5NzM5MWIwOTk0ZDhlODEzNTZhMjRjYmY0NiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiOTY1YjA5NDkxMGM5NjczMTAxMzg2NTlmNmVlOGNjYzU2ZWViYWY4YTRmODU1ZmZlMGNiNjg1NzQxMGUwMTQ1NCJ9"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L1961-L2077",
+          "version": "repo-lines-v1:sha256:07ac20e237c480477d7188a30139921ed862a5c07687162572e194189f14f56a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2ODgxYmUzNGIyN2FlNGMzZWQzY2RiNDQwMDI2MTllMjYzMmMzYzY4Nzk4ZDAwYTMwMjRlNWYwMmYyZWJiM2FkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhMDg5NDc3MjI4ZjRhNmNiM2QyMmY0YjZmYmNlMzJlZGFkNjc1NjQwM2QwODhmYzM1MzM4ZGRlZDhmY2I3YzRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmOThhMjZiNDUxYTUwMGFmYTg5YThmODg2OTUyMzUxYWM5ZjU2ZmU3Mzg0YTVmODBiNmQyZjU5NGMwOGIyZTUyIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L4529-L4567",
+          "version": "repo-lines-v1:sha256:b720f742ec6f09f0da127700df9319b2df5fff786bd87d1032fcea193e9516c8:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJkMzU3MWNmOWU1YTFmNDA1NjI4ZTA1MDI3MGJjOWY2NDMyYzhkZmE0MjIyNzMxNDNhNzVlZmQzMWFjOGM2ODkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkxYmUzNWQzZWU5ZGFiM2Y3ZGFhOTkxY2RkN2ViYzNjYmJjYjQzYzIxYTFiNTE0ZmM3MDQ5NDNiZTFjOTY3ZWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5ZTFhOTVhZDA0ZDdkN2E1OTlhMDU5N2VjZjhhZmYwMzkwNzEzMmUwNmQyNmEyN2VlZmY1YmE0OTVmNjMxM2UifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_eef2e728370842198097ff38abf18e7a",
+      "statement": "Both desktop account surfaces render a pending Route's concrete process PID and auth-home certainty or its exact typed fallback reason without receiving credential values.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift#L111-L203",
+          "version": "repo-lines-v1:sha256:6ddc83c5a193819ca0987720a6e788a2833ddf65f0a9cbbdfa9d988ac8e46ae7:eyJzZWxlY3RlZExpbmVDb3VudCI6OTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdiYzQ5ODczZDc0OGViZjljN2EwYjAzYzE2ODQ1MTJiNTNjNTFiOWY5MjYwOWIzMDg3MWIwYWMxYmExOTQxNWEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjBhZjNkMzZiZDUxZmQ3YWY1NTgwN2JhNmFkMzQwNGQyNTJlNjRhMmJkODkxMjdlNmQxZjhlMzY2NjFiNDRkZTgifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/shell.rs#L3088-L3130",
+          "version": "repo-lines-v1:sha256:6c3928af1599e587d6dec8bb9c1a92e8ec60c3078be65726ee39882e8cf4ba33:eyJzZWxlY3RlZExpbmVDb3VudCI6NDMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY1OTFiN2VkNzk3ZGM0MTBlNmI4Yjk0ZDkwNGM2MTYzYWQ4OGE3MjJiZWY2YzJjZjRmZDBkOGVjNTdhNjUzY2YiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImRjNDUzNGVjMmNlZGI4MTk5OWVkYmRlOWQxZWZiYzc5OGE5NzdhZTc2M2ZhZWYxZDRmNDZiMmYzNGE2ODFiODMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjRkMDE3MzI5OTUwMzM1MTU2ZWI4ZjA1NzEwNjMzMzIzNmYwNmU5MTlkODg1NmNiN2UyOWY4Mjc3MTEyMzNhMWEifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
+  }
+}

--- a/openwiki/.claims/operations/local-database.json
+++ b/openwiki/.claims/operations/local-database.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:0abc671710406dbf5c6772a81b49ced82fc9a7bf82aa5eaef3d96beb7361779a",
+  "claims": [
+    {
+      "id": "claim_e8d1527490f540cdafcbe921403c8c3c",
+      "statement": "Schema versions 9 and 10 retain the exact Route request and credential-negative progress in one reserved command receipt, with a unique partial index that permits at most one pending Route.",
+      "evidence": [
+        {
+          "resource": "repo://database/migrations/0009_durable_account_route.sql",
+          "version": "repo-file-v1:sha256:4a68cb2efd56bfdf2f93da58fa88fca770a3e2624c3a4ca39f259feae42f93f0"
+        },
+        {
+          "resource": "repo://database/migrations/0010_pending_account_route_progress.sql",
+          "version": "repo-file-v1:sha256:cd9e2fa0f8b7f465ef6b33116dcdfb4e195b356d6e1fb2a7e46e2688e251ee7e"
+        },
+        {
+          "resource": "repo://database/src/account_lifecycle.rs#L1048-L1155",
+          "version": "repo-lines-v1:sha256:84dd82815a2e2e544d0c7fec08a44d25eb3713efba617073fed857db0c5d2d15:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2NzZlMjg2ZTVhZWJkYzUyMDY4YmY0MWM4YTJiYzhkMWYyNmU0ODhiNzExZDc4MWU0NzY1NjU5Yjg2ZDk0MTFiIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2I5MDExNTAyNTgwNzhmYzYwNzdhMTI4OWIxZTIxNWQ2NGI0YTExNmY1MTc4ODY2ZGM0MmVjOTVjZjk5ZDAyIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIyMTljODMyZGEyMWIxODRmYWRkMjA3NjYxODU4YzRhMWE1MGFiMGY3NTIzZjQ3OGJlMmI0MjM4NjYwNDJiYmZlIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_1f226f97bf2a41839b2cf054b04f93c7",
+      "statement": "Creating a Pending Route immediately wakes recovery; while Pending exists the loop rechecks routing, account readiness, and external Codex liveness every 100 milliseconds, while idle recovery remains one second and never terminates or restarts Codex.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L3303-L3325",
+          "version": "repo-lines-v1:sha256:292eb1d9090cff0042d868367dddba109e6dbae12bcc0f0af2dc0e38bf1cf97f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMGMwOGUzM2E1M2JiN2U3MDUyYWY4NDg5YmRmMzc4MDY4ODdlOTViM2FlYmE2NDEyNGE0MjNmOTI1ODE1OTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ4NzY5YTZhZmQ3YTJmMGQzYTI1NzVmOGY1ZDQwMTE2MzM3NmI5MzM2MjFhZGM2ZjJkNDI0ZTBjNjMyYjcxNDQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVjYTVkYmUwN2RjMjRkOTc0MzMzZDBmNzkwN2Y2YmNkNDFiZTVjYzczYmQ4YjlkNmZmOGJkMTE0MDVmMTI5ZTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5NTI1YjExMTk0Mzc0MTMyNDA3MDgwZWU0ZDU1YTE2ZDIwOTEzZjc3YzEzNDczNzE0Njc0OTkxZTZhYTU4NWYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/application.rs#L413-L538",
+          "version": "repo-lines-v1:sha256:587de368a1668e1bc910f993e8298155cda4c709337552d510c9b35b93f4b02a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5YmY2MTY3NTk4MjFjNzQ5ZTExMTVjMTIxNDZlNjZlYmYwMGU5ZWViMmU5MjlmZTZiMWYzYThhNGFhYzk0NjdmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIxZDFjNThlNjgwMWJhMDg0MDlkMjY4MWUyZDBiMzczZWIyNGEwMzZhOGNiOGY3Y2NiOTVjZDEzOWFiNjQxNWE4In0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L303-L789",
+          "version": "repo-lines-v1:sha256:01b2a65c9ef1e33c3941574d066c00477733a807ba76fe1b3c17448e43f16279:eyJzZWxlY3RlZExpbmVDb3VudCI6NDg3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5NzI3MDc2YmZhMjUyYmE4NTFjYzViYzBlMWNjOGQ2ZmFmYzI3NjgxNDk3MGZkNzc0MjIzYzUyMjQ1OGFmYWRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGJkNTY2MWE4MDEyM2FiZGI1ZTMyMzM4OGVkMGQwNGMwYjBiMTJlNDUxOGM3MzM5Y2Y0MGNiZTY0YzQ5MGRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTUzOWJjMDE4NGY2YjM1NDc2YzM5ZjI5M2UwNDQzYzY5ZjA4ZWE1ZTkyZGQ4Mzc5ODgzNTgzMmRjYTI4YWRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZjQ3OWJhY2FiYWE4MmUzYzQ0OWRlYmEyNDYwN2E3YjZiYWY0MGYyNmM2ZDlkZjFmNzY4ODE0NTdkNmU3ZDZkIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_8c40d2c364214b2da04adc8b19ac5cd3",
+      "statement": "For the currently projected account, Decodex mirrors a successful refresh with an exact-source compare-and-swap; if Codex rotates first, Decodex adopts the valid non-older shared bundle through a deterministic successor operation instead of restoring the losing refresh token.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1794-L1887",
+          "version": "repo-lines-v1:sha256:577e9ce40fa2bca0f598e544a265e0216694720b93867f1f52d4c6ed6a7bb6fe:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyOWVjZDU3OGU1NmE0ODhhNDQ4ZmM2MGU2YmNiMDdjNDZlNGYwNWIxY2VkMDI2MmQxMzFhMmFhZTFmM2EwM2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkM2UxNTU2NmQ1MDkzMjA4YzU4MmI5ZTFjNDA0YTYzNzM0MjM4YzcwZjhkZjg1ZTRlOGRjNDk0OTk3NWVlOTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNjMzQ4NWJmMTY4YmM4NDRiMjk2YjYzYTQxOTg1MzMxMzQ4MTZmM2I4NWFlYmVlNTU3NmE2ODYxYjUyYTdiZTIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2815-L2931",
+          "version": "repo-lines-v1:sha256:eb72521235fe80d26c3ee84974a07dba4c6c102f94ee38bc7c6dc0636a526214:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyMzQ3ZTI1NWJlMzNmZjU4NWEwOTBkMWRhNzk5ZWQyMDZjY2M3MjViZWE2MTc3ZTdmNjI1NzAyNzBkODU2ZGU2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4YmJkNjE0MGEyYmEyMTgzYjEwOTk5MmU4ZDhhOTYwMDk3MjdkNGIzYjVhMThjYTRkZTEwOWEyNjU4NzY2ZWRmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0ZDNlMTU1NjZkNTA5MzIwOGM1ODJiOWUxYzQwNGE2MzczNDIzOGM3MGY4ZGY4NWU0ZThkYzQ5NDk5NzVlZTk1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1NzcxOWM1Mzc5NWNkZTI1OGViY2QwZjI4MGEyNjU5NTRjMjFiOTI2OTA1MGU4NDc5MDIzOTRiMDc2NWNlMjNiIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_98724e278ce34c6dace73217abcd73cc",
+      "statement": "A Pending Route exposes one closed operator reason: concrete external blockers contain at most eight positive PIDs with ChatGPT-or-Codex and shared-or-unknown auth-home evidence, while other variants name process observation, account readiness, shared-source stability or availability, or projection readback.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L1961-L2077",
+          "version": "repo-lines-v1:sha256:07ac20e237c480477d7188a30139921ed862a5c07687162572e194189f14f56a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2ODgxYmUzNGIyN2FlNGMzZWQzY2RiNDQwMDI2MTllMjYzMmMzYzY4Nzk4ZDAwYTMwMjRlNWYwMmYyZWJiM2FkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhMDg5NDc3MjI4ZjRhNmNiM2QyMmY0YjZmYmNlMzJlZGFkNjc1NjQwM2QwODhmYzM1MzM4ZGRlZDhmY2I3YzRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmOThhMjZiNDUxYTUwMGFmYTg5YThmODg2OTUyMzUxYWM5ZjU2ZmU3Mzg0YTVmODBiNmQyZjU5NGMwOGIyZTUyIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L4529-L4567",
+          "version": "repo-lines-v1:sha256:b720f742ec6f09f0da127700df9319b2df5fff786bd87d1032fcea193e9516c8:eyJzZWxlY3RlZExpbmVDb3VudCI6MzksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJkMzU3MWNmOWU1YTFmNDA1NjI4ZTA1MDI3MGJjOWY2NDMyYzhkZmE0MjIyNzMxNDNhNzVlZmQzMWFjOGM2ODkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjkxYmUzNWQzZWU5ZGFiM2Y3ZGFhOTkxY2RkN2ViYzNjYmJjYjQzYzIxYTFiNTE0ZmM3MDQ5NDNiZTFjOTY3ZWMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5ZTFhOTVhZDA0ZDdkN2E1OTlhMDU5N2VjZjhhZmYwMzkwNzEzMmUwNmQyNmEyN2VlZmY1YmE0OTVmNjMxM2UifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/application.rs#L3915-L3975",
+          "version": "repo-lines-v1:sha256:00a7b7b0ba6fa0a97fac703675ff52fce0475b1c2eb5c928ec949ffe039deaa3:eyJzZWxlY3RlZExpbmVDb3VudCI6NjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImMyZTljODQ1MGYyZjA1Y2MwYzVmMjJjMTc2NjQ5YzM0YWQ0OWY1OGIyODFlODU2ZTIzODg2NmMwYzgwZjM0OTciLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM2NzJkYTYxZWQxZDhkMzU5ZjUwNmRlMmRjN2I1YmM3OGY1ZmVkNGY3OTM1YWE4NDRiOThkMTRhMjI2NTBiMjQifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_fe4524af54094183a1ec2920c50ec62c",
+      "statement": "The installed daemon, CLI, native bridge, and GUI must agree on exact protocol 2.11 and artifact cohort 7 before the local account UI can communicate with the daemon.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift#L1-L34",
+          "version": "repo-lines-v1:sha256:4e863d5592f9025405ea9c364e0c320f508ce75170b9a9a4be6e89802a504107:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE1OGEyZDdmYzIzNTUyOWMzYWJiMjVmNmUzZDA4N2I2NGE1YmJkMGRkZTU5OTgxMTMzNGU3NDkzNTAyMmQxMzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ3ZGIwYmMzMTk2YTM1Mzg5MTZhNjAwNzc2NzcxYzhkNDA0NzZkZDc1YTQwYjU5M2YxMGUyYjQ0NjliMzU4NDkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAzZjU2NzQ1YjI2ZmIyMzc0ODBlMDYwZDFmYTgzMDlkYjA3ZTkzMzAzNTQyYmNjYjU0M2RhZmJkMmExM2YwODIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/lib.rs#L108-L116",
+          "version": "repo-lines-v1:sha256:53580d5cda74d1e06d80ddc27cc3d418b6c408c2c79fa52b0f2e1ec69c97884f:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiN2I2ODEwNzM5MjdjZDE5YTY2N2ExN2YyYjZhMzlkNDBjOGU4YzkzOWRkMWU3OWRkZjE4MjE4YjM2NGEwYjZhNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiYzkzNTRlYmE2ODEzNGY3YWU5ZGQwM2I4OTE1NjhjN2JhMjFmZGMwYzU4MTgyOTVmYTE2NTI2YTE1ZmU3ODM0MiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjBjODVjMjJlZWNjYWY1ZGQxMGI2NTYyMWFkNWM1MTEwYzE5NTU5NzM5MWIwOTk0ZDhlODEzNTZhMjRjYmY0NiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiOTY1YjA5NDkxMGM5NjczMTAxMzg2NTlmNmVlOGNjYzU2ZWViYWY4YTRmODU1ZmZlMGNiNjg1NzQxMGUwMTQ1NCJ9"
+        },
+        {
+          "resource": "repo://scripts/macos/test_decodex_app_stage.sh#L50-L58",
+          "version": "repo-lines-v1:sha256:77d73b90f6e129d477fe9bced422e2c3edd562f1a1e5b9385ad69bc36875fa5c:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiZTMyOGM3NTkyMTc0NDBmYTllNWNhYTEzOTNhOTJmMmQ0MzczNGU1ZGY2Mjc4YTc4NDVmMDg3MTdlN2RjNGFkNSIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiNGIwYzk5OTExZWRkMmJlNTk5MWM0NDU4NDdjOWU0YTA5MTJkYzk4YTg2YTc4YjIzZTVmNTBjZGJlNWRmMWI0ZCIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiZTdmNWNlZWY0YWJlZjA2NmUxMjkxYTg2MzBlMWJmMWU2ZGE3Y2M0MWM5NDUwOWQ2MGRmNDM1Zjc2NjgyNjBlOSIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiMzFjMmY4NDVhOTk4MjM0MDY0NTZmNDc2ZDQ2YTc3MjQxY2ZiOWJlOGI4MzE3NzkzOWFjYWJkZjQ2NDRmYTNlOCJ9"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
+  }
+}

--- a/openwiki/.claims/quickstart.json
+++ b/openwiki/.claims/quickstart.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pageVersion": "sha256:e53e9d31b596bd1399618af6542bc17a4f884ed67cc828e808e3d95c3f597b1b",
+  "pageVersion": "sha256:b2836095f3e2e294ab2ef99b9d1edb12dbe22676fca76cde9b974c3a23fa2c3f",
   "claims": [
     {
       "id": "claim_b34298a8647a4e0b8653926b7568c5d4",
@@ -37,10 +37,90 @@
           "version": "repo-lines-v1:sha256:f949160bd2560bc9c53707ce7fce786965ba3609a06998a9c60c1ff0ffc1bb79:eyJzZWxlY3RlZExpbmVDb3VudCI6MjQ5LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhN2I4OTgzZDgyNjI4MTRlYmMzMGVlNDIwMDYzMzJhN2NkOTg3NTY2OTQ5MWI1NzE3YTUzMTUxMjRhZjVlYTY0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1MGFhZjU0M2IwYjMxYmJmMjMyMGM2NWE2NTU5YTcyMjA1YjMxZGNmNzNhYWRkYmM2NmI0ODI4ZTYxN2E2YWZhIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MCwiZm9sbG93aW5nQ29udGV4dEhhc2giOiJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0"
         }
       ]
+    },
+    {
+      "id": "claim_5c32d93bc49f4780a7c8da7bdd3344c0",
+      "statement": "Account Route synchronizes the selected account to shared Codex auth, but a cross-account change remains Pending until external Codex quiescence; Pending creation immediately wakes recovery, active Pending work is checked every 100 milliseconds, and exact-source projection plus fixed routing then complete through the same receipt.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1013-L1358",
+          "version": "repo-lines-v1:sha256:c25d324df980fe664f720ac88628df356122ed701e4665ff4082aa9c8efb2afd:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQ2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3MWIxNTk0NDQwYTY0MWFkODI0NzQ1MzA1MmRjZmJiMDlkZTZkODZiZTE5MWZjYTQ0ZWVlNjNhNGYxMjYzZGZkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzNjBiODhhMDVkNWI1Mzg0NzYwMjI5YmU2MDU3MmZlNjJiMWMyOWNkYzU3ZWRiNWU2OTUxZGFhNGZkNDZjODAzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiYzYxOWNjNzMzMjBjYTk5ODE3ZWEyNGRlY2NlODg0ZTdmMTFmOTRlOTAyN2U2YzFmNTUxMmFmYzZjMGE5ZmNlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZGU4NjFhNDM2YTBhNzcyYTNmNjUxZmRhYjJkNzExODMwYjUyMDZhNTJkYjY0YTJmZDIwYjlmMjk2ZThjNWViIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L3303-L3325",
+          "version": "repo-lines-v1:sha256:292eb1d9090cff0042d868367dddba109e6dbae12bcc0f0af2dc0e38bf1cf97f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMGMwOGUzM2E1M2JiN2U3MDUyYWY4NDg5YmRmMzc4MDY4ODdlOTViM2FlYmE2NDEyNGE0MjNmOTI1ODE1OTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ4NzY5YTZhZmQ3YTJmMGQzYTI1NzVmOGY1ZDQwMTE2MzM3NmI5MzM2MjFhZGM2ZjJkNDI0ZTBjNjMyYjcxNDQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVjYTVkYmUwN2RjMjRkOTc0MzMzZDBmNzkwN2Y2YmNkNDFiZTVjYzczYmQ4YjlkNmZmOGJkMTE0MDVmMTI5ZTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5NTI1YjExMTk0Mzc0MTMyNDA3MDgwZWU0ZDU1YTE2ZDIwOTEzZjc3YzEzNDczNzE0Njc0OTkxZTZhYTU4NWYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L6190-L6397",
+          "version": "repo-lines-v1:sha256:8661525657818f6c5b2e28853d154057b0e51dbe5982ba4898dc8bf40951cb14:eyJzZWxlY3RlZExpbmVDb3VudCI6MjA4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlN2QwM2RiMjIwMTU5ZDBhZmI4NmJhMmI0ZTk1NTkzODJiZmZkYzI1NTViNWIxNzNmYWVkYmUwMDVhZDY1YzQyIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMjU2ZjRhYjQ5NTRkMzQxZDkyNGFiNjZlZGQ0MDBkYmIzYmEzNWRiYTMwYTdhMDUzMTlhYWMzOTgxZDFkZTJkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhOTMxODI0ODY5NTg0MzkwMTkwNTkzNTc2OWNhODViNGRiMGYxYjUwMDUxMzk0MWI2NjQ5YzdjYTA2NWIzMTU3In0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/application.rs#L413-L538",
+          "version": "repo-lines-v1:sha256:587de368a1668e1bc910f993e8298155cda4c709337552d510c9b35b93f4b02a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5YmY2MTY3NTk4MjFjNzQ5ZTExMTVjMTIxNDZlNjZlYmYwMGU5ZWViMmU5MjlmZTZiMWYzYThhNGFhYzk0NjdmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIxZDFjNThlNjgwMWJhMDg0MDlkMjY4MWUyZDBiMzczZWIyNGEwMzZhOGNiOGY3Y2NiOTVjZDEzOWFiNjQxNWE4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_52712ba1531a4ae8ac9a9ef98f801be6",
+      "statement": "A same-account refresh converges on one token lineage: Decodex mirrors its exact-source successor or adopts a valid non-older Codex winner without another provider call or a losing-token writeback.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1794-L1887",
+          "version": "repo-lines-v1:sha256:577e9ce40fa2bca0f598e544a265e0216694720b93867f1f52d4c6ed6a7bb6fe:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyOWVjZDU3OGU1NmE0ODhhNDQ4ZmM2MGU2YmNiMDdjNDZlNGYwNWIxY2VkMDI2MmQxMzFhMmFhZTFmM2EwM2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkM2UxNTU2NmQ1MDkzMjA4YzU4MmI5ZTFjNDA0YTYzNzM0MjM4YzcwZjhkZjg1ZTRlOGRjNDk0OTk3NWVlOTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNjMzQ4NWJmMTY4YmM4NDRiMjk2YjYzYTQxOTg1MzMxMzQ4MTZmM2I4NWFlYmVlNTU3NmE2ODYxYjUyYTdiZTIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2815-L2931",
+          "version": "repo-lines-v1:sha256:eb72521235fe80d26c3ee84974a07dba4c6c102f94ee38bc7c6dc0636a526214:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyMzQ3ZTI1NWJlMzNmZjU4NWEwOTBkMWRhNzk5ZWQyMDZjY2M3MjViZWE2MTc3ZTdmNjI1NzAyNzBkODU2ZGU2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4YmJkNjE0MGEyYmEyMTgzYjEwOTk5MmU4ZDhhOTYwMDk3MjdkNGIzYjVhMThjYTRkZTEwOWEyNjU4NzY2ZWRmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0ZDNlMTU1NjZkNTA5MzIwOGM1ODJiOWUxYzQwNGE2MzczNDIzOGM3MGY4ZGY4NWU0ZThkYzQ5NDk5NzVlZTk1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1NzcxOWM1Mzc5NWNkZTI1OGViY2QwZjI4MGEyNjU5NTRjMjFiOTI2OTA1MGU4NDc5MDIzOTRiMDc2NWNlMjNiIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L5668-L5820",
+          "version": "repo-lines-v1:sha256:36031bd9b217a1138f19f884e91a7de36e4cf0d31c437dcbc9237e283c59dac1:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3M2Y5OGVhZDgzNjU2MjE4YTkzMDU5NTAxZjg2MmE0ODM1MDc5MzQ2YmU4MWE2MmQ2NzhhMmFmOTY2ZjA4NzM0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMjU2ZjRhYjQ5NTRkMzQxZDkyNGFiNjZlZGQ0MDBkYmIzYmEzNWRiYTMwYTdhMDUzMTlhYWMzOTgxZDFkZTJkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZDdiMWY3MTQyZjBiMDZhMmRiZjI3MDJkN2E3MGJkZTc1YWM1ODRiM2M4YzQ4OGVlYTA2Yzk4NDM4NDgwNjA2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_57ca4c3c363e4f38b4f1b4ad2525ad11",
+      "statement": "While Route is Pending, both desktop surfaces display a bounded concrete PID/process blocker or exact typed fallback reason and tell the user what must close or recover; after terminal projection they say the synchronized account is ready and the app can be reopened, while Decodex never signals or restarts that process.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift#L32-L203",
+          "version": "repo-lines-v1:sha256:b0124179d068b95d226823895f1c59261664941518aa93c39583cf4fedfe5490:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlODhlYzkxZDBiMzkwNDIwYTM2NWUxOGZiYWQwMWFmY2Y2NmY3ZWVmMDQ0OTMwYThkMTVmMDY3MjA0YmQwNjk5IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwYWYzZDM2YmQ1MWZkN2FmNTU4MDdiYTZhZDM0MDRkMjUyZTY0YTJiZDg5MTI3ZTZkMWY4ZTM2NjYxYjQ0ZGU4In0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift#L37-L89",
+          "version": "repo-lines-v1:sha256:4690c10a2831755a867ae233b89503dec75d8acf3bb177da020b6459a15096ed:eyJzZWxlY3RlZExpbmVDb3VudCI6NTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRlNDExOWQ2MTcwMDY2Nzk2ZDQyODAzNTk1MDY3NWU4MTI2ZDU5NDgwY2IzODg0ZjhhMmE3NjI3YTA2YjIwZjQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJhOGUyNjhhMTA2YTNhMzZlMWZhNDQ0ZGIzMGQwMGQ4MTFlYzZmNjVmZDRjNzViYmJkZTRiYzE1Y2FkNjc5M2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY0ZmM1N2EzMWYxOWFhMzc1OTk2MWMzN2JmZGQ1MzNiZjNkNjBmYmEwNDZlZGNlNjVkYjIxZWM3N2NmYzI0NjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQwOGM1OWI5MjRjOGZhNTM0MjFhYTgzYTJjYzI2ZDBjMTNmY2U2MjZmM2JiYTEwZTFkNmZkNjg4MDFmZWZiNDUifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/shell.rs#L2903-L3130",
+          "version": "repo-lines-v1:sha256:f1ce16f3bcf12e44f488bdd18941636b21f6c3675f8dfb0d69060f6971a655c5:eyJzZWxlY3RlZExpbmVDb3VudCI6MjI4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4NzU4M2JjMGNjMDFmYTgyMmE5M2JlODg0ZjM3ZmJmODA5YjA5YjkxMDgwNWJkZjc2MDhhMmU0OGRkMjI0MGI0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2OWVmM2Y0MDhkMzJmYjNhOWYwMTM3NzI1YjNiZjAyNWRkODE3NzhhNWZlMGUyMmNiZTNkMzRiNjNjZTVhNjI5IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZDAxNzMyOTk1MDMzNTE1NmViOGYwNTcxMDYzMzMyMzZmMDZlOTE5ZDg4NTZjYjdlMjlmODI3NzExMjMzYTFhIn0"
+        },
+        {
+          "resource": "repo://tests/scripts/test_vnext_architecture.py#L188-L220",
+          "version": "repo-lines-v1:sha256:ed57ffaf1af93e48d27be3b1fc736b01cc7343477e2441921550a4216fef444c:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyYmFiMzhhNzkwNDZmNDFiOGM1ZmQzYTNjNWI5ODYzY2I4YmU0NzQ4MTU2MjBlNDgzZTlhYTAzMWRkMTcwODkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzNjRhZDA3OGQ0NzNkYmYxZmE1MmMwMjkwMGRiYzAwZWMyMWZlMjQ4OTMxZTA0MDE1MjE4MTYxZTdhZDM5Y2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM2ZDU4OWVmZDk0NDhmNmUyNDY4ZTlkYzQyMWI3N2ZkYzRhZThhNWQwYmVhMjJkZGIxNDg0MmQ0ZmVmYWM3ZTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJkMjE0YzY4ZGJlZDYzMzE2ZmZjMzVhNWE3MDM2NjllMGMyZTJkMDdlOWIzY2UxNjY5OTY5M2QzNTg3NWYxZjgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_325a3cf92d084aaa90d48550b257bb5a",
+      "statement": "Protocol 2.11 and artifact cohort 7 fence the closed Pending diagnostic shape: official app identities strictly block, a standalone CLI is ignored only with proved isolated CODEX_HOME evidence, and unknown home evidence remains a typed visible blocker.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-protocol/src/lib.rs#L108-L116",
+          "version": "repo-lines-v1:sha256:53580d5cda74d1e06d80ddc27cc3d418b6c408c2c79fa52b0f2e1ec69c97884f:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiN2I2ODEwNzM5MjdjZDE5YTY2N2ExN2YyYjZhMzlkNDBjOGU4YzkzOWRkMWU3OWRkZjE4MjE4YjM2NGEwYjZhNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiYzkzNTRlYmE2ODEzNGY3YWU5ZGQwM2I4OTE1NjhjN2JhMjFmZGMwYzU4MTgyOTVmYTE2NTI2YTE1ZmU3ODM0MiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjBjODVjMjJlZWNjYWY1ZGQxMGI2NTYyMWFkNWM1MTEwYzE5NTU5NzM5MWIwOTk0ZDhlODEzNTZhMjRjYmY0NiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiOTY1YjA5NDkxMGM5NjczMTAxMzg2NTlmNmVlOGNjYzU2ZWViYWY4YTRmODU1ZmZlMGNiNjg1NzQxMGUwMTQ1NCJ9"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L1961-L2077",
+          "version": "repo-lines-v1:sha256:07ac20e237c480477d7188a30139921ed862a5c07687162572e194189f14f56a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2ODgxYmUzNGIyN2FlNGMzZWQzY2RiNDQwMDI2MTllMjYzMmMzYzY4Nzk4ZDAwYTMwMjRlNWYwMmYyZWJiM2FkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhMDg5NDc3MjI4ZjRhNmNiM2QyMmY0YjZmYmNlMzJlZGFkNjc1NjQwM2QwODhmYzM1MzM4ZGRlZDhmY2I3YzRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmOThhMjZiNDUxYTUwMGFmYTg5YThmODg2OTUyMzUxYWM5ZjU2ZmU3Mzg0YTVmODBiNmQyZjU5NGMwOGIyZTUyIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L303-L789",
+          "version": "repo-lines-v1:sha256:01b2a65c9ef1e33c3941574d066c00477733a807ba76fe1b3c17448e43f16279:eyJzZWxlY3RlZExpbmVDb3VudCI6NDg3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5NzI3MDc2YmZhMjUyYmE4NTFjYzViYzBlMWNjOGQ2ZmFmYzI3NjgxNDk3MGZkNzc0MjIzYzUyMjQ1OGFmYWRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGJkNTY2MWE4MDEyM2FiZGI1ZTMyMzM4OGVkMGQwNGMwYjBiMTJlNDUxOGM3MzM5Y2Y0MGNiZTY0YzQ5MGRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTUzOWJjMDE4NGY2YjM1NDc2YzM5ZjI5M2UwNDQzYzY5ZjA4ZWE1ZTkyZGQ4Mzc5ODgzNTgzMmRjYTI4YWRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZjQ3OWJhY2FiYWE4MmUzYzQ0OWRlYmEyNDYwN2E3YjZiYWY0MGYyNmM2ZDlkZjFmNzY4ODE0NTdkNmU3ZDZkIn0"
+        }
+      ]
     }
   ],
   "verification": {
-    "by": "openwiki/0.4.0",
-    "at": "2026-08-26T21:13:26.303Z"
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
   }
 }

--- a/openwiki/.claims/specs/account-lifecycle-authority.json
+++ b/openwiki/.claims/specs/account-lifecycle-authority.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:dcf93765d9714e854d938ac9ee56f79c2607fe789c718eb67def0c379db06117",
+  "claims": [
+    {
+      "id": "claim_d7063028d6a742dfa815d671fa660272",
+      "statement": "A cross-account Route retains one credential-negative Pending receipt while an external Codex process may own the old refresh-token family, and completes the exact-source projection and fixed-routing commit only after quiescence.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1013-L1358",
+          "version": "repo-lines-v1:sha256:c25d324df980fe664f720ac88628df356122ed701e4665ff4082aa9c8efb2afd:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQ2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3MWIxNTk0NDQwYTY0MWFkODI0NzQ1MzA1MmRjZmJiMDlkZTZkODZiZTE5MWZjYTQ0ZWVlNjNhNGYxMjYzZGZkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzNjBiODhhMDVkNWI1Mzg0NzYwMjI5YmU2MDU3MmZlNjJiMWMyOWNkYzU3ZWRiNWU2OTUxZGFhNGZkNDZjODAzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiYzYxOWNjNzMzMjBjYTk5ODE3ZWEyNGRlY2NlODg0ZTdmMTFmOTRlOTAyN2U2YzFmNTUxMmFmYzZjMGE5ZmNlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZGU4NjFhNDM2YTBhNzcyYTNmNjUxZmRhYjJkNzExODMwYjUyMDZhNTJkYjY0YTJmZDIwYjlmMjk2ZThjNWViIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L266-L276",
+          "version": "repo-lines-v1:sha256:46dcd7353efa1c17c69f952f23066439d4ddf2164395e478f78ca4d2e119f545:eyJzZWxlY3RlZExpbmVDb3VudCI6MTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjRmYzZkNWU2YzkyOTM0NWVmZGU5ZjcwMDg2MzFhYWNjNjA2NzcyNzAwOGU5ZGI3NzQwZTE5YmY4MjdhYWMyNmQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhjOWZkNWE2ZGQ2YmJkMmQ5MGU3NTlmNmQ5OTU3ZmZhZWFhNTNhMWNmNGYzMWEyNWRmNjc4NTg3YjNlYmYxMWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRmZWZjNjBhYTRlNWI0ZjI0ZGY4OTdhZjkzOWQ0MjBlMmY5MmM5YjFkZDQ0Zjc1OWRlZGU3Yjc0OTY1MTg4YjMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFhMmY2NTdlZjM0NGJiZWVlOWEwZmUxMjBiNDFhZGFhY2JlYWQwYzBlMjJiYTYzNTNhMmQyOTJiYWM4ZjZlMDkifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L303-L789",
+          "version": "repo-lines-v1:sha256:01b2a65c9ef1e33c3941574d066c00477733a807ba76fe1b3c17448e43f16279:eyJzZWxlY3RlZExpbmVDb3VudCI6NDg3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5NzI3MDc2YmZhMjUyYmE4NTFjYzViYzBlMWNjOGQ2ZmFmYzI3NjgxNDk3MGZkNzc0MjIzYzUyMjQ1OGFmYWRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGJkNTY2MWE4MDEyM2FiZGI1ZTMyMzM4OGVkMGQwNGMwYjBiMTJlNDUxOGM3MzM5Y2Y0MGNiZTY0YzQ5MGRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTUzOWJjMDE4NGY2YjM1NDc2YzM5ZjI5M2UwNDQzYzY5ZjA4ZWE1ZTkyZGQ4Mzc5ODgzNTgzMmRjYTI4YWRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZjQ3OWJhY2FiYWE4MmUzYzQ0OWRlYmEyNDYwN2E3YjZiYWY0MGYyNmM2ZDlkZjFmNzY4ODE0NTdkNmU3ZDZkIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_c63559de68b5435796f4662f7be9c106",
+      "statement": "Pending Route creation immediately wakes recovery; while Pending work exists, recovery checks every 100 milliseconds and rechecks command identity, routing revision, account readiness, and external Codex liveness before reclaiming the original receipt, while the idle cadence remains one second and a newer compatible Route can supersede it.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L3303-L3325",
+          "version": "repo-lines-v1:sha256:292eb1d9090cff0042d868367dddba109e6dbae12bcc0f0af2dc0e38bf1cf97f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMGMwOGUzM2E1M2JiN2U3MDUyYWY4NDg5YmRmMzc4MDY4ODdlOTViM2FlYmE2NDEyNGE0MjNmOTI1ODE1OTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ4NzY5YTZhZmQ3YTJmMGQzYTI1NzVmOGY1ZDQwMTE2MzM3NmI5MzM2MjFhZGM2ZjJkNDI0ZTBjNjMyYjcxNDQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVjYTVkYmUwN2RjMjRkOTc0MzMzZDBmNzkwN2Y2YmNkNDFiZTVjYzczYmQ4YjlkNmZmOGJkMTE0MDVmMTI5ZTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5NTI1YjExMTk0Mzc0MTMyNDA3MDgwZWU0ZDU1YTE2ZDIwOTEzZjc3YzEzNDczNzE0Njc0OTkxZTZhYTU4NWYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/application.rs#L413-L538",
+          "version": "repo-lines-v1:sha256:587de368a1668e1bc910f993e8298155cda4c709337552d510c9b35b93f4b02a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5YmY2MTY3NTk4MjFjNzQ5ZTExMTVjMTIxNDZlNjZlYmYwMGU5ZWViMmU5MjlmZTZiMWYzYThhNGFhYzk0NjdmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIxZDFjNThlNjgwMWJhMDg0MDlkMjY4MWUyZDBiMzczZWIyNGEwMzZhOGNiOGY3Y2NiOTVjZDEzOWFiNjQxNWE4In0"
+        },
+        {
+          "resource": "repo://database/src/account_lifecycle.rs#L1048-L1155",
+          "version": "repo-lines-v1:sha256:84dd82815a2e2e544d0c7fec08a44d25eb3713efba617073fed857db0c5d2d15:eyJzZWxlY3RlZExpbmVDb3VudCI6MTA4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2NzZlMjg2ZTVhZWJkYzUyMDY4YmY0MWM4YTJiYzhkMWYyNmU0ODhiNzExZDc4MWU0NzY1NjU5Yjg2ZDk0MTFiIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIyN2I5MDExNTAyNTgwNzhmYzYwNzdhMTI4OWIxZTIxNWQ2NGI0YTExNmY1MTc4ODY2ZGM0MmVjOTVjZjk5ZDAyIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIyMTljODMyZGEyMWIxODRmYWRkMjA3NjYxODU4YzRhMWE1MGFiMGY3NTIzZjQ3OGJlMmI0MjM4NjYwNDJiYmZlIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_f8c6d3a7f9674b7cb7dbba5618c43deb",
+      "statement": "Passive shared-auth following requires a stable two-poll source and imports only one known same-account bundle that is not older than the current credential.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L654-L823",
+          "version": "repo-lines-v1:sha256:5a85272cacaa143adc987048c469e5d48ab969a52f82b097867d80b3575628c0:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhOTZlZGFkODUyNjY1OGFlZjUxMDRlYTU4NmJjNmExMjgwZTZlODQ3Yjg3MTA5OTQyMGM5OGI0MzZhNTg2OTU1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIwYjhkMzg1MzQzZDYxNThjMzRlZjg3ZmU2NGM2MWFhNzZhMmU2YzBhMTQxOGExNjZhODFjYzE1OWEzOGRmY2RkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2N2NjMTJlYjgyMWQ4NGRjNDdlNzVlMWI4ZWU2ODM5ZTU2ZTU1ZTcwZjkwNWUzMTk3NDcxYzVkMzNjM2RkNmNiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhZmYyMGZmYjU3ZDZkNTg5ZjViYzgwOWMyOTAzYTM0YWRmMTRhYzZiMmUzODdiYjY0MGY0NmU1NzkyNzg5M2NjIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L185-L245",
+          "version": "repo-lines-v1:sha256:ddaaf7ee519bc1c7cd715da3d32b5a4dd2e4af6a0f9bfcffd19356a3a8742699:eyJzZWxlY3RlZExpbmVDb3VudCI6NjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEyNDMxYmQxMDcyYzk5MDYwNzc4ZmRkMDQ3ZmE2YjM2ZmJkNzZkN2RmZmI0MDJlOWRjMjk0OTQwOGNjNWU3NmMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImI3YWI0NGUzOWVmNTNiM2I2OTNjZWMzNDZmOGI5Y2JjOWM1OGNkNzQ0M2MwNTZhZTM5ZjNmMzMyYjk4MDY4NWMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE4ZmE5YjBjMGQ4NzY0NGQyOTg0MzQ2NTY4M2VjOWRjMWI0N2IzZWUwZGJmMWUxODMzNzE1MWUwOTgzYzk4NGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImU5NWQ4NTFmZjlhMmRmNWI4OTg4NzNkMzFjOTQ4NjhiMWM4ZWM4MmI4MzFhNjczYWQ4MTRjZGFmZWE1YmZkZjcifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_f9e30bb6ea9948e79759fc010053f9b4",
+      "statement": "A Decodex refresh of the exact projected family captures the shared source version, conditionally mirrors its successor, and adopts a valid non-older Codex winner after source drift without making a second provider refresh.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1794-L1887",
+          "version": "repo-lines-v1:sha256:577e9ce40fa2bca0f598e544a265e0216694720b93867f1f52d4c6ed6a7bb6fe:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyOWVjZDU3OGU1NmE0ODhhNDQ4ZmM2MGU2YmNiMDdjNDZlNGYwNWIxY2VkMDI2MmQxMzFhMmFhZTFmM2EwM2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkM2UxNTU2NmQ1MDkzMjA4YzU4MmI5ZTFjNDA0YTYzNzM0MjM4YzcwZjhkZjg1ZTRlOGRjNDk0OTk3NWVlOTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNjMzQ4NWJmMTY4YmM4NDRiMjk2YjYzYTQxOTg1MzMxMzQ4MTZmM2I4NWFlYmVlNTU3NmE2ODYxYjUyYTdiZTIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2815-L2931",
+          "version": "repo-lines-v1:sha256:eb72521235fe80d26c3ee84974a07dba4c6c102f94ee38bc7c6dc0636a526214:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyMzQ3ZTI1NWJlMzNmZjU4NWEwOTBkMWRhNzk5ZWQyMDZjY2M3MjViZWE2MTc3ZTdmNjI1NzAyNzBkODU2ZGU2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4YmJkNjE0MGEyYmEyMTgzYjEwOTk5MmU4ZDhhOTYwMDk3MjdkNGIzYjVhMThjYTRkZTEwOWEyNjU4NzY2ZWRmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0ZDNlMTU1NjZkNTA5MzIwOGM1ODJiOWUxYzQwNGE2MzczNDIzOGM3MGY4ZGY4NWU0ZThkYzQ5NDk5NzVlZTk1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1NzcxOWM1Mzc5NWNkZTI1OGViY2QwZjI4MGEyNjU5NTRjMjFiOTI2OTA1MGU4NDc5MDIzOTRiMDc2NWNlMjNiIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L5668-L5820",
+          "version": "repo-lines-v1:sha256:36031bd9b217a1138f19f884e91a7de36e4cf0d31c437dcbc9237e283c59dac1:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3M2Y5OGVhZDgzNjU2MjE4YTkzMDU5NTAxZjg2MmE0ODM1MDc5MzQ2YmU4MWE2MmQ2NzhhMmFmOTY2ZjA4NzM0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMjU2ZjRhYjQ5NTRkMzQxZDkyNGFiNjZlZGQ0MDBkYmIzYmEzNWRiYTMwYTdhMDUzMTlhYWMzOTgxZDFkZTJkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZDdiMWY3MTQyZjBiMDZhMmRiZjI3MDJkN2E3MGJkZTc1YWM1ODRiM2M4YzQ4OGVlYTA2Yzk4NDM4NDgwNjA2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_c61aea0d2e524e149f408fdebf6472cf",
+      "statement": "A generation-bound refresh callback can return a registry successor only when the provider identity is unchanged, the credential version is strictly newer, the account revision is not older, and the original generation remains active.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1940-L1985",
+          "version": "repo-lines-v1:sha256:03361ee355660422b22e69254d6f31e75ef0cbd76c966702723b3fae24ec38ab:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZiZTZkYjExMTFhMDczNmE3ZDhiMTkzZjE5MTBmNDA2NWNmNzg3NGVkN2NlMmM3ZWJhYzBkYzRmYTliN2E1OGQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFmMjc2Y2VkOTkwOGZlMDI4NzRkOGZhMGQyZTY0ZDVjM2VmMTQ3YTNhYmRjN2YwNmY4ZTE1ZTUwMzNjM2VlNmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNhMThkNGQzNjIwNTMyNWE4OTc2MzEwNmFjOTE4ZjQ4M2E5NTY4MzcxZmE1M2E1NjQ0OWQ5OTc5YzYzNDA0NDIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAxYmYwNDUxMDc3MzRlMmZkZGRiNTUzYzFiNTY3NGU5ZDhhZDA0NmVkMWVmZTZkYjZhZDM4MDE4ODU4YzBmMDMifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2934-L2955",
+          "version": "repo-lines-v1:sha256:96bc2ed1d3a6154a9e3a037052bbe4cefe5d9ed21104a55c8a473ec5ce295183:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY5ZDVlMTQzN2ExOTAwNjk4NzM3ODYyMjMzMmYyYTVkY2IzMzIxZDFlMTdiYzYzNzM0ZDE1MjliNGUwMTRjOWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjZjNWM5NzhmYzUwNmVhZjFlOWFjNDBmYWE0YmE1ZjU4Mjg0NWNlZDE0ZWI0NDg1MzdjOTRmYjE1ZTZlYTYyZmUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjY1ZTNjNmM5MzUwYTg5NTJjZmRmZTk2MTBjMWY3MGMwNzM5YTkyY2NiNzc4MTgzM2VlY2E0ODU5YTNkOTg1MGYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L4647-L4664",
+          "version": "repo-lines-v1:sha256:5db3bdc1a0ca3f07592e890d957b0d499401e0cd707c080977d43fc7e2076b18:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRhOTYzMjVjYjUxYmFlYzliZmNiMDY3M2Q2Y2Q3YWY0NTJlZDVkZjI0NGU5YWE5YzNhMjAxMWI1ZDg0ODA3ZDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjIzNjY1MGJlYTE3MDY4OWVmYzFiNGUwNTc4ZjFhNTUyM2I4ODQzMWFiNTUwN2JmNmYzNTdhYWU2OGFlNmQ0ZmIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L7804-L7824",
+          "version": "repo-lines-v1:sha256:63b67879b75dd26e6da8943a6f94aade880d9173bcb2d75f54f15887f54a280b:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRkZjgzNTcwYTkwNjgwNGE0MDQyZjNjMjYwZmU3NGNiYmRhMDc2NjhmNTQ2Mzg2MjY0NDQwNTA1YmRiMGZkOWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgwODJhZmMzZTFkMmY0ODY0MDA4MDZhZTVlMDQ4ZGQ2YTY5NDRiOGQ5MDExODI4NmUwYTg3MzllMjYzYjIzNDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjUxMjU2OGQwZjc1MDQ0YjczNmVkMTg0YzllMmQ3NDhiMjRiZjNkMzNlMTVkYjNjMWRmZjFlOWQ1MmNjNzRkOTYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_7d593ab52eb2493c9831608219c7942d",
+      "statement": "GPUI and CLI show Pending or the authoritative terminal Route projection; Pending displays a bounded concrete PID/process blocker or exact typed fallback reason and tells the user what must close or recover, terminal completion says the app can be reopened, and Decodex never signals or restarts the process.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift#L32-L203",
+          "version": "repo-lines-v1:sha256:b0124179d068b95d226823895f1c59261664941518aa93c39583cf4fedfe5490:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlODhlYzkxZDBiMzkwNDIwYTM2NWUxOGZiYWQwMWFmY2Y2NmY3ZWVmMDQ0OTMwYThkMTVmMDY3MjA0YmQwNjk5IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwYWYzZDM2YmQ1MWZkN2FmNTU4MDdiYTZhZDM0MDRkMjUyZTY0YTJiZDg5MTI3ZTZkMWY4ZTM2NjYxYjQ0ZGU4In0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift#L37-L81",
+          "version": "repo-lines-v1:sha256:4adb70dfd5864a8928e3fd1decfede2c8c9bdb4d47ddeb79aa041b7d568eea48:eyJzZWxlY3RlZExpbmVDb3VudCI6NDUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRlNDExOWQ2MTcwMDY2Nzk2ZDQyODAzNTk1MDY3NWU4MTI2ZDU5NDgwY2IzODg0ZjhhMmE3NjI3YTA2YjIwZjQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhiZDU1NmU2NWM4MTcxNzgyMGM2ZGVkYjFmNTE4ZjI4ZDAwZGJmM2JlMThlOWM3YmFiOGNhNzQ3NzA5NmI5MDMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY0ZmM1N2EzMWYxOWFhMzc1OTk2MWMzN2JmZGQ1MzNiZjNkNjBmYmEwNDZlZGNlNjVkYjIxZWM3N2NmYzI0NjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImY2MTc4YWYwZDkzNjc2YWIxN2E3ZTNjNTQ0Yjk4OWJkNmYzNDZjYWQ1Njg2ZjEwMDE0Yjc5NTI2MGFhMjQwN2UifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/shell.rs#L2903-L3130",
+          "version": "repo-lines-v1:sha256:f1ce16f3bcf12e44f488bdd18941636b21f6c3675f8dfb0d69060f6971a655c5:eyJzZWxlY3RlZExpbmVDb3VudCI6MjI4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4NzU4M2JjMGNjMDFmYTgyMmE5M2JlODg0ZjM3ZmJmODA5YjA5YjkxMDgwNWJkZjc2MDhhMmU0OGRkMjI0MGI0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2OWVmM2Y0MDhkMzJmYjNhOWYwMTM3NzI1YjNiZjAyNWRkODE3NzhhNWZlMGUyMmNiZTNkMzRiNjNjZTVhNjI5IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZDAxNzMyOTk1MDMzNTE1NmViOGYwNTcxMDYzMzMyMzZmMDZlOTE5ZDg4NTZjYjdlMjlmODI3NzExMjMzYTFhIn0"
+        },
+        {
+          "resource": "repo://tests/scripts/test_vnext_architecture.py#L188-L220",
+          "version": "repo-lines-v1:sha256:ed57ffaf1af93e48d27be3b1fc736b01cc7343477e2441921550a4216fef444c:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyYmFiMzhhNzkwNDZmNDFiOGM1ZmQzYTNjNWI5ODYzY2I4YmU0NzQ4MTU2MjBlNDgzZTlhYTAzMWRkMTcwODkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzNjRhZDA3OGQ0NzNkYmYxZmE1MmMwMjkwMGRiYzAwZWMyMWZlMjQ4OTMxZTA0MDE1MjE4MTYxZTdhZDM5Y2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM2ZDU4OWVmZDk0NDhmNmUyNDY4ZTlkYzQyMWI3N2ZkYzRhZThhNWQwYmVhMjJkZGIxNDg0MmQ0ZmVmYWM3ZTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJkMjE0YzY4ZGJlZDYzMzE2ZmZjMzVhNWE3MDM2NjllMGMyZTJkMDdlOWIzY2UxNjY5OTY5M2QzNTg3NWYxZjgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_6e39050bb0f549b2b6f8f88dbbe5e642",
+      "statement": "Official ChatGPT and Codex bundle executables strictly block cross-account cutover, daemon descendants are excluded, and an independent Codex CLI is ignored only when bounded same-UID metadata proves an existing canonical CODEX_HOME distinct from the shared home; absent or withheld home evidence remains a visible fail-closed blocker.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L303-L789",
+          "version": "repo-lines-v1:sha256:01b2a65c9ef1e33c3941574d066c00477733a807ba76fe1b3c17448e43f16279:eyJzZWxlY3RlZExpbmVDb3VudCI6NDg3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5NzI3MDc2YmZhMjUyYmE4NTFjYzViYzBlMWNjOGQ2ZmFmYzI3NjgxNDk3MGZkNzc0MjIzYzUyMjQ1OGFmYWRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGJkNTY2MWE4MDEyM2FiZGI1ZTMyMzM4OGVkMGQwNGMwYjBiMTJlNDUxOGM3MzM5Y2Y0MGNiZTY0YzQ5MGRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTUzOWJjMDE4NGY2YjM1NDc2YzM5ZjI5M2UwNDQzYzY5ZjA4ZWE1ZTkyZGQ4Mzc5ODgzNTgzMmRjYTI4YWRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZjQ3OWJhY2FiYWE4MmUzYzQ0OWRlYmEyNDYwN2E3YjZiYWY0MGYyNmM2ZDlkZjFmNzY4ODE0NTdkNmU3ZDZkIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L877-L1110",
+          "version": "repo-lines-v1:sha256:de84c7e6e777fb6cf619a3a0a0e3032a375c62538258a0162d71677ac31a87c9:eyJzZWxlY3RlZExpbmVDb3VudCI6MjM0LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIwMWJhNDcxOWM4MGI2ZmU5MTFiMDkxYTdjMDUxMjRiNjRlZWVjZTk2NGUwOWMwNThlZjhmOTgwNWRhY2E1NDZiIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJjNWUyZjgxNWJhNzM0MDdkZTkxYmUxNDZlZTRhMTg4ZjEzNDAzMDAyYzZjNjEyYWRkYTdiMzBiMjk3NjlkNGE5IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI1NDViZTg2NmU3YWNkMWI2ZjkwMjYwMTZiNjM2ODIzZjVjMjlkMjlkZDU5YTcwY2E4M2U2NGZmZDlmYTRiMzAxIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI2M2NjMGMzMmEzOWI2Y2U2ZmFjOTg3ZDZmM2RkYzE4MDRmZjYwZTU1NGY2OWYzODMzMWUzNGU2M2U0NjJkOTMwIn0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
+  }
+}

--- a/openwiki/.claims/specs/account-login-authority.json
+++ b/openwiki/.claims/specs/account-login-authority.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:693ff94ca6e95437f3be9a6b43088d85559bb30aea6c0ab7fc3fae9964bdef1f",
+  "claims": [
+    {
+      "id": "claim_a3c49fc4897341d8af55579dc54de44e",
+      "statement": "Every current local account-login client and daemon must negotiate exact protocol 2.11 and artifact cohort 7; a version or cohort mismatch is refused before account-login exchange data is accepted.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-protocol/src/client.rs#L250-L280",
+          "version": "repo-lines-v1:sha256:c1b459ec30c0b5a73a630d4db78771155586cef088c3cf1b6948b4931db1598e:eyJzZWxlY3RlZExpbmVDb3VudCI6MzEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJhOGUyNjhhMTA2YTNhMzZlMWZhNDQ0ZGIzMGQwMGQ4MTFlYzZmNjVmZDRjNzViYmJkZTRiYzE1Y2FkNjc5M2QiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFiNDQzYmE5ZTQwNjBkNTVlYjNiN2M1Zjg1MDYwZWQ0ZThjZjE2OTJmYWVhZDdkZjAxN2IxNWJlNTJiNTY2MTAiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE5YjkxNDVmODhiYzM2ZDk3Zjc3M2U2ZWFhZTExNDYzNTgwMTQwYTBkZmE1NzhlZDRjMDc5MjU4MTY1YzA3ZmMiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImIxMTg5MzIxMTBkMmQ2NjBmYWQ1OGIzYjhhZmE2MWM1MjE1NDQxZTBhYmU4ODczMTk2OTA2ZGViZjY2MGFjY2IifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/lib.rs#L108-L162",
+          "version": "repo-lines-v1:sha256:afcd685392ff94d91a030dd02a9e74e93987c373fce12ad6de735f620b3b4948:eyJzZWxlY3RlZExpbmVDb3VudCI6NTUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjdiNjgxMDczOTI3Y2QxOWE2NjdhMTdmMmI2YTM5ZDQwYzhlOGM5MzlkZDFlNzlkZGYxODIxOGIzNjRhMGI2YTQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImM5ZjM4MmZmZWU2ZDFiMGFhNjUxZDc2N2YwMzczYmNjMTMyMTZlNDNiYzNjMmRkMGY4OGI2OTAzYzRmZjU4YmUiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImIwYzg1YzIyZWVjY2FmNWRkMTBiNjU2MjFhZDVjNTExMGMxOTU1OTczOTFiMDk5NGQ4ZTgxMzU2YTI0Y2JmNDYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjM4ZmM1NmUzOWRlNjQ0ZWM0NDdhZDM2NWYxMTI1YTM5NTBmMTA1MTM3NzZkMDU5NWM3OGFkMzEzNDc3ZGIyMjkifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L580-L670",
+          "version": "repo-lines-v1:sha256:589552b5306bf8ffaa2db68887001c64dea2f343a820856280828e41658ae742:eyJzZWxlY3RlZExpbmVDb3VudCI6OTEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImFjM2U0NTFmYzk3ZDNlYjdmMjA4NjJkNTBkNDc1YWFkNDlhNGE1NTYyYTg1NTUzNzMyMDdiNWVjNGZhOWMwOWEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImUzZTFmMzFlZTViNTE4MTNlNTAxZmEzYTkxNTUyYzNjZWU3MTlmYWQwMTQ3ZDQ3ZGNiMjQ1MGJmZDM4NmI5ZDciLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjNiMWFlNjdmMjE1NWZjMDVhMzZlMGY3MDUwN2I1ODI0NzMxODk4NGI5ZDUyNzZhZDU4ODkwYTY4ZjVmZThlZTgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjY0M2Y2YjU2ZGE4MWZmYWEzODhlYTcwZGE3ZDI3Mjc1ODFjYTRiZmZlNmJjYjY3Zjg5OTVmYzIzNDkxNDE1YWUifQ"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
+  }
+}

--- a/openwiki/.claims/specs/local-product-v1.json
+++ b/openwiki/.claims/specs/local-product-v1.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": 1,
+  "pageVersion": "sha256:3684fbc9d1932b896bdd128b4417df99a6b4255b5cb3197df84ce6febc01972e",
+  "claims": [
+    {
+      "id": "claim_43cc36a83ec3487a92f18c719c5bdd1a",
+      "statement": "The Route protocol accepts one operation, target account revision, and routing revision, and returns either credential-negative Pending for the same receipt or one authoritative AccountRouted projection.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-protocol/src/client.rs#L1239-L1268",
+          "version": "repo-lines-v1:sha256:91c4d5f5d879a8388a06e75b89cb0286cdc94898d5d7a4bbf5de500314377f65:eyJzZWxlY3RlZExpbmVDb3VudCI6MzAsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ5MzA5YjdmM2I1MGNiMWE1NDQwYTA3ZDczZTJkYzIwM2Y5ZmExZWVhZDVmZjEzMTI4OGNkYWY3MzYyYmVlODEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxYmE0NzE5YzgwYjZmZTkxMWIwOTFhN2MwNTEyNGI2NGVlZWNlOTY0ZTA5YzA1OGVmOGY5ODA1ZGFjYTU0NmIiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImQxZGNmYzhlNDcwMzY4ZjBlZjFiMGExZmNjNDZhNDg0OTJkM2VjYmZhZmI0NmJjNmNlZTM3ODJmMGRjZmU4NDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImI4MTYyZDJhNjAwMDRiZTAyN2EwYWYyZTg4ZWRiOTQzMTBkMDY2NWUxYjhlNDI4NDZmZjFjMDVhOTMxZmM3YTEifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L2744-L2762",
+          "version": "repo-lines-v1:sha256:cf1b8f97409b77d8f2509c7ac2f82611bec57c71cc1d75018d690175ad18ccc9:eyJzZWxlY3RlZExpbmVDb3VudCI6MTksImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3YTJhMmMzZjVkOTdiNTZmYjEyZDhhY2FkNDk4YzFiNzNhMDMxY2I0YWM1NjMwOGZlMGQ3OGVlMzMyZmJjZmMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImVmNjc0NGU1M2YyYTAyZjc1YzBhOGNlN2M3NWFiM2QzMDRhYTg0NWFiZWM3MTNjYTllMmVlMWQ1OWUzNDI2NzQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6Ijc2YWE0ODA1ZmZkZWFhODgyMzQ5NDhkYTI3Nzc5MGE3OTViOTczMTY3ZTE1ODgyYTc4YWM0NDllYjI0ZDk3M2YiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYwZmQxODM4MzBmYjE0MDkzOTNiNWQyN2U0MTc5N2ZlMDBkMzc0ZGVkYmU3M2ZmNTI3Y2Y0ZTY2NThmYjY2MjAifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L2938-L2962",
+          "version": "repo-lines-v1:sha256:c6126332a623e92b191888e6d8e3ce83fadab0df89ad03aa4ec1c033069df175:eyJzZWxlY3RlZExpbmVDb3VudCI6MjUsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjNlNjg3NjQ4MzBlM2E3MWFkYWVlYjhhNTRiZWRkNDM2ZWY5YjUzNGM0NzQxZGMwZmNmMjg3NzM3MDU3YWM2NGEiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQwNTFjNmZiYTg5ZDdmNGMyZWM5MWUxOTQ3ZmI1MzM0MmI5N2E4MzJkN2ZhZTk1YTMwYzQ5OGI1ZThmMjM3YWMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImZmNTA0MWVhZDIxZmIxMjFmZGM2MjA2YWU3OGFlZjU4NmFjMTM5NTUyYWZkNmRmODcyNjg4Njc2YzczODA2MTYiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImYyZGY5YTk4ZWQyYmRiODIyYjRjODNhZDgzZDBlMjE3M2QxOWMxYmIwMmYxN2FjOGQxOGExNjI2NzEzYzFjOWEifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_9a6547d7787f466d817acf5d6eaa6d46",
+      "statement": "Cross-account Route does not refresh, project, or commit fixed routing while external Codex may own the old account; Pending creation immediately wakes recovery, active Pending work is checked every 100 milliseconds, and the retained receipt completes only after stable-source and quiescence checks.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1013-L1358",
+          "version": "repo-lines-v1:sha256:c25d324df980fe664f720ac88628df356122ed701e4665ff4082aa9c8efb2afd:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQ2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3MWIxNTk0NDQwYTY0MWFkODI0NzQ1MzA1MmRjZmJiMDlkZTZkODZiZTE5MWZjYTQ0ZWVlNjNhNGYxMjYzZGZkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzNjBiODhhMDVkNWI1Mzg0NzYwMjI5YmU2MDU3MmZlNjJiMWMyOWNkYzU3ZWRiNWU2OTUxZGFhNGZkNDZjODAzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiYzYxOWNjNzMzMjBjYTk5ODE3ZWEyNGRlY2NlODg0ZTdmMTFmOTRlOTAyN2U2YzFmNTUxMmFmYzZjMGE5ZmNlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZGU4NjFhNDM2YTBhNzcyYTNmNjUxZmRhYjJkNzExODMwYjUyMDZhNTJkYjY0YTJmZDIwYjlmMjk2ZThjNWViIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L3303-L3325",
+          "version": "repo-lines-v1:sha256:292eb1d9090cff0042d868367dddba109e6dbae12bcc0f0af2dc0e38bf1cf97f:eyJzZWxlY3RlZExpbmVDb3VudCI6MjMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImZjMGMwOGUzM2E1M2JiN2U3MDUyYWY4NDg5YmRmMzc4MDY4ODdlOTViM2FlYmE2NDEyNGE0MjNmOTI1ODE1OTUiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImQ4NzY5YTZhZmQ3YTJmMGQzYTI1NzVmOGY1ZDQwMTE2MzM3NmI5MzM2MjFhZGM2ZjJkNDI0ZTBjNjMyYjcxNDQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImVjYTVkYmUwN2RjMjRkOTc0MzMzZDBmNzkwN2Y2YmNkNDFiZTVjYzczYmQ4YjlkNmZmOGJkMTE0MDVmMTI5ZTIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImQ5NTI1YjExMTk0Mzc0MTMyNDA3MDgwZWU0ZDU1YTE2ZDIwOTEzZjc3YzEzNDczNzE0Njc0OTkxZTZhYTU4NWYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L6190-L6397",
+          "version": "repo-lines-v1:sha256:8661525657818f6c5b2e28853d154057b0e51dbe5982ba4898dc8bf40951cb14:eyJzZWxlY3RlZExpbmVDb3VudCI6MjA4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlN2QwM2RiMjIwMTU5ZDBhZmI4NmJhMmI0ZTk1NTkzODJiZmZkYzI1NTViNWIxNzNmYWVkYmUwMDVhZDY1YzQyIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMjU2ZjRhYjQ5NTRkMzQxZDkyNGFiNjZlZGQ0MDBkYmIzYmEzNWRiYTMwYTdhMDUzMTlhYWMzOTgxZDFkZTJkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhOTMxODI0ODY5NTg0MzkwMTkwNTkzNTc2OWNhODViNGRiMGYxYjUwMDUxMzk0MWI2NjQ5YzdjYTA2NWIzMTU3In0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/application.rs#L413-L538",
+          "version": "repo-lines-v1:sha256:587de368a1668e1bc910f993e8298155cda4c709337552d510c9b35b93f4b02a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTI2LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5YmY2MTY3NTk4MjFjNzQ5ZTExMTVjMTIxNDZlNjZlYmYwMGU5ZWViMmU5MjlmZTZiMWYzYThhNGFhYzk0NjdmIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIxZDFjNThlNjgwMWJhMDg0MDlkMjY4MWUyZDBiMzczZWIyNGEwMzZhOGNiOGY3Y2NiOTVjZDEzOWFiNjQxNWE4In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_2da1007615b641c3b2416d8a17b13c98",
+      "statement": "The shared-auth writer uses exact-source compare-and-swap and readback, while passive following requires stable metadata and imports only same-account non-older rotations.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L654-L823",
+          "version": "repo-lines-v1:sha256:5a85272cacaa143adc987048c469e5d48ab969a52f82b097867d80b3575628c0:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcwLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJhOTZlZGFkODUyNjY1OGFlZjUxMDRlYTU4NmJjNmExMjgwZTZlODQ3Yjg3MTA5OTQyMGM5OGI0MzZhNTg2OTU1IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIwYjhkMzg1MzQzZDYxNThjMzRlZjg3ZmU2NGM2MWFhNzZhMmU2YzBhMTQxOGExNjZhODFjYzE1OWEzOGRmY2RkIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2N2NjMTJlYjgyMWQ4NGRjNDdlNzVlMWI4ZWU2ODM5ZTU2ZTU1ZTcwZjkwNWUzMTk3NDcxYzVkMzNjM2RkNmNiIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhZmYyMGZmYjU3ZDZkNTg5ZjViYzgwOWMyOTAzYTM0YWRmMTRhYzZiMmUzODdiYjY0MGY0NmU1NzkyNzg5M2NjIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/auth_projection.rs#L100-L250",
+          "version": "repo-lines-v1:sha256:dc1bdd59aa4de92d2b05a9082739aa8513d0fcd9f7111755ab33160cbc53a9c4:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUxLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiIzOTc1ZmMyZDU1NzkwYzI1YjU1ODIwNjEwNGZjM2JjZmMxMWYzZGY5NzY3MmFhY2Q3MzJjODVmOWQxNDJkNmU4IiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMzhiYjdiNzYyNzE2YWNiZWY1MDg5Njg1ZjE4ZGY2ZDBlNzlmZjA3YjcyMzg3MThjNWNhYzg3NWIwY2NlZjRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJhYzE2NDBlOGIxMTNkY2NmZjI4NDMzMWRmMGJhOTg3NTkwZTY3ZTM4ZDgwNmVjYWFhYWE1ODFmMGNmZDgxMmRmIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L185-L276",
+          "version": "repo-lines-v1:sha256:1834ac8653dd3fd983e680dc0ba74a282dd9993793783092fcdd93e0b836c928:eyJzZWxlY3RlZExpbmVDb3VudCI6OTIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImEyNDMxYmQxMDcyYzk5MDYwNzc4ZmRkMDQ3ZmE2YjM2ZmJkNzZkN2RmZmI0MDJlOWRjMjk0OTQwOGNjNWU3NmMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjhjOWZkNWE2ZGQ2YmJkMmQ5MGU3NTlmNmQ5OTU3ZmZhZWFhNTNhMWNmNGYzMWEyNWRmNjc4NTg3YjNlYmYxMWQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImE4ZmE5YjBjMGQ4NzY0NGQyOTg0MzQ2NTY4M2VjOWRjMWI0N2IzZWUwZGJmMWUxODMzNzE1MWUwOTgzYzk4NGIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6ImFhMmY2NTdlZjM0NGJiZWVlOWEwZmUxMjBiNDFhZGFhY2JlYWQwYzBlMjJiYTYzNTNhMmQyOTJiYWM4ZjZlMDkifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_05c59234ef2d415f8e2a203efc3dd504",
+      "statement": "For an exact projected account, a Decodex refresh mirrors its successor or adopts a concurrently written valid Codex winner through one additional deterministic SQLite rotation, without restoring the loser or calling the provider again.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1794-L1887",
+          "version": "repo-lines-v1:sha256:577e9ce40fa2bca0f598e544a265e0216694720b93867f1f52d4c6ed6a7bb6fe:eyJzZWxlY3RlZExpbmVDb3VudCI6OTQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyOWVjZDU3OGU1NmE0ODhhNDQ4ZmM2MGU2YmNiMDdjNDZlNGYwNWIxY2VkMDI2MmQxMzFhMmFhZTFmM2EwM2UiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjRkM2UxNTU2NmQ1MDkzMjA4YzU4MmI5ZTFjNDA0YTYzNzM0MjM4YzcwZjhkZjg1ZTRlOGRjNDk0OTk3NWVlOTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjNjMzQ4NWJmMTY4YmM4NDRiMjk2YjYzYTQxOTg1MzMxMzQ4MTZmM2I4NWFlYmVlNTU3NmE2ODYxYjUyYTdiZTIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2815-L2931",
+          "version": "repo-lines-v1:sha256:eb72521235fe80d26c3ee84974a07dba4c6c102f94ee38bc7c6dc0636a526214:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiIyMzQ3ZTI1NWJlMzNmZjU4NWEwOTBkMWRhNzk5ZWQyMDZjY2M3MjViZWE2MTc3ZTdmNjI1NzAyNzBkODU2ZGU2IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI4YmJkNjE0MGEyYmEyMTgzYjEwOTk5MmU4ZDhhOTYwMDk3MjdkNGIzYjVhMThjYTRkZTEwOWEyNjU4NzY2ZWRmIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI0ZDNlMTU1NjZkNTA5MzIwOGM1ODJiOWUxYzQwNGE2MzczNDIzOGM3MGY4ZGY4NWU0ZThkYzQ5NDk5NzVlZTk1IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI1NzcxOWM1Mzc5NWNkZTI1OGViY2QwZjI4MGEyNjU5NTRjMjFiOTI2OTA1MGU4NDc5MDIzOTRiMDc2NWNlMjNiIn0"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L5668-L5820",
+          "version": "repo-lines-v1:sha256:36031bd9b217a1138f19f884e91a7de36e4cf0d31c437dcbc9237e283c59dac1:eyJzZWxlY3RlZExpbmVDb3VudCI6MTUzLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI3M2Y5OGVhZDgzNjU2MjE4YTkzMDU5NTAxZjg2MmE0ODM1MDc5MzQ2YmU4MWE2MmQ2NzhhMmFmOTY2ZjA4NzM0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJiMjU2ZjRhYjQ5NTRkMzQxZDkyNGFiNjZlZGQ0MDBkYmIzYmEzNWRiYTMwYTdhMDUzMTlhYWMzOTgxZDFkZTJkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZDdiMWY3MTQyZjBiMDZhMmRiZjI3MDJkN2E3MGJkZTc1YWM1ODRiM2M4YzQ4OGVlYTA2Yzk4NDM4NDgwNjA2In0"
+        }
+      ]
+    },
+    {
+      "id": "claim_bcca5056a1fe4bf8ba8e123bbba1d493",
+      "statement": "GPUI and the menu-bar surface keep Route as one daemon command; Pending displays a bounded concrete PID/process blocker or exact typed fallback reason and tells the user what must close or recover, while terminal completion applies the projection and says the app can be reopened.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift#L32-L203",
+          "version": "repo-lines-v1:sha256:b0124179d068b95d226823895f1c59261664941518aa93c39583cf4fedfe5490:eyJzZWxlY3RlZExpbmVDb3VudCI6MTcyLCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiJlODhlYzkxZDBiMzkwNDIwYTM2NWUxOGZiYWQwMWFmY2Y2NmY3ZWVmMDQ0OTMwYThkMTVmMDY3MjA0YmQwNjk5IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJmMjk2NDA3OWMzYzVjODE1MjBlZjMzYTJiOWQyZTE1YTFiODRkNzI4MGRiODU5MGRjZDY1NzQ3ZTNlMDEyYTQwIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiIwYWYzZDM2YmQ1MWZkN2FmNTU4MDdiYTZhZDM0MDRkMjUyZTY0YTJiZDg5MTI3ZTZkMWY4ZTM2NjYxYjQ0ZGU4In0"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift#L37-L89",
+          "version": "repo-lines-v1:sha256:4690c10a2831755a867ae233b89503dec75d8acf3bb177da020b6459a15096ed:eyJzZWxlY3RlZExpbmVDb3VudCI6NTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRlNDExOWQ2MTcwMDY2Nzk2ZDQyODAzNTk1MDY3NWU4MTI2ZDU5NDgwY2IzODg0ZjhhMmE3NjI3YTA2YjIwZjQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjJhOGUyNjhhMTA2YTNhMzZlMWZhNDQ0ZGIzMGQwMGQ4MTFlYzZmNjVmZDRjNzViYmJkZTRiYzE1Y2FkNjc5M2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjY0ZmM1N2EzMWYxOWFhMzc1OTk2MWMzN2JmZGQ1MzNiZjNkNjBmYmEwNDZlZGNlNjVkYjIxZWM3N2NmYzI0NjUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjQwOGM1OWI5MjRjOGZhNTM0MjFhYTgzYTJjYzI2ZDBjMTNmY2U2MjZmM2JiYTEwZTFkNmZkNjg4MDFmZWZiNDUifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/accounts.rs#L397-L409",
+          "version": "repo-lines-v1:sha256:998abde0a858eb8a572587ab9a473c209820f0a411bc638599580d52362efb44:eyJzZWxlY3RlZExpbmVDb3VudCI6MTMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjgwMjk2YTNjMDQ3OGYxMTMxZDFjMzQ1ODI0YjA5ZDhjMTMwZDg3NmFkM2Q5Nzc2NjY4ZDIyNjE1YzkzNWIwMzIiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjAxMjliNmZkMWI1M2Y4MzU5MGExNTU5YWI1MWFmNDFiZTU4YjZkOWY0MTEwMGQyMGU1YzI4OWJhZTYwYmFjNmQiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjJiYThkYjU0ZjQ2YTI4OTcxOGJhY2U0ZGFjODgxYzUxNmY5NDU3NTQ5MzNlNTc1MjY1YzAzMGJmZTA3ZDc3NjgiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6Ijg3NjE1N2U1ZjU5OWFlMjI3MDAxOWFiM2JhZjc4MWE4YWE1ZThjMGViOTBlMzk2Yzk4YzY1YzNkMmNlNTRjNzcifQ"
+        },
+        {
+          "resource": "repo://apps/decodex-gpui/src/shell.rs#L2903-L3130",
+          "version": "repo-lines-v1:sha256:f1ce16f3bcf12e44f488bdd18941636b21f6c3675f8dfb0d69060f6971a655c5:eyJzZWxlY3RlZExpbmVDb3VudCI6MjI4LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI4NzU4M2JjMGNjMDFmYTgyMmE5M2JlODg0ZjM3ZmJmODA5YjA5YjkxMDgwNWJkZjc2MDhhMmU0OGRkMjI0MGI0IiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI0MTJjYTM0NWNjZjc1YmY5YzA4MDZiY2U2OTViZThkZTgwOGI3OTk4NDI1MWE3YTU0ZDIwMmNmNjEwMWRkNDUxIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiI2OWVmM2Y0MDhkMzJmYjNhOWYwMTM3NzI1YjNiZjAyNWRkODE3NzhhNWZlMGUyMmNiZTNkMzRiNjNjZTVhNjI5IiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiI0ZDAxNzMyOTk1MDMzNTE1NmViOGYwNTcxMDYzMzMyMzZmMDZlOTE5ZDg4NTZjYjdlMjlmODI3NzExMjMzYTFhIn0"
+        }
+      ]
+    },
+    {
+      "id": "claim_8c1eacecfcaa4b958aa839230fe09e2d",
+      "statement": "Decodex does not kill or restart an external Codex process during account handoff; official app identities strictly block, a standalone CLI is ignored only with proved isolated CODEX_HOME evidence, and uncertain observations fail closed with a typed visible reason.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/shared_auth_coordinator.rs#L303-L789",
+          "version": "repo-lines-v1:sha256:01b2a65c9ef1e33c3941574d066c00477733a807ba76fe1b3c17448e43f16279:eyJzZWxlY3RlZExpbmVDb3VudCI6NDg3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI5NzI3MDc2YmZhMjUyYmE4NTFjYzViYzBlMWNjOGQ2ZmFmYzI3NjgxNDk3MGZkNzc0MjIzYzUyMjQ1OGFmYWRhIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiJmNGJkNTY2MWE4MDEyM2FiZGI1ZTMyMzM4OGVkMGQwNGMwYjBiMTJlNDUxOGM3MzM5Y2Y0MGNiZTY0YzQ5MGRjIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiIwOTUzOWJjMDE4NGY2YjM1NDc2YzM5ZjI5M2UwNDQzYzY5ZjA4ZWE1ZTkyZGQ4Mzc5ODgzNTgzMmRjYTI4YWRlIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJjZjQ3OWJhY2FiYWE4MmUzYzQ0OWRlYmEyNDYwN2E3YjZiYWY0MGYyNmM2ZDlkZjFmNzY4ODE0NTdkNmU3ZDZkIn0"
+        },
+        {
+          "resource": "repo://tests/scripts/test_vnext_architecture.py#L188-L220",
+          "version": "repo-lines-v1:sha256:ed57ffaf1af93e48d27be3b1fc736b01cc7343477e2441921550a4216fef444c:eyJzZWxlY3RlZExpbmVDb3VudCI6MzMsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjEyYmFiMzhhNzkwNDZmNDFiOGM1ZmQzYTNjNWI5ODYzY2I4YmU0NzQ4MTU2MjBlNDgzZTlhYTAzMWRkMTcwODkiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6ImYzNjRhZDA3OGQ0NzNkYmYxZmE1MmMwMjkwMGRiYzAwZWMyMWZlMjQ4OTMxZTA0MDE1MjE4MTYxZTdhZDM5Y2QiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImM2ZDU4OWVmZDk0NDhmNmUyNDY4ZTlkYzQyMWI3N2ZkYzRhZThhNWQwYmVhMjJkZGIxNDg0MmQ0ZmVmYWM3ZTkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjJkMjE0YzY4ZGJlZDYzMzE2ZmZjMzVhNWE3MDM2NjllMGMyZTJkMDdlOWIzY2UxNjY5OTY5M2QzNTg3NWYxZjgifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_b5cc0287ee8e4a7b9fb95f79bcd9c603",
+      "statement": "A Quick Task refresh callback accepts an already-imported credential only when it is a strictly newer successor for the same provider and the original process generation remains active.",
+      "evidence": [
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L1940-L1985",
+          "version": "repo-lines-v1:sha256:03361ee355660422b22e69254d6f31e75ef0cbd76c966702723b3fae24ec38ab:eyJzZWxlY3RlZExpbmVDb3VudCI6NDYsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6IjZiZTZkYjExMTFhMDczNmE3ZDhiMTkzZjE5MTBmNDA2NWNmNzg3NGVkN2NlMmM3ZWJhYzBkYzRmYTliN2E1OGQiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjFmMjc2Y2VkOTkwOGZlMDI4NzRkOGZhMGQyZTY0ZDVjM2VmMTQ3YTNhYmRjN2YwNmY4ZTE1ZTUwMzNjM2VlNmYiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImNhMThkNGQzNjIwNTMyNWE4OTc2MzEwNmFjOTE4ZjQ4M2E5NTY4MzcxZmE1M2E1NjQ0OWQ5OTc5YzYzNDA0NDIiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAxYmYwNDUxMDc3MzRlMmZkZGRiNTUzYzFiNTY3NGU5ZDhhZDA0NmVkMWVmZTZkYjZhZDM4MDE4ODU4YzBmMDMifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L2934-L2955",
+          "version": "repo-lines-v1:sha256:96bc2ed1d3a6154a9e3a037052bbe4cefe5d9ed21104a55c8a473ec5ce295183:eyJzZWxlY3RlZExpbmVDb3VudCI6MjIsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImY5ZDVlMTQzN2ExOTAwNjk4NzM3ODYyMjMzMmYyYTVkY2IzMzIxZDFlMTdiYzYzNzM0ZDE1MjliNGUwMTRjOWMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjZjNWM5NzhmYzUwNmVhZjFlOWFjNDBmYWE0YmE1ZjU4Mjg0NWNlZDE0ZWI0NDg1MzdjOTRmYjE1ZTZlYTYyZmUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjY1ZTNjNmM5MzUwYTg5NTJjZmRmZTk2MTBjMWY3MGMwNzM5YTkyY2NiNzc4MTgzM2VlY2E0ODU5YTNkOTg1MGYifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L4647-L4664",
+          "version": "repo-lines-v1:sha256:5db3bdc1a0ca3f07592e890d957b0d499401e0cd707c080977d43fc7e2076b18:eyJzZWxlY3RlZExpbmVDb3VudCI6MTgsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRhOTYzMjVjYjUxYmFlYzliZmNiMDY3M2Q2Y2Q3YWY0NTJlZDVkZjI0NGU5YWE5YzNhMjAxMWI1ZDg0ODA3ZDMiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQxMmNhMzQ1Y2NmNzViZjljMDgwNmJjZTY5NWJlOGRlODA4Yjc5OTg0MjUxYTdhNTRkMjAyY2Y2MTAxZGQ0NTEiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImYyOTY0MDc5YzNjNWM4MTUyMGVmMzNhMmI5ZDJlMTVhMWI4NGQ3MjgwZGI4NTkwZGNkNjU3NDdlM2UwMTJhNDAiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjIzNjY1MGJlYTE3MDY4OWVmYzFiNGUwNTc4ZjFhNTUyM2I4ODQzMWFiNTUwN2JmNmYzNTdhYWU2OGFlNmQ0ZmIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-runtime/src/account_service.rs#L7804-L7824",
+          "version": "repo-lines-v1:sha256:63b67879b75dd26e6da8943a6f94aade880d9173bcb2d75f54f15887f54a280b:eyJzZWxlY3RlZExpbmVDb3VudCI6MjEsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImRkZjgzNTcwYTkwNjgwNGE0MDQyZjNjMjYwZmU3NGNiYmRhMDc2NjhmNTQ2Mzg2MjY0NDQwNTA1YmRiMGZkOWYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjY3Y2RhODJkYTYwNjIzOGUwNWU2MjM5OTU2OWM1ZWUwMzk5MzQxOTY0OGFlNWQ0M2EyYmY4Y2Q2MzQ3ZjgyNjMiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjozLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6IjgwODJhZmMzZTFkMmY0ODY0MDA4MDZhZTVlMDQ4ZGQ2YTY5NDRiOGQ5MDExODI4NmUwYTg3MzllMjYzYjIzNDkiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjUxMjU2OGQwZjc1MDQ0YjczNmVkMTg0YzllMmQ3NDhiMjRiZjNkMzNlMTVkYjNjMWRmZjFlOWQ1MmNjNzRkOTYifQ"
+        }
+      ]
+    },
+    {
+      "id": "claim_3359be68511c42479a5b6919a3921b57",
+      "statement": "The current exact local contract is protocol 2.11 with artifact cohort 7, which fences the required AccountRouteWaitReason shape across daemon, CLI, native bridge, and GUI.",
+      "evidence": [
+        {
+          "resource": "repo://apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift#L1-L34",
+          "version": "repo-lines-v1:sha256:4e863d5592f9025405ea9c364e0c320f508ce75170b9a9a4be6e89802a504107:eyJzZWxlY3RlZExpbmVDb3VudCI6MzQsImZpcnN0U2VsZWN0ZWRMaW5lSGFzaCI6ImE1OGEyZDdmYzIzNTUyOWMzYWJiMjVmNmUzZDA4N2I2NGE1YmJkMGRkZTU5OTgxMTMzNGU3NDkzNTAyMmQxMzYiLCJsYXN0U2VsZWN0ZWRMaW5lSGFzaCI6IjQ3ZGIwYmMzMTk2YTM1Mzg5MTZhNjAwNzc2NzcxYzhkNDA0NzZkZDc1YTQwYjU5M2YxMGUyYjQ0NjliMzU4NDkiLCJwcmVjZWRpbmdDb250ZXh0TGluZUNvdW50IjowLCJwcmVjZWRpbmdDb250ZXh0SGFzaCI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUiLCJmb2xsb3dpbmdDb250ZXh0TGluZUNvdW50IjozLCJmb2xsb3dpbmdDb250ZXh0SGFzaCI6IjAzZjU2NzQ1YjI2ZmIyMzc0ODBlMDYwZDFmYTgzMDlkYjA3ZTkzMzAzNTQyYmNjYjU0M2RhZmJkMmExM2YwODIifQ"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/lib.rs#L108-L116",
+          "version": "repo-lines-v1:sha256:53580d5cda74d1e06d80ddc27cc3d418b6c408c2c79fa52b0f2e1ec69c97884f:eyJzZWxlY3RlZExpbmVDb3VudCI6OSwiZmlyc3RTZWxlY3RlZExpbmVIYXNoIjoiN2I2ODEwNzM5MjdjZDE5YTY2N2ExN2YyYjZhMzlkNDBjOGU4YzkzOWRkMWU3OWRkZjE4MjE4YjM2NGEwYjZhNCIsImxhc3RTZWxlY3RlZExpbmVIYXNoIjoiYzkzNTRlYmE2ODEzNGY3YWU5ZGQwM2I4OTE1NjhjN2JhMjFmZGMwYzU4MTgyOTVmYTE2NTI2YTE1ZmU3ODM0MiIsInByZWNlZGluZ0NvbnRleHRMaW5lQ291bnQiOjMsInByZWNlZGluZ0NvbnRleHRIYXNoIjoiYjBjODVjMjJlZWNjYWY1ZGQxMGI2NTYyMWFkNWM1MTEwYzE5NTU5NzM5MWIwOTk0ZDhlODEzNTZhMjRjYmY0NiIsImZvbGxvd2luZ0NvbnRleHRMaW5lQ291bnQiOjMsImZvbGxvd2luZ0NvbnRleHRIYXNoIjoiOTY1YjA5NDkxMGM5NjczMTAxMzg2NTlmNmVlOGNjYzU2ZWViYWY4YTRmODU1ZmZlMGNiNjg1NzQxMGUwMTQ1NCJ9"
+        },
+        {
+          "resource": "repo://crates/decodex-protocol/src/wire.rs#L1961-L2077",
+          "version": "repo-lines-v1:sha256:07ac20e237c480477d7188a30139921ed862a5c07687162572e194189f14f56a:eyJzZWxlY3RlZExpbmVDb3VudCI6MTE3LCJmaXJzdFNlbGVjdGVkTGluZUhhc2giOiI2ODgxYmUzNGIyN2FlNGMzZWQzY2RiNDQwMDI2MTllMjYzMmMzYzY4Nzk4ZDAwYTMwMjRlNWYwMmYyZWJiM2FkIiwibGFzdFNlbGVjdGVkTGluZUhhc2giOiI2N2NkYTgyZGE2MDYyMzhlMDVlNjIzOTk1NjljNWVlMDM5OTM0MTk2NDhhZTVkNDNhMmJmOGNkNjM0N2Y4MjYzIiwicHJlY2VkaW5nQ29udGV4dExpbmVDb3VudCI6MywicHJlY2VkaW5nQ29udGV4dEhhc2giOiJhMDg5NDc3MjI4ZjRhNmNiM2QyMmY0YjZmYmNlMzJlZGFkNjc1NjQwM2QwODhmYzM1MzM4ZGRlZDhmY2I3YzRkIiwiZm9sbG93aW5nQ29udGV4dExpbmVDb3VudCI6MywiZm9sbG93aW5nQ29udGV4dEhhc2giOiJmOThhMjZiNDUxYTUwMGFmYTg5YThmODg2OTUyMzUxYWM5ZjU2ZmU3Mzg0YTVmODBiNmQyZjU5NGMwOGIyZTUyIn0"
+        }
+      ]
+    }
+  ],
+  "verification": {
+    "by": "openwiki/0.4.2",
+    "at": "2026-08-27T10:25:21.174Z"
+  }
+}

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,7 +1,7 @@
 {
-  "updatedAt": "2026-08-26T21:16:55.754Z",
+  "updatedAt": "2026-08-27T10:36:37.630Z",
   "command": "update",
-  "gitHead": "526ad15027311988c7ef77ddb9908f03c57f125b",
+  "gitHead": "06be9b19639a619c83e4ccef04b629b555950da3",
   "model": "host-agent/codex",
   "status": "complete",
   "language": "en"

--- a/openwiki/evidence/sqlite-local-product.md
+++ b/openwiki/evidence/sqlite-local-product.md
@@ -10,6 +10,19 @@ openwiki:
   test_paths: [database/src/desktop_settings.rs, tests/scripts/test_vnext_architecture.py, tests/scripts/test_account_login_architecture.py, apps/decodex-gpui/src/accounts.rs, apps/decodex-gpui/src/account_profile.rs, apps/decodex-gpui/src/desktop_settings.rs, apps/decodex-gpui/src/shell.rs, scripts/macos/test_decodex_app_stage.sh]
   invariants: [decodexd is the only normal SQLite owner.; GPUI and CLI are protocol-only clients.; Decodex.app is the only macOS GUI bundle.; The optional menu-bar item runs in the GPUI process.; Persistent desktop settings are revision-guarded in SQLite.; Reset Card consumption has no GUI claim without daemon-owned restart discovery.]
   validation_commands: [python3 scripts/vnext/local_database_gate.py, python3 -m unittest tests/scripts/test_vnext_architecture.py tests/scripts/test_account_login_architecture.py, cargo +stable test -p decodex-protocol --all-targets, DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo +stable test -p decodex-gpui --all-targets --features visual-capture, scripts/macos/test_decodex_app_stage.sh]
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
+sources:
+  - id: openwiki-source-98e7b23c4cc276d20fcb4649
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+  - id: openwiki-source-1291f5243fa6c9cb52149bda
+    resource: repo://apps/decodex-gpui/src/shell.rs
+  - id: openwiki-source-cc0439b23243c3697ba49199
+    resource: repo://crates/decodex-protocol/src/lib.rs
+  - id: openwiki-source-268229e2b9f21dae93c32513
+    resource: repo://crates/decodex-protocol/src/wire.rs
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
 ---
 
 # SQLite Local-Product Evidence
@@ -48,11 +61,18 @@ contract without requiring a live macOS window session.
 
 ## Protocol and GPUI evidence
 
-Protocol 2.10 with artifact cohort 6 adds one desktop-settings query, command, result,
-and event. The command requires the current positive revision. `decodexd` commits the
-SQLite change and publishes one complete `DesktopSettingsDto`. GPUI's retained-session
-controller routes only exact query, receipt, result, and event identities before the
-Settings presentation changes `NSStatusItem` visibility.
+Protocol 2.11 with artifact cohort 7 keeps the desktop-settings query, command, result,
+and event and adds one closed, credential-negative `AccountRouteWaitReason` to every Pending
+Route. Concrete external blockers carry only a bounded PID, `ChatGPT` or `Codex` identity,
+and shared-versus-unknown auth-home evidence. Other variants name process-observation,
+account-readiness, source-stability, source-availability, or projection-readback waits. The
+cohort fence prevents older daemon, native bridge, and GUI artifacts from accepting this new
+exact wire shape.
+
+The desktop-setting command still requires the current positive revision. `decodexd` commits
+the SQLite change and publishes one complete `DesktopSettingsDto`. GPUI's retained-session
+controller routes only exact query, receipt, result, and event identities before the Settings
+presentation changes `NSStatusItem` visibility.
 
 Focused GPUI tests prove:
 
@@ -61,6 +81,8 @@ Focused GPUI tests prove:
   commands;
 - quota rows render only current provider observations;
 - account profile is one exact selected-account query;
+- Pending Route results reject malformed blocker/readiness shapes and render the current PID or
+  exact typed fallback reason in both desktop surfaces;
 - desktop-setting commands accept only the matching daemon result; and
 - the simulated menu-bar host owns one in-process item.
 

--- a/openwiki/operations/local-database.md
+++ b/openwiki/operations/local-database.md
@@ -2,6 +2,31 @@
 type: "Reference"
 title: "Local Database Operations"
 openwiki_generated: true
+sources:
+  - id: openwiki-source-35eca69c3013fea5ba400887
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
+  - id: openwiki-source-cc0439b23243c3697ba49199
+    resource: repo://crates/decodex-protocol/src/lib.rs
+  - id: openwiki-source-268229e2b9f21dae93c32513
+    resource: repo://crates/decodex-protocol/src/wire.rs
+  - id: openwiki-source-f4724776aade804ebf838e2e
+    resource: repo://crates/decodex-runtime/src/account_service.rs
+  - id: openwiki-source-a09c082db4ad1473c4d1e557
+    resource: repo://crates/decodex-runtime/src/application.rs
+  - id: openwiki-source-a67672a943dfe221574b2501
+    resource: repo://crates/decodex-runtime/src/shared_auth_coordinator.rs
+  - id: openwiki-source-a89c2fe187b4f7bf37dc206d
+    resource: repo://database/migrations/0009_durable_account_route.sql
+  - id: openwiki-source-7fe11c5074beaf147aac2be4
+    resource: repo://database/migrations/0010_pending_account_route_progress.sql
+  - id: openwiki-source-63bea5f3704fcd7e4b161192
+    resource: repo://database/src/account_lifecycle.rs
+  - id: openwiki-source-76081c1a47ca8cf32593de34
+    resource: repo://scripts/macos/test_decodex_app_stage.sh
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
 ---
 
 # Local Database Operations
@@ -46,17 +71,40 @@ migration ledger.
 Schema version 9 adds one nullable, credential-negative `request_json` column to command
 receipts. Only a reserved `route_account` receipt must contain this value. The partial index
 supports bounded startup recovery. Schema version 10 adds nullable `progress_json` for decoding
-legacy pending Route progress and a unique partial index for at most one reserved receipt. These
-columns and constraints are compatibility storage: current Route is synchronous and does not
-normally create Pending state. On daemon startup, the runtime performs the one bounded legacy
-Route recovery pass before accepting protocol commands.
+pending Route progress and a unique partial index for at most one reserved receipt. Pending is a
+current accepted handoff state when an external Codex process may still own the old refresh-token
+family or when the exact shared-auth source is not stable enough to replace. The daemon retains the
+original request, account and routing revision fences, and idempotency receipt. Startup and the
+bounded background recovery loop reclaim that same receipt only after re-reading those fences and
+the current external Codex liveness state. Creating Pending immediately wakes the recovery loop.
+While any Pending Route exists, the loop checks every 100 milliseconds; without Pending work it
+uses a one-second idle cadence. A long Pending state therefore means that liveness still observes
+an auth-owning Codex process or another readiness fence, not that the timer is slow. Decodex does
+not terminate or restart Codex.
+
+Pending carries one closed operator reason. A concrete process wait lists at most eight positive
+PIDs, identifies each as ChatGPT or Codex, and states whether the normal shared auth home is proved
+or unknown. Official ChatGPT/Codex bundle executables always block. A standalone Codex CLI is
+ignored only when same-UID process metadata proves that its effective `CODEX_HOME` is an existing
+canonical directory distinct from the normal shared home. If macOS withholds environment metadata,
+the CLI remains a visible `auth home unknown` blocker. Other reasons name account readiness,
+shared-source stability or availability, process-observation availability, or atomic projection
+readback. Operators should quit the listed process or repair the displayed readiness boundary;
+they should not wait for a longer timer.
+
+After a Route projects an account, ordinary same-account refreshes remain journaled account
+operations. A successful Decodex refresh conditionally mirrors its successor to the exact shared
+auth source. If Codex rotates that source first, Decodex imports the valid non-older Codex bundle as
+the winner through a new deterministic credential rotation; it does not write the losing refresh
+token back to `auth.json`. Receipts and progress remain credential-negative throughout this
+convergence.
 
 Schema version 11 adds the singleton `desktop_settings` table. `decodexd` is its only
 reader and writer. The positive revision guards the **Show Decodex in the menu bar**
-preference; GPUI reads and changes it only through protocol 2.10.
+preference; GPUI reads and changes it only through protocol 2.11.
 
 The account-login restoration repair adds no schema migration. The current protocol uses exact
-artifact cohort 6. On startup, the daemon can compensate only the exact pre-repair
+artifact cohort 7. On startup, the daemon can compensate only the exact pre-repair
 `StoreApplied` enrollment collision described by the account-lifecycle contract; it deletes the
 proved orphan credential and cancels that operation. Installation therefore upgrades the signed
 daemon, CLI, and GPUI application as one cohort while retaining the pre-install database rollback
@@ -86,7 +134,7 @@ The macOS installer:
    `~/.decodex` as its stable working directory;
 5. starts the daemon; and
 6. runs doctor and account-list readback through the installed CLI, which proves the
-   running daemon uses the same protocol 2.10 and artifact cohort 6.
+   running daemon uses the same protocol 2.11 and artifact cohort 7.
 
 It does not install former server store, create roles or databases, manage a socket directory, or
 resolve a database password.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -7,17 +7,35 @@ openwiki:
   roles: [repository, architecture, workflow]
   change_kinds: [navigation]
   source_paths: [crates/decodex-runtime/src/quick_task.rs, crates/decodex-protocol/src/quick_task.rs, database/src/lib.rs]
-verified:
-  - by: openwiki/0.4.0
-    at: 2026-08-26T21:13:26.303Z
 sources:
+  - id: openwiki-source-98e7b23c4cc276d20fcb4649
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+  - id: openwiki-source-a5028d07257122cad396830e
+    resource: repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
   - id: openwiki-source-e3cbf7660b5f77bbecd437c5
     resource: repo://apps/decodex-gpui/src/bin/factory_visual_capture.rs
   - id: openwiki-source-4d0807cef0e852e926ce0974
     resource: repo://apps/decodex-gpui/src/factory_surface.rs
   - id: openwiki-source-31df4748243df01f1137f62f
     resource: repo://apps/decodex-gpui/src/program_graph.rs
-generated: {by: "codex", at: "2026-08-26T21:13:26.303Z"}
+  - id: openwiki-source-1291f5243fa6c9cb52149bda
+    resource: repo://apps/decodex-gpui/src/shell.rs
+  - id: openwiki-source-cc0439b23243c3697ba49199
+    resource: repo://crates/decodex-protocol/src/lib.rs
+  - id: openwiki-source-268229e2b9f21dae93c32513
+    resource: repo://crates/decodex-protocol/src/wire.rs
+  - id: openwiki-source-f4724776aade804ebf838e2e
+    resource: repo://crates/decodex-runtime/src/account_service.rs
+  - id: openwiki-source-a09c082db4ad1473c4d1e557
+    resource: repo://crates/decodex-runtime/src/application.rs
+  - id: openwiki-source-a67672a943dfe221574b2501
+    resource: repo://crates/decodex-runtime/src/shared_auth_coordinator.rs
+  - id: openwiki-source-a9515596a887b940d069c74e
+    resource: repo://tests/scripts/test_vnext_architecture.py
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
 ---
 
 # OpenWiki Quickstart
@@ -101,15 +119,25 @@ ProviderAttempt state, and exact command receipts. Missing or stale quota data m
 unknown capacity; it is not fabricated exhaustion. A current known depleted fact still
 blocks that account.
 
-Account Route is one daemon-owned synchronous command coordinated by `decodexd`'s
-`SharedAuthCoordinator`. The command reads the exact shared-auth source, reconciles a known source
-rotation, refreshes the target when required, performs exact-source CAS/write/readback, and commits
-fixed routing only after those checks succeed. Route has no Codex process/liveness wait and no
-normal `AccountRoutePending`. Passive shared-auth following uses stable metadata observations to
-import only same-account non-older rotations into daemon credentials; it never writes `auth.json`.
-`AccountRoutePending` remains only for legacy receipt decoding and one-time startup recovery. The
-optional in-process menu-bar item has no Route workflow state. `decodexd` never controls the Codex
-process.
+Account Route intentionally synchronizes the selected Decodex account to shared Codex auth. One
+daemon-owned `SharedAuthCoordinator` observes the exact source and external Codex liveness. A
+cross-account Route remains credential-negative Pending while a running or uncertain Codex process
+can still own the previous refresh-token family. After quiescence, the daemon refreshes the target
+when required, performs exact-source CAS/write/readback, and commits fixed routing through the same
+receipt. Decodex never terminates or restarts Codex. While Pending, the app displays either a
+bounded ChatGPT/Codex PID blocker or one exact typed process, readiness, source, or readback reason.
+Official app executables strictly block. A standalone CLI is ignored only when best-effort same-UID
+metadata proves an isolated canonical `CODEX_HOME`; unknown home evidence stays visibly fail-closed.
+The terminal result says that the synchronized account is ready and the app can be reopened.
+Creating Pending immediately wakes recovery, and active Pending work is checked every 100
+milliseconds; a long wait means that the displayed gate remains open, not that recovery is using
+its one-second idle cadence. Protocol 2.11 and artifact cohort 7 fence this exact diagnostic shape
+across the daemon and desktop clients.
+
+Same-account refresh uses a separate live convergence rule. Decodex conditionally mirrors a
+successful successor only from the exact projected source. If Codex rotates first, Decodex imports
+the valid non-older winner without a second provider call and never restores the losing refresh
+token. Stable passive following applies the same non-older same-account rule for later rotations.
 
 The runtime keeps the mature Codex app-server protocol and safety harness. It does not
 replace Codex with a new agent kernel. It preserves exact account binding, pre-spawn

--- a/openwiki/specs/account-lifecycle-authority.md
+++ b/openwiki/specs/account-lifecycle-authority.md
@@ -9,8 +9,29 @@ openwiki:
   source_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/application.rs, database/migrations/0010_pending_account_route_progress.sql]
   symbols: [SharedAuthCoordinator, AccountService::route_account_command, AccountService::follow_shared_auth_once, recover_pending_account_routes_once]
   test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs]
-  invariants: ["Route is one synchronous daemon command with exact shared-auth source read, exact-source compare-and-swap projection, and exact readback before routing commit.", "Passive shared-auth following imports only a same-account non-older managed rotation and never writes auth.json.", "AccountRoutePending is compatibility state for legacy decode and one-time startup recovery, not normal Route execution.", "UI clients submit Route intents and render authoritative results; they do not control Codex processes."]
-  validation_commands: ["cargo test -p decodex-runtime account_service::tests::cross_account_route_is_synchronous_even_when_codex_may_be_running", "cargo test -p decodex-runtime account_service::tests::stable_known_account_same_expiry_rotation_imports_once_without_provider_work", "cargo test -p decodex-runtime shared_auth_coordinator::tests"]
+  invariants: ["Cross-account Route waits for external Codex quiescence before exact-source compare-and-swap projection and routing commit.", "A successful same-account Decodex refresh mirrors its successor to the exact shared source; source drift adopts a valid non-older Codex winner.", "Passive shared-auth following imports only a same-account non-older managed rotation.", "AccountRoutePending is a normal credential-negative accepted handoff state.", "UI clients submit Route intents and render authoritative results; they do not control Codex processes."]
+  validation_commands: ["cargo test -p decodex-runtime account_service::tests::live_cross_account_route_waits_for_quiescence_then_follows_same_account_rotation", "cargo test -p decodex-runtime account_service::tests::projected_refresh_mirrors_success_and_adopts_a_concurrent_codex_winner", "cargo test -p decodex-runtime account_service::tests::quick_task_callback_accepts_only_a_newer_same_provider_sqlite_successor", "cargo test -p decodex-runtime shared_auth_coordinator::tests"]
+sources:
+  - id: openwiki-source-98e7b23c4cc276d20fcb4649
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+  - id: openwiki-source-a5028d07257122cad396830e
+    resource: repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+  - id: openwiki-source-1291f5243fa6c9cb52149bda
+    resource: repo://apps/decodex-gpui/src/shell.rs
+  - id: openwiki-source-f4724776aade804ebf838e2e
+    resource: repo://crates/decodex-runtime/src/account_service.rs
+  - id: openwiki-source-a09c082db4ad1473c4d1e557
+    resource: repo://crates/decodex-runtime/src/application.rs
+  - id: openwiki-source-a67672a943dfe221574b2501
+    resource: repo://crates/decodex-runtime/src/shared_auth_coordinator.rs
+  - id: openwiki-source-63bea5f3704fcd7e4b161192
+    resource: repo://database/src/account_lifecycle.rs
+  - id: openwiki-source-a9515596a887b940d069c74e
+    resource: repo://tests/scripts/test_vnext_architecture.py
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
 ---
 
 # Account Lifecycle Authority
@@ -175,7 +196,7 @@ The commands are deterministic:
 | --- | --- |
 | `enable_account` | If the expected account revision is current, set `enabled=true`. Change only the account revision when the value changes. |
 | `disable_account` | If the expected account revision is current, set `enabled=false`. Block new admission immediately. Do not terminate or rebind existing work. |
-| `route_account` | Under current routing and target Account revisions, synchronously read the exact shared-auth source, reconcile a known source rotation, refresh the target when required, perform exact-source CAS/readback, and then commit fixed mode plus the Route receipt. Preserve account order. Legacy pending receipts are compatibility input for startup recovery only. |
+| `route_account` | Under current routing and target Account revisions, read and reconcile the exact shared-auth source. If an external Codex process may still own another account, retain one durable Pending receipt. After quiescence, refresh the target when required, perform exact-source CAS/readback, and then commit fixed mode plus the same Route receipt. Preserve account order. |
 | `set_balanced_selection` | If the expected routing revision is current, set mode `balanced` and clear the fixed target. Preserve account order. |
 | `set_account_order` | If the expected routing revision is current, replace the order with one complete duplicate-free permutation of all non-tombstoned Account UUIDs. Preserve mode and a valid fixed target. |
 
@@ -200,45 +221,62 @@ behavior is accepted later.
 ## Daemon-owned Route and shared Codex auth
 
 `RouteAccount` is the only public fixed-account action. It is coordinated by one daemon-wide
-`SharedAuthCoordinator`, installed in `AccountService`; no second coordinator or client-side
-Route state machine exists. `AccountService::route_account_command` is synchronous at the
-command boundary: it takes the routing lock, checks routing and target revisions, performs an
-exact shared-auth source read, reconciles a known source rotation, refreshes the target when
-needed, performs the exact-source CAS projection, reads the result back, and only then commits
-fixed routing and the Route receipt. Tokens remain inside the daemon. Balanced selection and
-account order remain separate policy commands.
+`SharedAuthCoordinator`, installed in `AccountService`; no client owns a credential or a
+shared-auth writer. The command takes the routing lock, checks the routing and target revisions,
+and waits for a stable shared-auth source. It reconciles a known source-account rotation before it
+changes ownership.
+
+If shared auth names another account and an external Codex process may still be running, Route
+stores one credential-negative `AccountRoutePending` result in the original receipt. It does not
+refresh the target, change fixed routing, or write `auth.json`. A bounded startup and background
+recovery loop rechecks the same request, account and routing revisions, account readiness, and
+external Codex liveness. A newer Route can supersede the pending target through the existing
+receipt rules. Deferring Route stores a wake permit for the recovery loop. Active Pending work is
+checked every 100 milliseconds, while the no-Pending idle cadence remains one second. A long
+Pending state means that conservative liveness still sees an auth-owning Codex process or another
+readiness fence; it is not caused by a long retry timer.
+
+The liveness readback is structured rather than one opaque boolean. Official ChatGPT and Codex
+bundle executables are strict shared-home blockers. A daemon-descended app-server uses Decodex's
+external-token path and is excluded. For an independent Codex CLI, macOS process metadata can prove
+an explicit effective `CODEX_HOME`: an existing canonical home distinct from the normal shared
+home is isolated and does not block. Missing, relative, unreadable, non-canonical, or withheld home
+evidence remains fail-closed. The bounded public blocker projection contains only a positive PID,
+ChatGPT-or-Codex identity, shared-or-unknown home evidence, and an omitted count; it carries no
+process path, environment value, or credential.
+
+After external Codex is quiescent, Route refreshes the target when required, rechecks that the
+shared source did not change, and performs an exact-source compare-and-swap projection. The writer
+uses a same-directory mode-`0600` temporary file, synchronization, atomic rename, exact readback,
+and parent synchronization. Fixed routing and the terminal Route receipt commit only after the
+projected account revision and digest agree. Decodex never terminates, signals, or restarts Codex.
 
 Passive shared-auth following is a different loop. `follow_shared_auth_once` uses the
 coordinator's stable two-equal-metadata observation and imports only a known, same-account managed
 rotation whose credential is not older than the stored bundle. It updates daemon credentials
-through the normal account journal but never writes `~/.codex/auth.json`; absent, unmanaged,
-ambiguous, unstable, or unavailable sources are not treated as logout or Route completion.
+through the normal account journal. Absent, unmanaged, ambiguous, unstable, or unavailable sources
+are not treated as logout or Route completion.
 
-Normal Route has no Codex process/liveness wait and does not return `AccountRoutePending`. If
-shared auth already names the target and its exact credential bundle is already stored, the daemon
-can reconcile credentials and routing without rewriting `auth.json`. A cross-account projection
-still uses the exact-source CAS writer and its source/readback safety checks. A source change or
-failed readback fails the command before fixed routing is committed.
+After Route, the projected account has one shared refresh-token family. Before Decodex performs a
+provider refresh, it reads the exact shared source. A different same-account bundle that is valid
+and not older wins immediately and enters SQLite through a deterministic successor operation. If
+the shared bundle exactly matches SQLite, a successful Decodex refresh conditionally projects its
+successor with the captured source version. Exact readback then selects one result:
 
-`AccountRoutePending` and `AccountRoutePendingDto` remain only for decoding older durable
-receipts and the one-time startup compatibility pass in `recover_pending_account_routes_once`.
-They are not a normal waiting state, a client retry workflow, or a Codex liveness mechanism. The
-legacy receipt can be reclaimed and completed when its exact command identity and fences are
-recoverable; a newer explicit target may still produce the compatibility `route_superseded`
-result. The protocol and schema retain these types and columns so older pending receipts can be
-decoded safely.
+- the Decodex successor is current, so the callback can use it;
+- Codex wrote a valid non-older successor first, so Decodex imports that winner without a second
+  provider refresh;
+- the old shared bundle is still present, so Decodex retries its exact projection once; or
+- the source is conflicting, so the refresh fails closed and no losing token is written.
 
-The exact-source writer rejects an ambiguous `CODEX_HOME`, symbolic links, path drift, wrong
-ownership, wrong link count, and group- or other-writable ancestors. It creates one same-directory
-mode-`0600` temporary file, synchronizes it, atomically renames it over the exact target, reads
-back the exact account binding, and synchronizes the parent. Same-binding replay is successful
-without rewriting the file.
-
-The projection affects future Codex launches and new app-server processes; it does not hot-switch
-an already running Codex process. GPUI and CLI are protocol-only clients: they submit one Route
-intent and apply one authoritative result. They do not read credentials, write shared auth,
-refresh providers, own retry state, or control Codex processes. `decodexd` never starts, stops,
-signals, rebinds, or otherwise controls the Codex process.
+This same-account arbitration can run while Codex is active because provider identity, previous
+binding, current binding, and source version are exact. It is not authority for a cross-account
+hot switch. GPUI and CLI submit one Route intent and render Pending or the authoritative terminal
+result. They never receive credentials or control a Codex process. Pending carries one closed wait
+reason: concrete external blockers, process-observation unavailable, target readiness, shared-auth
+stabilizing or unavailable, or projection readback. The desktop and menu-bar surfaces display the
+current PID/reason and tell the user what must close or recover. After terminal Route, they tell the
+user that the synchronized account is ready and the app can be reopened.
 
 ## Account operations
 
@@ -275,11 +313,13 @@ an exact store write can be committed. A provider request with no proved store w
 not replayed unless the provider has an accepted idempotent result-readback contract.
 Otherwise, the account becomes `reauth_required`.
 
-Every ordinary committed refresh reads the exact persisted successor bundle. Route-internal
-refreshes suppress intermediate shared-auth writes: the single `SharedAuthCoordinator` owns source
-readback and the compound Route owns one final fail-closed exact-source CAS projection. An
-unreadable or changed identity is not overwrite authority. Projection failure does not undo or make
-the provider effect ambiguous, but it prevents fixed routing from committing.
+Every committed refresh reads the exact persisted successor bundle. Route-internal target refresh
+does not publish an intermediate bundle because the compound Route owns the final cross-account
+projection. An ordinary refresh records the shared source version only when that source is the
+exact current account bundle. It commits the provider result to SQLite, conditionally mirrors the
+successor, and then resolves the exact shared readback. A concurrent valid Codex successor becomes
+a deterministic additional credential rotation. An unreadable, older, or conflicting bundle is
+not overwrite or callback authority.
 
 Logout disables new launch admission and rejects with `account_in_use` while an active
 ProcessGeneration or unsettled ProviderAttempt is bound to the account. It then deletes
@@ -334,8 +374,8 @@ one-time code, plus closed session state. On successful login, the daemon opens 
 `auth.json`, verifies the exact provider identity and current account revision, journals an
 existing-account `Refresh`, and applies only the immediate next HostCredentialStore version by
 compare-and-swap. The temporary home is removed on success, failure, cancellation, timeout, or
-bridge destruction. Ambient `Use in Codex` remains a separate explicit projection command;
-neither action implies the other.
+bridge destruction. Account login only installs or repairs a Decodex credential. The explicit
+Route command is the separate action that synchronizes one installed account to shared Codex auth.
 Device polling reads one bounded structured error response. Only the closed pending-code set can
 continue polling; another structured 403 or 404 is a terminal typed device-authorization
 rejection, not permission to wait until the session timeout. The native failure tells the user to
@@ -362,6 +402,13 @@ its intent, launch-manifest identity, prepare command, and strict readback
 with the canonical initial account revision, credential version, credential fingerprint,
 provider binding, and runtime-negotiated account-capability profile. These fields are immutable
 launch facts. Same-account callback rotation does not rewrite them.
+
+A refresh callback first rechecks the active generation and its immutable initial binding. If the
+Account Registry still has that binding, the ordinary refresh and shared-source arbitration run.
+If a passive import or concurrent winner already advanced the registry, the callback can return
+only a strictly newer credential for the same provider identity and a non-older Account revision.
+A different provider, an equal or older version, or a non-active generation fails closed. The
+ProcessGeneration record remains the original launch fact.
 
 Immediately before spawn, the Account Service must read the exact HostCredentialStore
 metadata and compare every field with the ProcessGeneration intent and Account Registry.
@@ -597,7 +644,7 @@ surface.
 | Account lifecycle | Enrollment/import, stable derived alias, list, enable/disable, logout, refresh/CAS, and startup reconciliation | Same contract across all supported hosts plus full fault acceptance |
 | Routing | Initial eligible quota-aware fixed/balanced selection and explicit manual recovery | Automatic same-thread fallback and all-depleted wake after their later gate |
 | Presentation | All-account Reset Card, quota, and bounded profile data | Full bounded usage and history presentation |
-| Explicit Codex auth | `Use in Codex` projects one exact account to shared auth without changing routing | Same fail-closed explicit contract on every supported host |
+| Explicit Codex auth | Route projects one exact account after quiescent handoff and commits fixed routing in the same receipt | Same fail-closed synchronized contract on every supported host |
 | Legacy authority | No watcher, helper, or credential environment input on normal startup | Same, across every supported installation |
 | Evidence | Two-account Mac flow with restart boundaries and package proof | Broader platform and adversarial matrix |
 

--- a/openwiki/specs/account-login-authority.md
+++ b/openwiki/specs/account-login-authority.md
@@ -9,8 +9,19 @@ openwiki:
   source_paths: [crates/decodex-account-login/src/lib.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-runtime/src/bootstrap.rs, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/lib.rs, crates/decodex-protocol/src/client.rs, crates/decodex-protocol/src/wire.rs, apps/decodex-gpui/src/account_login.rs]
   symbols: [AccountLoginManager, AccountLoginInstallAuthority, AccountService, AccountLoginClient, AccountLoginController, CURRENT_VERSION, CURRENT_ARTIFACT_COHORT, LoginHome]
   test_paths: [tests/scripts/test_account_login_architecture.py, crates/decodex-account-login/src/lib.rs, crates/decodex-protocol/src/account_login.rs, crates/decodex-runtime/src/account_login.rs, crates/decodex-runtime/tests/websocket_protocol.rs, apps/decodex-gpui/src/account_login.rs]
-  invariants: ["decodexd is the only runtime owner of provider authorization and credential installation.", "The login exchange is transient and memory-only; login status is not retained in database snapshots, events, or command payloads.", "Clients must negotiate exact protocol 2.10 and artifact cohort 6.", "Cancellation waits for provider cleanup and the worker join before returning terminal status."]
+  invariants: ["decodexd is the only runtime owner of provider authorization and credential installation.", "The login exchange is transient and memory-only; login status is not retained in database snapshots, events, or command payloads.", "Clients must negotiate exact protocol 2.11 and artifact cohort 7.", "Cancellation waits for provider cleanup and the worker join before returning terminal status."]
   validation_commands: ["python3 tests/scripts/test_account_login_architecture.py", "cargo +stable test -p decodex-account-login", "cargo +stable test -p decodex-protocol", "cargo +stable test -p decodex-runtime", "cargo +stable test -p decodex-gpui"]
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
+sources:
+  - id: openwiki-source-6230c010baca677fa60c32c1
+    resource: repo://crates/decodex-protocol/src/client.rs
+  - id: openwiki-source-cc0439b23243c3697ba49199
+    resource: repo://crates/decodex-protocol/src/lib.rs
+  - id: openwiki-source-268229e2b9f21dae93c32513
+    resource: repo://crates/decodex-protocol/src/wire.rs
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
 ---
 
 # Daemon-Owned Account Login Authority
@@ -65,14 +76,14 @@ The client implementation is `AccountLoginClient` in `crates/decodex-protocol/sr
 
 ## Protocol negotiation
 
-The current wire contract is protocol `2.10` exactly:
+The current wire contract is protocol `2.11` exactly:
 
 - `CURRENT_VERSION` is `{ major: 2, minor: 10 }`.
-- `CURRENT_ARTIFACT_COHORT` is `6` and must match between daemon and every local consumer.
+- `CURRENT_ARTIFACT_COHORT` is `7` and must match between daemon and every local consumer.
 - Negotiation accepts only the exact current version. A major mismatch and an unsupported minor are distinct refusals; the nominal `PREVIOUS_MINOR_VERSION` is intentionally equal to the current version for the clean break.
 - A welcome with a missing or different artifact cohort is refused. Do not reintroduce older compatibility when documenting or changing the current protocol.
 
-The version and cohort definitions live in `crates/decodex-protocol/src/lib.rs`; handshake and cohort checks are exercised by `crates/decodex-protocol/src/client.rs`, `retained_session.rs`, and `wire.rs` tests. Account-login additions must preserve both the exact negotiation rule and cohort 6.
+The version and cohort definitions live in `crates/decodex-protocol/src/lib.rs`; handshake and cohort checks are exercised by `crates/decodex-protocol/src/client.rs`, `retained_session.rs`, and `wire.rs` tests. Account-login additions must preserve both the exact negotiation rule and cohort 7.
 
 ## AccountService installation
 
@@ -101,7 +112,7 @@ This is a protocol-only GPUI seam. It must not depend on `decodex-account-login`
 
 **Changing provider behavior:** edit `crates/decodex-account-login/src/lib.rs` and its focused tests. Preserve bounded response/callback parsing, no process execution, no logging, cancellation checks, and private-home cleanup. Then validate the runtime consumer and architecture gate; do not add provider dependencies to GPUI.
 
-**Changing the wire contract:** edit `crates/decodex-protocol/src/account_login.rs`, `client.rs`, and `wire.rs` together. Preserve exact 2.10 negotiation, cohort 6, 8 KiB URL bounds, `deny_unknown_fields`, canonical UUID validation, and exclusion from durable wire types. Run protocol account-login tests and the architecture gate before any broader package check.
+**Changing the wire contract:** edit `crates/decodex-protocol/src/account_login.rs`, `client.rs`, and `wire.rs` together. Preserve exact 2.11 negotiation, cohort 7, 8 KiB URL bounds, `deny_unknown_fields`, canonical UUID validation, and exclusion from durable wire types. Run protocol account-login tests and the architecture gate before any broader package check.
 
 **Changing installation or lifecycle:** start at `AccountLoginManager`, `AccountLoginInstallAuthority`, and `AccountService`. Update focused runtime tests for initial, completed, failed, same-session, busy, cancellation, replacement, shutdown, revision mismatch, and exact UUID restoration behavior. Escalate to runtime bootstrap and websocket tests only when composition or transport wiring changes.
 

--- a/openwiki/specs/local-product-v1.md
+++ b/openwiki/specs/local-product-v1.md
@@ -9,8 +9,39 @@ openwiki:
   source_paths: [crates/decodex-runtime/src/account_login.rs, crates/decodex-protocol/src/wire.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/account_service.rs, crates/decodex-runtime/src/auth_projection.rs, crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/host_credentials/sqlite_store.rs, database/src/account_lifecycle.rs, database/src/desktop_settings.rs, database/migrations/0009_durable_account_route.sql, database/migrations/0010_pending_account_route_progress.sql, database/migrations/0011_desktop_settings.sql, crates/decodex-runtime/src/quick_task.rs, crates/decodex-runtime/src/application.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/domain_packs/decodex.dev-1.0.0.json, crates/decodex-runtime/domain_packs/decodex.paper-investment-1.0.0.json, crates/decodex-codex/src/quick_task.rs, crates/decodex-protocol/src/domain_pack.rs, database/migrations/0007_builtin_domain_pack_binding.sql, database/src/program_cycles.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/desktop_settings.rs, apps/decodex-gpui/src/settings_surface.rs, apps/decodex-gpui/src/shell.rs]
   symbols: [SharedAuthCoordinator, AccountService::route_account_command, recover_pending_account_routes_once, AccountRoutePendingDto, QuickTaskExecutionSettings, QuickTaskRecoveryAction, control_thread, ExactSubmittedTurnReadback, UnknownQuickTaskAttemptReadback, TranscriptRow]
   test_paths: [crates/decodex-runtime/src/shared_auth_coordinator.rs, crates/decodex-runtime/src/account_service.rs, database/src/account_lifecycle.rs, database/src/desktop_settings.rs, crates/decodex-protocol/src/wire.rs, tests/scripts/test_account_login_architecture.py, tests/scripts/test_vnext_architecture.py, crates/decodex-protocol/src/account_login.rs, crates/decodex-protocol/src/client.rs, crates/decodex-runtime/src/auth_projection.rs, database/tests/quick_task_restart.rs, database/src/program_cycles.rs, crates/decodex-protocol/src/domain_pack.rs, crates/decodex-runtime/src/domain_packs.rs, crates/decodex-runtime/src/application.rs, apps/decodex-gpui/src/programs.rs, apps/decodex-gpui/src/factory_surface.rs, apps/decodex-gpui/src/desktop_settings.rs, apps/decodex-gpui/src/client_lifecycle/tests.rs]
-  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Route is synchronous exact-source CAS/readback with no Codex process/liveness wait.; Passive shared-auth following imports only same-account non-older rotations without writing auth.json.; AccountRoutePending is legacy-decode and one-time-startup-recovery compatibility state only.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
-  validation_commands: [cargo test -p decodex-runtime shared_auth_coordinator::tests, cargo test -p decodex-runtime account_service::tests::cross_account_route_is_synchronous_even_when_codex_may_be_running, cargo test -p decodex-runtime account_service::tests::stable_known_account_same_expiry_rotation_imports_once_without_provider_work, cargo test -p decodex-protocol account_route_pending, cargo test -p database pending_route_fences_balanced_and_order_revision_changes, cargo test --workspace --all-targets]
+  invariants: [Exact thread lifecycle readback precedes local archive commit.; Missing per-thread archive fields require exact filtered-list membership.; Composer content clears only after explicit submission acceptance.; A queued prompt remains visible until durable history contains it.; Adjacent assistant fragments with the same Turn identity render as one response.; A validated fresh history head replaces the old retained page window before its continuation is rebuilt.; Unknown ProviderAttempt evidence is never replay authority.; An inconclusive Turn becomes product-usable only after positive exact process death.; A successor Context Pack excludes the successor Turn itself.; Durable terminal evidence can finish an interrupted local Turn terminalization.; Fast is request-scoped and never mutates global Codex configuration.; A live account process generation rejects a second request before provider effect.; Re-enrollment restores the sole tombstoned provider owner and returns its resolved UUID.; A structured terminal device denial cannot remain pending.; Cross-account Route remains Pending until external Codex quiescence, then performs exact-source CAS/readback before routing commit.; A same-account Decodex refresh mirrors its successor or adopts a valid non-older Codex winner.; Passive shared-auth following imports only same-account non-older rotations.; AccountRoutePending is a normal credential-negative accepted handoff state.; Each Program has at most one immutable built-in Domain Pack identity.; Domain entity identities are derived from the Program and exact Pack digest.; Program capability admission precedes QuickTaskRuntime and ProviderAttempt creation.; GPUI alone renders bounded Pack projections.]
+  validation_commands: [cargo test -p decodex-runtime shared_auth_coordinator::tests, cargo test -p decodex-runtime account_service::tests::live_cross_account_route_waits_for_quiescence_then_follows_same_account_rotation, cargo test -p decodex-runtime account_service::tests::projected_refresh_mirrors_success_and_adopts_a_concurrent_codex_winner, cargo test -p decodex-runtime account_service::tests::quick_task_callback_accepts_only_a_newer_same_provider_sqlite_successor, cargo test -p decodex-protocol account_route_pending, cargo test -p decodex-database pending_route_fences_balanced_and_order_revision_changes, cargo test --workspace --all-targets]
+sources:
+  - id: openwiki-source-98e7b23c4cc276d20fcb4649
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+  - id: openwiki-source-35eca69c3013fea5ba400887
+    resource: repo://apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
+  - id: openwiki-source-a5028d07257122cad396830e
+    resource: repo://apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+  - id: openwiki-source-acf49c93c3e80379f0023c71
+    resource: repo://apps/decodex-gpui/src/accounts.rs
+  - id: openwiki-source-1291f5243fa6c9cb52149bda
+    resource: repo://apps/decodex-gpui/src/shell.rs
+  - id: openwiki-source-6230c010baca677fa60c32c1
+    resource: repo://crates/decodex-protocol/src/client.rs
+  - id: openwiki-source-cc0439b23243c3697ba49199
+    resource: repo://crates/decodex-protocol/src/lib.rs
+  - id: openwiki-source-268229e2b9f21dae93c32513
+    resource: repo://crates/decodex-protocol/src/wire.rs
+  - id: openwiki-source-f4724776aade804ebf838e2e
+    resource: repo://crates/decodex-runtime/src/account_service.rs
+  - id: openwiki-source-a09c082db4ad1473c4d1e557
+    resource: repo://crates/decodex-runtime/src/application.rs
+  - id: openwiki-source-82e4f987f46e34e31621081e
+    resource: repo://crates/decodex-runtime/src/auth_projection.rs
+  - id: openwiki-source-a67672a943dfe221574b2501
+    resource: repo://crates/decodex-runtime/src/shared_auth_coordinator.rs
+  - id: openwiki-source-a9515596a887b940d069c74e
+    resource: repo://tests/scripts/test_vnext_architecture.py
+generated: { by: "codex", at: "2026-08-27T10:25:21.174Z" }
+verified:
+  - by: openwiki/0.4.2
+    at: 2026-08-27T10:25:21.174Z
 ---
 
 # Local Product V1 Contract
@@ -166,12 +197,12 @@ bounded inline value or a digest and length.
 
 ## Repeatable Program Loop V1
 
-The current protocol accepts only exact 2.10 clients. It retains the bounded, manually repeated
+The current protocol accepts only exact 2.11 clients. It retains the bounded, manually repeated
 Program aggregate above the existing Quick Task execution path. The initial command
 creates one Program charter, one sourced Signal, one Claim, one non-executable Proposal,
 one finite Objective, and one ready WorkItem in one SQLite transaction.
 
-Every local 2.10 hello and welcome also carries artifact cohort `6`. The daemon, CLI,
+Every local 2.11 hello and welcome also carries artifact cohort `7`. The daemon, CLI,
 and retained clients fail before application work when the cohort is absent or
 differs. This is one compatibility fence inside the existing protocol. It does not add a
 second version service or runtime authority.
@@ -401,7 +432,7 @@ revision and the immediate successor credential version, then appends that UUID 
 The provisional client UUID is retained only in the strict `AccountRestored` command result.
 `AccountLoginClient` completion returns the daemon-resolved UUID, and GPUI refreshes that row
 before reporting success. A live provider owner remains `provider_already_enrolled`. Artifact
-cohort `6` fences the result shape from older local clients.
+cohort `7` fences the result shape from older local clients.
 
 Startup also compensates the one exact pre-repair collision in which a version-one enrollment
 credential reached `StoreApplied` under a provisional UUID but the provider's retained tombstone
@@ -428,37 +459,55 @@ appear in Debug output, protocol data, logs, migration output, or transfer repor
 GPUI sends one `RouteAccount` command with one Route operation UUID, the target Account UUID
 and revision, the routing revision, and one idempotency key. GPUI does not run a refresh,
 projection, or fixed-selection workflow. It applies the daemon's authoritative `AccountRouted`
-result, including the target Account, routing control, and credential-negative projection digest.
-`AccountRoutePending` is retained only so older receipts can be decoded and recovered at startup.
+result, including the target Account, routing control, and credential-negative projection digest,
+or the accepted `AccountRoutePending` handoff for that same command.
 
 `AccountService` holds one routing lock across Route, balanced selection, and order changes.
 One daemon-wide `SharedAuthCoordinator` owns exact source reads, stable passive-following polls,
-and the exact-source projection seam; there is no client-side or second coordinator. A stable
-passive read requires two equal file-metadata observations. While following shared auth, the
-coordinator may import only a valid newer same-account managed bundle into SQLite and never writes
-shared auth. Route itself is synchronous and performs its exact-source CAS/readback directly; it
-has no Codex process/liveness wait or normal Pending result.
+external Codex liveness observation, and the exact-source projection seam; there is no client-side
+or second coordinator. A stable passive read requires two equal file-metadata observations.
 
 Route coordinates the normal shared `~/.codex/auth.json`. If the file is absent or unmanaged, the
 Route can continue with the target. A managed identity naming another enrolled Account is first
 reconciled into that source Account using a stable account-scoped operation derived from the Route
-operation UUID. Unknown, unreadable, unsafe, or inconsistent managed identity fails closed. Route rechecks the exact source stamp and snapshot as part of the same synchronous command,
-refreshes the target when needed, and projects the target only with an exact-source
-compare-and-swap. It does not wait for Codex Desktop or an app-server process to exit. The writer
-uses one same-directory mode-0600 temporary file, synchronization, atomic rename, exact readback,
-and parent synchronization; source drift fails before rename, while an already-current target is
-idempotent.
+operation UUID. Unknown, unreadable, unsafe, or inconsistent managed identity fails closed.
 
-Route executes synchronously under the routing lock. `AccountService::route_account_command`
-reads the exact shared-auth source, performs any same-account source reconciliation, refreshes the
-target when needed, performs exact-source CAS/write/readback, and commits fixed routing and the
-receipt only after success. It does not wait for Codex liveness or return a normal Pending state.
-`AccountRoutePending` and `AccountRoutePendingDto`, plus migrations
-`0009_durable_account_route.sql` and `0010_pending_account_route_progress.sql`, remain only to
-decode legacy receipts and support the one-time `recover_pending_account_routes_once` startup
-recovery pass. They are not a client-owned retry workflow. Passive following imports only same-
-account non-older rotations into daemon credentials and never writes `auth.json`.
-Client disconnect or application exit does not cancel admitted daemon work.
+For a cross-account switch, an external Codex process can still hold and rotate the old refresh
+token even after the file changes. Route therefore returns a credential-negative Pending result
+while external Codex liveness is present or uncertain. It does not refresh the target, change
+fixed routing, or write the file in that state. The daemon retains the original receipt and
+request. Its bounded recovery loop rechecks routing and account revisions, readiness, the stable
+source, and liveness. Deferring Route immediately wakes that loop. While Pending work exists, it
+checks every 100 milliseconds; only the no-Pending idle cadence remains one second. A long Pending
+state therefore means that conservative liveness still sees an auth-owning Codex process or
+another readiness fence. It never terminates or restarts Codex.
+
+The liveness observation identifies official ChatGPT/Codex bundle executables as strict blockers
+and excludes daemon-descended app-server processes. A standalone Codex CLI is ignored only when
+bounded same-UID metadata proves that its effective `CODEX_HOME` is an existing canonical home
+different from normal shared auth. Unavailable or withheld home evidence stays fail-closed.
+`AccountRoutePending` carries one closed `AccountRouteWaitReason`: up to eight positive PID/process
+blockers with shared-or-unknown home evidence, or a typed process-observation, account-readiness,
+source-stability, source-availability, or projection-readback wait. No path, environment value, or
+credential crosses the protocol.
+
+After quiescence, Route refreshes the target when required, rechecks the source, performs the
+exact-source compare-and-swap, and reads the projected account back before it commits fixed routing
+and the terminal receipt. The writer uses one same-directory mode-`0600` temporary file,
+synchronization, atomic rename, exact readback, and parent synchronization. An already-current
+target is idempotent. A client disconnect or application exit does not cancel admitted work.
+
+For the current projected account, Decodex and Codex can both encounter token expiry. Before a
+Decodex refresh, the Account Service reads the exact shared source. A valid non-older same-account
+Codex rotation is imported without provider work. If the source exactly matches SQLite, Decodex can
+refresh and conditionally mirror its successor. Exact readback then keeps the Decodex successor,
+retries one unchanged predecessor, or imports a valid Codex winner through a deterministic
+successor operation. A conflicting or older source fails closed. The losing refresh token is never
+written back and winner adoption does not call the provider again.
+
+Passive following remains separate. It imports only stable same-account non-older rotations into
+daemon credentials. `AccountRoutePending`, its protocol DTO, and migrations 9 and 10 are current
+handoff authority, not legacy-only decode shapes.
 
 Focused implementation checks are in `crates/decodex-runtime/src/shared_auth_coordinator.rs`
 for stable-read and exact-source coordination, `crates/decodex-runtime/src/account_service.rs` for
@@ -467,13 +516,14 @@ same-receipt pending recovery, `database/src/account_lifecycle.rs` for revision 
 the workspace suite; generated indexes and client projections are not hand-edited as part of this
 contract.
 
-The app has one Route button and applies the daemon's authoritative terminal Route result. It does
-not project a normal Pending state or maintain a separate preparation workflow. The retained
-`AccountRoutePending` UI/protocol shapes exist only to decode and recover older receipts during the
-one-time startup compatibility pass. Account, profile, inventory, quota, and aggregate values
-follow authoritative revisions. Any displayed reset-card `Total` is derived from the registry-backed
-account observation, not preserved as a client-owned value across partial reads. Retryable partial
-account reads retain safe prior projections and retry using bounded delays.
+The app has one Route button and applies the daemon's authoritative Pending or terminal result. It
+does not own a refresh or projection workflow. While Pending, both desktop surfaces show the
+current blocking PID or exact typed fallback reason and tell the user what must quit or recover.
+After terminal Route, they report that the synchronized account is ready and the app can be
+reopened. Account, profile, inventory, quota, and aggregate values follow authoritative revisions.
+Any displayed reset-card `Total` is derived from the registry-backed account observation, not
+preserved as a client-owned value across partial reads. Retryable partial account reads retain safe
+prior projections and retry using bounded delays.
 
 Route does not terminate, restart, signal, inject into, or otherwise control Codex Desktop or an
 app-server process. It uses no private Codex IPC, unstable app-server injection, watcher, backup,
@@ -505,9 +555,13 @@ Acceptance requires:
 - a daemon restart followed by a later response on the same Conversation and Codex
   thread, with no duplicate ProviderAttempt dispatch;
 - protocol-only GPUI and CLI operation;
-- protocol 2.10 with matching artifact cohort 6 across the running daemon, CLI, and GPUI app;
+- protocol 2.11 with matching artifact cohort 7 across the running daemon, CLI, and GPUI app;
 - one GPUI `Decodex.app` bundle whose optional menu-bar item runs in the same process and
   follows the daemon-owned `desktop_settings` revision;
+- a live cross-account Route that retains Pending without changing shared auth, then completes
+  the same receipt after external Codex quiescence;
+- same-account refresh proof for both a successful Decodex mirror and a concurrent Codex winner,
+  with no losing refresh token restored and no second provider call during adoption;
 - local-history-first Conversation opening, immediate queued-prompt projection, and
   Turn-level adjacent assistant-fragment coalescing;
 - exact selected-thread refresh, verified archive, and request-scoped execution controls;

--- a/scripts/macos/test_decodex_app_stage.sh
+++ b/scripts/macos/test_decodex_app_stage.sh
@@ -53,7 +53,7 @@ plutil -extract CFBundleIconFile raw "$info" | grep -qx 'AppIcon'
 plutil -extract LSMinimumSystemVersion raw "$info" | grep -qx '27.0'
 plutil -extract NSSupportsAutomaticTermination raw "$info" | grep -qx 'false'
 plutil -extract NSSupportsSuddenTermination raw "$info" | grep -qx 'false'
-"$contents/Helpers/decodexd" artifact-cohort | grep -q '"artifact_cohort":6'
+"$contents/Helpers/decodexd" artifact-cohort | grep -q '"artifact_cohort":7'
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_create' >/dev/null
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_set_visible' >/dev/null
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_launch_at_login_status' >/dev/null

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -185,24 +185,27 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
         )
         self.assertNotIn(".app", service_stage)
 
-    def test_shared_auth_route_uses_exact_source_cas_without_process_gating(self) -> None:
+    def test_shared_auth_coordinator_is_read_only_until_quiescent_cutover(self) -> None:
         coordinator = read(
             "crates/decodex-runtime/src/shared_auth_coordinator.rs"
         )
         application = read("crates/decodex-runtime/src/application.rs")
         account_service = read("crates/decodex-runtime/src/account_service.rs")
-        for removed in (
-            "proc_listpids",
-            "proc_pidpath",
-            "CodexLiveness",
-            "CodexLivenessPort",
-            "MayBeRunning",
-            "Quiescent",
-            "project_if_quiescent",
-        ):
-            self.assertNotIn(removed, coordinator)
+        wire = read("crates/decodex-protocol/src/wire.rs")
+        menu = read(
+            "apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift"
+        )
+        self.assertIn("proc_listpids", coordinator)
+        self.assertIn("proc_pidpath", coordinator)
+        self.assertIn("KERN_PROCARGS2", coordinator)
+        self.assertIn("Zeroizing::new", coordinator)
+        self.assertIn("CodexLiveness::MayBeRunning", coordinator)
+        self.assertIn("MacosCodexHomeRelation::Isolated", coordinator)
+        self.assertIn("CodexLivenessObservation::Blocked", coordinator)
         self.assertIn("project_shared_codex_auth_cas", coordinator)
-        self.assertIn("read_current_exact", coordinator)
+        self.assertIn("AccountRouteWaitReasonDto", wire)
+        self.assertIn("AccountRoutePendingStatusView", menu)
+        self.assertIn("PID \\(blocker.pid)", menu)
         for forbidden in (
             "std::process::Command",
             "libc::kill",
@@ -210,12 +213,10 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
             "SIGKILL",
         ):
             self.assertNotIn(forbidden, coordinator)
-        self.assertNotIn("shared_auth_may_be_running", application)
-        self.assertIn("reclaim_account_route_command", application)
-        self.assertIn("follow_shared_auth_changes", application)
-        self.assertNotIn("async fn recover_pending_account_routes(", application)
-        self.assertNotIn("defer_route_command", account_service)
-        self.assertNotIn("project_if_quiescent", account_service)
+        self.assertLess(
+            application.index("shared_auth_may_be_running"),
+            application.index("reclaim_account_route_command"),
+        )
         self.assertNotIn("reproject_shared", account_service)
 
     def test_credentials_are_narrow_and_daemon_private(self) -> None:


### PR DESCRIPTION
Summary

- Synchronize cross-account Route through external Codex quiescence, exact-source CAS, auth.json readback, and only then fixed-routing commit.
- Converge same-account refresh-token races on one non-older winner without restoring the losing token or repeating provider refresh.
- Report actionable Pending blockers with bounded process PIDs, auth-home evidence, and typed readiness/source reasons; recover within 100 ms while Pending.
- Move the exact local wire contract to protocol 2.11 and artifact cohort 7.

Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer cargo +stable test --workspace --all-targets
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/decodex-gpui/menubar
- python3 -m unittest tests/scripts/test_vnext_architecture.py
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer scripts/macos/test_decodex_app_stage.sh
- cargo +stable clippy -p decodex-runtime -p decodex-protocol --all-targets