### PR TITLE
Simplify release and toolchain configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,5 @@ vergen-gitcl       = { version = "10.0", features = ["cargo"] }
 wait-timeout       = { version = "0.2.1" }
 zeroize            = { version = "1.9" }
 
-[profile.final-release]
-inherits = "release"
-lto      = true
+[profile.release]
+lto = "thin"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,9 @@
 # Decodex workspace tasks.
 
+[config]
+default_to_workspace = false
+skip_core_tasks      = true
+
 # Audit
 # | task                    | type      | cwd  |
 # | ----------------------- | --------- | ---- |
@@ -13,7 +17,6 @@
 # | prepare-node            | command   | site |
 
 [tasks.audit-node]
-workspace = false
 dependencies = [
 	"audit-node-lock",
 	"prepare-node",
@@ -23,7 +26,6 @@ dependencies = [
 ]
 
 [tasks.audit-node-advisories]
-workspace = false
 cwd = "site"
 dependencies = ["audit-node-lock"]
 command = "npm"
@@ -33,7 +35,6 @@ args = [
 ]
 
 [tasks.audit-node-signatures]
-workspace = false
 cwd = "site"
 dependencies = ["audit-node-lock"]
 command = "npm"
@@ -43,7 +44,6 @@ args = [
 ]
 
 [tasks.audit-node-lock]
-workspace = false
 command = "python3"
 args = [
 	"scripts/audit_node_lock.py",
@@ -51,7 +51,6 @@ args = [
 ]
 
 [tasks.audit-node-provenance]
-workspace = false
 dependencies = ["prepare-node"]
 command = "python3"
 args = [
@@ -59,7 +58,6 @@ args = [
 ]
 
 [tasks.audit-node-runtime]
-workspace = false
 command = "python3"
 args = [
 	"scripts/audit_node_lock.py",
@@ -67,14 +65,12 @@ args = [
 ]
 
 [tasks.audit-vstyle-rust]
-workspace = false
 command = "python3"
 args = [
 	"scripts/vstyle_audit.py",
 ]
 
 [tasks.prepare-node]
-workspace = false
 cwd = "site"
 dependencies = ["audit-node-lock"]
 command = "npm"
@@ -97,7 +93,6 @@ args = [
 
 [tasks.check]
 clear = true
-workspace = false
 dependencies = [
 	"audit-node",
 	"build",
@@ -110,7 +105,6 @@ dependencies = [
 
 [tasks.check-automations]
 clear = true
-workspace = false
 dependencies = [
 	"audit-node",
 	"build",
@@ -123,7 +117,6 @@ dependencies = [
 
 [tasks.check-automations-sandboxed]
 clear = true
-workspace = false
 dependencies = [
 	"build",
 	"check-node",
@@ -135,7 +128,6 @@ dependencies = [
 
 [tasks.check-sandboxed]
 clear = true
-workspace = false
 dependencies = [
 	"build",
 	"check-node",
@@ -146,13 +138,11 @@ dependencies = [
 ]
 
 [tasks.check-node]
-workspace = false
 dependencies = [
 	"check-node-types",
 ]
 
 [tasks.check-node-types]
-workspace = false
 cwd = "site"
 dependencies = ["audit-node-lock"]
 command = "npm"
@@ -162,20 +152,20 @@ args = [
 ]
 
 [tasks.check-rust]
-workspace = false
 command = "cargo"
 args = [
 	"check",
+	"--locked",
 	"--all-features",
 	"--all-targets",
 	"--workspace",
 ]
 
 [tasks.check-rust-headless]
-workspace = false
 command = "cargo"
 args = [
 	"check",
+	"--locked",
 	"--all-features",
 	"--all-targets",
 	"--workspace",
@@ -191,13 +181,11 @@ args = [
 
 [tasks.build]
 clear = true
-workspace = false
 dependencies = [
 	"build-node",
 ]
 
 [tasks.build-node]
-workspace = false
 cwd = "site"
 dependencies = ["audit-node-lock"]
 command = "npm"
@@ -219,28 +207,24 @@ args = [
 # | fmt-toml-check | extend    |     |
 
 [tasks.fmt]
-workspace = false
 dependencies = [
 	"fmt-rust",
 	"fmt-toml",
 ]
 
 [tasks.fmt-check]
-workspace = false
 dependencies = [
 	"fmt-rust-check",
 	"fmt-toml-check",
 ]
 
 [tasks.fmt-check-sandboxed]
-workspace = false
 dependencies = [
 	"fmt-rust-check-sandboxed",
 	"fmt-toml-check",
 ]
 
 [tasks.fmt-rust]
-workspace = false
 command = "rustup"
 args = [
 	"run",
@@ -263,7 +247,6 @@ args = [
 ]
 
 [tasks.fmt-rust-check-sandboxed]
-workspace = false
 command = "${DECODEX_TRUSTED_NIGHTLY_CARGO_FMT}"
 args = [
 	"--all",
@@ -272,7 +255,6 @@ args = [
 ]
 
 [tasks.fmt-toml]
-workspace = false
 command = "taplo"
 args = [
 	"fmt",
@@ -293,18 +275,15 @@ args = [
 # | lint-rust-headless | command | |
 
 [tasks.lint]
-workspace = false
 dependencies = [
 	"lint-rust",
 ]
 
 [tasks.lint-rust]
-workspace = false
 command = "python3"
 args = ["scripts/lint_rust_workspace.py"]
 
 [tasks.lint-rust-headless]
-workspace = false
 command = "python3"
 args = ["scripts/lint_rust_workspace.py", "--headless"]
 
@@ -315,18 +294,17 @@ args = ["scripts/lint_rust_workspace.py", "--headless"]
 # | lint-rust-fix | command   |     |
 
 [tasks.lint-fix]
-workspace = false
 dependencies = [
 	"lint-rust-fix",
 ]
 
 [tasks.lint-rust-fix]
-workspace = false
 command = "cargo"
 args = [
 	"clippy",
 	"--fix",
 	"--allow-dirty",
+	"--locked",
 	"--all-features",
 	"--all-targets",
 	"--workspace",
@@ -366,7 +344,6 @@ args = [
 
 [tasks.test]
 clear = true
-workspace = false
 dependencies = [
 	"test-automations",
 	"test-gate-contract",
@@ -377,7 +354,6 @@ dependencies = [
 ]
 
 [tasks.test-automations]
-workspace = false
 command = "python3"
 args = [
 	"-m",
@@ -387,7 +363,6 @@ args = [
 
 [tasks.test-sandboxed]
 clear = true
-workspace = false
 dependencies = [
 	"test-automations",
 	"test-gate-contract",
@@ -399,7 +374,6 @@ dependencies = [
 
 [tasks.test-headless]
 clear = true
-workspace = false
 dependencies = [
 	"test-automations",
 	"test-gate-contract",
@@ -411,7 +385,6 @@ dependencies = [
 
 [tasks.test-headless-sandboxed]
 clear = true
-workspace = false
 dependencies = [
 	"test-automations",
 	"test-gate-contract",
@@ -422,7 +395,6 @@ dependencies = [
 ]
 
 [tasks.test-gate-contract]
-workspace = false
 command = "python3"
 args = [
 	"-m",
@@ -433,22 +405,22 @@ args = [
 ]
 
 [tasks.test-rust]
-workspace = false
 command = "cargo"
 args = [
 	"nextest",
 	"run",
+	"--locked",
 	"--workspace",
 	"--all-targets",
 	"--all-features",
 ]
 
 [tasks.test-rust-headless]
-workspace = false
 command = "cargo"
 args = [
 	"nextest",
 	"run",
+	"--locked",
 	"--workspace",
 	"--all-targets",
 	"--all-features",
@@ -457,7 +429,6 @@ args = [
 ]
 
 [tasks.test-vnext-architecture]
-workspace = false
 command = "python3"
 args = [
 	"-m",
@@ -466,14 +437,12 @@ args = [
 ]
 
 [tasks.test-vnext-cli-diagnostics]
-workspace = false
 command = "python3"
 args = [
 	"scripts/vnext/cli_diagnostics_test.py",
 ]
 
 [tasks.test-local-database]
-workspace = false
 command = "python3"
 args = [
 	"scripts/vnext/local_database_gate.py",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel    = "stable"
-components = ["cargo", "clippy", "rust-analyzer", "rust-src", "rustc", "rustfmt"]
+components = ["clippy"]
 profile    = "minimal"

--- a/scripts/macos/stage_decodex_local_service.sh
+++ b/scripts/macos/stage_decodex_local_service.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 STAGE_ROOT=${DECODEX_LOCAL_SERVICE_STAGE_DIR:-"$ROOT/target/decodex-local-service"}
 SIGN_IDENTITY=${DECODEX_LOCAL_SERVICE_SIGN_IDENTITY:?set DECODEX_LOCAL_SERVICE_SIGN_IDENTITY to a Developer ID or Apple Development identity}
-PROFILE=final-release
+PROFILE=release
 
 if [[ $SIGN_IDENTITY == "-" ]]; then
 	echo "error: an ad-hoc signature has no TeamIdentifier and cannot be installed" >&2

--- a/tests/scripts/test_gate_contract.py
+++ b/tests/scripts/test_gate_contract.py
@@ -17,7 +17,9 @@ class GateContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         with (REPO_ROOT / "Makefile.toml").open("rb") as source:
-            cls.tasks = tomllib.load(source)["tasks"]
+            document = tomllib.load(source)
+        cls.config = document["config"]
+        cls.tasks = document["tasks"]
         spec = importlib.util.spec_from_file_location(
             "decodex_local_database_gate",
             REPO_ROOT / "scripts/vnext/local_database_gate.py",
@@ -38,8 +40,39 @@ class GateContractTests(unittest.TestCase):
     def test_active_rust_toolchain_remains_stable(self) -> None:
         with (REPO_ROOT / "rust-toolchain.toml").open("rb") as source:
             toolchain = tomllib.load(source)["toolchain"]
-        self.assertEqual(toolchain["channel"], "stable")
-        self.assertIn("rustfmt", toolchain["components"])
+        self.assertEqual(
+            toolchain,
+            {
+                "channel": "stable",
+                "components": ["clippy"],
+                "profile": "minimal",
+            },
+        )
+
+    def test_cargo_make_uses_global_workspace_defaults(self) -> None:
+        self.assertEqual(
+            self.config,
+            {"default_to_workspace": False, "skip_core_tasks": True},
+        )
+        self.assertTrue(all("workspace" not in task for task in self.tasks.values()))
+
+    def test_direct_cargo_validation_tasks_use_the_lockfile(self) -> None:
+        for task_name in (
+            "check-rust",
+            "check-rust-headless",
+            "lint-rust-fix",
+            "test-rust",
+            "test-rust-headless",
+        ):
+            with self.subTest(task=task_name):
+                task = self.tasks[task_name]
+                self.assertEqual(task["command"], "cargo")
+                self.assertIn("--locked", task["args"])
+
+    def test_cargo_uses_the_standard_thin_release_profile(self) -> None:
+        with (REPO_ROOT / "Cargo.toml").open("rb") as source:
+            cargo_manifest = tomllib.load(source)
+        self.assertEqual(cargo_manifest["profile"], {"release": {"lto": "thin"}})
 
     def test_blocking_test_aggregates_include_the_local_database_gate(self) -> None:
         for task_name in ("test", "test-sandboxed", "test-headless", "test-headless-sandboxed"):
@@ -53,7 +86,6 @@ class GateContractTests(unittest.TestCase):
         self.assertEqual(
             self.tasks["test-local-database"],
             {
-                "workspace": False,
                 "command": "python3",
                 "args": ["scripts/vnext/local_database_gate.py"],
             },


### PR DESCRIPTION
Summary:
- Set the active Rust toolchain to stable/minimal with only Clippy.
- Simplify cargo-make workspace defaults and lock direct Cargo validation tasks.
- Use the standard thin-LTO release profile and update local-service staging.
- Keep the existing decodex checks and gate contract; do not modify generated OpenWiki.

Validation:
- python3 -m unittest tests/scripts/test_gate_contract.py
- cargo make --silent fmt-toml-check
- cargo metadata --locked --format-version 1 --no-deps
- rustup show active-toolchain; stable Clippy component installed
- cargo check --locked --release -p decodex-core
- bash -n scripts/macos/stage_decodex_local_service.sh
- git diff HEAD^ HEAD --check