### PR TITLE
Repair account switching and bundled daemon supervision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,10 @@ dependencies = [
 name = "decodexd"
 version = "0.2.0"
 dependencies = [
+ "base64",
  "clap",
+ "decodex-core",
+ "decodex-database",
  "decodex-protocol",
  "decodex-runtime",
  "libc",

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlCLIClient.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlCLIClient.swift
@@ -320,12 +320,8 @@ enum AccountControlError: Error, Equatable, LocalizedError, Sendable {
 			return "The Decodex service returned an invalid account response."
 		case .client(let error):
 			switch error {
-			case .nativeClientUnavailable:
-				return "The native Decodex client is unavailable."
-			case .timedOut:
-				return "The account request timed out."
-			case .transportDisconnected:
-				return "The Decodex daemon is not reachable."
+			case .nativeClientUnavailable, .timedOut, .transportDisconnected:
+				return "Restart Decodex."
 			case .transportBackpressured:
 				return "The Decodex account service is busy."
 			case .outputTooLarge:

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/AccountControlViews.swift
@@ -27,6 +27,23 @@ struct AccountRouteActionPresentation: Equatable {
 	var usesDisabledEnvironment: Bool {
 		isCurrent || isVisuallyDisabled
 	}
+
+	func title(
+		isSwitching: Bool,
+		pending: AccountRoutePending?,
+		keepsCurrentRoute: Bool
+	) -> String {
+		if let pending {
+			return pending.actionTitle
+		}
+		if isSwitching {
+			return "Switching"
+		}
+		if keepsCurrentRoute {
+			return "Keep"
+		}
+		return isCurrent ? "Ready" : "Switch"
+	}
 }
 
 struct AccountPrimaryActionsView: View {
@@ -36,9 +53,11 @@ struct AccountPrimaryActionsView: View {
 	var body: some View {
 		HStack(alignment: .firstTextBaseline, spacing: PanelSpacing.compact) {
 			CompactAccountActionButton(
-				title: isPendingTarget
-					? "Pending"
-					: (keepsCurrentRoute ? "Keep" : (presentation.isCurrent ? "Routed" : "Route")),
+				title: presentation.title(
+					isSwitching: isSwitching,
+					pending: isPendingTarget ? store.pendingRoute : nil,
+					keepsCurrentRoute: keepsCurrentRoute
+				),
 				symbol: isPendingTarget
 					? "clock"
 					: (presentation.isCurrent
@@ -54,7 +73,7 @@ struct AccountPrimaryActionsView: View {
 				),
 				help: isPendingTarget
 					? store.pendingRoute?.helpText
-						?? "Keep ChatGPT or Codex closed until Pending changes to Routed, then reopen it."
+						?? "Decodex will finish the account switch automatically."
 					: (keepsCurrentRoute
 						? "Keep this account and replace the other pending route."
 						: (presentation.isCurrent
@@ -100,6 +119,10 @@ struct AccountPrimaryActionsView: View {
 		store.pendingRoute?.accountID == state.account.accountID
 	}
 
+	private var isSwitching: Bool {
+		store.isControllingAccount(state.account.accountID, activity: .route)
+	}
+
 	private var isFixed: Bool {
 		guard case .fixed(let accountID) = store.routing?.mode else {
 			return false
@@ -133,71 +156,35 @@ struct AccountRoutePendingStatusView: View {
 }
 
 extension AccountRoutePending {
+	var actionTitle: String {
+		switch waitReason {
+		case .externalCodex, .codexObservationUnavailable:
+			return "Waiting"
+		case .accountReadiness, .sharedAuthStabilizing, .sharedAuthUnavailable,
+			.projectionReadback:
+			return "Switching"
+		}
+	}
+
 	var statusText: String {
 		switch waitReason {
-		case .externalCodex(let blockers, let omitted):
-			let total = blockers.count + Int(omitted)
-			let first = blockers.first.map(Self.blockerLabel) ?? "Codex"
-			if total == 1 {
-				return "Waiting for \(first) to quit."
-			}
-			let remaining = total - 1
-			let noun = remaining == 1 ? "process" : "Codex processes"
-			return "Waiting for \(first) and \(remaining) more \(noun) to quit."
-		case .codexObservationUnavailable:
-			return "Waiting for safe Codex process inspection."
-		case .accountReadiness(let readiness):
-			return Self.accountReadinessStatus(readiness)
-		case .sharedAuthStabilizing:
-			return "Waiting for shared Codex auth to stabilize."
-		case .sharedAuthUnavailable:
-			return "Shared Codex auth is unavailable or unsafe."
-		case .projectionReadback:
-			return "Verifying the atomic auth.json update."
+		case .externalCodex, .codexObservationUnavailable:
+			return "Waiting for Codex to close or restart."
+		case .accountReadiness, .sharedAuthStabilizing, .sharedAuthUnavailable,
+			.projectionReadback:
+			return "Switching"
 		}
 	}
 
 	var helpText: String {
 		switch waitReason {
-		case .externalCodex(let blockers, let omitted):
-			var labels = blockers.map(Self.blockerLabel)
-			if omitted > 0 {
-				labels.append("\(omitted) more")
-			}
-			return "Quit \(labels.joined(separator: ", ")), then keep ChatGPT or Codex closed until Pending changes to Routed. Reopen it after routing completes."
+		case .externalCodex:
+			return "Close Codex and ChatGPT. Reopen them after the account is ready."
 		case .codexObservationUnavailable:
-			return "Decodex could not prove which Codex process owns the shared auth home, so the account switch remains safely blocked."
-		case .accountReadiness(let readiness):
-			return "\(Self.accountReadinessStatus(readiness)) Decodex retries automatically."
-		case .sharedAuthStabilizing:
-			return "Decodex is waiting for two matching auth.json observations before the atomic update."
-		case .sharedAuthUnavailable:
-			return "Check ~/.codex ownership, permissions, and path safety. Decodex retries automatically."
-		case .projectionReadback:
-			return "The auth.json update may have completed. Decodex is reading it back before routing is committed."
-		}
-	}
-
-	private static func blockerLabel(_ blocker: AccountRouteProcessBlocker) -> String {
-		let process = blocker.process == .chatgpt ? "ChatGPT" : "Codex"
-		let uncertainty = blocker.authHome == .unknown ? "; auth home unknown" : ""
-		return "\(process) PID \(blocker.pid)\(uncertainty)"
-	}
-
-	private static func accountReadinessStatus(
-		_ readiness: ResetCardLifecycleReadiness
-	) -> String {
-		switch readiness {
-		case .storeUnavailable:
-			return "Waiting for the credential store."
-		case .storeMismatch:
-			return "Waiting for credential binding reconciliation."
-		case .operationUnsettled:
-			return "Waiting for the current account operation to settle."
-		case .callbackCapabilityUnready:
-			return "Waiting for Codex refresh callback readiness."
-		case .ready, .credentialAbsent, .providerMismatch, .tombstoned:
-			return "Waiting for target account readiness."
+			return "Close Codex and ChatGPT so Decodex can finish safely."
+		case .accountReadiness, .sharedAuthStabilizing, .sharedAuthUnavailable,
+			.projectionReadback:
+			return "Decodex will finish the account switch automatically."
 		}
 	}
 }

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexApp.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexApp.swift
@@ -78,16 +78,10 @@ enum AppAssets {
 }
 
 private let menuBarABIVersion: UInt32 = 1
-private let menuBarArtifactCohort: UInt32 = 7
 
 @_cdecl("decodex_menu_bar_abi_version")
 public func decodexMenuBarABIVersion() -> UInt32 {
 	menuBarABIVersion
-}
-
-@_cdecl("decodex_menu_bar_artifact_cohort")
-public func decodexMenuBarArtifactCohort() -> UInt32 {
-	menuBarArtifactCohort
 }
 
 @_cdecl("decodex_menu_bar_create")

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/DecodexNativeCompatibility.swift
@@ -2,7 +2,6 @@ import Darwin
 import Foundation
 
 let decodexNativeClientABIVersion: UInt32 = 1
-let decodexNativeArtifactCohort: UInt32 = 7
 
 enum DecodexNativeCompatibility {
 	private typealias Version = @convention(c) () -> UInt32
@@ -22,13 +21,6 @@ enum DecodexNativeCompatibility {
 				named: "decodex_app_native_client_abi_version"
 			)
 			guard abiVersion() == decodexNativeClientABIVersion else {
-				throw LoadError.unavailable
-			}
-			let artifactCohort: Version = try symbol(
-				image,
-				named: "decodex_app_native_client_artifact_cohort"
-			)
-			guard artifactCohort() == decodexNativeArtifactCohort else {
 				throw LoadError.unavailable
 			}
 			return image

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/FastModeControl.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/FastModeControl.swift
@@ -10,7 +10,7 @@ enum FastModeClientError: Error, LocalizedError {
 	var errorDescription: String? {
 		switch self {
 		case .unavailable:
-			return "The native Decodex client is unavailable."
+			return "Restart Decodex."
 		case .timedOut:
 			return "Fast mode did not respond."
 		case .invalidResponse:

--- a/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardCLIClient.swift
+++ b/apps/decodex-gpui/menubar/Sources/DecodexApp/ResetCardCLIClient.swift
@@ -341,7 +341,7 @@ enum ResetCardClientError: Error, Equatable, LocalizedError, Sendable, CustomDeb
 	var errorDescription: String? {
 		switch self {
 		case .nativeClientUnavailable:
-			return "The native Decodex client is unavailable."
+			return "Restart Decodex."
 		case .timedOut:
 			return "The Decodex request timed out."
 		case .transportDisconnected:

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/AccountPanelPresentationTests.swift
@@ -34,7 +34,7 @@ final class AccountPanelPresentationTests: XCTestCase {
 		XCTAssertTrue(presentation.usesDisabledEnvironment)
 	}
 
-	func testPendingRouteNamesConcreteSharedAuthBlockers() {
+	func testPendingRouteHidesConcreteSharedAuthBlockers() {
 		let pending = AccountRoutePending(
 			operationID: "33333333-3333-4333-8333-333333333333",
 			accountID: "11111111-1111-4111-8111-111111111111",
@@ -58,9 +58,12 @@ final class AccountPanelPresentationTests: XCTestCase {
 
 		XCTAssertEqual(
 			pending.statusText,
-			"Waiting for ChatGPT PID 44662 and 1 more process to quit."
+			"Waiting for Codex to close or restart."
 		)
-		XCTAssertTrue(pending.helpText.contains("Codex PID 44768; auth home unknown"))
+		XCTAssertEqual(
+			pending.helpText,
+			"Close Codex and ChatGPT. Reopen them after the account is ready."
+		)
 
 		let hostingView = NSHostingView(
 			rootView: AccountRoutePendingStatusView(pending: pending)
@@ -69,6 +72,100 @@ final class AccountPanelPresentationTests: XCTestCase {
 		hostingView.layoutSubtreeIfNeeded()
 		XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
 		XCTAssertLessThanOrEqual(hostingView.fittingSize.height, 52)
+	}
+
+	func testPendingRouteActionAndStatusDeriveFromEveryExactWaitReason() {
+		let blocker = AccountRouteProcessBlocker(
+			pid: 44662,
+			process: .codex,
+			authHome: .shared
+		)
+		let cases: [(AccountRouteWaitReason, String, String)] = [
+			(.externalCodex(blockers: [blocker], omitted: 0), "Waiting", "Waiting for Codex to close or restart."),
+			(.codexObservationUnavailable, "Waiting", "Waiting for Codex to close or restart."),
+			(.accountReadiness(.storeUnavailable), "Switching", "Switching"),
+			(.accountReadiness(.storeMismatch), "Switching", "Switching"),
+			(.accountReadiness(.operationUnsettled), "Switching", "Switching"),
+			(.accountReadiness(.callbackCapabilityUnready), "Switching", "Switching"),
+			(.sharedAuthStabilizing, "Switching", "Switching"),
+			(.sharedAuthUnavailable, "Switching", "Switching"),
+			(.projectionReadback, "Switching", "Switching"),
+		]
+
+		for (waitReason, actionTitle, statusText) in cases {
+			let pending = AccountRoutePending(
+				operationID: "33333333-3333-4333-8333-333333333333",
+				accountID: "11111111-1111-4111-8111-111111111111",
+				routingRevision: 9,
+				waitReason: waitReason
+			)
+			XCTAssertEqual(pending.actionTitle, actionTitle)
+			XCTAssertEqual(pending.statusText, statusText)
+		}
+	}
+
+	func testRouteActionDoesNotTreatEveryPendingTargetAsWaiting() {
+		let presentation = AccountRouteActionPresentation(
+			isCurrent: false,
+			canSelect: false,
+			canPerformDirectAccountControl: true,
+			isAccountControlInProgress: false,
+			isSubmittingResetCard: false
+		)
+		let switching = AccountRoutePending(
+			operationID: "33333333-3333-4333-8333-333333333333",
+			accountID: "11111111-1111-4111-8111-111111111111",
+			routingRevision: 9,
+			waitReason: .projectionReadback
+		)
+
+		XCTAssertEqual(
+			presentation.title(
+				isSwitching: false,
+				pending: switching,
+				keepsCurrentRoute: false
+			),
+			"Switching"
+		)
+
+		let waiting = AccountRoutePending(
+			operationID: "44444444-4444-4444-8444-444444444444",
+			accountID: "11111111-1111-4111-8111-111111111111",
+			routingRevision: 9,
+			waitReason: .codexObservationUnavailable
+		)
+		XCTAssertEqual(
+			presentation.title(
+				isSwitching: true,
+				pending: waiting,
+				keepsCurrentRoute: false
+			),
+			"Waiting"
+		)
+	}
+
+	func testTerminalReadbackAndNativeRecoveryUseReadyAndRestartStates() {
+		let current = AccountRouteActionPresentation(
+			isCurrent: true,
+			canSelect: false,
+			canPerformDirectAccountControl: true,
+			isAccountControlInProgress: false,
+			isSubmittingResetCard: false
+		)
+
+		XCTAssertEqual(
+			current.title(isSwitching: false, pending: nil, keepsCurrentRoute: false),
+			"Ready"
+		)
+		XCTAssertEqual(
+			ResetCardClientError.nativeClientUnavailable.errorDescription,
+			"Restart Decodex."
+		)
+		XCTAssertEqual(
+			AccountControlError.client(.nativeClientUnavailable).errorDescription,
+			"Restart Decodex."
+		)
+		XCTAssertEqual(FastModeClientError.unavailable.errorDescription, "Restart Decodex.")
 	}
 
 	func testRouteCapabilityDoesNotDependOnQuickTaskCallbackReadiness() {

--- a/apps/decodex-gpui/menubar/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
+++ b/apps/decodex-gpui/menubar/Tests/DecodexAppTests/ResetCardArchitectureTests.swift
@@ -645,12 +645,15 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(store.contains("&& pendingRoute == nil"))
 		XCTAssertTrue(store.contains("pendingRoute?.accountID != accountID"))
 		XCTAssertTrue(store.contains("replacesPendingRoute = pendingRoute != nil"))
-		XCTAssertTrue(actions.contains("title: isPendingTarget"))
-		XCTAssertTrue(actions.contains(#"? "Pending""#))
+		XCTAssertTrue(actions.contains("title: presentation.title("))
+		XCTAssertTrue(actions.contains("return pending.actionTitle"))
+		XCTAssertTrue(actions.contains(#"return "Waiting""#))
+		XCTAssertTrue(actions.contains(#"return "Switching""#))
+		XCTAssertTrue(actions.contains(#"return isCurrent ? "Ready" : "Switch""#))
 		XCTAssertTrue(actions.contains("keepsCurrentRoute"))
-		XCTAssertTrue(actions.contains("keep ChatGPT or Codex closed until Pending changes to Routed"))
+		XCTAssertTrue(actions.contains("Waiting for Codex to close or restart."))
 		XCTAssertTrue(actions.contains("AccountRoutePendingStatusView"))
-		XCTAssertTrue(actions.contains("PID \\(blocker.pid)"))
+		XCTAssertFalse(actions.contains("PID \\(blocker.pid)"))
 		XCTAssertTrue(section.contains("AccountRoutePendingStatusView(pending: pending)"))
 		XCTAssertTrue(
 			actions.contains("store.pendingRoute?.accountID != state.account.accountID")
@@ -811,12 +814,12 @@ final class ResetCardArchitectureTests: XCTestCase {
 			script.contains(#"DEFAULT_SIGN_TEAM_IDENTIFIER="4N949UKQ55""#)
 		)
 		XCTAssertTrue(script.contains(#"verify_signing_team "$APP""#))
+		XCTAssertTrue(script.contains("verify_decodex_bundle_contracts.py"))
 		XCTAssertTrue(
 			compatibility.contains("decodexNativeClientABIVersion: UInt32 = 1")
 		)
-		XCTAssertTrue(
-			compatibility.contains("decodexNativeArtifactCohort: UInt32 = 7")
-		)
+		XCTAssertFalse(compatibility.contains("decodexNativeArtifactCohort"))
+		XCTAssertFalse(compatibility.contains("artifact_cohort"))
 		XCTAssertTrue(
 			compatibility.contains("static func openLibrary(at libraryURL: URL)")
 		)
@@ -826,6 +829,8 @@ final class ResetCardArchitectureTests: XCTestCase {
 		XCTAssertTrue(
 			stageTest.contains("libdecodex_app_client_ffi.dylib")
 		)
+		XCTAssertTrue(stageTest.contains("mismatched_native_client.c"))
+		XCTAssertTrue(stageTest.contains("verify_decodex_bundle_contracts.py"))
 		for retiredPackageTerm in ["-p decodex-cli", "DecodexMenuBar.app", ":8192"] {
 			XCTAssertFalse(
 				script.contains(retiredPackageTerm),

--- a/apps/decodex-gpui/src/accounts.rs
+++ b/apps/decodex-gpui/src/accounts.rs
@@ -399,14 +399,25 @@ impl AccountsController {
 				if matches!(&routing.mode, AccountSelectionModeDto::Fixed(selected) if selected == &account.account_id)
 					&& routing.revision == event.entity_revision =>
 			{
+				let completes_pending = state
+					.pending_route
+					.as_ref()
+					.is_none_or(|pending| pending.account_id == account.account_id);
 				state.upsert_account((**account).clone());
 				state.routing = Some(routing.clone());
 				state.pending_route = None;
-				state.route_reopen_notice = true;
+				state.route_reopen_notice = completes_pending;
+				state.command = if completes_pending {
+					AccountCommandState::Accepted
+				} else {
+					AccountCommandState::Refused
+				};
 				state.sort_accounts();
 			},
 			EventPayload::AccountRoutePending { pending } => {
 				state.pending_route = Some(pending.clone());
+				state.route_reopen_notice = false;
+				state.command = AccountCommandState::AwaitingResult;
 			},
 			_ => {},
 		}
@@ -442,9 +453,25 @@ impl AccountsController {
 				routing,
 				pending_route,
 			}) => {
+				let pending_target =
+					state.pending_route.as_ref().map(|pending| pending.account_id.clone());
 				state.accounts = accounts.clone();
 				state.routing = routing.clone();
 				state.pending_route = pending_route.clone();
+				if pending_route.is_some() {
+					state.route_reopen_notice = false;
+					state.command = AccountCommandState::AwaitingResult;
+				} else if let Some(pending_target) = pending_target {
+					let exact_target_ready = routing.as_ref().is_some_and(|routing| {
+						matches!(&routing.mode, AccountSelectionModeDto::Fixed(account_id) if account_id == &pending_target)
+					});
+					state.command = if exact_target_ready {
+						AccountCommandState::Accepted
+					} else {
+						AccountCommandState::Refused
+					};
+					state.route_reopen_notice = exact_target_ready;
+				}
 				state.sort_accounts();
 				state.load = AccountsLoadState::Ready;
 				AccountRouteOutcome::Fresh
@@ -525,7 +552,11 @@ impl AccountsController {
 				let logout_succeeded =
 					matches!(&in_flight.envelope.payload, CommandPayload::LogoutAccount { .. });
 				if state.apply_success(&in_flight.envelope, result) {
-					state.command = AccountCommandState::Accepted;
+					state.command = if state.pending_route.is_some() {
+						AccountCommandState::AwaitingResult
+					} else {
+						AccountCommandState::Accepted
+					};
 					let query_queued = if logout_succeeded {
 						state.reset_query();
 						state.queue_list()
@@ -615,6 +646,7 @@ impl State {
 	fn snapshot(&self) -> AccountsSnapshot {
 		let idle = self.session.is_some()
 			&& self.load == AccountsLoadState::Ready
+			&& self.pending_route.is_none()
 			&& self.pending_command.is_none()
 			&& self.in_flight_command.is_none()
 			&& !matches!(
@@ -773,6 +805,8 @@ impl State {
 				&& result.entity_revision == Some(pending.routing_revision) =>
 			{
 				self.pending_route = Some(pending.clone());
+				self.route_reopen_notice = false;
+				self.command = AccountCommandState::AwaitingResult;
 				true
 			},
 			(
@@ -992,7 +1026,7 @@ mod tests {
 	}
 
 	#[test]
-	fn legacy_pending_snapshot_does_not_trigger_a_second_route_for_the_current_target() {
+	fn pending_snapshot_does_not_trigger_a_second_route_for_the_current_target() {
 		let controller = AccountsController::production();
 		let server = server();
 		let first = account("10000000-0000-4000-8000-000000000001", "Primary", true, 3);
@@ -1033,10 +1067,48 @@ mod tests {
 			AccountRouteOutcome::Fresh
 		);
 		let snapshot = controller.snapshot();
-		assert!(snapshot.can_manage);
-		assert!(snapshot.can_route);
+		assert!(!snapshot.can_manage);
+		assert!(!snapshot.can_route);
+		assert_eq!(snapshot.command, AccountCommandState::AwaitingResult);
 		controller.select_fixed(&second.account_id).expect("current target is an exact no-op");
 		assert!(controller.try_take_dispatch(2, &server).is_none());
+		assert_eq!(
+			controller.select_fixed(&first.account_id),
+			Err(AccountInputError::Busy),
+			"one pending RouteAccount remains the only routing operation"
+		);
+		assert!(controller.refresh());
+		let AccountDispatch::Query(readback) =
+			controller.try_take_dispatch(2, &server).expect("terminal readback is queued")
+		else {
+			panic!("account refresh must remain a query")
+		};
+		let ready_routing = AccountRoutingControlDto {
+			revision: EntityRevision(6),
+			mode: AccountSelectionModeDto::Fixed(first.account_id.clone()),
+			order: vec![first.account_id.clone(), second.account_id.clone()],
+		};
+		assert_eq!(
+			controller.route_query_result(
+				2,
+				&server,
+				&QueryResultEnvelope {
+					version: CURRENT_VERSION,
+					server_id: server.clone(),
+					query_id: readback.query_id,
+					payload: QueryResultPayload::Accounts(AccountsResult::Available {
+						accounts: vec![first, second],
+						routing: Some(ready_routing),
+						pending_route: None,
+					}),
+				},
+			),
+			AccountRouteOutcome::Fresh
+		);
+		let ready = controller.snapshot();
+		assert_eq!(ready.command, AccountCommandState::Accepted);
+		assert!(ready.route_reopen_notice);
+		assert!(ready.can_route);
 	}
 
 	#[test]

--- a/apps/decodex-gpui/src/bundled_daemon.rs
+++ b/apps/decodex-gpui/src/bundled_daemon.rs
@@ -1,5 +1,6 @@
 //! Local-only launcher for the `decodexd` payload carried by `Decodex.app`.
 
+use std::sync::{Arc, Mutex};
 #[cfg(target_os = "macos")]
 use std::{
 	fs::Metadata,
@@ -29,22 +30,130 @@ pub(crate) enum BundledDaemonFailure {
 	UnsupportedPlatform,
 }
 
-pub(crate) struct BundledDaemonGuard {
+const MAX_RECOVERY_RESTARTS: u8 = 2;
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct DaemonEnvironment {
+	home: PathBuf,
+	path: PathBuf,
+}
+
+struct BundledDaemonGuard {
 	#[cfg(target_os = "macos")]
-	parent_lifetime: UnixStream,
+	parent_lifetime: Option<UnixStream>,
+	#[cfg(target_os = "macos")]
+	child: Option<std::process::Child>,
 }
 
 impl BundledDaemonGuard {
+	#[cfg(target_os = "macos")]
+	fn launch_macos(
+		daemon: &Path,
+		environment: Option<&DaemonEnvironment>,
+	) -> Result<Self, BundledDaemonFailure> {
+		let metadata = std::fs::symlink_metadata(&daemon)
+			.map_err(|_| BundledDaemonFailure::PayloadUnavailable)?;
+		if !is_executable_regular_file(&metadata) || metadata.file_type().is_symlink() {
+			return Err(BundledDaemonFailure::PayloadUnavailable);
+		}
+
+		let (parent_lifetime, child_lifetime) =
+			lifetime_channel().map_err(|_| BundledDaemonFailure::LifetimeChannelUnavailable)?;
+		let child_fd = child_lifetime.as_raw_fd();
+		let mut command = Command::new(daemon);
+		command
+			.arg("serve")
+			.arg("--parent-fd")
+			.arg(child_fd.to_string())
+			.stdin(Stdio::null())
+			.stdout(Stdio::null())
+			.stderr(Stdio::null());
+		if let Some(environment) = environment {
+			command.env("HOME", &environment.home).env("PATH", &environment.path);
+		}
+		let child = command.spawn().map_err(|_| BundledDaemonFailure::LaunchFailed)?;
+		drop(child_lifetime);
+
+		Ok(Self { parent_lifetime: Some(parent_lifetime), child: Some(child) })
+	}
+
+	#[cfg(target_os = "macos")]
+	fn request_shutdown(&mut self) {
+		if let Some(parent_lifetime) = self.parent_lifetime.take() {
+			let _ = parent_lifetime.shutdown(std::net::Shutdown::Both);
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn stop_for_restart(mut self) {
+		self.request_shutdown();
+		let Some(mut child) = self.child.take() else {
+			return;
+		};
+		for _ in 0..20 {
+			if child.try_wait().ok().flatten().is_some() {
+				return;
+			}
+			std::thread::sleep(std::time::Duration::from_millis(25));
+		}
+		// This handle names only the child spawned with our private lifetime channel.
+		let _ = child.kill();
+		let _ = child.wait();
+	}
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for BundledDaemonGuard {
+	fn drop(&mut self) {
+		self.request_shutdown();
+		if let Some(mut child) = self.child.take() {
+			let _ = std::thread::Builder::new().name("decodexd-reaper".into()).spawn(move || {
+				let _ = child.wait();
+			});
+		}
+	}
+}
+
+struct SupervisorState {
+	guard: Option<BundledDaemonGuard>,
+	restarts: u8,
+}
+
+/// Ownership-aware recovery for the daemon child carried by this exact app bundle.
+pub(crate) struct BundledDaemonSupervisor {
+	#[cfg(target_os = "macos")]
+	daemon: PathBuf,
+	#[cfg(target_os = "macos")]
+	environment: Option<DaemonEnvironment>,
+	state: Mutex<SupervisorState>,
+}
+
+impl crate::client_lifecycle::AppOwnedDaemonRecovery for BundledDaemonSupervisor {
+	fn recover_transport(&self) -> bool {
+		self.recover_transport()
+	}
+}
+
+impl BundledDaemonSupervisor {
 	pub(crate) fn launch_for_profile(
 		profile: &ClientProfile,
-	) -> Result<Option<Self>, BundledDaemonFailure> {
+	) -> Result<Option<Arc<Self>>, BundledDaemonFailure> {
 		if profile.kind() == ProfileKind::Remote {
 			return Ok(None);
 		}
 
 		#[cfg(target_os = "macos")]
 		{
-			Self::launch_macos().map(Some)
+			let executable =
+				std::env::current_exe().map_err(|_| BundledDaemonFailure::NotBundled)?;
+			let daemon = bundled_daemon_path(&executable)?;
+			let guard = BundledDaemonGuard::launch_macos(&daemon, None)?;
+			Ok(Some(Arc::new(Self {
+				daemon,
+				environment: None,
+				state: Mutex::new(SupervisorState { guard: Some(guard), restarts: 0 }),
+			})))
 		}
 		#[cfg(not(target_os = "macos"))]
 		{
@@ -52,60 +161,89 @@ impl BundledDaemonGuard {
 		}
 	}
 
-	#[cfg(target_os = "macos")]
-	fn launch_macos() -> Result<Self, BundledDaemonFailure> {
-		let executable = std::env::current_exe().map_err(|_| BundledDaemonFailure::NotBundled)?;
-		let daemon = bundled_daemon_path(&executable)?;
-		let metadata = std::fs::symlink_metadata(&daemon)
-			.map_err(|_| BundledDaemonFailure::PayloadUnavailable)?;
-		if !is_executable_regular_file(&metadata) || metadata.file_type().is_symlink() {
-			return Err(BundledDaemonFailure::PayloadUnavailable);
+	/// Restart only the child represented by the retained private lifetime channel.
+	/// Return whether this supervisor retains authority for a later bounded attempt.
+	pub(crate) fn recover_transport(&self) -> bool {
+		let mut state = self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+		if state.restarts >= MAX_RECOVERY_RESTARTS {
+			return false;
 		}
+		state.restarts += 1;
 
-		let (parent_lifetime, child_lifetime) = lifetime_channel()
-			.map_err(|_| BundledDaemonFailure::LifetimeChannelUnavailable)?;
-		let child_fd = child_lifetime.as_raw_fd();
-		let mut child = Command::new(daemon)
-			.arg("serve")
-			.arg("--parent-fd")
-			.arg(child_fd.to_string())
-			.stdin(Stdio::null())
-			.stdout(Stdio::null())
-			.stderr(Stdio::null())
-			.spawn()
-			.map_err(|_| BundledDaemonFailure::LaunchFailed)?;
-		drop(child_lifetime);
-
-		let _ = std::thread::Builder::new()
-			.name("decodexd-reaper".into())
-			.spawn(move || {
-				let _ = child.wait();
-			});
-
-		Ok(Self { parent_lifetime })
+		#[cfg(target_os = "macos")]
+		{
+			if let Some(guard) = state.guard.take() {
+				guard.stop_for_restart();
+			}
+			match BundledDaemonGuard::launch_macos(&self.daemon, self.environment.as_ref()) {
+				Ok(guard) => {
+					state.guard = Some(guard);
+					true
+				},
+				Err(_) => state.restarts < MAX_RECOVERY_RESTARTS,
+			}
+		}
+		#[cfg(not(target_os = "macos"))]
+		{
+			false
+		}
 	}
-}
 
-#[cfg(target_os = "macos")]
-impl Drop for BundledDaemonGuard {
-	fn drop(&mut self) {
-		let _ = self.parent_lifetime.shutdown(std::net::Shutdown::Both);
+	#[cfg(all(test, target_os = "macos"))]
+	fn launch_test(
+		daemon: PathBuf,
+		home: PathBuf,
+		path: PathBuf,
+	) -> Result<Arc<Self>, BundledDaemonFailure> {
+		let environment = DaemonEnvironment { home, path };
+		let guard = BundledDaemonGuard::launch_macos(&daemon, Some(&environment))?;
+		Ok(Arc::new(Self {
+			daemon,
+			environment: Some(environment),
+			state: Mutex::new(SupervisorState { guard: Some(guard), restarts: 0 }),
+		}))
+	}
+
+	#[cfg(all(test, target_os = "macos"))]
+	fn child_id(&self) -> Option<u32> {
+		self.state
+			.lock()
+			.unwrap_or_else(std::sync::PoisonError::into_inner)
+			.guard
+			.as_ref()
+			.and_then(|guard| guard.child.as_ref())
+			.map(std::process::Child::id)
+	}
+
+	#[cfg(all(test, target_os = "macos"))]
+	fn child_has_exited(&self) -> bool {
+		self.state
+			.lock()
+			.unwrap_or_else(std::sync::PoisonError::into_inner)
+			.guard
+			.as_mut()
+			.and_then(|guard| guard.child.as_mut())
+			.is_some_and(|child| child.try_wait().ok().flatten().is_some())
+	}
+
+	fn shutdown(&self) {
+		self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner).guard.take();
 	}
 }
 
 struct BundledDaemonOwner {
-	guard: Option<BundledDaemonGuard>,
+	supervisor: Arc<BundledDaemonSupervisor>,
 	_quit: Option<Subscription>,
 }
 
 impl BundledDaemonOwner {
-	fn new(guard: BundledDaemonGuard, cx: &mut Context<Self>) -> Self {
+	fn new(supervisor: Arc<BundledDaemonSupervisor>, cx: &mut Context<Self>) -> Self {
 		let quit = cx.on_app_quit(|owner, _| owner.shutdown());
-		Self { guard: Some(guard), _quit: Some(quit) }
+		Self { supervisor, _quit: Some(quit) }
 	}
 
 	fn shutdown(&mut self) -> Pin<Box<dyn Future<Output = ()> + 'static>> {
-		self.guard.take();
+		self.supervisor.shutdown();
 		Box::pin(async {})
 	}
 }
@@ -116,12 +254,12 @@ struct BundledDaemonGlobal {
 
 impl Global for BundledDaemonGlobal {}
 
-pub(crate) fn retain(guard: BundledDaemonGuard, cx: &mut App) {
+pub(crate) fn retain(supervisor: Arc<BundledDaemonSupervisor>, cx: &mut App) {
 	debug_assert!(
 		!cx.has_global::<BundledDaemonGlobal>(),
 		"Decodex retains at most one bundled-daemon lifetime"
 	);
-	let owner = cx.new(|cx| BundledDaemonOwner::new(guard, cx));
+	let owner = cx.new(|cx| BundledDaemonOwner::new(supervisor, cx));
 	cx.set_global(BundledDaemonGlobal { _owner: owner });
 }
 
@@ -147,14 +285,8 @@ fn is_executable_regular_file(metadata: &Metadata) -> bool {
 fn lifetime_channel() -> io::Result<(UnixStream, OwnedFd)> {
 	let mut descriptors = [-1_i32; 2];
 	// SAFETY: `descriptors` has room for the two fds written by `socketpair`.
-	if unsafe {
-		libc::socketpair(
-			libc::AF_UNIX,
-			libc::SOCK_STREAM,
-			0,
-			descriptors.as_mut_ptr(),
-		)
-	} != 0
+	if unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, descriptors.as_mut_ptr()) }
+		!= 0
 	{
 		return Err(io::Error::last_os_error());
 	}
@@ -185,6 +317,16 @@ fn set_close_on_exec(raw_fd: i32, enabled: bool) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+	use std::{
+		fs,
+		os::unix::fs::PermissionsExt as _,
+		process::Child,
+		time::{Duration, Instant},
+	};
+
+	use decodex_protocol::DoctorClient;
+	use tempfile::TempDir;
+
 	use super::*;
 
 	#[cfg(target_os = "macos")]
@@ -211,5 +353,231 @@ mod tests {
 		let child_flags = unsafe { libc::fcntl(child.as_raw_fd(), libc::F_GETFD) };
 		assert_ne!(parent_flags & libc::FD_CLOEXEC, 0);
 		assert_eq!(child_flags & libc::FD_CLOEXEC, 0);
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	#[ignore = "run through scripts/test_gpui_bundled_daemon_supervision.sh with a freshly built decodexd"]
+	fn process_listener_loss_restarts_exact_owned_daemon_and_rebinds_client() {
+		let fixture = ProcessFixture::new();
+		let supervisor = BundledDaemonSupervisor::launch_test(
+			fixture.daemon.clone(),
+			fixture.home.clone(),
+			fixture.path.clone(),
+		)
+		.expect("launch isolated app-owned daemon");
+		let runtime = tokio::runtime::Builder::new_current_thread()
+			.enable_all()
+			.build()
+			.expect("build isolated client runtime");
+
+		wait_for_client(&runtime, &fixture.root);
+		let first_pid = supervisor.child_id().expect("owned daemon PID is retained");
+		fs::remove_file(&fixture.socket).expect("remove exact isolated canonical socket");
+		wait_until("listener owner exits after publication loss", || supervisor.child_has_exited());
+
+		assert!(supervisor.recover_transport(), "owned transport recovery remains available");
+		wait_for_client(&runtime, &fixture.root);
+		let replacement_pid = supervisor.child_id().expect("replacement daemon PID is retained");
+
+		assert_ne!(replacement_pid, first_pid, "recovery must launch a fresh owned process");
+		assert!(process_is_alive(replacement_pid));
+		supervisor.shutdown();
+		wait_until("recovered owned daemon exits with the app lifetime", || {
+			!process_is_alive(replacement_pid)
+		});
+	}
+
+	#[cfg(target_os = "macos")]
+	#[test]
+	#[ignore = "run through scripts/test_gpui_bundled_daemon_supervision.sh with a freshly built decodexd"]
+	fn process_recovery_never_terminates_independently_managed_daemon() {
+		let fixture = ProcessFixture::new();
+		let mut independent = fixture.launch_independent();
+		let runtime = tokio::runtime::Builder::new_current_thread()
+			.enable_all()
+			.build()
+			.expect("build isolated client runtime");
+		wait_for_client(&runtime, &fixture.root);
+		let independent_pid = independent.id();
+		let independent_socket_inode =
+			fs::symlink_metadata(&fixture.socket).expect("read independent daemon socket").ino();
+
+		let supervisor = BundledDaemonSupervisor::launch_test(
+			fixture.daemon.clone(),
+			fixture.home.clone(),
+			fixture.path.clone(),
+		)
+		.expect("launch isolated bundled contender");
+		wait_until("bundled contender observes the independent singleton", || {
+			supervisor.child_has_exited()
+		});
+		assert!(supervisor.recover_transport(), "bounded recovery may launch one more contender");
+		wait_until("replacement contender also preserves the independent singleton", || {
+			supervisor.child_has_exited()
+		});
+
+		assert!(process_is_alive(independent_pid), "supervisor must not kill an unowned daemon");
+		assert_eq!(
+			fs::symlink_metadata(&fixture.socket)
+				.expect("independent socket remains published")
+				.ino(),
+			independent_socket_inode,
+			"supervisor must not unlink or replace an unowned publication"
+		);
+		wait_for_client(&runtime, &fixture.root);
+		supervisor.shutdown();
+		assert!(process_is_alive(independent_pid), "supervisor shutdown owns no foreign process");
+		independent.stop();
+	}
+
+	#[cfg(target_os = "macos")]
+	struct ProcessFixture {
+		_temporary: TempDir,
+		daemon: PathBuf,
+		home: PathBuf,
+		path: PathBuf,
+		root: PathBuf,
+		socket: PathBuf,
+	}
+
+	#[cfg(target_os = "macos")]
+	impl ProcessFixture {
+		fn new() -> Self {
+			let temporary =
+				TempDir::new_in("/private/tmp").expect("create short process test home");
+			let home = temporary.path().canonicalize().expect("canonicalize process test home");
+			let root = home.join(".decodex");
+			let path = home.join("bin");
+			let server = root.join("server");
+			fs::create_dir(&root).expect("create isolated Decodex root");
+			fs::create_dir(&path).expect("create isolated executable path");
+			fs::create_dir(&server).expect("create isolated server root");
+			fs::set_permissions(&root, fs::Permissions::from_mode(0o700))
+				.expect("scope isolated Decodex root");
+			fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+				.expect("scope isolated executable path");
+			fs::set_permissions(&server, fs::Permissions::from_mode(0o700))
+				.expect("scope isolated server root");
+			let config = root.join("config.toml");
+			fs::write(
+				&config,
+				format!(
+					r#"version = 1
+active_profile = "local"
+
+[profiles.local]
+kind = "local"
+policy = "same_uid"
+service_owner_uid = {}
+
+[cache]
+max_entries = 16
+max_bytes = 1048576
+max_entry_bytes = 65536
+"#,
+					fs::metadata(&root).expect("read isolated root metadata").uid(),
+				),
+			)
+			.expect("write isolated client/server config");
+			fs::set_permissions(&config, fs::Permissions::from_mode(0o600))
+				.expect("scope isolated client/server config");
+			let daemon = PathBuf::from(
+				std::env::var_os("DECODEX_TEST_DAEMON")
+					.expect("repository process test runner sets DECODEX_TEST_DAEMON"),
+			);
+			assert!(
+				is_executable_regular_file(
+					&fs::symlink_metadata(&daemon).expect("read real decodexd test binary")
+				),
+				"process fixture requires an executable real decodexd binary"
+			);
+			let socket = server.join("decodex.sock");
+			Self { _temporary: temporary, daemon, home, path, root, socket }
+		}
+
+		fn launch_independent(&self) -> IndependentDaemon {
+			let child = Command::new(&self.daemon)
+				.arg("serve")
+				.env("HOME", &self.home)
+				.env("PATH", &self.path)
+				.stdin(Stdio::null())
+				.stdout(Stdio::null())
+				.stderr(Stdio::null())
+				.spawn()
+				.expect("launch independently managed daemon");
+			IndependentDaemon { child: Some(child) }
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	struct IndependentDaemon {
+		child: Option<Child>,
+	}
+
+	#[cfg(target_os = "macos")]
+	impl IndependentDaemon {
+		fn id(&self) -> u32 {
+			self.child.as_ref().expect("independent daemon remains retained").id()
+		}
+
+		fn stop(&mut self) {
+			let Some(mut child) = self.child.take() else {
+				return;
+			};
+			// SAFETY: this PID is the exact child owned by this isolated process fixture.
+			let _ = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+			let deadline = Instant::now() + Duration::from_secs(20);
+			loop {
+				if child.try_wait().expect("poll independent daemon").is_some() {
+					return;
+				}
+				if Instant::now() >= deadline {
+					let _ = child.kill();
+					let _ = child.wait();
+					panic!("independent daemon did not stop before timeout");
+				}
+				std::thread::sleep(Duration::from_millis(20));
+			}
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	impl Drop for IndependentDaemon {
+		fn drop(&mut self) {
+			if let Some(mut child) = self.child.take() {
+				let _ = child.kill();
+				let _ = child.wait();
+			}
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn wait_for_client(runtime: &tokio::runtime::Runtime, root: &Path) {
+		let deadline = Instant::now() + Duration::from_secs(20);
+		loop {
+			if let Ok(profile) = ClientProfile::load(root, None)
+				&& runtime.block_on(DoctorClient::new(profile).query()).is_ok()
+			{
+				return;
+			}
+			assert!(Instant::now() < deadline, "new client did not connect before timeout");
+			std::thread::sleep(Duration::from_millis(25));
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn wait_until(label: &str, mut predicate: impl FnMut() -> bool) {
+		let deadline = Instant::now() + Duration::from_secs(20);
+		while !predicate() {
+			assert!(Instant::now() < deadline, "{label}");
+			std::thread::sleep(Duration::from_millis(20));
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn process_is_alive(pid: u32) -> bool {
+		// SAFETY: signal 0 performs a liveness/permission check and has no process effect.
+		unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 	}
 }

--- a/apps/decodex-gpui/src/client_lifecycle.rs
+++ b/apps/decodex-gpui/src/client_lifecycle.rs
@@ -38,6 +38,11 @@ use crate::{
 	work_items::{WorkItemDispatch, WorkItemRouteOutcome, WorkItems},
 };
 
+pub(crate) trait AppOwnedDaemonRecovery: Send + Sync {
+	/// Attempt recovery and report whether this exact owner retains later restart authority.
+	fn recover_transport(&self) -> bool;
+}
+
 const RETRY_DELAYS: [Duration; 4] = [
 	Duration::from_millis(100),
 	Duration::from_millis(250),
@@ -272,10 +277,12 @@ impl LifecycleIo for TokioIo {
 
 	async fn next(&mut self) -> Result<Delivery<Self::Confirmation>, RetainedSessionFailure> {
 		match self.session.as_mut().ok_or(RetainedSessionFailure::Closed)?.next().await? {
-			SessionDelivery::Snapshot { snapshot, confirmation } =>
-				Ok(Delivery::Snapshot { snapshot, confirmation }),
-			SessionDelivery::Event { event, confirmation } =>
-				Ok(Delivery::Event { event, confirmation }),
+			SessionDelivery::Snapshot { snapshot, confirmation } => {
+				Ok(Delivery::Snapshot { snapshot, confirmation })
+			},
+			SessionDelivery::Event { event, confirmation } => {
+				Ok(Delivery::Event { event, confirmation })
+			},
 			SessionDelivery::QueryResult(result) => Ok(Delivery::QueryResult(result)),
 			SessionDelivery::CommandReceipt(receipt) => Ok(Delivery::CommandReceipt(receipt)),
 			SessionDelivery::CommandResult(result) => Ok(Delivery::CommandResult(result)),
@@ -348,6 +355,7 @@ pub(crate) struct ClientLifecycle {
 	view: ConnectionView,
 	view_observer: Option<Sender<ConnectionView>>,
 	cancellation: LifecycleCancellation,
+	app_owned_daemon: Option<Arc<dyn AppOwnedDaemonRecovery>>,
 }
 
 impl ClientLifecycle {
@@ -414,7 +422,16 @@ impl ClientLifecycle {
 			view,
 			view_observer: None,
 			cancellation: LifecycleCancellation::new(),
+			app_owned_daemon: None,
 		})
+	}
+
+	/// Permit transport recovery only through the exact bundled child owned by this app process.
+	pub(crate) fn supervise_app_owned_daemon<T>(&mut self, supervisor: Arc<T>)
+	where
+		T: AppOwnedDaemonRecovery + 'static,
+	{
+		self.app_owned_daemon = Some(supervisor);
 	}
 
 	/// Current narrow shell-facing state.
@@ -519,6 +536,7 @@ impl ClientLifecycle {
 					if let Some(result) = self.closed_failure(failure) {
 						return result;
 					}
+					self.recover_app_owned_transport(failure);
 
 					if !self.retry(io, attempt, generation).await {
 						return self.retry_terminal(attempt);
@@ -563,6 +581,7 @@ impl ClientLifecycle {
 			if let Some(result) = self.closed_failure(failure) {
 				return result;
 			}
+			self.recover_app_owned_transport(failure);
 			if !self.retry(io, attempt, generation).await {
 				return self.retry_terminal(attempt);
 			}
@@ -621,7 +640,7 @@ impl ClientLifecycle {
 			}
 
 			match step {
-				SessionStep::Account(dispatch) =>
+				SessionStep::Account(dispatch) => {
 					if let Some(command) = dispatch.command() {
 						let send_result = io.send_command(command.clone()).await;
 						if let Err(failure) = send_result {
@@ -633,7 +652,8 @@ impl ClientLifecycle {
 						&& let Err(failure) = io.send_query(query.clone()).await
 					{
 						return failure;
-					},
+					}
+				},
 				SessionStep::DesktopSettings(dispatch) => {
 					if let Some(command) = dispatch.command() {
 						let send_result = io.send_command(command.clone()).await;
@@ -672,7 +692,7 @@ impl ClientLifecycle {
 						self.history_pager.lookup_sent_request(&send_token);
 					}
 				},
-				SessionStep::Program(dispatch) =>
+				SessionStep::Program(dispatch) => {
 					if let Some(command) = dispatch.command() {
 						let send_result = io.send_command(command.clone()).await;
 						if let Err(failure) = send_result {
@@ -684,8 +704,9 @@ impl ClientLifecycle {
 						&& let Err(failure) = io.send_query(query.clone()).await
 					{
 						return failure;
-					},
-				SessionStep::QuickTask(dispatch) =>
+					}
+				},
+				SessionStep::QuickTask(dispatch) => {
 					if let Some(command) = dispatch.command() {
 						let send_result = io.send_command(command.clone()).await;
 						if let Err(failure) = send_result {
@@ -697,8 +718,9 @@ impl ClientLifecycle {
 						&& let Err(failure) = io.send_query(query.clone()).await
 					{
 						return failure;
-					},
-				SessionStep::WorkItem(dispatch) =>
+					}
+				},
+				SessionStep::WorkItem(dispatch) => {
 					if let Some(command) = dispatch.command() {
 						let send_result = io.send_command(command.clone()).await;
 						if let Err(failure) = send_result {
@@ -710,7 +732,8 @@ impl ClientLifecycle {
 						&& let Err(failure) = io.send_query(query.clone()).await
 					{
 						return failure;
-					},
+					}
+				},
 				SessionStep::Delivery(delivery) => match *delivery {
 					Ok(Delivery::Snapshot { snapshot, confirmation }) => {
 						let cursor = snapshot.cursor;
@@ -844,7 +867,9 @@ impl ClientLifecycle {
 			Ok(Some(inspection))
 				if inspection.generation == binding.generation
 					&& inspection.authority == self.cache_authority =>
-				Some(binding.checkpoint),
+			{
+				Some(binding.checkpoint)
+			},
 			_ => {
 				self.enter_quarantine(
 					QuarantineReason::ContentAttestation,
@@ -914,8 +939,9 @@ impl ClientLifecycle {
 		}
 		match self.health_query.route_result(generation, &self.server_id, &result) {
 			HealthRouteOutcome::Unmatched => self.route_history_result(generation, result),
-			HealthRouteOutcome::Fresh | HealthRouteOutcome::Refused | HealthRouteOutcome::Stale =>
-				Ok(()),
+			HealthRouteOutcome::Fresh | HealthRouteOutcome::Refused | HealthRouteOutcome::Stale => {
+				Ok(())
+			},
 		}
 	}
 
@@ -1183,6 +1209,23 @@ impl ClientLifecycle {
 		}
 	}
 
+	fn recover_app_owned_transport(&mut self, failure: RetainedSessionFailure) {
+		if matches!(
+			failure,
+			RetainedSessionFailure::OperationTimeout
+				| RetainedSessionFailure::Closed
+				| RetainedSessionFailure::Disconnected
+		) {
+			if self
+				.app_owned_daemon
+				.as_ref()
+				.is_some_and(|supervisor| !supervisor.recover_transport())
+			{
+				self.app_owned_daemon = None;
+			}
+		}
+	}
+
 	async fn retry<I>(&mut self, io: &mut I, attempt: u8, generation: u64) -> bool
 	where
 		I: LifecycleIo,
@@ -1303,7 +1346,7 @@ fn initialize_cache(
 				Err(_) => unsafe_cache_quarantine(),
 			}
 		},
-		Err(error) if is_disposable_corruption(error) =>
+		Err(error) if is_disposable_corruption(error) => {
 			if ClientCache::dispose_all(root).is_ok() {
 				match ClientCache::open(root, limits, authority) {
 					Ok(cache) => (
@@ -1317,7 +1360,8 @@ fn initialize_cache(
 				}
 			} else {
 				unsafe_cache_quarantine()
-			},
+			}
+		},
 		Err(_) => unsafe_cache_quarantine(),
 	}
 }

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -27,9 +27,9 @@ use decodex_protocol::{
 
 use crate::{
 	client_lifecycle::{
-		AppliedEntity, CLIENT_CACHE_SCHEMA_GENERATION, CacheAuthority, CacheError, CacheLimits,
-		ClientCache, ClientLifecycle, CompatibilityReason, ConnectionView, Delivery,
-		LifecycleBuildError, LifecycleCancellation, LifecycleIo, QuarantineReason,
+		AppOwnedDaemonRecovery, AppliedEntity, CLIENT_CACHE_SCHEMA_GENERATION, CacheAuthority,
+		CacheError, CacheLimits, ClientCache, ClientLifecycle, CompatibilityReason, ConnectionView,
+		Delivery, LifecycleBuildError, LifecycleCancellation, LifecycleIo, QuarantineReason,
 		QuarantineRecovery, RunResult, production_cache_parent,
 	},
 	history_pager::{
@@ -37,6 +37,16 @@ use crate::{
 		HistoryNavigationResult, HistoryPageSource, HistoryRetryReason, HistoryStaleReason,
 	},
 };
+
+struct BoundedRecoveryProbe {
+	attempts: AtomicUsize,
+}
+
+impl AppOwnedDaemonRecovery for BoundedRecoveryProbe {
+	fn recover_transport(&self) -> bool {
+		self.attempts.fetch_add(1, Ordering::SeqCst) < 2
+	}
+}
 
 const SERVER: &str = "018f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
 const OTHER_SERVER: &str = "028f0f9e-7b6e-4a31-8f4c-1d2e3f405162";
@@ -338,13 +348,7 @@ fn production_owner_keeps_the_session_after_window_close_and_stops_only_on_app_q
 		lifecycle.run_with_io(&mut io).await
 	});
 	let owner = visual.update(|_, cx| {
-		retain_lifecycle_task(
-			shell.downgrade(),
-			cancellation,
-			views,
-			background,
-			cx,
-		)
+		retain_lifecycle_task(shell.downgrade(), cancellation, views, background, cx)
 	});
 
 	visual.run_until_parked();
@@ -1554,6 +1558,37 @@ async fn observer_receives_the_complete_bounded_retry_progression() {
 			ConnectionView::Stopped,
 		]
 	);
+}
+
+#[tokio::test]
+async fn app_owned_transport_recovery_is_bounded_and_protocol_failure_never_restarts() {
+	let temporary = TempDir::new().expect("temporary directory is available");
+	let root = cache_parent(&temporary);
+	let recovery = Arc::new(BoundedRecoveryProbe { attempts: AtomicUsize::new(0) });
+	let mut disconnected_lifecycle = lifecycle(&root);
+	disconnected_lifecycle.supervise_app_owned_daemon(Arc::clone(&recovery));
+	let failures =
+		(0..5).map(|_| ConnectAction::Fail(RetainedSessionFailure::Disconnected)).collect();
+	let mut io = FakeIo::new(root, failures);
+
+	assert_eq!(
+		disconnected_lifecycle.run_with_io(&mut io).await,
+		RunResult::RetryExhausted
+	);
+	assert_eq!(recovery.attempts.load(Ordering::SeqCst), 3);
+
+	let protocol_temporary = TempDir::new().expect("temporary directory is available");
+	let protocol_root = cache_parent(&protocol_temporary);
+	let protocol_recovery = Arc::new(BoundedRecoveryProbe { attempts: AtomicUsize::new(0) });
+	let mut protocol_lifecycle = lifecycle(&protocol_root);
+	protocol_lifecycle.supervise_app_owned_daemon(Arc::clone(&protocol_recovery));
+	let mut protocol_io = FakeIo::new(
+		protocol_root,
+		vec![ConnectAction::Fail(RetainedSessionFailure::ArtifactCohortMismatch)],
+	);
+
+	assert_eq!(protocol_lifecycle.run_with_io(&mut protocol_io).await, RunResult::Incompatible);
+	assert_eq!(protocol_recovery.attempts.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/apps/decodex-gpui/src/main.rs
+++ b/apps/decodex-gpui/src/main.rs
@@ -68,12 +68,14 @@ fn main() {
 	application.run(move |cx: &mut App| {
 		shell::bind_keys(cx);
 		let profile = ClientProfile::load_default(None);
-		if let Ok(profile) = profile.as_ref()
-			&& let Ok(Some(daemon)) = bundled_daemon::BundledDaemonGuard::launch_for_profile(profile)
-		{
-			bundled_daemon::retain(daemon, cx);
+		let bundled_daemon = profile.as_ref().ok().and_then(|profile| {
+			bundled_daemon::BundledDaemonSupervisor::launch_for_profile(profile).ok().flatten()
+		});
+		if let Some(supervisor) = bundled_daemon.as_ref() {
+			bundled_daemon::retain(Arc::clone(supervisor), cx);
 		}
-		let (initial_connection, lifecycle, account_login) = compose_lifecycle(profile);
+		let (initial_connection, lifecycle, account_login) =
+			compose_lifecycle(profile, bundled_daemon);
 		let bounds = Bounds::centered(None, size(px(1248.0), px(840.0)), cx);
 		let window = cx
 			.open_window(
@@ -159,8 +161,8 @@ fn order_out_native_windows() {
 
 fn compose_lifecycle(
 	profile: Result<ClientProfile, ClientFailure>,
-)
--> (ConnectionView, Option<ClientLifecycle>, Option<Arc<AccountLoginController>>) {
+	bundled_daemon: Option<Arc<bundled_daemon::BundledDaemonSupervisor>>,
+) -> (ConnectionView, Option<ClientLifecycle>, Option<Arc<AccountLoginController>>) {
 	let profile = match profile {
 		Ok(profile) => profile,
 		Err(failure) => {
@@ -183,7 +185,12 @@ fn compose_lifecycle(
 		},
 	};
 	match ClientLifecycle::production(config) {
-		Ok(lifecycle) => (lifecycle.view(), Some(lifecycle), Some(account_login)),
+		Ok(mut lifecycle) => {
+			if let Some(supervisor) = bundled_daemon {
+				lifecycle.supervise_app_owned_daemon(supervisor);
+			}
+			(lifecycle.view(), Some(lifecycle), Some(account_login))
+		},
 		Err(_) => (
 			ConnectionView::Quarantined {
 				reason: QuarantineReason::CacheRootUnsafe,

--- a/apps/decodex-gpui/src/native_menu_bar.rs
+++ b/apps/decodex-gpui/src/native_menu_bar.rs
@@ -10,9 +10,6 @@ use std::{
 };
 
 #[cfg(all(target_os = "macos", not(test)))]
-use decodex_protocol::CURRENT_ARTIFACT_COHORT;
-
-#[cfg(all(target_os = "macos", not(test)))]
 const MENU_BAR_ABI_VERSION: u32 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -34,9 +31,9 @@ impl NativeMenuBarFailure {
 	pub(crate) const fn detail(self) -> &'static str {
 		match self {
 			Self::NotBundled => "The native menu bar is available from staged Decodex.app builds.",
-			Self::LibraryUnavailable => "Decodex could not load its signed native menu-bar module.",
-			Self::Incompatible => "The native menu-bar module does not match this Decodex build.",
-			Self::HostUnavailable => "Decodex could not create the native Swift menu-bar host.",
+			Self::LibraryUnavailable | Self::Incompatible | Self::HostUnavailable => {
+				"Restart Decodex."
+			},
 			Self::ApplyFailed => "The native Swift menu bar refused the requested visibility.",
 			Self::LoginItemFailed => "macOS refused the requested login-item operation.",
 			Self::UnsupportedPlatform => "The menu-bar surface is available only on macOS.",
@@ -246,13 +243,8 @@ impl SwiftMenuBarBridge {
 
 		// SAFETY: every symbol is verified non-null before it is copied to its exact C ABI type.
 		let abi: VersionFn = unsafe { symbol(image, c"decodex_menu_bar_abi_version")? };
-		// SAFETY: same checked C ABI boundary as `abi`.
-		let cohort: VersionFn = unsafe { symbol(image, c"decodex_menu_bar_artifact_cohort")? };
-		// SAFETY: version functions have no arguments and no side effects outside the loaded image.
-		if unsafe { abi() } != MENU_BAR_ABI_VERSION
-			// SAFETY: the cohort function has the same exact checked signature.
-			|| unsafe { cohort() } != CURRENT_ARTIFACT_COHORT
-		{
+		// SAFETY: the version function has no arguments and no side effects outside the loaded image.
+		if unsafe { abi() } != MENU_BAR_ABI_VERSION {
 			return Err(NativeMenuBarFailure::Incompatible);
 		}
 		// SAFETY: each exported symbol has a fixed ABI that is covered by Swift and Rust tests.

--- a/apps/decodex-gpui/src/shell.rs
+++ b/apps/decodex-gpui/src/shell.rs
@@ -21,8 +21,8 @@ use gpui::{
 use decodex_protocol::{
 	AccountDto, AccountLifecycleReadinessDto, AccountLoginInstallMode, AccountLoginMethod,
 	AccountLoginStart, AccountLoginState, AccountLoginStatus, AccountObservedStateDto,
-	AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto, AccountRouteAuthHomeDto,
-	AccountRouteBlockingProcessDto, AccountRoutePendingDto, AccountRouteWaitReasonDto,
+	AccountProfileResult, AccountQuotaStateDto, AccountQuotaWindowDto, AccountRoutePendingDto,
+	AccountRouteWaitReasonDto,
 	AccountSelectionModeDto, AppServerCapability, ClientFailure, DoctorComponent, DoctorIssue,
 	DoctorStatus, EntityId, HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto,
 	HistoryPayloadDto, HistoryTurnRole, IdempotencyKey, QuickTaskRecoveryAction, QuickTaskState,
@@ -37,8 +37,7 @@ use crate::{
 		AccountsSnapshot, canonical_uuid_v4,
 	},
 	client_lifecycle::{
-		ClientLifecycle, CompatibilityReason, ConnectionView, LifecycleCancellation,
-		QuarantineReason, QuarantineRecovery,
+		ClientLifecycle, ConnectionView, LifecycleCancellation,
 	},
 	composer_input::{self, ComposerEvent, ComposerInput, MAX_COMPOSER_BYTES, SubmitComposer},
 	desktop_settings::{DesktopSettingsController, DesktopSettingsSnapshot},
@@ -375,46 +374,29 @@ struct ConnectionPresentation {
 
 fn connection_presentation(view: ConnectionView) -> ConnectionPresentation {
 	match view {
-		ConnectionView::Connecting { attempt } => ConnectionPresentation {
+		ConnectionView::Connecting { .. } => ConnectionPresentation {
 			label: "Connecting",
-			detail: format!("Establishing verified session · attempt {attempt}").into(),
+			detail: "Starting Decodex.".into(),
 			color: 0xf59e0b,
 		},
-		ConnectionView::Online { generation, applied } => ConnectionPresentation {
+		ConnectionView::Online { .. } => ConnectionPresentation {
 			label: "Online",
-			detail: match applied {
-				Some(cursor) => format!("Authority generation {generation} · applied {}", cursor.0),
-				None => format!("Authority generation {generation} · awaiting snapshot"),
-			}
-			.into(),
+			detail: "Connected and ready.".into(),
 			color: 0x22c55e,
 		},
-		ConnectionView::OfflineRetrying { next_attempt, delay } => ConnectionPresentation {
-			label: "Offline · retrying",
-			detail: format!(
-				"Connection unavailable · attempt {next_attempt} in {} ms",
-				delay.as_millis()
-			)
-			.into(),
+		ConnectionView::OfflineRetrying { .. } => ConnectionPresentation {
+			label: "Reconnecting",
+			detail: "Trying to restore Decodex.".into(),
 			color: 0xf97316,
 		},
-		ConnectionView::Incompatible(reason) => ConnectionPresentation {
-			label: "Incompatible",
-			detail: match reason {
-				CompatibilityReason::Startup(failure) => startup_failure(failure),
-				CompatibilityReason::InvalidEndpoint => "Selected endpoint is not supported",
-				CompatibilityReason::ProtocolMajor => "Protocol generation does not match",
-				CompatibilityReason::ProtocolMinor => "Protocol revision is not supported",
-				CompatibilityReason::PublicationIdentityUnavailable => {
-					"Publication identity is unavailable"
-				},
-			}
-			.into(),
+		ConnectionView::Incompatible(_) => ConnectionPresentation {
+			label: "Restart Decodex",
+			detail: "Restart Decodex to restore the connection.".into(),
 			color: 0xef4444,
 		},
-		ConnectionView::Quarantined { reason, recovery } => ConnectionPresentation {
-			label: quarantine_label(reason),
-			detail: format!("{} · {}", quarantine_reason(reason), recovery_label(recovery)).into(),
+		ConnectionView::Quarantined { .. } => ConnectionPresentation {
+			label: "Restart Decodex",
+			detail: "Restart Decodex to restore the connection.".into(),
 			color: 0xdc2626,
 		},
 		ConnectionView::ShuttingDown => ConnectionPresentation {
@@ -423,8 +405,8 @@ fn connection_presentation(view: ConnectionView) -> ConnectionPresentation {
 			color: 0x94a3b8,
 		},
 		ConnectionView::Stopped => ConnectionPresentation {
-			label: "Stopped",
-			detail: "No connection or retry work remains".into(),
+			label: "Restart Decodex",
+			detail: "Restart Decodex to restore the connection.".into(),
 			color: 0x64748b,
 		},
 	}
@@ -447,54 +429,16 @@ const fn startup_failure(failure: ClientFailure) -> &'static str {
 		ClientFailure::UnsafeLocalEndpoint => "Local daemon endpoint is unsafe",
 		ClientFailure::LocalPeerIdentityUnavailable => "Local daemon identity is unavailable",
 		ClientFailure::LocalPeerUidMismatch => "Local daemon peer UID does not match",
-		ClientFailure::ProtocolDisconnected => "Daemon protocol is disconnected",
-		ClientFailure::ProtocolTimeout => "Daemon protocol timed out",
-		ClientFailure::ProtocolMajorMismatch => "Protocol generation does not match",
-		ClientFailure::ProtocolMinorMismatch => "Protocol revision is not supported",
-		ClientFailure::ArtifactCohortMismatch => "Installed Decodex artifacts do not match",
+		ClientFailure::ProtocolDisconnected
+		| ClientFailure::ProtocolTimeout
+		| ClientFailure::ProtocolMajorMismatch
+		| ClientFailure::ProtocolMinorMismatch
+		| ClientFailure::ArtifactCohortMismatch => "Restart Decodex.",
 		ClientFailure::ServerIdentityMismatch => "Stable server identity does not match",
 		ClientFailure::ProtocolMalformed => "Daemon response is malformed",
 		ClientFailure::ProtocolViolation => "Daemon protocol ordering was refused",
 		ClientFailure::ProtocolBackpressure => "Daemon message allowance was exhausted",
 		ClientFailure::ApplicationAcceptanceUnknown => "Application command acceptance is unknown",
-	}
-}
-
-const fn quarantine_label(reason: QuarantineReason) -> &'static str {
-	match reason {
-		QuarantineReason::StableServerIdentity
-		| QuarantineReason::AuthorityChanged
-		| QuarantineReason::PublicationInstanceChanged
-		| QuarantineReason::CheckpointMismatch => "Quarantined · identity mismatch",
-		QuarantineReason::CacheCorrupt
-		| QuarantineReason::CacheRootUnsafe
-		| QuarantineReason::ContentAttestation => "Quarantined · cache integrity",
-		QuarantineReason::ApplicationOrder => "Quarantined · application order",
-		QuarantineReason::ApplicationConfirmation => "Quarantined · confirmation failure",
-		QuarantineReason::StaleConnectionGeneration => "Quarantined · generation fence",
-	}
-}
-
-const fn quarantine_reason(reason: QuarantineReason) -> &'static str {
-	match reason {
-		QuarantineReason::StableServerIdentity => "Stable server identity changed",
-		QuarantineReason::AuthorityChanged => "Selected authority changed",
-		QuarantineReason::PublicationInstanceChanged => "Publication instance changed",
-		QuarantineReason::CheckpointMismatch => "Checkpoint identity did not match",
-		QuarantineReason::CacheCorrupt => "Disposable cache could not be attested",
-		QuarantineReason::CacheRootUnsafe => "Disposable cache root is unsafe",
-		QuarantineReason::ContentAttestation => "Published content failed attestation",
-		QuarantineReason::ApplicationOrder => "Application order was invalid",
-		QuarantineReason::ApplicationConfirmation => "Application confirmation failed",
-		QuarantineReason::StaleConnectionGeneration => "Connection generation became stale",
-	}
-}
-
-const fn recovery_label(recovery: QuarantineRecovery) -> &'static str {
-	match recovery {
-		QuarantineRecovery::VerifiedSnapshotReplacement => "waiting for verified replacement",
-		QuarantineRecovery::DisposedBeforeRebuild => "disposed before bounded rebuild",
-		QuarantineRecovery::OperatorRequired => "operator action required",
 	}
 }
 
@@ -3087,45 +3031,14 @@ fn accounts_content(shell: &Shell, cx: &mut Context<Shell>) -> AnyElement {
 
 fn account_route_pending_label(pending: &AccountRoutePendingDto) -> String {
 	match &pending.wait_reason {
-		AccountRouteWaitReasonDto::ExternalCodex { blockers, omitted } => {
-			let mut labels = blockers
-				.iter()
-				.map(|blocker| {
-					let process = match blocker.process {
-						AccountRouteBlockingProcessDto::Chatgpt => "ChatGPT",
-						AccountRouteBlockingProcessDto::Codex => "Codex",
-					};
-					let uncertainty = match blocker.auth_home {
-						AccountRouteAuthHomeDto::Shared => "",
-						AccountRouteAuthHomeDto::Unknown => "; auth home unknown",
-					};
-					format!("{process} PID {}{uncertainty}", blocker.pid)
-				})
-				.collect::<Vec<_>>();
-		if *omitted > 0 {
-			labels.push(format!("{omitted} more"));
-		}
-		format!(
-			"Route pending. Quit {}. Keep ChatGPT or Codex closed until routing completes.",
-			labels.join(", ")
-		)
+		AccountRouteWaitReasonDto::ExternalCodex { .. }
+		| AccountRouteWaitReasonDto::CodexObservationUnavailable => {
+			"Waiting for Codex to close or restart.".to_owned()
 		},
-		AccountRouteWaitReasonDto::CodexObservationUnavailable => {
-			"Route pending. Codex process ownership could not be inspected safely.".to_owned()
-		},
-		AccountRouteWaitReasonDto::AccountReadiness { readiness } => format!(
-			"Route pending. Target account readiness is {}.",
-			account_readiness_label(*readiness)
-		),
-		AccountRouteWaitReasonDto::SharedAuthStabilizing => {
-			"Route pending. Waiting for stable shared Codex auth.".to_owned()
-		},
-		AccountRouteWaitReasonDto::SharedAuthUnavailable => {
-			"Route pending. Shared Codex auth is unavailable or unsafe.".to_owned()
-		},
-		AccountRouteWaitReasonDto::ProjectionReadback => {
-			"Route pending. Verifying the atomic shared-auth update.".to_owned()
-		},
+		AccountRouteWaitReasonDto::AccountReadiness { .. }
+		| AccountRouteWaitReasonDto::SharedAuthStabilizing
+		| AccountRouteWaitReasonDto::SharedAuthUnavailable
+		| AccountRouteWaitReasonDto::ProjectionReadback => "Switching".to_owned(),
 	}
 }
 
@@ -3628,9 +3541,9 @@ fn account_pool_row(
 								}))
 						})
 						.child(if fixed {
-							"Routed"
+							"Ready"
 						} else {
-							"Route"
+							"Switch"
 						}),
 				)
 				.child(
@@ -3882,12 +3795,9 @@ fn accounts_load_label(load: AccountsLoadState) -> &'static str {
 fn account_command_label(command: AccountCommandState) -> Option<&'static str> {
 	match command {
 		AccountCommandState::Idle => None,
-		AccountCommandState::Sending => Some("Sending account command…"),
-		AccountCommandState::AwaitingResult => Some("Waiting for durable account result…"),
-		AccountCommandState::Accepted => Some("Account pool updated."),
-		AccountCommandState::OutcomeUnknown => {
-			Some("Outcome is unknown. Refresh readback before another account change.")
-		},
+		AccountCommandState::Sending | AccountCommandState::AwaitingResult => Some("Switching"),
+		AccountCommandState::Accepted => Some("Ready"),
+		AccountCommandState::OutcomeUnknown => Some("Restart Decodex."),
 		AccountCommandState::Refused => Some("The account change was refused. Refresh and retry."),
 	}
 }
@@ -5931,17 +5841,17 @@ mod tests {
 			[
 				"Connecting",
 				"Online",
-				"Offline · retrying",
-				"Incompatible",
-				"Quarantined · identity mismatch",
+				"Reconnecting",
+				"Restart Decodex",
+				"Restart Decodex",
 				"Shutting down",
-				"Stopped",
+				"Restart Decodex",
 			]
 		);
 	}
 
 	#[test]
-	fn startup_failures_preserve_their_typed_presentation() {
+	fn startup_failure_details_remain_available_outside_connection_recovery() {
 		let cases = [
 			(ClientFailure::ConfigurationMissing, "Client configuration is missing"),
 			(ClientFailure::ConfigurationMalformed, "Client configuration is malformed"),
@@ -5951,9 +5861,9 @@ mod tests {
 		];
 
 		for (failure, detail) in cases {
-			let view = ConnectionView::Incompatible(CompatibilityReason::Startup(failure));
-			assert_eq!(connection_presentation(view).detail, detail);
+			assert_eq!(startup_failure(failure), detail);
 		}
+		assert_eq!(startup_failure(ClientFailure::ArtifactCohortMismatch), "Restart Decodex.");
 	}
 
 	#[test]
@@ -5995,7 +5905,7 @@ mod tests {
 	}
 
 	#[test]
-	fn pending_route_status_names_the_blocking_process() {
+	fn pending_route_status_hides_process_and_transport_internals() {
 		let pending = AccountRoutePendingDto {
 			operation_id: EntityId::new("30000000-0000-4000-8000-000000000001").unwrap(),
 			account_id: EntityId::new("10000000-0000-4000-8000-000000000001").unwrap(),
@@ -6003,34 +5913,52 @@ mod tests {
 			wait_reason: AccountRouteWaitReasonDto::ExternalCodex {
 				blockers: vec![decodex_protocol::AccountRouteProcessBlockerDto {
 					pid: 44_662,
-					process: AccountRouteBlockingProcessDto::Chatgpt,
-					auth_home: AccountRouteAuthHomeDto::Shared,
+					process: decodex_protocol::AccountRouteBlockingProcessDto::Chatgpt,
+					auth_home: decodex_protocol::AccountRouteAuthHomeDto::Shared,
 				}],
 				omitted: 0,
 			},
 		};
 		assert_eq!(
 			account_route_pending_label(&pending),
-			"Route pending. Quit ChatGPT PID 44662. Keep ChatGPT or Codex closed until routing completes."
+			"Waiting for Codex to close or restart."
 		);
+		let mut observation = pending.clone();
+		observation.wait_reason = AccountRouteWaitReasonDto::CodexObservationUnavailable;
+		assert_eq!(
+			account_route_pending_label(&observation),
+			"Waiting for Codex to close or restart."
+		);
+		for wait_reason in [
+			AccountRouteWaitReasonDto::AccountReadiness {
+				readiness: AccountLifecycleReadinessDto::StoreUnavailable,
+			},
+			AccountRouteWaitReasonDto::SharedAuthStabilizing,
+			AccountRouteWaitReasonDto::SharedAuthUnavailable,
+			AccountRouteWaitReasonDto::ProjectionReadback,
+		] {
+			let mut switching = pending.clone();
+			switching.wait_reason = wait_reason;
+			assert_eq!(account_route_pending_label(&switching), "Switching");
+		}
 	}
 
 	#[test]
-	fn quarantine_labels_describe_the_actual_typed_reason() {
+	fn quarantine_reasons_present_one_recovery_action() {
 		let cases = [
-			(QuarantineReason::StableServerIdentity, "Quarantined · identity mismatch"),
-			(QuarantineReason::CacheCorrupt, "Quarantined · cache integrity"),
-			(QuarantineReason::ApplicationOrder, "Quarantined · application order"),
-			(QuarantineReason::ApplicationConfirmation, "Quarantined · confirmation failure"),
-			(QuarantineReason::StaleConnectionGeneration, "Quarantined · generation fence"),
+			QuarantineReason::StableServerIdentity,
+			QuarantineReason::CacheCorrupt,
+			QuarantineReason::ApplicationOrder,
+			QuarantineReason::ApplicationConfirmation,
+			QuarantineReason::StaleConnectionGeneration,
 		];
 
-		for (reason, label) in cases {
+		for reason in cases {
 			let view = ConnectionView::Quarantined {
 				reason,
 				recovery: QuarantineRecovery::OperatorRequired,
 			};
-			assert_eq!(connection_presentation(view).label, label);
+			assert_eq!(connection_presentation(view).label, "Restart Decodex");
 		}
 	}
 

--- a/apps/decodexd/Cargo.toml
+++ b/apps/decodexd/Cargo.toml
@@ -8,6 +8,9 @@ name                 = "decodexd"
 repository.workspace = true
 version.workspace    = true
 
+[features]
+process-acceptance-fixture = ["decodex-runtime/process-acceptance-fixture"]
+
 [dependencies]
 clap             = { workspace = true }
 decodex-protocol = { workspace = true }
@@ -19,4 +22,7 @@ tokio            = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
+base64          = { workspace = true }
+decodex-core    = { workspace = true }
+decodex-database = { workspace = true }
+tempfile        = { workspace = true }

--- a/apps/decodexd/tests/account_route_process.rs
+++ b/apps/decodexd/tests/account_route_process.rs
@@ -1,0 +1,661 @@
+//! Process-level account Route acceptance over the production daemon composition root.
+
+#![cfg(all(target_os = "macos", feature = "process-acceptance-fixture", debug_assertions))]
+#![allow(unused_crate_dependencies)]
+
+use std::{
+	collections::VecDeque,
+	fs,
+	io::{BufRead as _, BufReader, Read as _, Write as _},
+	net::{TcpListener, TcpStream},
+	os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+	path::{Path, PathBuf},
+	process::{Child, Command, Stdio},
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, Ordering},
+		mpsc,
+	},
+	thread::{self, JoinHandle},
+	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use decodex_core::{AccountId, AccountSelectionMode, DecodexRoot};
+use decodex_database::SqliteStore;
+use decodex_protocol::{
+	AccountClient, AccountCommandResponse, AccountRouteWaitReasonDto, AccountsResult,
+	ClientProfile, CodexAuthProjectionResult, CommandPayload, EntityId, EntityRevision,
+	IdempotencyKey, ResultPayload, WireText,
+};
+use decodex_runtime::{HostCredentialStore as _, SqliteCredentialStore};
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir_in};
+use tokio::time;
+
+const READY_LINE: &str = "decodexd serving WebSocket /v1/ws over same-UID local transport";
+const ACCOUNT_A: &str = "21000000-0000-4000-8000-0000000000a1";
+const ACCOUNT_B: &str = "21000000-0000-4000-8000-0000000000b1";
+const PROVIDER_A: &str = "process-fixture-provider-a";
+const PROVIDER_B: &str = "process-fixture-provider-b";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn actual_daemon_routes_a_b_a_restarts_and_routes_again_with_exact_readback() {
+	let fixture = Fixture::new();
+	let initial_a = fixture.tokens(PROVIDER_A, "a-initial");
+	let initial_b = fixture.tokens(PROVIDER_B, "b-initial");
+	let routed_b = fixture.tokens(PROVIDER_B, "b-routed");
+	let routed_a = fixture.tokens(PROVIDER_A, "a-routed");
+	let restarted_b = fixture.tokens(PROVIDER_B, "b-restarted");
+	fixture.write_shared_auth(&initial_a);
+	let import_a = fixture.write_import("account-a.json", &initial_a);
+	let import_b = fixture.write_import("account-b.json", &initial_b);
+	let refresh = RefreshServer::start(vec![
+		(initial_b.refresh_token.clone(), routed_b.clone()),
+		(initial_a.refresh_token.clone(), routed_a.clone()),
+		(routed_b.refresh_token.clone(), restarted_b.clone()),
+	]);
+	let mut first = RunningDaemon::start(fixture.home(), refresh.endpoint());
+	let client = fixture.client();
+
+	import_account(
+		&client,
+		ACCOUNT_A,
+		"22000000-0000-4000-8000-0000000000a1",
+		"process-import-a",
+		&import_a,
+	)
+	.await;
+	import_account(
+		&client,
+		ACCOUNT_B,
+		"22000000-0000-4000-8000-0000000000b1",
+		"process-import-b",
+		&import_b,
+	)
+	.await;
+	wait_for_projection(&client, ACCOUNT_A).await;
+	let routed = route_account(
+		&client,
+		ACCOUNT_A,
+		"22000000-0000-4000-8000-0000000000a0",
+		"process-route-initial-a",
+	)
+	.await;
+	fixture.assert_exact_readback(ACCOUNT_A, PROVIDER_A, &initial_a, routed).await;
+
+	let routed = route_account(
+		&client,
+		ACCOUNT_B,
+		"22000000-0000-4000-8000-0000000000b2",
+		"process-route-b",
+	)
+	.await;
+	fixture.assert_exact_readback(ACCOUNT_B, PROVIDER_B, &routed_b, routed).await;
+
+	let routed = route_account(
+		&client,
+		ACCOUNT_A,
+		"22000000-0000-4000-8000-0000000000a2",
+		"process-route-a",
+	)
+	.await;
+	fixture.assert_exact_readback(ACCOUNT_A, PROVIDER_A, &routed_a, routed).await;
+	let first_output = first.stop();
+
+	let mut restarted = RunningDaemon::start(fixture.home(), refresh.endpoint());
+	let restarted_client = fixture.client();
+	let routed = route_account(
+		&restarted_client,
+		ACCOUNT_B,
+		"22000000-0000-4000-8000-0000000000b3",
+		"process-route-b-after-restart",
+	)
+	.await;
+	fixture.assert_exact_readback(ACCOUNT_B, PROVIDER_B, &restarted_b, routed).await;
+	let restarted_output = restarted.stop();
+
+	refresh.finish();
+	let secrets = [initial_a, initial_b, routed_b, routed_a, restarted_b]
+		.into_iter()
+		.flat_map(TokenFixture::secret_values)
+		.collect::<Vec<_>>();
+	assert_no_credentials(&first_output, &secrets);
+	assert_no_credentials(&restarted_output, &secrets);
+}
+
+struct Fixture {
+	_home: TempDir,
+	home: PathBuf,
+	root: DecodexRoot,
+	expires_at_seconds: i64,
+}
+
+impl Fixture {
+	fn new() -> Self {
+		let parent = PathBuf::from(std::env::var_os("HOME").expect("read process fixture parent"));
+		let temporary = tempdir_in(parent).expect("create owner-private process fixture");
+		let home = temporary.path().canonicalize().expect("canonicalize process fixture");
+		let root = DecodexRoot::from_home(&home).expect("type process fixture root");
+		let paths = root.paths();
+		fs::create_dir(paths.root().as_path()).expect("create process fixture root");
+		fs::create_dir(paths.server_dir()).expect("create process fixture server directory");
+		fs::create_dir(home.join(".codex")).expect("create process fixture Codex directory");
+		for directory in
+			[paths.root().as_path(), paths.server_dir().as_path(), &home.join(".codex")]
+		{
+			fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+				.expect("scope process fixture directory");
+		}
+		fs::write(
+			paths.config_file(),
+			format!(
+				r#"version = 1
+active_profile = "local"
+
+[profiles.local]
+kind = "local"
+policy = "same_uid"
+service_owner_uid = {}
+
+[cache]
+max_entries = 16
+max_bytes = 1048576
+max_entry_bytes = 65536
+"#,
+				fs::metadata(paths.root().as_path()).expect("read fixture root metadata").uid(),
+			),
+		)
+		.expect("write process fixture config");
+		fs::set_permissions(paths.config_file(), fs::Permissions::from_mode(0o600))
+			.expect("scope process fixture config");
+		let expires_at_seconds = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("fixture clock after epoch")
+			.as_secs()
+			.saturating_add(86_400)
+			.try_into()
+			.expect("fixture expiry fits i64");
+		Self { _home: temporary, home, root, expires_at_seconds }
+	}
+
+	fn home(&self) -> &Path {
+		&self.home
+	}
+
+	fn client(&self) -> AccountClient {
+		let profile = ClientProfile::load(self.root.as_path(), None)
+			.expect("load isolated daemon client profile");
+		AccountClient::new(profile)
+	}
+
+	fn tokens(&self, provider: &str, suffix: &str) -> TokenFixture {
+		TokenFixture {
+			provider: provider.to_owned(),
+			email: format!("{suffix}@example.test"),
+			expires_at_micros: self
+				.expires_at_seconds
+				.checked_mul(1_000_000)
+				.expect("fixture expiry micros fit i64"),
+			access_token: jwt(json!({"exp": self.expires_at_seconds, "fixture": suffix})),
+			refresh_token: format!("process-fixture-refresh-{suffix}"),
+			id_token: jwt(json!({
+				"email": format!("{suffix}@example.test"),
+				"https://api.openai.com/auth": {
+					"chatgpt_account_id": provider,
+					"chatgpt_plan_type": "pro"
+				}
+			})),
+		}
+	}
+
+	fn write_shared_auth(&self, tokens: &TokenFixture) {
+		let path = self.home.join(".codex/auth.json");
+		write_private_json(&path, &tokens.shared_auth());
+	}
+
+	fn write_import(&self, name: &str, tokens: &TokenFixture) -> PathBuf {
+		let path = self.home.join(name);
+		write_private_json(&path, &tokens.versioned_import());
+		path
+	}
+
+	async fn assert_exact_readback(
+		&self,
+		account: &str,
+		provider: &str,
+		tokens: &TokenFixture,
+		expected_account_revision: EntityRevision,
+	) {
+		let store = SqliteStore::open(&self.root.paths()).expect("open exact readback store");
+		let account_id = AccountId::new(account).expect("type fixture account ID");
+		let rows = store
+			.read_account_registry(Some(&account_id), 1)
+			.await
+			.expect("read exact account row");
+		assert!(rows.len() == 1, "exact account row must exist");
+		let row = &rows[0];
+		assert!(
+			row.revision == i64::try_from(expected_account_revision.0).expect("revision fits i64"),
+			"SQLite account revision must match the terminal Route result"
+		);
+		let binding = row.credential.as_ref().expect("routed account must retain a binding");
+		assert!(
+			binding.provider.account_id() == provider,
+			"SQLite provider identity must be exact"
+		);
+		let stored = SqliteCredentialStore::new(store.clone())
+			.read_exact(&account_id, binding)
+			.expect("read exact SQLite credential binding");
+		assert!(
+			stored.bundle().access_token() == tokens.access_token,
+			"SQLite access credential must match the scripted successor"
+		);
+		assert!(
+			stored.bundle().refresh_token() == tokens.refresh_token,
+			"SQLite refresh credential must match the scripted successor"
+		);
+		assert!(
+			stored.bundle().id_token() == Some(tokens.id_token.as_str()),
+			"SQLite identity credential must match the scripted successor"
+		);
+		let routing =
+			store.read_account_routing_control().await.expect("read exact SQLite routing control");
+		assert!(
+			matches!(routing.mode, AccountSelectionMode::Fixed(ref selected) if selected == &account_id),
+			"SQLite routing control must select the exact account"
+		);
+		let auth: Value = serde_json::from_slice(
+			&fs::read(self.home.join(".codex/auth.json")).expect("read isolated shared auth"),
+		)
+		.expect("decode isolated shared auth");
+		assert!(
+			auth.pointer("/tokens/account_id").and_then(Value::as_str) == Some(provider),
+			"shared-auth provider identity must be exact"
+		);
+		assert!(
+			auth.pointer("/tokens/access_token").and_then(Value::as_str)
+				== Some(tokens.access_token.as_str()),
+			"shared-auth access credential must match SQLite"
+		);
+		assert!(
+			auth.pointer("/tokens/refresh_token").and_then(Value::as_str)
+				== Some(tokens.refresh_token.as_str()),
+			"shared-auth refresh credential must match SQLite"
+		);
+		assert!(
+			auth.pointer("/tokens/id_token").and_then(Value::as_str)
+				== Some(tokens.id_token.as_str()),
+			"shared-auth identity credential must match SQLite"
+		);
+	}
+}
+
+#[derive(Clone)]
+struct TokenFixture {
+	provider: String,
+	email: String,
+	expires_at_micros: i64,
+	access_token: String,
+	refresh_token: String,
+	id_token: String,
+}
+
+impl TokenFixture {
+	fn shared_auth(&self) -> Value {
+		json!({
+			"auth_mode": "chatgpt",
+			"OPENAI_API_KEY": null,
+			"tokens": {
+				"id_token": self.id_token,
+				"access_token": self.access_token,
+				"refresh_token": self.refresh_token,
+				"account_id": self.provider,
+			},
+			"last_refresh": "2026-01-01T00:00:00Z",
+		})
+	}
+
+	fn versioned_import(&self) -> Value {
+		json!({
+			"schema": "decodex/account-credential-import/1",
+			"provider": "chatgpt",
+			"provider_account_id": self.provider,
+			"provider_email": self.email,
+			"access_token": self.access_token,
+			"refresh_token": self.refresh_token,
+			"id_token": self.id_token,
+			"plan_type": "pro",
+			"token_type": "bearer",
+			"access_token_expires_at_unix_micros": self.expires_at_micros,
+		})
+	}
+
+	fn refresh_response(&self) -> Value {
+		json!({
+			"id_token": self.id_token,
+			"access_token": self.access_token,
+			"refresh_token": self.refresh_token,
+			"token_type": "bearer",
+			"expires_in": 86400,
+		})
+	}
+
+	fn secret_values(self) -> [String; 3] {
+		[self.access_token, self.refresh_token, self.id_token]
+	}
+}
+
+async fn import_account(
+	client: &AccountClient,
+	account: &str,
+	operation: &str,
+	key: &str,
+	source: &Path,
+) {
+	let response = client
+		.execute(
+			CommandPayload::ImportAccountCredentialFile {
+				operation_id: entity(operation),
+				account_id: entity(account),
+				enabled: true,
+				source_descriptor: WireText::new(source.to_string_lossy().into_owned())
+					.expect("bound fixture source path"),
+			},
+			None,
+			idempotency(key),
+		)
+		.await
+		.expect("dispatch account import");
+	assert!(
+		matches!(response, AccountCommandResponse::Applied { result, .. } if matches!(*result, ResultPayload::AccountChanged { .. })),
+		"account import must commit"
+	);
+}
+
+async fn route_account(
+	client: &AccountClient,
+	account: &str,
+	operation: &str,
+	key: &str,
+) -> EntityRevision {
+	let (account_revision, routing_revision) = account_revisions(client, account).await;
+	let deadline = time::Instant::now() + Duration::from_secs(15);
+	let mut wait_reason = "none";
+	loop {
+		let response = client
+			.route_account(
+				entity(operation),
+				entity(account),
+				account_revision,
+				routing_revision,
+				idempotency(key),
+			)
+			.await
+			.expect("dispatch RouteAccount");
+		match response {
+			AccountCommandResponse::Applied { result, .. } => match *result {
+				ResultPayload::AccountRouted { account: routed, routing, .. } => {
+					assert!(
+						routed.account_id.as_str() == account,
+						"Route result account must be exact"
+					);
+					assert!(
+						matches!(routing.mode, decodex_protocol::AccountSelectionModeDto::Fixed(ref selected) if selected.as_str() == account),
+						"Route result routing mode must be exact"
+					);
+					return routed.account_revision;
+				},
+				ResultPayload::AccountRoutePending { pending } => {
+					wait_reason = match pending.wait_reason {
+						AccountRouteWaitReasonDto::ExternalCodex { .. } => "external_codex",
+						AccountRouteWaitReasonDto::CodexObservationUnavailable => {
+							"codex_observation_unavailable"
+						},
+						AccountRouteWaitReasonDto::AccountReadiness { .. } => "account_readiness",
+						AccountRouteWaitReasonDto::SharedAuthStabilizing => {
+							"shared_auth_stabilizing"
+						},
+						AccountRouteWaitReasonDto::SharedAuthUnavailable => {
+							"shared_auth_unavailable"
+						},
+						AccountRouteWaitReasonDto::ProjectionReadback => "projection_readback",
+					};
+				},
+				_ => panic!("RouteAccount returned an unrelated credential-negative result"),
+			},
+			AccountCommandResponse::Rejected { .. } => {
+				panic!("RouteAccount was rejected without credential output")
+			},
+			AccountCommandResponse::PotentiallyDispatched { .. } => {},
+		}
+		assert!(
+			time::Instant::now() < deadline,
+			"RouteAccount {key} did not settle before deadline: {wait_reason}"
+		);
+		time::sleep(Duration::from_millis(100)).await;
+	}
+}
+
+async fn account_revisions(
+	client: &AccountClient,
+	account: &str,
+) -> (EntityRevision, EntityRevision) {
+	let AccountsResult::Available { accounts, routing: Some(routing), .. } =
+		client.list().await.expect("list exact account state")
+	else {
+		panic!("account state must be available");
+	};
+	let account_revision = accounts
+		.iter()
+		.find(|candidate| candidate.account_id.as_str() == account)
+		.map(|candidate| candidate.account_revision)
+		.expect("target account must exist");
+	(account_revision, routing.revision)
+}
+
+async fn wait_for_projection(client: &AccountClient, account: &str) {
+	let deadline = time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if matches!(
+			client.codex_auth_projection().await.expect("read shared-auth projection"),
+			CodexAuthProjectionResult::Current { account_id, .. } if account_id.as_str() == account
+		) {
+			return;
+		}
+		assert!(time::Instant::now() < deadline, "shared auth did not become stable");
+		time::sleep(Duration::from_millis(100)).await;
+	}
+}
+
+struct RefreshServer {
+	endpoint: String,
+	stop: Arc<AtomicBool>,
+	thread: JoinHandle<()>,
+}
+
+impl RefreshServer {
+	fn start(script: Vec<(String, TokenFixture)>) -> Self {
+		let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback refresh fixture");
+		listener.set_nonblocking(true).expect("make refresh fixture nonblocking");
+		let endpoint = format!(
+			"http://127.0.0.1:{}/oauth/token",
+			listener.local_addr().expect("read refresh fixture address").port()
+		);
+		let stop = Arc::new(AtomicBool::new(false));
+		let thread_stop = Arc::clone(&stop);
+		let thread = thread::spawn(move || {
+			let mut script = VecDeque::from(script);
+			while !thread_stop.load(Ordering::Acquire) || !script.is_empty() {
+				match listener.accept() {
+					Ok((stream, _)) => serve_refresh(stream, &mut script),
+					Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+						thread::sleep(Duration::from_millis(10));
+					},
+					Err(_) => panic!("loopback refresh fixture failed"),
+				}
+			}
+			assert!(script.is_empty(), "all scripted refreshes must be consumed");
+		});
+		Self { endpoint, stop, thread }
+	}
+
+	fn endpoint(&self) -> &str {
+		&self.endpoint
+	}
+
+	fn finish(self) {
+		self.stop.store(true, Ordering::Release);
+		self.thread.join().expect("join loopback refresh fixture");
+	}
+}
+
+fn serve_refresh(mut stream: TcpStream, script: &mut VecDeque<(String, TokenFixture)>) {
+	let clone = stream.try_clone().expect("clone refresh fixture stream");
+	let mut reader = BufReader::new(clone);
+	let mut content_length = None;
+	let mut first = true;
+	loop {
+		let mut line = String::new();
+		reader.read_line(&mut line).expect("read refresh request header");
+		assert!(!line.is_empty(), "refresh request headers must be complete");
+		if first {
+			assert!(line.starts_with("POST /oauth/token "), "refresh request path must be exact");
+			first = false;
+		}
+		if line == "\r\n" {
+			break;
+		}
+		if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+			content_length = value.trim().parse::<usize>().ok();
+		}
+	}
+	let mut body = vec![0_u8; content_length.expect("refresh request content length")];
+	reader.read_exact(&mut body).expect("read refresh request body");
+	let request: Value = serde_json::from_slice(&body).expect("decode refresh request");
+	let (expected_refresh, response) = script.pop_front().expect("unexpected refresh request");
+	assert!(
+		request.get("refresh_token").and_then(Value::as_str) == Some(expected_refresh.as_str()),
+		"refresh request must use the exact expected credential"
+	);
+	let body = serde_json::to_vec(&response.refresh_response()).expect("encode refresh response");
+	write!(
+		stream,
+		"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+		body.len()
+	)
+	.expect("write refresh response headers");
+	stream.write_all(&body).expect("write refresh response body");
+}
+
+struct RunningDaemon {
+	child: Child,
+	stdout: Arc<Mutex<Vec<u8>>>,
+	stderr: Arc<Mutex<Vec<u8>>>,
+	stdout_reader: JoinHandle<()>,
+	stderr_reader: JoinHandle<()>,
+}
+
+impl RunningDaemon {
+	fn start(home: &Path, refresh_endpoint: &str) -> Self {
+		let mut child = Command::new(env!("CARGO_BIN_EXE_decodexd"))
+			.env("HOME", home)
+			.env("DECODEX_PROCESS_TEST_REFRESH_ENDPOINT", refresh_endpoint)
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()
+			.expect("start actual daemon process");
+		let stdout = Arc::new(Mutex::new(Vec::new()));
+		let stderr = Arc::new(Mutex::new(Vec::new()));
+		let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+		let stdout_pipe = child.stdout.take().expect("capture daemon stdout");
+		let stdout_bytes = Arc::clone(&stdout);
+		let stdout_reader = thread::spawn(move || {
+			for line in BufReader::new(stdout_pipe).lines() {
+				let line = line.expect("read daemon stdout");
+				stdout_bytes.lock().expect("lock daemon stdout").extend_from_slice(line.as_bytes());
+				stdout_bytes.lock().expect("lock daemon stdout").push(b'\n');
+				if line == READY_LINE {
+					let _ = ready_sender.send(());
+				}
+			}
+		});
+		let stderr_pipe = child.stderr.take().expect("capture daemon stderr");
+		let stderr_bytes = Arc::clone(&stderr);
+		let stderr_reader = thread::spawn(move || {
+			let mut reader = BufReader::new(stderr_pipe);
+			reader
+				.read_to_end(&mut stderr_bytes.lock().expect("lock daemon stderr"))
+				.expect("read daemon stderr");
+		});
+		if ready_receiver.recv_timeout(Duration::from_secs(30)).is_err() {
+			let _ = child.kill();
+			let _ = child.wait();
+			panic!("actual daemon did not become ready");
+		}
+		Self { child, stdout, stderr, stdout_reader, stderr_reader }
+	}
+
+	fn stop(&mut self) -> Vec<u8> {
+		assert!(
+			unsafe { libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM) } == 0,
+			"signal actual daemon"
+		);
+		let deadline = Instant::now() + Duration::from_secs(20);
+		let status = loop {
+			if let Some(status) = self.child.try_wait().expect("poll daemon exit") {
+				break status;
+			}
+			assert!(Instant::now() < deadline, "actual daemon did not stop before deadline");
+			thread::sleep(Duration::from_millis(20));
+		};
+		assert!(status.success(), "actual daemon must stop cleanly");
+		let stdout_reader = std::mem::replace(&mut self.stdout_reader, thread::spawn(|| {}));
+		let stderr_reader = std::mem::replace(&mut self.stderr_reader, thread::spawn(|| {}));
+		stdout_reader.join().expect("join daemon stdout reader");
+		stderr_reader.join().expect("join daemon stderr reader");
+		let mut output = self.stdout.lock().expect("lock final daemon stdout").clone();
+		output.extend_from_slice(&self.stderr.lock().expect("lock final daemon stderr"));
+		output
+	}
+}
+
+impl Drop for RunningDaemon {
+	fn drop(&mut self) {
+		if self.child.try_wait().ok().flatten().is_none() {
+			let _ = self.child.kill();
+			let _ = self.child.wait();
+		}
+	}
+}
+
+fn assert_no_credentials(output: &[u8], secrets: &[String]) {
+	assert!(
+		secrets.iter().all(|secret| !contains_bytes(output, secret.as_bytes())),
+		"daemon output must remain credential-negative"
+	);
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+	!needle.is_empty() && haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+fn write_private_json(path: &Path, value: &Value) {
+	fs::write(path, serde_json::to_vec(value).expect("encode private fixture"))
+		.expect("write private fixture");
+	fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("scope private fixture");
+}
+
+fn jwt(payload: Value) -> String {
+	let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+	let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).expect("encode JWT fixture"));
+	format!("{header}.{payload}.fixture")
+}
+
+fn entity(value: &str) -> EntityId {
+	EntityId::new(value).expect("canonical fixture entity ID")
+}
+
+fn idempotency(value: &str) -> IdempotencyKey {
+	IdempotencyKey::new(value).expect("bounded fixture idempotency key")
+}

--- a/crates/decodex-runtime/Cargo.toml
+++ b/crates/decodex-runtime/Cargo.toml
@@ -8,6 +8,9 @@ name                 = "decodex-runtime"
 repository.workspace = true
 version.workspace    = true
 
+[features]
+process-acceptance-fixture = []
+
 [dependencies]
 base64                = { workspace = true }
 decodex-account-login = { workspace = true }

--- a/crates/decodex-runtime/src/account_api.rs
+++ b/crates/decodex-runtime/src/account_api.rs
@@ -1,4 +1,5 @@
 //! One authenticated OpenAI/Codex backend API client for account observation.
+#![cfg_attr(all(feature = "process-acceptance-fixture", debug_assertions), allow(dead_code))]
 
 use std::{sync::Arc, time::Duration};
 

--- a/crates/decodex-runtime/src/account_import.rs
+++ b/crates/decodex-runtime/src/account_import.rs
@@ -302,7 +302,7 @@ pub(crate) fn decode_chatgpt_identity(
 	Ok(DecodedChatgptIdentity { provider, provider_email, plan_type })
 }
 
-fn decode_expiry_micros(token: &str) -> Result<i64, CredentialImportError> {
+pub(crate) fn decode_expiry_micros(token: &str) -> Result<i64, CredentialImportError> {
 	let claims: ExpiryClaims = decode_claims(token)?;
 	claims
 		.exp

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -6330,7 +6330,7 @@ mod tests {
 				key,
 			)
 			.await;
-			assert_eq!(response["outcome"], "routed", "unexpected response: {response}");
+			assert_eq!(response["outcome"], "routed");
 			assert_eq!(response["account_id"], account_id.as_str());
 			assert_eq!(response["projection_digest"].as_str().map(str::len), Some(64));
 			assert_exact_route_readback(

--- a/crates/decodex-runtime/src/account_service.rs
+++ b/crates/decodex-runtime/src/account_service.rs
@@ -33,7 +33,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
 	account_import::{
-		CredentialImportError, ImportedCredential, decode_chatgpt_identity,
+		CredentialImportError, ImportedCredential, decode_chatgpt_identity, decode_expiry_micros,
 		read_explicit_credential_file, read_explicit_shared_codex_credential_file,
 		read_shared_codex_credential,
 	},
@@ -41,13 +41,17 @@ use crate::{
 	host_credentials::{
 		CredentialSecretBundle, CredentialStoreError, HostCredentialStore, StoredCredential,
 	},
-		shared_auth_coordinator::{
-			CodexAuthOwnerBlocker, CodexLiveness, CodexLivenessObservation, SharedAuthCoordinator,
-			StableSharedAuthPoll, StableSharedAuthRead,
-		},
+	shared_auth_coordinator::{
+		CodexAuthOwnerBlocker, CodexLiveness, CodexLivenessObservation, SharedAuthCoordinator,
+		StableSharedAuthPoll, StableSharedAuthRead,
+	},
 };
 
+#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
 const REFRESH_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
+#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+pub(crate) const PROCESS_TEST_REFRESH_ENDPOINT_ENV: &str =
+	"DECODEX_PROCESS_TEST_REFRESH_ENDPOINT";
 const CHATGPT_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const MAX_ACCOUNT_READ: u16 = 512;
 const MAX_UNSETTLED_ACCOUNT_OPERATION_READ: u16 = 1_024;
@@ -332,9 +336,10 @@ impl CredentialRefreshPort for OpenAiCredentialRefresher {
 			grant_type: "refresh_token",
 			refresh_token: current.refresh_token(),
 		};
+		let endpoint = refresh_endpoint()?;
 		let response = self
 			.client
-			.post(REFRESH_ENDPOINT)
+			.post(endpoint)
 			.json(&request)
 			.send()
 			.map_err(|_| CredentialRefreshError::Ambiguous)?;
@@ -356,6 +361,41 @@ impl CredentialRefreshPort for OpenAiCredentialRefresher {
 
 		credential_refresh_result(current, refreshed, observed_at_micros)
 	}
+}
+
+fn refresh_endpoint() -> Result<String, CredentialRefreshError> {
+	#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+	{
+		return process_acceptance_fixture_endpoint()
+			.ok_or(CredentialRefreshError::Unavailable);
+	}
+
+	#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
+	{
+		Ok(REFRESH_ENDPOINT.to_owned())
+	}
+}
+
+#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+pub(crate) fn process_acceptance_fixture_endpoint() -> Option<String> {
+	std::env::var_os(PROCESS_TEST_REFRESH_ENDPOINT_ENV)
+		.and_then(|value| value.into_string().ok())
+		.filter(|endpoint| process_test_refresh_endpoint_is_safe(endpoint))
+}
+
+#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+fn process_test_refresh_endpoint_is_safe(value: &str) -> bool {
+	let Ok(endpoint) = reqwest::Url::parse(value) else {
+		return false;
+	};
+	endpoint.scheme() == "http"
+		&& endpoint.host_str() == Some("127.0.0.1")
+		&& endpoint.port().is_some()
+		&& endpoint.path() == "/oauth/token"
+		&& endpoint.query().is_none()
+		&& endpoint.fragment().is_none()
+		&& endpoint.username().is_empty()
+		&& endpoint.password().is_none()
 }
 
 #[derive(Serialize)]
@@ -395,13 +435,14 @@ fn credential_refresh_result(
 	let identity =
 		decode_chatgpt_identity(&id_token).map_err(|_| CredentialRefreshError::Ambiguous)?;
 	let token_type = refreshed.token_type.take().ok_or(CredentialRefreshError::Ambiguous)?;
-	let expires_in = refreshed.expires_in.ok_or(CredentialRefreshError::Ambiguous)?;
-	let lifetime_micros = i64::try_from(expires_in)
-		.ok()
-		.and_then(|seconds| seconds.checked_mul(1_000_000))
-		.ok_or(CredentialRefreshError::Ambiguous)?;
+	if refreshed.expires_in.is_none_or(|expires_in| expires_in == 0) {
+		return Err(CredentialRefreshError::Ambiguous);
+	}
 	let expires_at_micros =
-		observed_at_micros.checked_add(lifetime_micros).ok_or(CredentialRefreshError::Ambiguous)?;
+		decode_expiry_micros(&access_token).map_err(|_| CredentialRefreshError::Ambiguous)?;
+	if expires_at_micros <= observed_at_micros {
+		return Err(CredentialRefreshError::Ambiguous);
+	}
 	let bundle = CredentialSecretBundle::chatgpt(
 		access_token,
 		refresh_token,
@@ -5106,6 +5147,10 @@ mod tests {
 		resolve_reauthentication_store_effect, route_resume_revision_is_valid,
 		stable_account_alias,
 	};
+	#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
+	use super::{REFRESH_ENDPOINT, refresh_endpoint};
+	#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+	use super::process_test_refresh_endpoint_is_safe;
 	use std::{
 		collections::{HashMap, HashSet, VecDeque},
 		fs,
@@ -5362,6 +5407,10 @@ mod tests {
 			let state = self.state.lock().expect("shared auth state");
 			(state.bundle.access_token().to_owned(), state.bundle.refresh_token().to_owned())
 		}
+
+		fn current_provider(&self) -> ProviderIdentity {
+			self.state.lock().expect("shared auth state").provider.clone()
+		}
 	}
 
 	impl SharedAuthFilePort for RefreshRaceSharedAuthFile {
@@ -5516,6 +5565,84 @@ mod tests {
 		)
 		.expect("accept enrollment commit");
 		account_id
+	}
+
+	async fn route_test_account_once(
+		service: &AccountService,
+		store: &SqliteStore,
+		account_id: &AccountId,
+		expected_account_revision: i64,
+		operation_id: &str,
+		idempotency_key: &str,
+	) -> serde_json::Value {
+		let _ = service.shared_auth.poll_stable_change();
+		let _ = service.shared_auth.poll_stable_change();
+		let routing = store.read_account_routing_control().await.expect("read routing control");
+		let request = format!(
+			r#"{{"name":"route_account","arguments":{{"operation_id":"{operation_id}","account_id":"{}","expected_account_revision":{expected_account_revision}}}}}"#,
+			account_id.as_str(),
+		);
+		let command = CommandIdentity::new(idempotency_key, request.as_bytes())
+			.expect("Route command identity");
+		let lease = match store
+			.reserve_account_route_command(&command, routing.revision, &request)
+			.await
+			.expect("reserve Route command")
+		{
+			AccountCommandReceiptClaim::Owned(lease) => lease,
+			AccountCommandReceiptClaim::Pending(_) | AccountCommandReceiptClaim::Replayed(_) => {
+				panic!("new Route command did not acquire its receipt")
+			},
+		};
+		service
+			.route_account_command(
+				lease,
+				AccountOperationId::new(operation_id).expect("Route operation identity"),
+				account_id,
+				expected_account_revision,
+				routing.revision,
+				false,
+				|result| {
+					Ok(match result {
+						Ok(AccountRouteResult::Committed(commit)) => json!({
+							"outcome": "routed",
+							"account_id": commit.account.account_id.as_str(),
+							"account_revision": commit.account.revision,
+							"routing_revision": commit.routing.revision,
+							"projection_digest": commit.projection_digest,
+						}),
+						Ok(AccountRouteResult::Pending(pending)) => json!({
+							"outcome": "pending",
+							"wait_reason": format!("{:?}", pending.wait_reason),
+						}),
+						Err(_) => json!({"outcome": "rejected"}),
+					})
+				},
+			)
+			.await
+			.expect("complete Route command")
+	}
+
+	async fn assert_exact_route_readback(
+		store: &SqliteStore,
+		credentials: &Arc<dyn HostCredentialStore>,
+		shared_auth: &RefreshRaceSharedAuthFile,
+		account_id: &AccountId,
+		provider_account_id: &str,
+	) {
+		let routing = store.read_account_routing_control().await.expect("read routed control");
+		assert_eq!(routing.mode, AccountSelectionMode::Fixed(account_id.clone()));
+		let account = store
+			.read_account_registry(Some(account_id), 1)
+			.await
+			.expect("read routed account")
+			.pop()
+			.expect("routed account exists");
+		let binding = account.credential.expect("routed credential binding");
+		let stored = credentials.read_exact(account_id, &binding).expect("read exact credential");
+		assert_eq!(shared_auth.current_provider().account_id(), provider_account_id);
+		assert_eq!(shared_auth.current_tokens().0, stored.bundle().access_token());
+		assert_eq!(shared_auth.current_tokens().1, stored.bundle().refresh_token());
 	}
 
 	#[test]
@@ -6072,6 +6199,185 @@ mod tests {
 				.expect("read pending Routes")
 				.is_empty()
 		);
+	}
+
+	#[tokio::test]
+	async fn account_route_a_b_a_and_post_restart_switch_keep_sqlite_and_shared_auth_exact() {
+		let directory = tempdir().expect("temporary product root");
+		let root = DecodexRoot::new(fs::canonicalize(directory.path()).expect("canonical root"))
+			.expect("typed product root");
+		let store = SqliteStore::open(&root.paths()).expect("open product store");
+		let credentials: Arc<dyn HostCredentialStore> =
+			Arc::new(SqliteCredentialStore::new(store.clone()));
+		let expiry = i64::MAX / 2;
+		let account_a = enroll_route_test_account_with_expiry(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000e1",
+			"22000000-0000-4000-8000-0000000000e1",
+			"round-trip-provider-a",
+			"round-trip-access-a",
+			expiry,
+		)
+		.await;
+		let account_b = enroll_route_test_account_with_expiry(
+			&store,
+			&credentials,
+			"21000000-0000-4000-8000-0000000000e2",
+			"22000000-0000-4000-8000-0000000000e2",
+			"round-trip-provider-b",
+			"round-trip-access-b",
+			expiry,
+		)
+		.await;
+		let shared_auth = Arc::new(RefreshRaceSharedAuthFile::new(
+			"round-trip-provider-a",
+			shared_bundle("round-trip-provider-a", "round-trip-access-a", expiry),
+		));
+		let provider_calls = Arc::new(AtomicUsize::new(0));
+		let refresher = Arc::new(ScriptedCredentialRefresher {
+			calls: Arc::clone(&provider_calls),
+			results: Mutex::new(VecDeque::from([
+				CredentialRefreshResult {
+					returned_provider: ProviderIdentity::new(
+						AccountProvider::Chatgpt,
+						"round-trip-provider-b",
+					)
+					.expect("provider B identity"),
+					bundle: shared_bundle_with_refresh(
+						"round-trip-provider-b",
+						"round-trip-access-b-routed",
+						"round-trip-refresh-b-routed",
+						expiry,
+					),
+				},
+				CredentialRefreshResult {
+					returned_provider: ProviderIdentity::new(
+						AccountProvider::Chatgpt,
+						"round-trip-provider-a",
+					)
+					.expect("provider A identity"),
+					bundle: shared_bundle_with_refresh(
+						"round-trip-provider-a",
+						"round-trip-access-a-routed",
+						"round-trip-refresh-a-routed",
+						expiry,
+					),
+				},
+				CredentialRefreshResult {
+					returned_provider: ProviderIdentity::new(
+						AccountProvider::Chatgpt,
+						"round-trip-provider-b",
+					)
+					.expect("provider B identity"),
+					bundle: shared_bundle_with_refresh(
+						"round-trip-provider-b",
+						"round-trip-access-b-restarted",
+						"round-trip-refresh-b-restarted",
+						expiry,
+					),
+				},
+			])),
+		});
+		let build_service = || {
+			AccountService::new(
+				store.clone(),
+				Arc::clone(&credentials),
+				Arc::clone(&refresher) as Arc<dyn CredentialRefreshPort>,
+			)
+			.with_shared_auth_coordinator(test_coordinator(
+				Arc::clone(&shared_auth) as Arc<dyn SharedAuthFilePort>,
+				CodexLiveness::Quiescent,
+			))
+		};
+		let service = build_service();
+		assert!(
+			service
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "round-trip-route-build".to_owned(),
+					executable_sha256: "1".repeat(64),
+					schema_sha256: "2".repeat(64),
+					callback_profile_sha256: "3".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest callback capability")
+		);
+
+		for (account_id, expected_revision, provider, operation, key) in [
+			(
+				&account_b,
+				1,
+				"round-trip-provider-b",
+				"22000000-0000-4000-8000-0000000000e3",
+				"round-trip-route-b",
+			),
+			(
+				&account_a,
+				1,
+				"round-trip-provider-a",
+				"22000000-0000-4000-8000-0000000000e4",
+				"round-trip-route-a",
+			),
+		] {
+			let response = route_test_account_once(
+				&service,
+				&store,
+				account_id,
+				expected_revision,
+				operation,
+				key,
+			)
+			.await;
+			assert_eq!(response["outcome"], "routed", "unexpected response: {response}");
+			assert_eq!(response["account_id"], account_id.as_str());
+			assert_eq!(response["projection_digest"].as_str().map(str::len), Some(64));
+			assert_exact_route_readback(
+				&store,
+				&credentials,
+				&shared_auth,
+				account_id,
+				provider,
+			)
+			.await;
+		}
+
+		drop(service);
+		let restarted = build_service();
+		assert!(
+			restarted
+				.attest_callback_capability(CodexAccountCapabilityAttestation {
+					build_identity: "round-trip-route-restarted-build".to_owned(),
+					executable_sha256: "4".repeat(64),
+					schema_sha256: "5".repeat(64),
+					callback_profile_sha256: "6".repeat(64),
+					login_chatgpt_auth_tokens: true,
+					refresh_callback: true,
+				})
+				.await
+				.expect("attest restarted callback capability")
+		);
+		let response = route_test_account_once(
+			&restarted,
+			&store,
+			&account_b,
+			2,
+			"22000000-0000-4000-8000-0000000000e5",
+			"round-trip-route-b-after-restart",
+		)
+		.await;
+		assert_eq!(response["outcome"], "routed");
+		assert_exact_route_readback(
+			&store,
+			&credentials,
+			&shared_auth,
+			&account_b,
+			"round-trip-provider-b",
+		)
+		.await;
+		assert_eq!(shared_auth.project_attempts.load(Ordering::Relaxed), 3);
+		assert_eq!(provider_calls.load(Ordering::Relaxed), 3);
 	}
 
 	#[tokio::test]
@@ -7907,13 +8213,41 @@ mod tests {
 	}
 
 	fn response(id_token: Option<String>) -> RefreshResponse {
+		let access_payload =
+			URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json!({"exp": 61_i64})).unwrap());
 		RefreshResponse {
 			id_token,
-			access_token: Some("fresh-access".to_owned()),
+			access_token: Some(format!("header.{access_payload}.signature")),
 			refresh_token: None,
 			token_type: Some("bearer".to_owned()),
 			expires_in: Some(60),
 		}
+	}
+
+	#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+	#[test]
+	fn process_acceptance_refresh_endpoint_accepts_only_exact_loopback_http() {
+		assert!(process_test_refresh_endpoint_is_safe("http://127.0.0.1:49152/oauth/token"));
+		for unsafe_endpoint in [
+			"https://127.0.0.1:49152/oauth/token",
+			"http://localhost:49152/oauth/token",
+			"http://127.0.0.1/oauth/token",
+			"http://127.0.0.1:49152/other",
+			"http://127.0.0.1:49152/oauth/token?redirect=true",
+			"http://user@127.0.0.1:49152/oauth/token",
+			"https://auth.openai.com/oauth/token",
+		] {
+			assert!(!process_test_refresh_endpoint_is_safe(unsafe_endpoint));
+		}
+	}
+
+	#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
+	#[test]
+	fn ordinary_build_refresh_endpoint_is_the_fixed_https_authority() {
+		assert!(
+			matches!(refresh_endpoint(), Ok(endpoint) if endpoint == REFRESH_ENDPOINT),
+			"ordinary builds must retain the fixed refresh authority"
+		);
 	}
 
 	fn binding(provider_account_id: &str, version: u64) -> CredentialBinding {
@@ -8167,6 +8501,11 @@ mod tests {
 		assert_eq!(refreshed.bundle.provider_email(), "fresh@example.test");
 		assert_eq!(refreshed.bundle.plan_type(), Some("pro"));
 		assert_eq!(refreshed.bundle.refresh_token(), "old-refresh");
+		assert_eq!(
+			refreshed.bundle.access_token_expires_at_unix_micros(),
+			61_000_000,
+			"stored expiry must use the access-token authority used by shared-auth readback",
+		);
 
 		let account_id = AccountId::new("20000000-0000-4000-8000-000000000001").unwrap();
 		let operation_id = AccountOperationId::new("30000000-0000-4000-8000-000000000001").unwrap();

--- a/crates/decodex-runtime/src/bootstrap.rs
+++ b/crates/decodex-runtime/src/bootstrap.rs
@@ -544,6 +544,13 @@ async fn bootstrap_macos_account_runtime(
 	if let Some(profile) = &quick_task_launch_profile {
 		let _ = service.attest_callback_capability(profile.account_callback_attestation()).await;
 	}
+	#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+	let api = if crate::account_service::process_acceptance_fixture_endpoint().is_some() {
+		None
+	} else {
+		AccountApiRuntime::new(Arc::clone(&service)).ok().map(Arc::new)
+	};
+	#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
 	let api = AccountApiRuntime::new(Arc::clone(&service)).ok().map(Arc::new);
 	let status = match &api {
 		Some(_) => DoctorStatus::Ready,

--- a/crates/decodex-runtime/src/shared_auth_coordinator.rs
+++ b/crates/decodex-runtime/src/shared_auth_coordinator.rs
@@ -1,4 +1,5 @@
 //! Single daemon-owned coordinator for stable shared Codex auth observation and cutover.
+#![cfg_attr(all(feature = "process-acceptance-fixture", debug_assertions), allow(dead_code))]
 
 use std::sync::{Arc, Mutex};
 
@@ -288,7 +289,18 @@ struct ProductionCodexLiveness;
 #[cfg(target_os = "macos")]
 impl CodexLivenessPort for ProductionCodexLiveness {
 	fn observe(&self) -> CodexLivenessObservation {
-		observe_macos_codex_liveness()
+		#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]
+		{
+			if crate::account_service::process_acceptance_fixture_endpoint().is_some() {
+				CodexLivenessObservation::Quiescent
+			} else {
+				observe_macos_codex_liveness()
+			}
+		}
+		#[cfg(not(all(feature = "process-acceptance-fixture", debug_assertions)))]
+		{
+			observe_macos_codex_liveness()
+		}
 	}
 }
 

--- a/crates/decodex-runtime/src/websocket.rs
+++ b/crates/decodex-runtime/src/websocket.rs
@@ -61,6 +61,7 @@ type WebSocket = WebSocketStream<LocalTransportStream>;
 type OwnedFuture = Pin<Box<dyn Future<Output = OwnedTaskResult> + Send + 'static>>;
 
 const PRODUCT_MAXIMUM_SESSION_TASKS: usize = 64;
+const LISTENER_PUBLICATION_HEALTH_INTERVAL: Duration = Duration::from_millis(100);
 
 // Tungstenite fixes this callback's error type to the full HTTP response.
 #[allow(clippy::result_large_err)]
@@ -1352,6 +1353,7 @@ where
 {
 	server: ProtocolServer<A>,
 	listener: LocalTransportListener,
+	listener_health: time::Interval,
 	shutdown_receiver: oneshot::Receiver<()>,
 	phase: OwnerPhase,
 	deadline: Option<OwnerDeadline>,
@@ -1444,6 +1446,7 @@ enum CommandShutdownState {
 
 enum AcceptingWake {
 	RequestedShutdown,
+	ListenerHealth,
 	OwnedTask(Option<Result<(TokioTaskId, OwnedTaskCompletion), JoinError>>),
 	Operation(ActiveActorOperationCompletion),
 	Ordinary(Box<AcceptingOrdinaryWake>),
@@ -1545,9 +1548,12 @@ where
 		let (service_stop_sender, service_stop_receiver) = watch::channel(false);
 		let event_eof = !server.inner.application.has_publication_source();
 		let services = server.inner.application.daemon_service_tasks(service_stop_receiver);
+		let mut listener_health = time::interval(LISTENER_PUBLICATION_HEALTH_INTERVAL);
+		listener_health.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 		let mut owner = Self {
 			server,
 			listener,
+			listener_health,
 			shutdown_receiver,
 			phase: OwnerPhase::Accepting,
 			deadline: None,
@@ -1791,6 +1797,7 @@ where
 		let has_tasks = !self.tasks.is_empty();
 		let wake = {
 			let listener = &mut self.listener;
+			let listener_health = &mut self.listener_health;
 			let actor_receiver = &mut self.actor_receiver;
 			let application = &self.server.inner.application;
 			let ordinary = async {
@@ -1812,6 +1819,7 @@ where
 				biased;
 
 				_ = &mut self.shutdown_receiver => AcceptingWake::RequestedShutdown,
+				_ = listener_health.tick() => AcceptingWake::ListenerHealth,
 				joined = self.tasks.set.join_next_with_id(), if has_tasks => {
 					AcceptingWake::OwnedTask(joined)
 				},
@@ -1825,6 +1833,12 @@ where
 		match wake {
 			AcceptingWake::RequestedShutdown => {
 				OwnerDirective::BeginStopping(StopCause::RequestedShutdown)
+			},
+			AcceptingWake::ListenerHealth => match self.listener.revalidate() {
+				Ok(()) => OwnerDirective::Continue,
+				Err(refusal) => {
+					OwnerDirective::BeginStopping(StopCause::EndpointRefusal(refusal))
+				},
 			},
 			AcceptingWake::OwnedTask(Some(joined)) => self.harvest_task(joined),
 			AcceptingWake::OwnedTask(None) => {
@@ -2589,6 +2603,7 @@ where
 		let Self {
 			server,
 			listener,
+			listener_health,
 			shutdown_receiver,
 			phase: _,
 			deadline,
@@ -2619,6 +2634,7 @@ where
 		drop(shutdown_receiver);
 		drop(tasks);
 		drop(server);
+		drop(listener_health);
 
 		if let Err(refusal) = listener.cleanup() {
 			receipt.record_cleanup_refusal(refusal);

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -228,6 +228,12 @@ async fn fresh_sqlite_bootstrap_is_ready_and_deferred_surfaces_are_explicit() {
 	assert_eq!(status(&bootstrap, DoctorComponent::Protocol), DoctorStatus::Ready);
 	assert_eq!(status(&bootstrap, DoctorComponent::ProtocolVersion), DoctorStatus::Ready);
 	assert_eq!(status(&bootstrap, DoctorComponent::ServerIdentity), DoctorStatus::Ready);
+	#[cfg(target_os = "macos")]
+	assert_eq!(
+		status(&bootstrap, DoctorComponent::CredentialVault),
+		DoctorStatus::Ready,
+		"all-features without the strict process-fixture endpoint must retain AccountApi readiness"
+	);
 	assert_eq!(
 		status(&bootstrap, DoctorComponent::ManagedRepository),
 		DoctorStatus::Unavailable(DoctorIssue::Disabled)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -2,7 +2,9 @@
 #![allow(unused_crate_dependencies)]
 
 use std::{
+	fs,
 	future::{self, Future},
+	os::unix::{fs::PermissionsExt as _, net::UnixListener as StandardUnixListener},
 	pin::Pin,
 	sync::{Arc, Mutex},
 	time::Duration,
@@ -33,7 +35,7 @@ use decodex_protocol::{
 };
 use decodex_runtime::{
 	ActorCommandDeadlineClass, Application, ApplicationPublication, ProtocolServer, ServerConfig,
-	TerminationPrimary, TerminationReceipt,
+	ServerError, TerminationPrimary, TerminationReceipt,
 };
 
 type Client = WebSocketStream<LocalTransportStream>;
@@ -1455,6 +1457,102 @@ async fn daemon_service_settlement_holds_namespace_authority_until_zero_survivor
 	.expect("namespace authority must release after service settlement");
 
 	restarted.shutdown().await.expect("shutdown restarted service-settlement server");
+}
+
+#[tokio::test]
+async fn missing_canonical_publication_stops_established_service_and_allows_rebind() {
+	let (temp, transport) = local_transport();
+	let socket_path = temp.path().join(".decodex/server/decodex.sock");
+	let mut bound = server(
+		"missing-listener-publication",
+		FixtureApplication::default(),
+		ServerConfig::default(),
+	)
+	.bind(transport.clone())
+	.await
+	.expect("bind listener-loss fixture server");
+	let mut established = connect(&transport, CURRENT_VERSION).await;
+
+	receive_initial(&mut established).await;
+	fs::remove_file(&socket_path).expect("remove canonical publication");
+
+	let error = time::timeout(Duration::from_secs(2), bound.wait())
+		.await
+		.expect("listener loss must stop the service")
+		.expect_err("listener loss must be abnormal");
+	let ServerError::Terminated(receipt) = error else {
+		panic!("expected deterministic terminated receipt, got {error:?}");
+	};
+	assert_eq!(receipt.endpoint_refusal, Some(LocalTransportRefusal::EndpointReplaced));
+	assert_eq!(receipt.cleanup_refusal, Some(LocalTransportRefusal::EndpointReplaced));
+	let old_stream = time::timeout(Duration::from_secs(1), established.next())
+		.await
+		.expect("established stream must stop with the lost publication");
+	assert!(matches!(old_stream, None | Some(Ok(Message::Close(_))) | Some(Err(_))));
+
+	let mut restarted = server(
+		"missing-listener-publication-restarted",
+		FixtureApplication::default(),
+		ServerConfig::default(),
+	)
+	.bind(transport.clone())
+	.await
+	.expect("app-owned recovery must republish after listener loss");
+	let mut reconnected = connect(&transport, CURRENT_VERSION).await;
+
+	receive_initial(&mut reconnected).await;
+	drop(reconnected);
+	drop(established);
+	restarted.shutdown().await.expect("shutdown republished fixture server");
+}
+
+#[tokio::test]
+async fn replacement_publication_stops_service_without_unlinking_replacement() {
+	let (temp, transport) = local_transport();
+	let socket_path = temp.path().join(".decodex/server/decodex.sock");
+	let retained_path = socket_path.with_file_name("retained.sock");
+	let mut bound = server(
+		"replaced-listener-publication",
+		FixtureApplication::default(),
+		ServerConfig::default(),
+	)
+	.bind(transport.clone())
+	.await
+	.expect("bind listener-replacement fixture server");
+	let mut established = connect(&transport, CURRENT_VERSION).await;
+
+	receive_initial(&mut established).await;
+	fs::rename(&socket_path, &retained_path).expect("move owned publication aside");
+	let replacement =
+		StandardUnixListener::bind(&socket_path).expect("publish unowned replacement socket");
+	fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))
+		.expect("scope replacement socket");
+
+	let error = time::timeout(Duration::from_secs(2), bound.wait())
+		.await
+		.expect("listener replacement must stop the service")
+		.expect_err("listener replacement must be abnormal");
+	let ServerError::Terminated(receipt) = error else {
+		panic!("expected deterministic terminated receipt, got {error:?}");
+	};
+	assert_eq!(receipt.endpoint_refusal, Some(LocalTransportRefusal::EndpointReplaced));
+	assert_eq!(receipt.cleanup_refusal, Some(LocalTransportRefusal::EndpointReplaced));
+	assert!(socket_path.exists(), "cleanup must preserve an unowned replacement");
+	assert!(matches!(
+		server(
+			"replacement-contender",
+			FixtureApplication::default(),
+			ServerConfig::default(),
+		)
+		.bind(transport)
+		.await,
+		Err(ServerError::LocalTransport(LocalTransportRefusal::EndpointInUse))
+	));
+
+	drop(established);
+	drop(replacement);
+	fs::remove_file(&socket_path).expect("remove replacement fixture socket");
+	fs::remove_file(&retained_path).expect("remove retained fixture socket");
 }
 
 #[tokio::test]

--- a/scripts/macos/fixtures/mismatched_native_client.c
+++ b/scripts/macos/fixtures/mismatched_native_client.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+uint32_t decodex_app_native_client_abi_version(void) {
+	return 1;
+}
+
+uint32_t decodex_app_native_client_artifact_cohort(void) {
+	return UINT32_MAX;
+}

--- a/scripts/macos/stage_decodex_app.sh
+++ b/scripts/macos/stage_decodex_app.sh
@@ -60,6 +60,11 @@ chmod 755 \
 	"$FRAMEWORKS/$NATIVE_CLIENT_LIBRARY" \
 	"$FRAMEWORKS/$MENU_BAR_LIBRARY"
 
+python3 "$ROOT/scripts/macos/verify_decodex_bundle_contracts.py" \
+	--daemon "$HELPERS/decodexd" \
+	--native-client "$FRAMEWORKS/$NATIVE_CLIENT_LIBRARY" \
+	--menu-bar "$FRAMEWORKS/$MENU_BAR_LIBRARY"
+
 codesign --force --options runtime --timestamp=none --sign "$SIGN_IDENTITY" \
 	--identifier box.acg.decodex.daemon "$HELPERS/decodexd"
 codesign --force --options runtime --timestamp=none --sign "$SIGN_IDENTITY" \

--- a/scripts/macos/test_decodex_app_stage.sh
+++ b/scripts/macos/test_decodex_app_stage.sh
@@ -53,7 +53,10 @@ plutil -extract CFBundleIconFile raw "$info" | grep -qx 'AppIcon'
 plutil -extract LSMinimumSystemVersion raw "$info" | grep -qx '27.0'
 plutil -extract NSSupportsAutomaticTermination raw "$info" | grep -qx 'false'
 plutil -extract NSSupportsSuddenTermination raw "$info" | grep -qx 'false'
-"$contents/Helpers/decodexd" artifact-cohort | grep -q '"artifact_cohort":7'
+python3 scripts/macos/verify_decodex_bundle_contracts.py \
+  --daemon "$contents/Helpers/decodexd" \
+  --native-client "$contents/Frameworks/libdecodex_app_client_ffi.dylib" \
+  --menu-bar "$contents/Frameworks/libDecodexMenuBar.dylib"
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_create' >/dev/null
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_set_visible' >/dev/null
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_launch_at_login_status' >/dev/null
@@ -62,6 +65,17 @@ nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_app_was_launched_as_login_item' >/dev/null
 nm -gj "$contents/Frameworks/libDecodexMenuBar.dylib" | grep -Fx '_decodex_menu_bar_destroy' >/dev/null
 nm -gj "$contents/Frameworks/libdecodex_app_client_ffi.dylib" | grep -Fx '_decodex_app_native_client_create' >/dev/null
+
+mismatch_library="$stage_root/libmismatched_native_client.dylib"
+xcrun clang -dynamiclib scripts/macos/fixtures/mismatched_native_client.c -o "$mismatch_library"
+if python3 scripts/macos/verify_decodex_bundle_contracts.py \
+  --daemon "$contents/Helpers/decodexd" \
+  --native-client "$mismatch_library" \
+  --menu-bar "$contents/Frameworks/libDecodexMenuBar.dylib"
+then
+  echo "The staged bundle contract check accepted a mismatched native client fixture." >&2
+  exit 1
+fi
 if plutil -extract LSUIElement raw "$info" >/dev/null 2>&1; then
   echo "Decodex.app must remain a regular windowed application." >&2
   exit 1

--- a/scripts/macos/verify_decodex_bundle_contracts.py
+++ b/scripts/macos/verify_decodex_bundle_contracts.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify the live compatibility exports in a staged Decodex bundle."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+NATIVE_CLIENT_ABI_VERSION = 1
+MENU_BAR_ABI_VERSION = 1
+
+
+class ContractError(RuntimeError):
+	"""The staged native components do not implement one compatible contract."""
+
+
+def exported_u32(library_path: Path, symbol_name: str) -> int:
+	try:
+		library = ctypes.CDLL(str(library_path))
+	except OSError as error:
+		raise ContractError(f"cannot load {library_path.name}: {error}") from error
+	try:
+		symbol = getattr(library, symbol_name)
+	except AttributeError as error:
+		raise ContractError(
+			f"{library_path.name} does not export {symbol_name}"
+		) from error
+	symbol.argtypes = []
+	symbol.restype = ctypes.c_uint32
+	return int(symbol())
+
+
+def daemon_artifact_cohort(daemon_path: Path) -> int:
+	try:
+		completed = subprocess.run(
+			[str(daemon_path), "artifact-cohort"],
+			check=True,
+			capture_output=True,
+			text=True,
+		)
+	except (OSError, subprocess.CalledProcessError) as error:
+		raise ContractError("daemon artifact contract is unavailable") from error
+	try:
+		document = json.loads(completed.stdout)
+		cohort = document["artifact_cohort"]
+	except (json.JSONDecodeError, KeyError, TypeError) as error:
+		raise ContractError("daemon artifact contract is malformed") from error
+	if not isinstance(cohort, int) or isinstance(cohort, bool) or cohort < 1:
+		raise ContractError("daemon artifact contract is malformed")
+	return cohort
+
+
+def verify(daemon_path: Path, native_client_path: Path, menu_bar_path: Path) -> None:
+	daemon_cohort = daemon_artifact_cohort(daemon_path)
+	native_abi = exported_u32(
+		native_client_path, "decodex_app_native_client_abi_version"
+	)
+	if native_abi != NATIVE_CLIENT_ABI_VERSION:
+		raise ContractError("native client ABI does not match the app")
+	native_cohort = exported_u32(
+		native_client_path, "decodex_app_native_client_artifact_cohort"
+	)
+	if native_cohort != daemon_cohort:
+		raise ContractError("native client and daemon artifact contracts differ")
+	menu_bar_abi = exported_u32(menu_bar_path, "decodex_menu_bar_abi_version")
+	if menu_bar_abi != MENU_BAR_ABI_VERSION:
+		raise ContractError("menu-bar ABI does not match the app")
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--daemon", required=True, type=Path)
+	parser.add_argument("--native-client", required=True, type=Path)
+	parser.add_argument("--menu-bar", required=True, type=Path)
+	args = parser.parse_args()
+	try:
+		verify(args.daemon, args.native_client, args.menu_bar)
+	except ContractError as error:
+		print(f"Decodex bundle contract check failed: {error}", file=sys.stderr)
+		return 1
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/test_gpui_bundled_daemon_supervision.sh
+++ b/scripts/test_gpui_bundled_daemon_supervision.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$repository_root"
+
+cargo +stable build -p decodexd
+DECODEX_TEST_DAEMON="$repository_root/target/debug/decodexd" \
+	cargo +stable test -p decodex-gpui 'bundled_daemon::tests::process_' -- --ignored

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -205,7 +205,10 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
         self.assertIn("project_shared_codex_auth_cas", coordinator)
         self.assertIn("AccountRouteWaitReasonDto", wire)
         self.assertIn("AccountRoutePendingStatusView", menu)
-        self.assertIn("PID \\(blocker.pid)", menu)
+        self.assertIn("Waiting for Codex to close or restart.", menu)
+        self.assertNotIn("PID \\(blocker.pid)", menu)
+        self.assertNotIn("auth.json", menu)
+        self.assertNotIn("atomic shared-auth", menu)
         for forbidden in (
             "std::process::Command",
             "libc::kill",
@@ -244,6 +247,31 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
         self.assertIn("cargo +stable build --locked", staging)
         for retired in ("pg_ctl", "initdb", "createuser", "createdb"):
             self.assertNotIn(retired, installer)
+
+    def test_process_acceptance_ports_are_explicit_and_release_closed(self) -> None:
+        account_service = read("crates/decodex-runtime/src/account_service.rs")
+        bootstrap = read("crates/decodex-runtime/src/bootstrap.rs")
+        shared_auth = read("crates/decodex-runtime/src/shared_auth_coordinator.rs")
+        process_test = read("apps/decodexd/tests/account_route_process.rs")
+        supervisor_test = read("apps/decodex-gpui/src/bundled_daemon.rs")
+        self.assertIn(
+            '#[cfg(all(feature = "process-acceptance-fixture", debug_assertions))]',
+            account_service,
+        )
+        self.assertIn('Ok(REFRESH_ENDPOINT.to_owned())', account_service)
+        self.assertIn('endpoint.host_str() == Some("127.0.0.1")', account_service)
+        self.assertIn(
+            ".filter(|endpoint| process_test_refresh_endpoint_is_safe(endpoint))",
+            account_service,
+        )
+        self.assertIn("process_acceptance_fixture_endpoint().is_some()", bootstrap)
+        self.assertIn("AccountApiRuntime::new", bootstrap)
+        self.assertIn("process_acceptance_fixture_endpoint().is_some()", shared_auth)
+        self.assertIn('CARGO_BIN_EXE_decodexd', process_test)
+        self.assertIn('actual_daemon_routes_a_b_a', process_test)
+        self.assertIn('assert_no_credentials', process_test)
+        self.assertIn('process_listener_loss_restarts_exact_owned_daemon', supervisor_test)
+        self.assertIn('process_recovery_never_terminates_independently_managed_daemon', supervisor_test)
 
     def test_quick_task_restart_contract_is_executable(self) -> None:
         test = read("database/tests/quick_task_restart.rs")


### PR DESCRIPTION
Repair account switching and app-owned bundled daemon supervision without carrying the separate Conversation, QuickTask, Program, or database WIP.

Validation:
- cargo make test (1,176 Rust tests, architecture, database, and CLI diagnostics)
- cargo make check-rust
- Swift 240/240
- real daemon account route A→B→A, SIGTERM/restart, and another switch
- socket publication replacement and foreign-daemon safety proofs
- signed Decodex.app staging and deliberate artifact-mismatch rejection

Known repository-baseline gate limits:
- aggregate cargo make check stops on host npm 11.19.0 versus exact repository npm 11.17.0
- formatter and clippy tasks report broad pre-existing main-branch drift outside this repair scope