### PR TITLE
Remove the fake execution decision query

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ replace the account and discard provider cache affinity.
 ## Removed and deferred surfaces
 
 The unsupported WorkItem board protocol and UI, and the static Coordinator/Agent/Review/Replay
-Factory preview, are deleted. Their old command names are not part of protocol 2.12 and fail
-decoding. ManagedRepository, Reset Card execution, execution-decision projections, automation,
-ManagedRun, remote workers, and multi-machine coordination remain deferred without a public fake
-workflow or legacy storage fallback.
+Factory preview, are deleted. Their old command names are not part of protocol 2.13 and fail
+decoding. The fake Execution Decision query and projection are also removed from the protocol and
+runtime. ManagedRepository, Reset Card execution, automation, ManagedRun, remote workers, and
+multi-machine coordination remain deferred without a public fake workflow or legacy storage
+fallback.
 
 Ontology and graph engineering remain central to the direction of Decodex. They will be
 projections over proven Goals, tasks, threads, artifacts, claims, dependencies, gates,
@@ -107,7 +108,7 @@ and evidence. They are not a second speculative execution engine.
 ## Persistence compatibility
 
 This cutover requires no data migration and does not rewrite existing conversations or immutable
-Program Pack bindings. Protocol 2.12 and artifact cohort 8 make the public breaking rename exact.
+Program Pack bindings. Protocol 2.13 and artifact cohort 9 make the public surface removal exact.
 The compatibility allowlist is limited to persisted/internal bytes that existing databases or
 Pack digests already own:
 

--- a/apps/decodex-cli/src/account.rs
+++ b/apps/decodex-cli/src/account.rs
@@ -1,4 +1,4 @@
-//! Operator account client over the same-UID V2.12 daemon protocol.
+//! Operator account client over the same-UID V2.13 daemon protocol.
 
 use std::path::{Path, PathBuf};
 

--- a/apps/decodex-cli/src/lib.rs
+++ b/apps/decodex-cli/src/lib.rs
@@ -122,7 +122,7 @@ pub enum Command {
 	/// Observe and consume reset cards through the common daemon authority.
 	#[command(subcommand)]
 	ResetCard(reset_card::ResetCardCommand),
-	/// Manage daemon-owned accounts through the same-UID V2.12 protocol.
+	/// Manage daemon-owned accounts through the same-UID V2.13 protocol.
 	#[command(subcommand)]
 	Account(account::AccountCommand),
 	/// Read or update the current user's local Codex Fast mode setting.

--- a/apps/decodex-gpui/src/client_lifecycle/tests.rs
+++ b/apps/decodex-gpui/src/client_lifecycle/tests.rs
@@ -112,16 +112,16 @@ fn production_cache_parent_normalizes_only_fixed_platform_prefix() {
 }
 
 #[test]
-fn production_client_cache_authority_is_valid_at_protocol_v2_12() {
+fn production_client_cache_authority_is_valid_at_protocol_v2_13() {
 	let temporary = TempDir::new().expect("temporary directory is available");
 	let fixture_temp_dir =
 		temporary.path().canonicalize().expect("fixture temporary directory canonicalizes");
 	let config = retained_config(&fixture_temp_dir.join("config-cache-parent"), SERVER);
 	let lifecycle = ClientLifecycle::production_with_temp_dir(config, &fixture_temp_dir)
-		.expect("production lifecycle constructs at protocol V2.12");
+		.expect("production lifecycle constructs at protocol V2.13");
 
 	assert_eq!(CURRENT_VERSION.major, 2);
-	assert_eq!(CURRENT_VERSION.minor, 12);
+	assert_eq!(CURRENT_VERSION.minor, 13);
 	assert_eq!(CLIENT_CACHE_SCHEMA_GENERATION, 1);
 	assert!(lifecycle.cache.is_some(), "the production client cache opens");
 	let encoded =

--- a/crates/decodex-protocol/src/client.rs
+++ b/crates/decodex-protocol/src/client.rs
@@ -987,7 +987,7 @@ pub enum AccountCommandResponse {
 	},
 }
 
-/// Same-UID V2.12 client for daemon-owned account queries and lifecycle commands.
+/// Same-UID V2.13 client for daemon-owned account queries and lifecycle commands.
 pub struct AccountClient {
 	transport: ResetCardClient,
 }
@@ -1969,12 +1969,12 @@ max_entry_bytes = 0
 	}
 
 	#[test]
-	fn protocol_constants_expose_only_the_exact_v2_12_window() {
-		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 12 });
+	fn protocol_constants_expose_only_the_exact_v2_13_window() {
+		assert_eq!(CURRENT_VERSION, ProtocolVersion { major: 2, minor: 13 });
 		assert_eq!(PREVIOUS_MINOR_VERSION, CURRENT_VERSION);
 		assert_eq!(
 			SupportedVersions::current(),
-			SupportedVersions { major: 2, minimum_minor: 12, maximum_minor: 12 },
+			SupportedVersions { major: 2, minimum_minor: 13, maximum_minor: 13 },
 		);
 		assert!(WireText::new("bounded").is_ok());
 	}

--- a/crates/decodex-protocol/src/lib.rs
+++ b/crates/decodex-protocol/src/lib.rs
@@ -74,14 +74,11 @@ pub use self::{
 		CommandEnvelope, CommandError, CommandOutcome, CommandPayload, CommandReceipt,
 		CommandResultEnvelope, ConversationHistoryPage, ConversationHistoryResult, CorrelationId,
 		Cursor, DESKTOP_SETTINGS_ENTITY_ID, DesktopSettingsDto, DesktopSettingsResult, EntityId,
-		EntityRevision, EventEnvelope, EventPayload, ExecutionConsumerDto, ExecutionDecisionDto,
-		ExecutionDecisionQueryError, ExecutionDecisionResult, ExecutionQuotaExclusionDto,
-		ExecutionQuotaWindowDto, ExecutionRouteBlockerDto, ExecutionRouteCauseDto,
-		ExecutionRouteDto, HistoryArtifactId, HistoryArtifactReference, HistoryArtifactRevision,
-		HistoryBlobLength, HistoryBlobReference, HistoryCursorToken, HistoryItemDto,
-		HistoryItemKindDto, HistoryItemStatusDto, HistoryMediaType, HistoryMetadata,
-		HistoryMetadataValue, HistoryPayloadDto, HistoryQueryError, HistorySideEffectState,
-		HistoryText, HistoryTurnRole, IdempotencyKey, IdempotencyKeyError,
+		EntityRevision, EventEnvelope, EventPayload, HistoryArtifactId, HistoryArtifactReference,
+		HistoryArtifactRevision, HistoryBlobLength, HistoryBlobReference, HistoryCursorToken,
+		HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto, HistoryMediaType,
+		HistoryMetadata, HistoryMetadataValue, HistoryPayloadDto, HistoryQueryError,
+		HistorySideEffectState, HistoryText, HistoryTurnRole, IdempotencyKey, IdempotencyKeyError,
 		MAX_ACCOUNT_PROFILE_DAILY_USAGE, MAX_ACCOUNT_ROUTE_PROCESS_BLOCKERS,
 		MAX_HISTORY_INLINE_BYTES, MAX_HISTORY_METADATA_FIELDS, MAX_HISTORY_METADATA_KEY_BYTES,
 		MAX_HISTORY_METADATA_VALUE_BYTES, MAX_HISTORY_PAGE_SIZE, MAX_IDEMPOTENCY_KEY_BYTES,
@@ -100,9 +97,9 @@ use serde::{Deserialize, Serialize};
 use decodex_core::FoundationStatus;
 
 /// The only protocol generation and revision accepted by this build.
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 12 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 2, minor: 13 };
 /// Build/protocol cohort that must agree across the daemon and every local consumer.
-pub const CURRENT_ARTIFACT_COHORT: u32 = 8;
+pub const CURRENT_ARTIFACT_COHORT: u32 = 9;
 /// The lower bound of the exact-current protocol window.
 ///
 /// This equals [`CURRENT_VERSION`]. The name remains to avoid an unrelated

--- a/crates/decodex-protocol/src/local_transport.rs
+++ b/crates/decodex-protocol/src/local_transport.rs
@@ -77,7 +77,7 @@ impl tokio::io::AsyncWrite for LocalTransportStream {
 	}
 }
 
-/// The complete V2.12 local endpoint authority.
+/// The complete V2.13 local endpoint authority.
 #[derive(Clone, Eq, PartialEq)]
 pub struct LocalTransportAuthority {
 	paths: DecodexPaths,

--- a/crates/decodex-protocol/src/wire.rs
+++ b/crates/decodex-protocol/src/wire.rs
@@ -1,4 +1,4 @@
-//! Structured JSON envelopes for the exact-current V2.12 WebSocket connection.
+//! Structured JSON envelopes for the exact-current V2.13 WebSocket connection.
 
 pub use decodex_core::{
 	HistoryMediaType, HistoryMetadata, HistoryMetadataValue, MAX_HISTORY_METADATA_FIELDS,
@@ -24,7 +24,7 @@ use crate::{
 	},
 };
 
-/// Maximum UTF-8 size of any human-readable text carried by V2.12.
+/// Maximum UTF-8 size of any human-readable text carried by V2.13.
 pub const MAX_WIRE_TEXT_BYTES: usize = 4_096;
 /// Maximum UTF-8 size of one logical-command idempotency key.
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
@@ -141,7 +141,7 @@ impl<'de> Deserialize<'de> for HistoryCursorToken {
 	}
 }
 
-/// A string-backed wire scalar exceeded its V2.12 byte limit.
+/// A string-backed wire scalar exceeded its V2.13 byte limit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WireScalarTooLong {
 	actual_bytes: usize,
@@ -459,7 +459,7 @@ pub struct ResumeCursor {
 	pub server_id: ServerId,
 	/// Ephemeral publication epoch that issued the cursor.
 	///
-	/// A V2.12 resume requires this field. Older hello envelopes can omit it
+	/// A V2.13 resume requires this field. Older hello envelopes can omit it
 	/// only so negotiation can return a typed version refusal.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
@@ -515,7 +515,7 @@ pub struct ServerWelcome {
 	pub server_id: ServerId,
 	/// Ephemeral identity of the in-memory publication epoch.
 	///
-	/// This is present in the exact-current V2.12 welcome.
+	/// This is present in the exact-current V2.13 welcome.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub instance_id: Option<ServerInstanceId>,
 	/// Informational server high-water mark; never a client resume checkpoint by itself.
@@ -1645,7 +1645,7 @@ impl<'de> Deserialize<'de> for AccountProfileResult {
 /// One required independently observed quota duration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountQuotaWindowDto {
-	/// Exact window duration. The V2.12 account contract accepts 300 and 10080 minutes only.
+	/// Exact window duration. The V2.13 account contract accepts 300 and 10080 minutes only.
 	pub duration_minutes: u32,
 	/// Exact observation time, absent only when state is unknown.
 	pub observed_at_unix_micros: Option<i64>,
@@ -2311,7 +2311,7 @@ impl AccountObservationSignal {
 	}
 }
 
-/// Live queries available through the exact-current V2.12 protocol.
+/// Live queries available through the exact-current V2.13 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryPayload {
@@ -2339,12 +2339,6 @@ pub enum QueryPayload {
 	},
 	/// Revalidate and return the bounded authoritative doctor/status report.
 	GetDoctorStatus,
-	/// Read one immutable Routing Decision execution-route decision without acquiring execution
-	/// authority.
-	GetExecutionDecision {
-		/// Stable Routing Decision identity.
-		decision_id: EntityId,
-	},
 	/// Read one bounded deterministic logical-conversation history page.
 	GetConversationHistory {
 		/// Stable logical Conversation identity.
@@ -2400,7 +2394,7 @@ impl QueryPayload {
 	}
 }
 
-/// Commands available through the exact-current V2.12 protocol.
+/// Commands available through the exact-current V2.13 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "arguments", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CommandPayload {
@@ -2901,7 +2895,7 @@ impl ResultPayload {
 	}
 }
 
-/// Typed live-query results available through the exact-current V2.12 protocol.
+/// Typed live-query results available through the exact-current V2.13 protocol.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "name", content = "data", rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryResultPayload {
@@ -2917,8 +2911,6 @@ pub enum QueryResultPayload {
 	Conversation(ConversationResult),
 	/// Bounded authoritative doctor/status readback.
 	DoctorStatus(DoctorReport),
-	/// Immutable execution-consumer and exact route-cause projection.
-	ExecutionDecision(ExecutionDecisionResult),
 	/// Bounded daemon-owned logical-conversation history result.
 	ConversationHistory(ConversationHistoryResult),
 	/// Bounded current reset-card observation or a closed unavailable reason.
@@ -2937,243 +2929,6 @@ pub enum QueryResultPayload {
 	CodexAuthProjection(CodexAuthProjectionResult),
 	/// One daemon account-observation change or bounded heartbeat.
 	AccountObservation(AccountObservationSignal),
-}
-
-/// Result of an immutable Routing Decision route-decision observation.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "outcome", content = "data", rename_all = "snake_case")]
-pub enum ExecutionDecisionResult {
-	/// Complete verified decision projection.
-	Decision(ExecutionDecisionDto),
-	/// Closed unavailable result without infrastructure detail.
-	Unavailable {
-		/// Stable reason class.
-		error: ExecutionDecisionQueryError,
-	},
-}
-
-/// Closed execution-decision query failure classes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExecutionDecisionQueryError {
-	/// Decision identity was invalid or no exact decision exists.
-	InvalidRequest,
-	/// Authoritative product state was unavailable.
-	ProductStateUnavailable,
-	/// Persisted decision evidence failed integrity verification.
-	IntegrityUnavailable,
-}
-
-/// Immutable Routing Decision plus its exact ordinary or managed consumer.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct ExecutionDecisionDto {
-	/// Stable immutable decision identity.
-	pub decision_id: EntityId,
-	/// Exact consumer whose account decision was persisted.
-	pub consumer: ExecutionConsumerDto,
-	/// Cause-preserving route projection.
-	pub route: ExecutionRouteDto,
-}
-
-/// Closed execution-consumer union. Ordinary Conversation work never implies a ManagedRun.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "kind", content = "identity", rename_all = "snake_case")]
-pub enum ExecutionConsumerDto {
-	/// One ordinary Conversation Turn with optional initial source RuntimeSession lineage.
-	ConversationTurn {
-		/// Conversation identity.
-		conversation_id: EntityId,
-		/// Positive Conversation revision.
-		conversation_revision: i64,
-		/// Source RuntimeSession identity, absent only for an initial Turn intent.
-		source_runtime_session_id: Option<EntityId>,
-		/// Positive source revision, jointly absent only for an initial Turn intent.
-		source_runtime_session_revision: Option<i64>,
-		/// Conversation-owned Turn identity.
-		turn_id: EntityId,
-	},
-	/// One exact ManagedRun execution intent.
-	ManagedRunExecution {
-		/// ManagedRun identity.
-		managed_run_id: EntityId,
-		/// Positive ManagedRun revision.
-		managed_run_revision: i64,
-		/// Exact execution intent identity.
-		managed_execution_id: EntityId,
-	},
-}
-
-/// Cause-preserving Routing Decision route projection.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
-pub enum ExecutionRouteDto {
-	/// One independently eligible account was selected.
-	Selected {
-		/// Persisted selected account identity.
-		account_id: EntityId,
-		/// Exact positive quota exclusions that were skipped before selection.
-		quota_exclusions: Vec<ExecutionQuotaExclusionDto>,
-	},
-	/// Every otherwise eligible account is blocked only by positive quota depletion.
-	WaitingUsage {
-		/// Earliest exact quota reset instant in Unix microseconds.
-		ready_at_micros: i64,
-		/// Complete exact account-scoped causes.
-		causes: Vec<ExecutionRouteCauseDto>,
-		/// Independent 300-minute and 10,080-minute depletion facts.
-		quota_exclusions: Vec<ExecutionQuotaExclusionDto>,
-	},
-	/// Every otherwise eligible path is blocked only by unresolved execution authority.
-	WaitingReconciliation {
-		/// Complete exact account-scoped process or attempt causes.
-		causes: Vec<ExecutionRouteCauseDto>,
-	},
-	/// No route exists and no wake or task failure is implied.
-	NoRoute {
-		/// Complete causes from the persisted policy-member universe.
-		#[serde(deserialize_with = "deserialize_nonempty_route_causes")]
-		causes: Vec<ExecutionRouteCauseDto>,
-	},
-}
-
-fn deserialize_nonempty_route_causes<'de, D>(
-	deserializer: D,
-) -> Result<Vec<ExecutionRouteCauseDto>, D::Error>
-where
-	D: Deserializer<'de>,
-{
-	let causes = Vec::<ExecutionRouteCauseDto>::deserialize(deserializer)?;
-	if causes.is_empty() {
-		Err(D::Error::custom("NoRoute requires at least one exact cause"))
-	} else {
-		Ok(causes)
-	}
-}
-
-/// One exact account-scoped blocker retained without category collapse.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct ExecutionRouteCauseDto {
-	/// Account path affected by this cause.
-	pub account_id: EntityId,
-	/// Exact typed blocker.
-	pub blocker: ExecutionRouteBlockerDto,
-}
-
-/// Exact typed blockers that Routing Decision can persist.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExecutionRouteBlockerDto {
-	/// Persisted policy excludes the account.
-	ExcludedByPolicy,
-	/// Account observation is later than the decision clock.
-	AccountFromFuture,
-	/// Account observation or revision is stale.
-	AccountStale,
-	/// Account is known to be unavailable.
-	AccountUnavailable,
-	/// Account state is unknown.
-	AccountUnknown,
-	/// Account state reports depletion independently of quota facts.
-	AccountDepleted,
-	/// Account authentication failed.
-	AccountAuthFailed,
-	/// Account-owned plugin readiness is absent.
-	AccountPluginUnready,
-	/// Account is administratively disabled.
-	AccountDisabled,
-	/// Compatibility evidence is absent.
-	EvidenceMissing,
-	/// Compatibility evidence is later than the decision clock.
-	EvidenceFromFuture,
-	/// Compatibility evidence is stale.
-	EvidenceStale,
-	/// Evidence names a different account identity or revision.
-	EvidenceAccountMismatch,
-	/// Evidence names a different role or role-profile revision.
-	EvidenceProfileMismatch,
-	/// Evidence names a different exact provider build.
-	EvidenceBuildMismatch,
-	/// The exact 300-minute quota fact is absent.
-	QuotaFiveHourMissing,
-	/// The 300-minute quota observation is from the future.
-	QuotaFiveHourFromFuture,
-	/// The 300-minute quota observation is stale.
-	QuotaFiveHourStale,
-	/// The 300-minute quota value or confidence is unknown.
-	QuotaFiveHourUnknown,
-	/// The 300-minute quota reset is not in the future.
-	QuotaFiveHourResetElapsed,
-	/// Positive 300-minute quota evidence reports depletion.
-	QuotaFiveHourDepleted,
-	/// The exact 10,080-minute quota fact is absent.
-	QuotaSevenDayMissing,
-	/// The 10,080-minute quota observation is from the future.
-	QuotaSevenDayFromFuture,
-	/// The 10,080-minute quota observation is stale.
-	QuotaSevenDayStale,
-	/// The 10,080-minute quota value or confidence is unknown.
-	QuotaSevenDayUnknown,
-	/// The 10,080-minute quota reset is not in the future.
-	QuotaSevenDayResetElapsed,
-	/// Positive 10,080-minute quota evidence reports depletion.
-	QuotaSevenDayDepleted,
-	/// A required capability lacks positive applicable evidence.
-	RequiredCapabilityUnsatisfied,
-	/// Authentication is required or unresolved.
-	AuthenticationRequired,
-	/// Required plugin readiness is unresolved.
-	PluginUnready,
-	/// An exact dependency blocks this path.
-	DependencyBlocked,
-	/// Required approval is absent.
-	ApprovalRequired,
-	/// Explicit user input is required.
-	UserRequired,
-	/// External authority blocks this path.
-	ExternalBlocked,
-	/// Usage state lacks pure positive depletion evidence.
-	UsageUnproven,
-	/// ManagedRun reconciliation lacks exact unresolved process or attempt authority.
-	ReconciliationUnproven,
-	/// No execution-scoped independent Reviewer is available.
-	ReviewerUnavailable,
-	/// Independent review rejected the result.
-	ReviewerFailed,
-	/// Reviewer output is missing or ambiguous.
-	ReviewerAmbiguous,
-	/// ProcessGeneration authority is unresolved.
-	ProcessGenerationUnresolved,
-	/// No live fenced ProcessGeneration exists.
-	ProcessGenerationUnavailable,
-	/// The exact ProviderAttempt is unresolved.
-	ProviderAttemptUnresolved,
-	/// The exact consumer intent already has a terminal ProviderAttempt.
-	ProviderAttemptCompleted,
-}
-
-/// One independently typed positive quota-depletion exclusion.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct ExecutionQuotaExclusionDto {
-	/// Account identity excluded by this exact fact.
-	pub account_id: EntityId,
-	/// Exact quota-window class.
-	pub window: ExecutionQuotaWindowDto,
-	/// Exact duration: 300 or 10,080 minutes.
-	pub duration_minutes: u16,
-	/// Positive source observation revision.
-	pub observation_revision: i64,
-	/// Exact future reset instant in Unix microseconds.
-	pub resets_at_micros: i64,
-}
-
-/// Independent quota-window identity.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExecutionQuotaWindowDto {
-	/// Exact 300-minute pool.
-	FiveHour,
-	/// Exact 10,080-minute pool.
-	SevenDay,
 }
 
 /// Result of a bounded Conversation-history observation.
@@ -3396,12 +3151,12 @@ pub enum Refusal {
 	},
 }
 
-/// Serialize a message using the only V2.12 wire encoding.
+/// Serialize a message using the only V2.13 wire encoding.
 pub fn encode_server_message(message: &ServerMessage) -> Result<String, Error> {
 	serde_json::to_string(message)
 }
 
-/// Parse a client message using the only V2.12 wire encoding.
+/// Parse a client message using the only V2.13 wire encoding.
 pub fn decode_client_message(message: &str) -> Result<ClientMessage, Error> {
 	let decoded = serde_json::from_str(message)?;
 	validate_client_message(&decoded).map_err(|reason| {
@@ -4384,6 +4139,32 @@ mod tests {
 	}
 
 	#[test]
+	fn exact_current_queries_round_trip_and_removed_execution_decision_fails_closed() {
+		let remaining = ClientMessage::Query(QueryEnvelope {
+			version: CURRENT_VERSION,
+			query_id: QueryId::new("doctor-query").expect("bounded query ID"),
+			payload: QueryPayload::GetDoctorStatus,
+		});
+		let encoded = serde_json::to_string(&remaining).expect("query serializes");
+		assert_eq!(decode_client_message(&encoded).unwrap(), remaining);
+
+		let removed = serde_json::json!({
+			"type": "query",
+			"body": {
+				"version": CURRENT_VERSION,
+				"query_id": "execution-decision-query",
+				"payload": {
+					"name": "get_execution_decision",
+					"arguments": {
+						"decision_id": "01234567-89ab-4def-8123-456789abcdef"
+					}
+				}
+			}
+		});
+		assert!(decode_client_message(&removed.to_string()).is_err());
+	}
+
+	#[test]
 	fn conversation_routing_recovery_has_clean_break_wire_shapes() {
 		let source =
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical source ID");
@@ -4883,8 +4664,8 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"hello","body":{"version":{"major":2,"minor":12},"#,
-				r#""artifact_cohort":8,"#,
+				r#"{"type":"hello","body":{"version":{"major":2,"minor":13},"#,
+				r#""artifact_cohort":9,"#,
 				r#""resume":{"server_id":"server-a","instance_id":"instance-a","cursor":42}}}"#,
 			)
 		);
@@ -4893,7 +4674,7 @@ mod tests {
 	#[test]
 	fn exact_current_resume_requires_a_publication_instance() {
 		let current_without_instance = concat!(
-			r#"{"type":"hello","body":{"version":{"major":2,"minor":12},"#,
+			r#"{"type":"hello","body":{"version":{"major":2,"minor":13},"#,
 			r#""resume":{"server_id":"server-a","cursor":42}}}"#,
 		);
 		let old_hello = concat!(
@@ -4935,7 +4716,7 @@ mod tests {
 		assert_eq!(
 			serde_json::to_string(&message).unwrap(),
 			concat!(
-				r#"{"type":"command","body":{"version":{"major":2,"minor":12},"#,
+				r#"{"type":"command","body":{"version":{"major":2,"minor":13},"#,
 				r#""client_command_id":"reset-card-use:key-1","idempotency_key":"key-1","#,
 				r#""expected_revision":9,"correlation_id":"reset-card-use:key-1","#,
 				r#""causation_id":null,"payload":{"name":"consume_reset_card","arguments":{"#,
@@ -5178,7 +4959,7 @@ mod tests {
 			EntityId::new("01234567-89ab-4def-8123-456789abcdef").expect("canonical account ID");
 		let descriptor = ResetCardDescriptorDto::new(100, 200).expect("valid descriptor");
 		let legacy = crate::ProtocolVersion { major: 1, minor: 5 };
-		let future = crate::ProtocolVersion { major: 2, minor: 13 };
+		let future = crate::ProtocolVersion { major: 2, minor: 14 };
 		let query = QueryPayload::GetAccountProfile {
 			account_id: account_id.clone(),
 			include_email: false,

--- a/crates/decodex-runtime/src/application.rs
+++ b/crates/decodex-runtime/src/application.rs
@@ -48,8 +48,7 @@ use decodex_protocol::{
 	ConversationRecoveryAction, ConversationResult, ConversationState, ConversationSummary,
 	ConversationTitle, ConversationTurnOutcome, CorrelationId, DESKTOP_SETTINGS_ENTITY_ID,
 	DesktopSettingsDto, DesktopSettingsResult, DoctorCheck, DoctorComponent, DoctorIssue,
-	DoctorReport, DoctorStatus, EntityId, EntityRevision, EventPayload,
-	ExecutionDecisionQueryError, ExecutionDecisionResult, HistoryArtifactId,
+	DoctorReport, DoctorStatus, EntityId, EntityRevision, EventPayload, HistoryArtifactId,
 	HistoryArtifactReference, HistoryArtifactRevision, HistoryBlobLength, HistoryBlobReference,
 	HistoryCursorToken, HistoryItemDto, HistoryItemKindDto, HistoryItemStatusDto,
 	HistoryPayloadDto, HistoryQueryError, HistorySideEffectState, HistoryText, HistoryTurnRole,
@@ -993,13 +992,6 @@ impl ServiceApplication {
 
 		decode_account_command_receipt(value)
 			.map_err(|_| application_unavailable("account command receipt is incompatible"))?
-	}
-
-	async fn execution_decision(&self, decision_id: &EntityId) -> ExecutionDecisionResult {
-		let _ = decision_id;
-		ExecutionDecisionResult::Unavailable {
-			error: ExecutionDecisionQueryError::ProductStateUnavailable,
-		}
 	}
 
 	async fn reset_card_inventory(&self, account_id: &EntityId) -> ResetCardInventoryResult {
@@ -2088,8 +2080,6 @@ impl Application for ServiceApplication {
 				QueryResultPayload::Conversation(self.conversation_get(conversation_id).await),
 			QueryPayload::GetDoctorStatus =>
 				QueryResultPayload::DoctorStatus(self.refreshed_doctor().await),
-			QueryPayload::GetExecutionDecision { decision_id } =>
-				QueryResultPayload::ExecutionDecision(self.execution_decision(decision_id).await),
 			QueryPayload::GetConversationHistory { conversation_id, after, page_size } =>
 				QueryResultPayload::ConversationHistory(
 					self.conversation_history(conversation_id, after.as_ref(), *page_size).await,
@@ -3146,140 +3136,6 @@ fn conversation_summary_publication(
 		entity_revision: EntityRevision(1),
 		event: EventPayload::ConversationChanged { conversation },
 	})
-}
-
-#[cfg(any())]
-fn execution_decision_dto(readback: ExecutionDecisionReadback) -> Result<ExecutionDecisionDto, ()> {
-	let consumer = match readback.consumer {
-		ExecutionConsumer::ConversationTurn {
-			conversation_id,
-			conversation_revision,
-			source_runtime_session_id,
-			source_runtime_session_revision,
-			turn_id,
-		} => ExecutionConsumerDto::ConversationTurn {
-			conversation_id: entity(conversation_id.as_str())?,
-			conversation_revision,
-			source_runtime_session_id: source_runtime_session_id
-				.as_ref()
-				.map(|id| entity(id.as_str()))
-				.transpose()?,
-			source_runtime_session_revision,
-			turn_id: entity(turn_id.as_str())?,
-		},
-		ExecutionConsumer::ManagedRunExecution {
-			managed_run_id,
-			managed_run_revision,
-			execution_id,
-		} => ExecutionConsumerDto::ManagedRunExecution {
-			managed_run_id: entity(managed_run_id.as_str())?,
-			managed_run_revision,
-			managed_execution_id: entity(execution_id.as_str())?,
-		},
-	};
-	let causes = readback
-		.causes
-		.into_iter()
-		.map(|cause| {
-			Ok(ExecutionRouteCauseDto {
-				account_id: entity(cause.account_id.as_str())?,
-				blocker: blocker_dto(cause.blocker),
-			})
-		})
-		.collect::<Result<Vec<_>, ()>>()?;
-	let quota_exclusions = readback
-		.quota_exclusions
-		.into_iter()
-		.map(quota_exclusion_dto)
-		.collect::<Result<Vec<_>, ()>>()?;
-	let route = match readback.kind {
-		RoutingDecisionKind::Selected => ExecutionRouteDto::Selected {
-			account_id: entity(readback.selected_account_id.as_ref().ok_or(())?.as_str())?,
-			quota_exclusions,
-		},
-		RoutingDecisionKind::WaitingUsage => ExecutionRouteDto::WaitingUsage {
-			ready_at_micros: readback.waiting_ready_at_micros.ok_or(())?,
-			causes,
-			quota_exclusions,
-		},
-		RoutingDecisionKind::WaitingReconciliation =>
-			ExecutionRouteDto::WaitingReconciliation { causes },
-		RoutingDecisionKind::NoRoute if !causes.is_empty() => ExecutionRouteDto::NoRoute { causes },
-		RoutingDecisionKind::NoRoute => return Err(()),
-	};
-	Ok(ExecutionDecisionDto { decision_id: entity(&readback.decision_id)?, consumer, route })
-}
-
-#[cfg(any())]
-fn quota_exclusion_dto(
-	exclusion: ExecutionQuotaExclusion,
-) -> Result<ExecutionQuotaExclusionDto, ()> {
-	Ok(ExecutionQuotaExclusionDto {
-		account_id: entity(exclusion.account_id.as_str())?,
-		window: match exclusion.window {
-			QuotaWindowClass::FiveHour => ExecutionQuotaWindowDto::FiveHour,
-			QuotaWindowClass::SevenDay => ExecutionQuotaWindowDto::SevenDay,
-		},
-		duration_minutes: exclusion.duration_minutes,
-		observation_revision: exclusion.observation_revision,
-		resets_at_micros: exclusion.resets_at_micros,
-	})
-}
-
-#[cfg(any())]
-const fn blocker_dto(blocker: RoutingBlocker) -> ExecutionRouteBlockerDto {
-	use ExecutionRouteBlockerDto as Dto;
-	use RoutingBlocker as Core;
-	match blocker {
-		Core::ExcludedByPolicy => Dto::ExcludedByPolicy,
-		Core::AccountFromFuture => Dto::AccountFromFuture,
-		Core::AccountStale => Dto::AccountStale,
-		Core::AccountUnavailable => Dto::AccountUnavailable,
-		Core::AccountUnknown => Dto::AccountUnknown,
-		Core::AccountDepleted => Dto::AccountDepleted,
-		Core::AccountAuthFailed => Dto::AccountAuthFailed,
-		Core::AccountPluginUnready => Dto::AccountPluginUnready,
-		Core::AccountDisabled => Dto::AccountDisabled,
-		Core::EvidenceMissing => Dto::EvidenceMissing,
-		Core::EvidenceFromFuture => Dto::EvidenceFromFuture,
-		Core::EvidenceStale => Dto::EvidenceStale,
-		Core::EvidenceAccountMismatch => Dto::EvidenceAccountMismatch,
-		Core::EvidenceProfileMismatch => Dto::EvidenceProfileMismatch,
-		Core::EvidenceBuildMismatch => Dto::EvidenceBuildMismatch,
-		Core::QuotaFiveHourMissing => Dto::QuotaFiveHourMissing,
-		Core::QuotaFiveHourFromFuture => Dto::QuotaFiveHourFromFuture,
-		Core::QuotaFiveHourStale => Dto::QuotaFiveHourStale,
-		Core::QuotaFiveHourUnknown => Dto::QuotaFiveHourUnknown,
-		Core::QuotaFiveHourResetElapsed => Dto::QuotaFiveHourResetElapsed,
-		Core::QuotaFiveHourDepleted => Dto::QuotaFiveHourDepleted,
-		Core::QuotaSevenDayMissing => Dto::QuotaSevenDayMissing,
-		Core::QuotaSevenDayFromFuture => Dto::QuotaSevenDayFromFuture,
-		Core::QuotaSevenDayStale => Dto::QuotaSevenDayStale,
-		Core::QuotaSevenDayUnknown => Dto::QuotaSevenDayUnknown,
-		Core::QuotaSevenDayResetElapsed => Dto::QuotaSevenDayResetElapsed,
-		Core::QuotaSevenDayDepleted => Dto::QuotaSevenDayDepleted,
-		Core::RequiredCapabilityUnsatisfied => Dto::RequiredCapabilityUnsatisfied,
-		Core::AuthenticationRequired => Dto::AuthenticationRequired,
-		Core::PluginUnready => Dto::PluginUnready,
-		Core::DependencyBlocked => Dto::DependencyBlocked,
-		Core::ApprovalRequired => Dto::ApprovalRequired,
-		Core::UserRequired => Dto::UserRequired,
-		Core::ExternalBlocked => Dto::ExternalBlocked,
-		Core::UsageUnproven => Dto::UsageUnproven,
-		Core::ReconciliationUnproven => Dto::ReconciliationUnproven,
-		Core::ReviewerUnavailable => Dto::ReviewerUnavailable,
-		Core::ReviewerFailed => Dto::ReviewerFailed,
-		Core::ReviewerAmbiguous => Dto::ReviewerAmbiguous,
-		Core::ProcessGenerationUnresolved => Dto::ProcessGenerationUnresolved,
-		Core::ProcessGenerationUnavailable => Dto::ProcessGenerationUnavailable,
-		Core::ProviderAttemptUnresolved => Dto::ProviderAttemptUnresolved,
-		Core::ProviderAttemptCompleted => Dto::ProviderAttemptCompleted,
-	}
-}
-
-#[cfg(any())]
-fn entity(value: &str) -> Result<EntityId, ()> {
-	EntityId::new(value.to_owned()).map_err(|_| ())
 }
 
 fn core_reset_descriptor(descriptor: ResetCardDescriptorDto) -> Result<ResetCardDescriptor, ()> {

--- a/crates/decodex-runtime/src/lib.rs
+++ b/crates/decodex-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! `decodexd` lifecycle assembly and the same-UID V2.12 local connection owner.
+//! `decodexd` lifecycle assembly and the same-UID V2.13 local connection owner.
 //!
 //! Account-process and routing composition remain crate-private. The ordinary Conversation owner
 //! composes them without exporting raw process, routing, or provider-dispatch facades.

--- a/crates/decodex-runtime/tests/bootstrap_doctor.rs
+++ b/crates/decodex-runtime/tests/bootstrap_doctor.rs
@@ -369,7 +369,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut future,
 		ClientMessage::Hello(ClientHello {
-			version: ProtocolVersion { major: 2, minor: 13 },
+			version: ProtocolVersion { major: 2, minor: 14 },
 			artifact_cohort: Some(decodex_protocol::CURRENT_ARTIFACT_COHORT),
 			expected_server_id: Some(server_id.clone()),
 			resume: None,
@@ -377,7 +377,7 @@ async fn assert_exact_current_doctor_queries(
 	)
 	.await;
 	let ServerMessage::Refusal(refusal) = receive(&mut future).await else {
-		panic!("expected V2.13 minor-version refusal");
+		panic!("expected V2.14 minor-version refusal");
 	};
 	assert!(matches!(
 		refusal.refusal,
@@ -423,7 +423,7 @@ async fn assert_exact_current_doctor_queries(
 	send(
 		&mut current,
 		ClientMessage::Query(doctor_query(
-			ProtocolVersion { major: 2, minor: 13 },
+			ProtocolVersion { major: 2, minor: 14 },
 			"future-query-on-current-session",
 		)),
 	)

--- a/crates/decodex-runtime/tests/websocket_protocol.rs
+++ b/crates/decodex-runtime/tests/websocket_protocol.rs
@@ -553,8 +553,8 @@ async fn exact_current_and_pre_payload_version_refusals_use_real_websockets() {
 		panic!("expected welcome");
 	};
 	assert_eq!(welcome.version, CURRENT_VERSION);
-	assert_eq!(welcome.supported.minimum_minor, 12);
-	assert_eq!(welcome.supported.maximum_minor, 12);
+	assert_eq!(welcome.supported.minimum_minor, 13);
+	assert_eq!(welcome.supported.maximum_minor, 13);
 	assert!(welcome.instance_id.is_some());
 	assert!(matches!(receive(&mut client).await, ServerMessage::Snapshot(_)));
 	execute_and_receive_event(&mut client, CURRENT_VERSION, 1).await;

--- a/tests/scripts/test_vnext_architecture.py
+++ b/tests/scripts/test_vnext_architecture.py
@@ -98,6 +98,19 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
                 self.assertNotIn("rusqlite", dependencies)
                 self.assertNotIn("redb", dependencies)
 
+    def test_exact_current_protocol_and_artifact_cohort_cross_every_bundle_boundary(self) -> None:
+        protocol = read("crates/decodex-protocol/src/lib.rs")
+        gpui = read("apps/decodex-gpui/src/client_lifecycle/tests.rs")
+        native_client = read("crates/decodex-app-client-ffi/src/lib.rs")
+        staging = read("scripts/macos/stage_decodex_app.sh")
+        bundle_verifier = read("scripts/macos/verify_decodex_bundle_contracts.py")
+        self.assertIn("ProtocolVersion { major: 2, minor: 13 }", protocol)
+        self.assertIn("CURRENT_ARTIFACT_COHORT: u32 = 9", protocol)
+        self.assertIn("assert_eq!(CURRENT_VERSION.minor, 13)", gpui)
+        self.assertIn("decodex_protocol::CURRENT_ARTIFACT_COHORT", native_client)
+        self.assertIn("verify_decodex_bundle_contracts.py", staging)
+        self.assertIn("decodex_app_native_client_artifact_cohort", bundle_verifier)
+
     def test_gpui_is_the_only_macos_gui_and_loads_the_original_swift_menu_bar(self) -> None:
         for retired in (
             "apps/decodex",
@@ -296,12 +309,12 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
             self.assertIn(".codex_url()", consumer)
             self.assertNotIn('format!("codex://threads/', consumer)
 
-    def test_retired_board_does_not_keep_protocol_or_runtime_surface_alive(self) -> None:
+    def test_retired_board_and_execution_decision_surfaces_stay_absent(self) -> None:
         application = read("crates/decodex-runtime/src/application.rs")
         protocol = read("crates/decodex-protocol/src/wire.rs")
+        protocol_exports = read("crates/decodex-protocol/src/lib.rs")
         managed_repository = read("crates/decodex-runtime/src/managed_repository_disabled.rs")
         reset_card = read("crates/decodex-runtime/src/account_launch/api_reset_card_disabled.rs")
-        self.assertIn("ExecutionDecisionQueryError::ProductStateUnavailable", application)
         for retired in (
             "WorkItemBoard",
             "ListProjects",
@@ -313,6 +326,25 @@ class LocalSqliteArchitectureTests(unittest.TestCase):
         ):
             self.assertNotIn(retired, application)
             self.assertNotIn(retired, protocol)
+        for retired in (
+            "GetExecutionDecision",
+            "ExecutionDecisionResult",
+            "ExecutionDecisionDto",
+            "ExecutionConsumerDto",
+            "ExecutionRouteDto",
+            "ExecutionRouteCauseDto",
+            "ExecutionRouteBlockerDto",
+            "ExecutionQuotaExclusionDto",
+            "ExecutionQuotaWindowDto",
+            "execution_decision_dto",
+            "quota_exclusion_dto",
+            "blocker_dto",
+        ):
+            with self.subTest(retired=retired):
+                self.assertNotIn(retired, application)
+                self.assertNotIn(retired, protocol)
+                self.assertNotIn(retired, protocol_exports)
+        self.assertNotIn("#[cfg(any())]", application)
         self.assertFalse((ROOT / "apps/decodex-gpui/src/work_items.rs").exists())
         self.assertIn("ManagedRepositoryUnavailableReason", managed_repository)
         self.assertIn("ProductStateUnavailable", reset_card)


### PR DESCRIPTION
## Summary

- Remove the fake `GetExecutionDecision` query, result payload, isolated DTO family, runtime arm, constant unavailable response, and disabled conversion helpers.
- Keep retired WorkItem-board protection and add fail-closed coverage for removed execution-decision input.
- Bump the exact-current protocol from 2.12 to 2.13 and the artifact cohort from 8 to 9 across Rust, GPUI tests, FFI/bundle validation, wire goldens, and documentation.
- State explicitly that the Execution Decision projection is removed rather than exposed as a deferred protocol workflow.

## Preserved contracts

This change does not alter Conversation create/send/continue/refresh/archive/interrupt behavior, Program aggregates or WorkItem binding, graph/review evidence rules, SQLite schema or persisted compatibility spellings, Codex app-server execution, account routing and credential ownership, ProcessGeneration fencing, ProviderAttempt replay safety, opaque provider thread IDs, or app-server lifecycle behavior. ManagedRepository, Reset Card, automation, and ManagedRun remain outside this outcome.

No database migration, persisted-byte rewrite, app installation, app restart, or account-state mutation is included.

## Validation

Passed:

- `cargo +stable test -p decodex-protocol --all-targets`
- `cargo +stable test -p decodex-runtime --all-targets`
- `python3 -m unittest tests/scripts/test_vnext_architecture.py`
- `cargo make test` with the repository-required Xcode beta and host-managed Node 24.19.0/npm 11.17.0: 1,148 Rust tests passed, plus architecture, database, automation, gate-contract, and live CLI diagnostics.
- The normal `cargo make check` passed Node provenance/audits, site build/check, and workspace `cargo check --locked --all-features --all-targets` before reaching the repository-wide format check.

## Remaining risk

The normal full gate is not wholly green on authoritative main: its pinned formatter reports broad drift in untouched files, and the workspace lint audit reports existing Clippy/documentation/line-count failures across unrelated FFI, core, database, GPUI, protocol, runtime, daemon, and Radar surfaces. This PR intentionally does not expand into the prohibited repository-wide formatting or unrelated cleanup. The changed behavior is covered by the focused suites and the complete workspace test gate.